### PR TITLE
Fix CSP blocking Next.js inline scripts on sign-in page

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -10,7 +10,7 @@
 		Referrer-Policy "strict-origin-when-cross-origin"
 		Permissions-Policy "camera=(), microphone=(), geolocation=()"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'"
+		Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'"
 		-Server
 	}
 


### PR DESCRIPTION
## Summary
- Add `'unsafe-inline'` to `script-src` in the Caddyfile CSP header
- Next.js requires inline scripts for hydration — the strict CSP was blocking all 6 inline scripts, preventing the GitHub sign-in button from rendering

## Test plan
- [ ] Deploy to VPS, restart Caddy, verify sign-in page shows the GitHub button
- [ ] Verify no CSP errors in browser console
- [ ] Complete full OAuth sign-in flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)