### PR TITLE
Add capital awareness & affordability to options scanner

### DIFF
--- a/frontend/components/options/OptionScanner.jsx
+++ b/frontend/components/options/OptionScanner.jsx
@@ -8,7 +8,7 @@ import LoadingSkeleton from '../layout/LoadingSkeleton';
 
 export default function OptionScannerPage() {
   const scanner = useOptionScanner();
-  const { result, loading, error } = scanner;
+  const { result, loading, error, capitalData } = scanner;
   const schwab = useSchwabStatus();
 
   return (
@@ -122,11 +122,76 @@ export default function OptionScannerPage() {
                 </div>
               </div>
 
+              {/* Budget Alert Banner */}
+              {capitalData.utilization?.noAffordable && (
+                <div
+                  data-testid="budget-alert-banner"
+                  className="flex items-start gap-3 px-4 py-3 rounded-lg border border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/30 text-red-800 dark:text-red-200"
+                  role="alert"
+                >
+                  <svg className="w-5 h-5 shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.072 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                  </svg>
+                  <div>
+                    <p className="text-sm font-medium">Insufficient capital</p>
+                    <p className="text-xs mt-1 text-red-600 dark:text-red-400">
+                      Your ${capitalData.utilization.capital.toLocaleString()} budget cannot cover any of the {result.recommendations.length} available strikes.
+                      {result.strategy === 'cash_secured_put'
+                        ? ` The lowest strike requires $${(Math.min(...result.recommendations.map(r => r.strike)) * 100).toLocaleString()} in collateral.`
+                        : ` Each contract requires $${(result.current_price * 100).toLocaleString()} in collateral.`}
+                      {' '}Try lowering your strike targets or increasing capital.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              {/* Capital Utilization Card */}
+              {capitalData.utilization && !capitalData.utilization.noAffordable && (
+                <div
+                  data-testid="capital-utilization-card"
+                  className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl p-4"
+                >
+                  <h3 className="text-sm font-medium text-slate-700 dark:text-slate-200 mb-3">Capital Deployment</h3>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+                    <div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">Best Strike</div>
+                      <div className="font-medium text-slate-900 dark:text-white">${capitalData.utilization.bestStrike.toFixed(2)}</div>
+                      <div className="text-xs text-slate-400 dark:text-slate-500">{capitalData.utilization.bestExpiration}</div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">Contracts</div>
+                      <div className="font-medium text-slate-900 dark:text-white">{capitalData.utilization.contracts}</div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">Max Income</div>
+                      <div className="font-medium text-green-600 dark:text-green-400">${capitalData.utilization.maxIncome.toFixed(2)}</div>
+                    </div>
+                    <div>
+                      <div className="text-xs text-slate-500 dark:text-slate-400">Idle Capital</div>
+                      <div className="font-medium text-slate-900 dark:text-white">${capitalData.utilization.idle.toFixed(2)}</div>
+                    </div>
+                  </div>
+                  <div className="mt-3">
+                    <div className="flex justify-between text-xs text-slate-500 dark:text-slate-400 mb-1">
+                      <span>Deployment</span>
+                      <span>{capitalData.utilization.deploymentPct.toFixed(0)}%</span>
+                    </div>
+                    <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
+                      <div
+                        className="bg-blue-600 dark:bg-blue-500 h-2 rounded-full transition-all"
+                        style={{ width: `${Math.min(capitalData.utilization.deploymentPct, 100)}%` }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              )}
+
               {/* Strike Table */}
               <StrikeTable
-                recommendations={result.recommendations}
+                recommendations={capitalData.enriched}
                 selectedStrikes={scanner.selectedStrikes}
                 onToggleSelection={scanner.toggleStrikeSelection}
+                hasCapital={!!capitalData.utilization}
               />
 
               {/* Risk/Reward Comparison */}

--- a/frontend/components/options/StrikeTable.jsx
+++ b/frontend/components/options/StrikeTable.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export default function StrikeTable({ recommendations, selectedStrikes, onToggleSelection }) {
+export default function StrikeTable({ recommendations, selectedStrikes, onToggleSelection, hasCapital = false }) {
   const [sortField, setSortField] = useState('rank');
   const [sortDir, setSortDir] = useState('asc');
   const [expandedRow, setExpandedRow] = useState(null);
@@ -29,7 +29,7 @@ export default function StrikeTable({ recommendations, selectedStrikes, onToggle
   }
 
   return (
-    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+    <div data-testid="strike-table" className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
       <div className="overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="bg-slate-50 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700">
@@ -46,6 +46,12 @@ export default function StrikeTable({ recommendations, selectedStrikes, onToggle
               <SortHeader field="return_on_capital_pct" label="Return%" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
               <SortHeader field="annualized_return_pct" label="Ann.%" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
               <SortHeader field="distance_from_price_pct" label="Dist.%" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+              {hasCapital && (
+                <>
+                  <SortHeader field="contracts" label="Contracts" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                  <SortHeader field="maxIncome" label="Max Income" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+                </>
+              )}
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
@@ -54,20 +60,27 @@ export default function StrikeTable({ recommendations, selectedStrikes, onToggle
               const isSelected = selectedStrikes.some((sel) => `${sel.strike}-${sel.expiration}` === key);
               const isExpanded = expandedRow === key;
               const allPass = s.rule_compliance && Object.values(s.rule_compliance).every(Boolean);
+              const unaffordable = hasCapital && s.isAffordable === false;
 
               return (
                 <RowGroup key={key}>
                   <tr
-                    className={`hover:bg-slate-50 dark:hover:bg-slate-700/50 cursor-pointer transition-colors ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : ''}`}
+                    className={`hover:bg-slate-50 dark:hover:bg-slate-700/50 cursor-pointer transition-colors ${isSelected ? 'bg-blue-50 dark:bg-blue-900/20' : ''} ${unaffordable ? 'opacity-50' : ''}`}
                     onClick={() => setExpandedRow(isExpanded ? null : key)}
                   >
                     <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        onChange={() => onToggleSelection(s)}
-                        className="rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500"
-                      />
+                      {unaffordable ? (
+                        <svg className="w-4 h-4 text-slate-400 dark:text-slate-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-label="Unaffordable">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+                        </svg>
+                      ) : (
+                        <input
+                          type="checkbox"
+                          checked={isSelected}
+                          onChange={() => onToggleSelection(s)}
+                          className="rounded border-slate-300 dark:border-slate-600 text-blue-600 focus:ring-blue-500"
+                        />
+                      )}
                     </td>
                     <td className="px-3 py-2 text-slate-500 dark:text-slate-400">{s.rank}</td>
                     <td className={`px-3 py-2 text-right font-medium ${allPass ? 'text-green-700 dark:text-green-400' : 'text-yellow-700 dark:text-yellow-400'}`}>
@@ -84,10 +97,20 @@ export default function StrikeTable({ recommendations, selectedStrikes, onToggle
                     <td className="px-3 py-2 text-right font-medium text-blue-600 dark:text-blue-400">{s.return_on_capital_pct.toFixed(2)}%</td>
                     <td className="px-3 py-2 text-right text-slate-700 dark:text-slate-300">{s.annualized_return_pct.toFixed(1)}%</td>
                     <td className="px-3 py-2 text-right text-slate-700 dark:text-slate-300">{s.distance_from_price_pct.toFixed(1)}%</td>
+                    {hasCapital && (
+                      <>
+                        <td className="px-3 py-2 text-right font-medium text-slate-700 dark:text-slate-300">
+                          {s.contracts ?? '-'}
+                        </td>
+                        <td className="px-3 py-2 text-right font-medium text-green-600 dark:text-green-400">
+                          {s.maxIncome != null ? `$${s.maxIncome.toFixed(2)}` : '-'}
+                        </td>
+                      </>
+                    )}
                   </tr>
                   {isExpanded && (
                     <tr>
-                      <td colSpan={12} className="px-6 py-4 bg-slate-50 dark:bg-slate-900/50">
+                      <td colSpan={hasCapital ? 14 : 12} className="px-6 py-4 bg-slate-50 dark:bg-slate-900/50">
                         <ExpandedDetails strike={s} />
                       </td>
                     </tr>

--- a/frontend/e2e/options-capital-awareness.spec.js
+++ b/frontend/e2e/options-capital-awareness.spec.js
@@ -1,0 +1,240 @@
+import { test, expect } from '@playwright/test';
+
+const MOCK_SCAN_RESPONSE = {
+  ticker: 'SOFI',
+  current_price: 12.50,
+  strategy: 'cash_secured_put',
+  scan_time: '2026-03-18T12:00:00Z',
+  earnings_date: '2026-04-15',
+  iv_rank: null,
+  recommendations: [
+    {
+      rank: 1,
+      strike: 11.0,
+      expiration: '2026-04-18',
+      dte: 31,
+      bid: 0.35,
+      ask: 0.40,
+      mid: 0.375,
+      delta: -0.25,
+      gamma: 0.05,
+      theta: -0.02,
+      vega: 0.03,
+      iv: 0.45,
+      open_interest: 5200,
+      volume: 340,
+      premium_per_contract: 37.50,
+      total_premium: 37.50,
+      return_on_capital_pct: 0.34,
+      annualized_return_pct: 4.01,
+      distance_from_price_pct: 12.0,
+      distance_from_basis_pct: null,
+      max_profit: 37.50,
+      breakeven: 10.625,
+      fifty_pct_profit_target: 18.75,
+      rule_compliance: {
+        passes_10pct_rule: true,
+        passes_dte_range: true,
+        passes_delta_range: true,
+        passes_earnings_check: true,
+        passes_return_target: true,
+      },
+      greeks_source: 'market',
+      flags: [],
+    },
+    {
+      rank: 2,
+      strike: 50.0,
+      expiration: '2026-04-18',
+      dte: 31,
+      bid: 0.10,
+      ask: 0.15,
+      mid: 0.125,
+      delta: -0.10,
+      gamma: 0.02,
+      theta: -0.01,
+      vega: 0.01,
+      iv: 0.40,
+      open_interest: 1200,
+      volume: 80,
+      premium_per_contract: 12.50,
+      total_premium: 12.50,
+      return_on_capital_pct: 0.025,
+      annualized_return_pct: 0.29,
+      distance_from_price_pct: 300.0,
+      distance_from_basis_pct: null,
+      max_profit: 12.50,
+      breakeven: 49.875,
+      fifty_pct_profit_target: 6.25,
+      rule_compliance: {
+        passes_10pct_rule: true,
+        passes_dte_range: true,
+        passes_delta_range: true,
+        passes_earnings_check: true,
+        passes_return_target: false,
+      },
+      greeks_source: 'market',
+      flags: [],
+    },
+  ],
+  rejected: [],
+  market_context: {
+    vix: 18.5,
+    beta: 1.8,
+    fifty_two_week_high: 15.0,
+    fifty_two_week_low: 6.0,
+    daily_volume: 120000000,
+  },
+};
+
+function setupMocks(page, scanResponse = MOCK_SCAN_RESPONSE) {
+  return Promise.all([
+    page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ configured: true, valid: true, error: null, token_expiry: null }),
+      })
+    ),
+    page.route('**/api/options/scan', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(scanResponse),
+      })
+    ),
+  ]);
+}
+
+async function fillAndScan(page, capital) {
+  await page.getByPlaceholder('SOFI, AAPL, F...').fill('SOFI');
+  await page.getByPlaceholder('5000').fill(capital);
+  await page.getByRole('button', { name: 'Scan Options' }).click();
+  await page.waitForSelector('[data-testid="strike-table"], [data-testid="budget-alert-banner"]', { timeout: 5000 });
+}
+
+test.describe('Options capital awareness & affordability', () => {
+  test.skip('light and dark mode styling is correct', async () => {
+    // Manual verification: budget alert banner, capital utilization card, dimmed rows,
+    // and lock icons should be visually correct in both light and dark themes.
+  });
+
+  test('Contracts and Max Income columns appear when capitalAvailable is set', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+
+    await fillAndScan(page, '2000');
+
+    // The new columns should be visible in the table header
+    const table = page.locator('table');
+    await expect(table.getByText('Contracts')).toBeVisible();
+    await expect(table.getByText('Max Income')).toBeVisible();
+  });
+
+  test('table looks the same when capitalAvailable is not set', async ({ page }) => {
+    // Use a scan response but without capital set — the table shouldn't show new columns.
+    // To do this we need a strategy that doesn't require capital; we'll use covered_call.
+    const ccResponse = {
+      ...MOCK_SCAN_RESPONSE,
+      strategy: 'covered_call',
+    };
+    await page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ configured: true, valid: true, error: null, token_expiry: null }),
+      })
+    );
+    await page.route('**/api/options/scan', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(ccResponse),
+      })
+    );
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+
+    // Switch to Covered Call and scan without setting capital
+    await page.getByRole('button', { name: 'Covered Call' }).click();
+    await page.getByPlaceholder('SOFI, AAPL, F...').fill('SOFI');
+    await page.getByPlaceholder('15.50').fill('10');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.waitForSelector('table');
+
+    const table = page.locator('table');
+    await expect(table.getByText('Contracts')).not.toBeVisible();
+    await expect(table.getByText('Max Income')).not.toBeVisible();
+  });
+
+  test('unaffordable rows are dimmed with lock icon and not selectable', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+
+    // $2000 can afford strike $11 (collateral $1100) but not strike $50 (collateral $5000)
+    await fillAndScan(page, '2000');
+
+    const rows = page.locator('table tbody tr');
+    // Find the $50 strike row — it should be dimmed (opacity-50)
+    const expensiveRow = rows.filter({ hasText: '$50.00' }).first();
+    await expect(expensiveRow).toHaveClass(/opacity-50/);
+
+    // The expensive row should have a lock icon SVG, not a checkbox
+    await expect(expensiveRow.locator('svg[aria-label="Unaffordable"]')).toBeVisible();
+    await expect(expensiveRow.locator('input[type="checkbox"]')).not.toBeVisible();
+
+    // The affordable row ($11) should have a checkbox, not a lock
+    const affordableRow = rows.filter({ hasText: '$11.00' }).first();
+    await expect(affordableRow.locator('input[type="checkbox"]')).toBeVisible();
+    await expect(affordableRow).not.toHaveClass(/opacity-50/);
+  });
+
+  test('budget alert banner appears when no strikes are affordable', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+
+    // $500 can't afford any strike (cheapest collateral is $1100 for strike $11)
+    await fillAndScan(page, '500');
+
+    const banner = page.getByTestId('budget-alert-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Insufficient capital');
+    await expect(banner).toContainText('$500');
+  });
+
+  test('capital utilization card shows deployment summary', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+
+    await fillAndScan(page, '2000');
+
+    const card = page.getByTestId('capital-utilization-card');
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Capital Deployment');
+    await expect(card).toContainText('Best Strike');
+    await expect(card).toContainText('Contracts');
+    await expect(card).toContainText('Max Income');
+    await expect(card).toContainText('Idle Capital');
+    // Should show deployment percentage
+    await expect(card).toContainText('Deployment');
+    await expect(card).toContainText('%');
+  });
+
+  test('CSP collateral = strike * 100', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+
+    // $2000 capital, $11 strike → collateral = $1100 → 1 contract, maxIncome = 1 * $37.50
+    await fillAndScan(page, '2000');
+
+    const table = page.locator('table');
+    const affordableRow = table.locator('tbody tr').filter({ hasText: '$11.00' }).first();
+    // Contracts column should show 1 (floor(2000/1100) = 1)
+    await expect(affordableRow).toContainText('$37.50');
+  });
+});

--- a/frontend/hooks/useOptionScanner.js
+++ b/frontend/hooks/useOptionScanner.js
@@ -1,6 +1,43 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import toast from 'react-hot-toast';
 import { scanOptions } from '../api/client';
+
+function computeCapitalFields(recommendations, strategy, capitalAvailable, currentPrice) {
+  const capital = parseFloat(capitalAvailable);
+  if (!capital || capital <= 0) return { enriched: recommendations, utilization: null };
+
+  const enriched = recommendations.map((rec) => {
+    const collateral = strategy === 'covered_call'
+      ? currentPrice * 100
+      : rec.strike * 100;
+    const contracts = Math.floor(capital / collateral);
+    const maxIncome = contracts * rec.total_premium;
+    return { ...rec, contracts, maxIncome, isAffordable: contracts > 0 };
+  });
+
+  const affordable = enriched.filter((r) => r.isAffordable);
+  if (affordable.length === 0) {
+    return { enriched, utilization: { noAffordable: true, capital } };
+  }
+
+  const best = affordable.reduce((a, b) => b.maxIncome > a.maxIncome ? b : a);
+  const deployed = best.contracts * (strategy === 'covered_call' ? currentPrice * 100 : best.strike * 100);
+  const idle = capital - deployed;
+
+  return {
+    enriched,
+    utilization: {
+      noAffordable: false,
+      capital,
+      bestStrike: best.strike,
+      bestExpiration: best.expiration,
+      contracts: best.contracts,
+      maxIncome: best.maxIncome,
+      idle,
+      deploymentPct: (deployed / capital) * 100,
+    },
+  };
+}
 
 export function useOptionScanner() {
   const [result, setResult] = useState(null);
@@ -21,6 +58,11 @@ export function useOptionScanner() {
   const [earningsBuffer, setEarningsBuffer] = useState(5);
 
   const [selectedStrikes, setSelectedStrikes] = useState([]);
+
+  const capitalData = useMemo(() => {
+    if (!result || !capitalAvailable) return { enriched: result?.recommendations || [], utilization: null };
+    return computeCapitalFields(result.recommendations, strategy, capitalAvailable, result.current_price);
+  }, [result, capitalAvailable, strategy]);
 
   const runScan = useCallback(async () => {
     if (!ticker.trim()) {
@@ -116,5 +158,6 @@ export function useOptionScanner() {
     selectedStrikes, toggleStrikeSelection,
     result, loading, error,
     runScan, reset,
+    capitalData,
   };
 }


### PR DESCRIPTION
## Summary

- **Capital-enriched recommendations**: When `capitalAvailable` is set, compute `contracts` (`floor(capital / collateral)`), `maxIncome`, and `isAffordable` per strike
- **Budget alert banner**: Red warning when no strikes are affordable, showing shortfall and collateral requirements
- **Capital utilization card**: Displays best strike, contracts sellable, max income, idle capital, and a deployment progress bar
- **Strike table enhancements**: Contracts and Max Income columns appear conditionally; unaffordable rows are dimmed with lock icons and non-selectable

Closes #37

## Test plan

- [x] Contracts and Max Income columns appear when capitalAvailable is set
- [x] Table unchanged when capitalAvailable is not set
- [x] Unaffordable rows dimmed with lock icon, not selectable
- [x] Budget alert banner when no strikes affordable
- [x] Capital utilization card shows deployment summary
- [x] CSP collateral = strike × 100
- [ ] Works in both light and dark mode (manual)
- [x] All existing e2e tests still pass (32 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)