### PR TITLE
Group regression stats into labeled sections (#39)

### DIFF
--- a/frontend/components/results/StatsPanel.jsx
+++ b/frontend/components/results/StatsPanel.jsx
@@ -1,5 +1,16 @@
 import { formatNumber, formatPercent, formatPValue, pValueColor } from '../../utils/formatters';
 
+function StatsSection({ title, first, children }) {
+  return (
+    <div className={!first ? 'pt-4 border-t border-slate-200 dark:border-slate-700' : ''}>
+      <h4 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-3">
+        {title}
+      </h4>
+      {children}
+    </div>
+  );
+}
+
 function StatCard({ label, value, tooltip, colorClass }) {
   return (
     <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 relative group">
@@ -23,40 +34,54 @@ function dwColor(dw) {
 
 function LinearStats({ result }) {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
-      <StatCard
-        label="R-Squared"
-        value={formatNumber(result.r_squared, 4)}
-        tooltip="Proportion of variance explained by the model (0-1)"
-      />
-      <StatCard
-        label="Slope (per period)"
-        value={formatNumber(result.slope, 4)}
-        tooltip="Change in value per time period"
-      />
-      <StatCard
-        label="Intercept"
-        value={formatNumber(result.intercept, 2)}
-        tooltip="Starting value when time = 0"
-      />
-      <StatCard
-        label="P-Value"
-        value={formatPValue(result.p_value)}
-        colorClass={pValueColor(result.p_value)}
-        tooltip="Statistical significance: < 0.05 is significant"
-      />
-      <StatCard
-        label="Std Error"
-        value={formatNumber(result.std_error, 4)}
-        tooltip="Standard error of the slope estimate"
-      />
+    <div className="space-y-4">
+      <StatsSection title="Model Fit" first>
+        <div className="grid grid-cols-2 gap-3">
+          <StatCard
+            label="R-Squared"
+            value={formatNumber(result.r_squared, 4)}
+            tooltip="Proportion of variance explained by the model (0-1)"
+          />
+          <StatCard
+            label="P-Value"
+            value={formatPValue(result.p_value)}
+            colorClass={pValueColor(result.p_value)}
+            tooltip="Statistical significance: < 0.05 is significant"
+          />
+        </div>
+      </StatsSection>
+
+      <StatsSection title="Trend">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <StatCard
+            label="Slope (per period)"
+            value={formatNumber(result.slope, 4)}
+            tooltip="Change in value per time period"
+          />
+          <StatCard
+            label="Intercept"
+            value={formatNumber(result.intercept, 2)}
+            tooltip="Starting value when time = 0"
+          />
+          <StatCard
+            label="Std Error"
+            value={formatNumber(result.std_error, 4)}
+            tooltip="Standard error of the slope estimate"
+          />
+        </div>
+      </StatsSection>
+
       {result.durbin_watson != null && (
-        <StatCard
-          label="Durbin-Watson"
-          value={formatNumber(result.durbin_watson, 3)}
-          colorClass={dwColor(result.durbin_watson)}
-          tooltip="Tests for autocorrelation in residuals. Values near 2 indicate no autocorrelation (1.5-2.5 is good)"
-        />
+        <StatsSection title="Diagnostics">
+          <div className="grid grid-cols-2 gap-3">
+            <StatCard
+              label="Durbin-Watson"
+              value={formatNumber(result.durbin_watson, 3)}
+              colorClass={dwColor(result.durbin_watson)}
+              tooltip="Tests for autocorrelation in residuals. Values near 2 indicate no autocorrelation (1.5-2.5 is good)"
+            />
+          </div>
+        </StatsSection>
       )}
     </div>
   );
@@ -73,98 +98,100 @@ function MultiFactorStats({ result }) {
   const hasVif = result.vif && Object.keys(result.vif).length > 0;
 
   return (
-    <div className="space-y-3">
-      {/* Summary stats */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
-        <StatCard
-          label="R-Squared"
-          value={formatNumber(result.r_squared, 4)}
-          tooltip="Proportion of variance explained by all factors"
-        />
-        <StatCard
-          label="Adjusted R-Squared"
-          value={formatNumber(result.adjusted_r_squared, 4)}
-          tooltip="R-squared adjusted for number of predictors"
-        />
-        <StatCard
-          label="F-Statistic"
-          value={formatNumber(result.f_statistic, 2)}
-          tooltip="Overall significance of the regression model"
-        />
-        <StatCard
-          label="Intercept"
-          value={formatNumber(result.intercept, 4)}
-          tooltip="Constant term in the regression equation"
-        />
-        {result.durbin_watson != null && (
+    <div className="space-y-4">
+      <StatsSection title="Summary" first>
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
           <StatCard
-            label="Durbin-Watson"
-            value={formatNumber(result.durbin_watson, 3)}
-            colorClass={dwColor(result.durbin_watson)}
-            tooltip="Tests for autocorrelation in residuals. Values near 2 indicate no autocorrelation (1.5-2.5 is good)"
+            label="R-Squared"
+            value={formatNumber(result.r_squared, 4)}
+            tooltip="Proportion of variance explained by all factors"
           />
-        )}
-      </div>
-
-      {/* Coefficients table */}
-      <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-slate-200 dark:border-slate-700">
-              <th className="text-left px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">Factor</th>
-              <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">Coefficient</th>
-              <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">P-Value</th>
-              {hasVif && <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">VIF</th>}
-              <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">Significance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(result.coefficients).map(([name, coef]) => {
-              const p = result.p_values[name];
-              const vif = result.vif?.[name];
-              return (
-                <tr key={name} className="border-b border-slate-100 dark:border-slate-700/50">
-                  <td className="px-4 py-2 font-medium text-slate-900 dark:text-white">{name}</td>
-                  <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">{formatNumber(coef, 4)}</td>
-                  <td className={`px-4 py-2 text-right ${pValueColor(p)}`}>{formatPValue(p)}</td>
-                  {hasVif && (
-                    <td className={`px-4 py-2 text-right text-slate-700 dark:text-slate-300 relative group ${vifBg(vif)}`}>
-                      {vif != null ? formatNumber(vif, 2) : '—'}
-                      {vif != null && vif >= 5 && (
-                        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-slate-800 dark:bg-slate-600 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-10">
-                          {vif >= 10 ? 'Severe multicollinearity' : 'Moderate multicollinearity'}
-                        </div>
-                      )}
-                    </td>
-                  )}
-                  <td className="px-4 py-2 text-right">
-                    <span className={`text-xs px-2 py-0.5 rounded-full ${
-                      p < 0.05 ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200'
-                      : p < 0.10 ? 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200'
-                      : 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200'
-                    }`}>
-                      {p < 0.05 ? 'Significant' : p < 0.10 ? 'Marginal' : 'Not Significant'}
-                    </span>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-
-      {/* Stationarity info */}
-      {result.stationarity && (
-        <div className="text-xs text-slate-500 dark:text-slate-400 space-y-1">
-          <div className="font-medium">Stationarity (ADF test):</div>
-          <div className="flex flex-wrap gap-2">
-            {Object.entries(result.stationarity).map(([name, s]) => (
-              <span key={name} className={`px-2 py-0.5 rounded-full ${s.is_stationary ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300' : 'bg-yellow-100 dark:bg-yellow-900/50 text-yellow-700 dark:text-yellow-300'}`}>
-                {name === '__dependent__' ? 'Dependent' : name}: {s.is_stationary ? 'Stationary' : 'Non-stationary'} (p={formatNumber(s.p_value, 3)})
-              </span>
-            ))}
-          </div>
+          <StatCard
+            label="Adjusted R-Squared"
+            value={formatNumber(result.adjusted_r_squared, 4)}
+            tooltip="R-squared adjusted for number of predictors"
+          />
+          <StatCard
+            label="F-Statistic"
+            value={formatNumber(result.f_statistic, 2)}
+            tooltip="Overall significance of the regression model"
+          />
+          <StatCard
+            label="Intercept"
+            value={formatNumber(result.intercept, 4)}
+            tooltip="Constant term in the regression equation"
+          />
+          {result.durbin_watson != null && (
+            <StatCard
+              label="Durbin-Watson"
+              value={formatNumber(result.durbin_watson, 3)}
+              colorClass={dwColor(result.durbin_watson)}
+              tooltip="Tests for autocorrelation in residuals. Values near 2 indicate no autocorrelation (1.5-2.5 is good)"
+            />
+          )}
         </div>
+      </StatsSection>
+
+      <StatsSection title="Coefficients">
+        <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-slate-700">
+                <th className="text-left px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">Factor</th>
+                <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">Coefficient</th>
+                <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">P-Value</th>
+                {hasVif && <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">VIF</th>}
+                <th className="text-right px-4 py-2 text-xs font-medium text-slate-500 dark:text-slate-400">Significance</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(result.coefficients).map(([name, coef]) => {
+                const p = result.p_values[name];
+                const vif = result.vif?.[name];
+                return (
+                  <tr key={name} className="border-b border-slate-100 dark:border-slate-700/50">
+                    <td className="px-4 py-2 font-medium text-slate-900 dark:text-white">{name}</td>
+                    <td className="px-4 py-2 text-right text-slate-700 dark:text-slate-300">{formatNumber(coef, 4)}</td>
+                    <td className={`px-4 py-2 text-right ${pValueColor(p)}`}>{formatPValue(p)}</td>
+                    {hasVif && (
+                      <td className={`px-4 py-2 text-right text-slate-700 dark:text-slate-300 relative group ${vifBg(vif)}`}>
+                        {vif != null ? formatNumber(vif, 2) : '—'}
+                        {vif != null && vif >= 5 && (
+                          <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-slate-800 dark:bg-slate-600 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-10">
+                            {vif >= 10 ? 'Severe multicollinearity' : 'Moderate multicollinearity'}
+                          </div>
+                        )}
+                      </td>
+                    )}
+                    <td className="px-4 py-2 text-right">
+                      <span className={`text-xs px-2 py-0.5 rounded-full ${
+                        p < 0.05 ? 'bg-green-100 dark:bg-green-900 text-green-800 dark:text-green-200'
+                        : p < 0.10 ? 'bg-yellow-100 dark:bg-yellow-900 text-yellow-800 dark:text-yellow-200'
+                        : 'bg-red-100 dark:bg-red-900 text-red-800 dark:text-red-200'
+                      }`}>
+                        {p < 0.05 ? 'Significant' : p < 0.10 ? 'Marginal' : 'Not Significant'}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </StatsSection>
+
+      {result.stationarity && (
+        <StatsSection title="Stationarity">
+          <div className="text-xs text-slate-500 dark:text-slate-400 space-y-1">
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(result.stationarity).map(([name, s]) => (
+                <span key={name} className={`px-2 py-0.5 rounded-full ${s.is_stationary ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300' : 'bg-yellow-100 dark:bg-yellow-900/50 text-yellow-700 dark:text-yellow-300'}`}>
+                  {name === '__dependent__' ? 'Dependent' : name}: {s.is_stationary ? 'Stationary' : 'Non-stationary'} (p={formatNumber(s.p_value, 3)})
+                </span>
+              ))}
+            </div>
+          </div>
+        </StatsSection>
       )}
     </div>
   );
@@ -179,47 +206,56 @@ function RollingStats({ result }) {
   const max = (arr) => Math.max(...arr);
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-      <StatCard
-        label="Current Slope"
-        value={formatNumber(slopes[slopes.length - 1], 4)}
-        tooltip="Most recent window's slope"
-      />
-      <StatCard
-        label="Current R-Squared"
-        value={formatNumber(r2s[r2s.length - 1], 4)}
-        tooltip="Most recent window's R-squared"
-      />
-      <StatCard
-        label="Avg Slope"
-        value={formatNumber(avg(slopes), 4)}
-        tooltip="Average slope across all windows"
-      />
-      <StatCard
-        label="Avg R-Squared"
-        value={formatNumber(avg(r2s), 4)}
-        tooltip="Average R-squared across all windows"
-      />
-      <StatCard
-        label="Min Slope"
-        value={formatNumber(min(slopes), 4)}
-        tooltip="Minimum slope observed"
-      />
-      <StatCard
-        label="Max Slope"
-        value={formatNumber(max(slopes), 4)}
-        tooltip="Maximum slope observed"
-      />
-      <StatCard
-        label="Min R-Squared"
-        value={formatNumber(min(r2s), 4)}
-        tooltip="Weakest trend fit observed"
-      />
-      <StatCard
-        label="Max R-Squared"
-        value={formatNumber(max(r2s), 4)}
-        tooltip="Strongest trend fit observed"
-      />
+    <div className="space-y-4">
+      <StatsSection title="Current Window" first>
+        <div className="grid grid-cols-2 gap-3">
+          <StatCard
+            label="Current Slope"
+            value={formatNumber(slopes[slopes.length - 1], 4)}
+            tooltip="Most recent window's slope"
+          />
+          <StatCard
+            label="Current R-Squared"
+            value={formatNumber(r2s[r2s.length - 1], 4)}
+            tooltip="Most recent window's R-squared"
+          />
+        </div>
+      </StatsSection>
+
+      <StatsSection title="Historical Range">
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+          <StatCard
+            label="Avg Slope"
+            value={formatNumber(avg(slopes), 4)}
+            tooltip="Average slope across all windows"
+          />
+          <StatCard
+            label="Min Slope"
+            value={formatNumber(min(slopes), 4)}
+            tooltip="Minimum slope observed"
+          />
+          <StatCard
+            label="Max Slope"
+            value={formatNumber(max(slopes), 4)}
+            tooltip="Maximum slope observed"
+          />
+          <StatCard
+            label="Avg R-Squared"
+            value={formatNumber(avg(r2s), 4)}
+            tooltip="Average R-squared across all windows"
+          />
+          <StatCard
+            label="Min R-Squared"
+            value={formatNumber(min(r2s), 4)}
+            tooltip="Weakest trend fit observed"
+          />
+          <StatCard
+            label="Max R-Squared"
+            value={formatNumber(max(r2s), 4)}
+            tooltip="Strongest trend fit observed"
+          />
+        </div>
+      </StatsSection>
     </div>
   );
 }

--- a/frontend/e2e/stats-grouped-display.spec.js
+++ b/frontend/e2e/stats-grouped-display.spec.js
@@ -1,0 +1,284 @@
+import { test, expect } from '@playwright/test';
+
+const LINEAR_RESULT = {
+  dates: ['2024-01-01', '2024-01-02', '2024-01-03'],
+  values: [100, 101, 102],
+  actual_values: [100, 101, 102],
+  trend_line: [100, 101, 102],
+  r_squared: 0.9876,
+  slope: 0.0023,
+  intercept: 99.5,
+  p_value: 0.001,
+  std_error: 0.0005,
+  durbin_watson: 1.95,
+  sample_size: 100,
+  data_quality: { score: 95, gaps: 0, interpolated: 0 },
+};
+
+const ROLLING_RESULT = {
+  dates: ['2024-01-01', '2024-01-02', '2024-01-03'],
+  values: [100, 101, 102],
+  slope_over_time: [0.001, 0.002, 0.003],
+  r_squared_over_time: [0.8, 0.85, 0.9],
+  sample_size: 100,
+  data_quality: { score: 95, gaps: 0, interpolated: 0 },
+};
+
+const MULTI_FACTOR_RESULT = {
+  dates: ['2024-01-01', '2024-01-02', '2024-01-03'],
+  actual: [100, 101, 102],
+  predicted: [100.1, 101.2, 101.9],
+  residuals: [0.1, -0.2, 0.1],
+  r_squared: 0.95,
+  adjusted_r_squared: 0.94,
+  f_statistic: 45.2,
+  intercept: 0.5,
+  durbin_watson: 2.01,
+  coefficients: { SPY: 0.85, QQQ: 0.12 },
+  p_values: { SPY: 0.001, QQQ: 0.04 },
+  vif: { SPY: 1.2, QQQ: 1.2 },
+  stationarity: {
+    __dependent__: { is_stationary: true, p_value: 0.01 },
+    SPY: { is_stationary: false, p_value: 0.15 },
+  },
+  sample_size: 100,
+  data_quality: { score: 95, gaps: 0, interpolated: 0 },
+};
+
+const SEARCH_RESULTS = {
+  results: [
+    { identifier: 'SPY', name: 'S&P 500 ETF', source: 'yahoo', category: 'indices' },
+  ],
+};
+
+/**
+ * Mock all backend API endpoints so the page loads without a running backend.
+ * Playwright route() intercepts browser-level fetches before Next.js rewrites proxy them.
+ */
+async function mockBackendAPIs(page, regressionOverrides = {}) {
+  // Catch-all: intercept any /api/ request not matched by a more specific route
+  await page.route('**/api/**', (route) => {
+    const url = route.request().url();
+
+    // Sessions — listSessions expects { sessions: [] }
+    if (url.includes('/api/sessions')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sessions: [] }) });
+    }
+
+    // Source health — checkSourceHealth expects { all_down: false, ... }
+    if (url.includes('/api/health/sources')) {
+      return route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ all_down: false, fred: { available: true }, yahoo: { available: true } }),
+      });
+    }
+
+    // Settings health — checkFredHealth expects { configured: true }
+    if (url.includes('/api/settings/health') || url.includes('/api/health')) {
+      return route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ available: true, configured: true, error: null }),
+      });
+    }
+
+    // Asset search
+    if (url.includes('/api/assets/search')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(SEARCH_RESULTS) });
+    }
+
+    // Regression endpoints
+    if (url.includes('/api/regression/linear')) {
+      const result = regressionOverrides.linear || LINEAR_RESULT;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+    }
+    if (url.includes('/api/regression/rolling')) {
+      const result = regressionOverrides.rolling || ROLLING_RESULT;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+    }
+    if (url.includes('/api/regression/multi-factor')) {
+      const result = regressionOverrides.multiFactor || MULTI_FACTOR_RESULT;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+    }
+
+    // Fallback — let unmatched requests through (e.g. Next.js internal routes)
+    return route.continue();
+  });
+}
+
+async function selectAssetAndRun(page, { multiFactor = false } = {}) {
+  const searchInput = page.getByPlaceholder('Search assets...').first();
+  await searchInput.click();
+  await searchInput.fill('SPY');
+  await page.getByText('S&P 500 ETF').click();
+
+  if (multiFactor) {
+    const factorInput = page.getByPlaceholder('Add factors...');
+    await factorInput.click();
+    await factorInput.fill('SPY');
+    await page.getByText('S&P 500 ETF').click();
+  }
+
+  await page.getByRole('button', { name: 'Run Analysis' }).click();
+}
+
+test.describe('Regression stats grouped display', () => {
+  test.describe('Linear mode sections', () => {
+    test('displays Model Fit, Trend, and Diagnostics section headers', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Model Fit', { exact: true })).toBeVisible();
+      await expect(page.getByText('Trend', { exact: true })).toBeVisible();
+      await expect(page.getByText('Diagnostics', { exact: true })).toBeVisible();
+    });
+
+    test('Model Fit section contains R-Squared and P-Value cards', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('R-Squared')).toBeVisible();
+      await expect(page.getByText('P-Value')).toBeVisible();
+    });
+
+    test('Trend section contains Slope, Intercept, and Std Error cards', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Slope (per period)')).toBeVisible();
+      await expect(page.getByText('Intercept')).toBeVisible();
+      await expect(page.getByText('Std Error')).toBeVisible();
+    });
+
+    test('Diagnostics section hidden when durbin_watson is null', async ({ page }) => {
+      await mockBackendAPIs(page, { linear: { ...LINEAR_RESULT, durbin_watson: null } });
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Model Fit', { exact: true })).toBeVisible();
+      await expect(page.getByText('Trend', { exact: true })).toBeVisible();
+      await expect(page.getByText('Diagnostics', { exact: true })).not.toBeVisible();
+    });
+  });
+
+  test.describe('Rolling mode sections', () => {
+    test('displays Current Window and Historical Range section headers', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Rolling' }).click();
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Current Window', { exact: true })).toBeVisible();
+      await expect(page.getByText('Historical Range', { exact: true })).toBeVisible();
+    });
+
+    test('Current Window contains Current Slope and Current R-Squared', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Rolling' }).click();
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Current Slope', { exact: true })).toBeVisible();
+      await expect(page.getByText('Current R-Squared', { exact: true })).toBeVisible();
+    });
+
+    test('Historical Range contains Avg/Min/Max stats', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Rolling' }).click();
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Avg Slope')).toBeVisible();
+      await expect(page.getByText('Min Slope')).toBeVisible();
+      await expect(page.getByText('Max Slope')).toBeVisible();
+      await expect(page.getByText('Avg R-Squared')).toBeVisible();
+      await expect(page.getByText('Min R-Squared')).toBeVisible();
+      await expect(page.getByText('Max R-Squared')).toBeVisible();
+    });
+  });
+
+  test.describe('Multi-Factor mode sections', () => {
+    test('displays Summary, Coefficients, and Stationarity section headers', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Multi-Factor' }).click();
+      await selectAssetAndRun(page, { multiFactor: true });
+
+      await expect(page.getByText('Summary', { exact: true })).toBeVisible();
+      await expect(page.getByText('Coefficients', { exact: true })).toBeVisible();
+      await expect(page.getByText('Stationarity', { exact: true })).toBeVisible();
+    });
+
+    test('Summary section contains stat cards', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Multi-Factor' }).click();
+      await selectAssetAndRun(page, { multiFactor: true });
+
+      await expect(page.getByText('R-Squared', { exact: true })).toBeVisible();
+      await expect(page.getByText('Adjusted R-Squared', { exact: true })).toBeVisible();
+      await expect(page.getByText('F-Statistic', { exact: true })).toBeVisible();
+    });
+
+    test('Stationarity section hidden when stationarity is null', async ({ page }) => {
+      await mockBackendAPIs(page, { multiFactor: { ...MULTI_FACTOR_RESULT, stationarity: null } });
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Multi-Factor' }).click();
+      await selectAssetAndRun(page, { multiFactor: true });
+
+      await expect(page.getByText('Summary', { exact: true })).toBeVisible();
+      await expect(page.getByText('Coefficients', { exact: true })).toBeVisible();
+      await expect(page.getByText('Stationarity', { exact: true })).not.toBeVisible();
+    });
+  });
+
+  test.describe('Dark mode support', () => {
+    test('section headers visible in dark mode for linear stats', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Model Fit', { exact: true })).toBeVisible();
+      await expect(page.getByText('Trend', { exact: true })).toBeVisible();
+      await expect(page.getByText('Diagnostics', { exact: true })).toBeVisible();
+    });
+
+    test('section headers visible in dark mode for rolling stats', async ({ page }) => {
+      await mockBackendAPIs(page);
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.goto('/');
+      await page.waitForLoadState('networkidle');
+
+      await page.getByRole('button', { name: 'Rolling' }).click();
+      await selectAssetAndRun(page);
+
+      await expect(page.getByText('Current Window', { exact: true })).toBeVisible();
+      await expect(page.getByText('Historical Range', { exact: true })).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `StatsSection` helper component with uppercase label headers and dividers matching the existing `ChainFilters.jsx` pattern
- Refactor `LinearStats` into Model Fit, Trend, and Diagnostics (conditional) sections
- Refactor `RollingStats` into Current Window and Historical Range sections
- Wrap `MultiFactorStats` content with Summary, Coefficients, and Stationarity (conditional) section headers
- Add 12 Playwright e2e tests covering all three modes, conditional sections, and dark mode

Closes #39

## Test plan
- [x] `cd frontend && npx playwright test stats-grouped-display` — 12 tests pass
- [x] All existing 49 Playwright tests still pass (no regressions)
- [x] `cd frontend && npx next build` succeeds
- [ ] Manual: verify grouped display in Linear, Rolling, and Multi-Factor modes
- [ ] Manual: toggle dark mode, verify section headers visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)