### PR TITLE
Surface backend error details in import toast messages

### DIFF
--- a/frontend/hooks/useJournal.js
+++ b/frontend/hooks/useJournal.js
@@ -117,8 +117,13 @@ export function useJournal() {
       const data = await previewSchwabImport(startDate, endDate);
       setImportPreview(data);
       return data;
-    } catch {
-      toast.error('Failed to preview Schwab import');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      if (err?.response?.status === 401) {
+        toast.error(detail || 'Schwab authentication required. Run schwab-auth CLI to connect.');
+      } else {
+        toast.error(detail || 'Failed to preview Schwab import');
+      }
       return null;
     } finally {
       setImportLoading(false);
@@ -133,8 +138,13 @@ export function useJournal() {
       setImportPreview(null);
       await fetchPositions();
       return result;
-    } catch {
-      toast.error('Failed to import trades');
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      if (err?.response?.status === 401) {
+        toast.error(detail || 'Schwab authentication required. Run schwab-auth CLI to connect.');
+      } else {
+        toast.error(detail || 'Failed to import trades');
+      }
       return null;
     } finally {
       setImportLoading(false);


### PR DESCRIPTION
## Summary

- Import preview/execute error toasts now show the actual backend error detail (e.g. "Schwab authentication required") instead of a generic "Failed to preview Schwab import"
- 401 errors specifically prompt the user to run the schwab-auth CLI

Fixes the bug where clicking Preview shows a generic error toast with no actionable info about what went wrong.

## Test plan

- [x] `npx playwright test e2e/import.spec.js` — 5 tests pass
- [ ] Manual: click Import from Schwab → Preview with no Schwab auth configured, verify toast shows "Schwab authentication required"

🤖 Generated with [Claude Code](https://claude.com/claude-code)