### PR TITLE
Add structured JSON logging with request ID propagation

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,4 +18,4 @@ EXPOSE 8000
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/health')" || exit 1
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--no-access-log"]

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,51 @@
+import contextvars
+import logging
+import sys
+
+from pythonjsonlogger.json import JsonFormatter
+
+request_id_ctx: contextvars.ContextVar[str] = contextvars.ContextVar(
+    "request_id", default="-"
+)
+
+
+class RequestIdFilter(logging.Filter):
+    """Injects request_id from context var into every log record."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_ctx.get()  # type: ignore[attr-defined]
+        return True
+
+
+def setup_logging(json_output: bool = True) -> None:
+    """Configure root logger with JSON or plain text output.
+
+    Args:
+        json_output: Use JSON formatter (True) or plain text (False, for dev/tests).
+    """
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+
+    # Remove existing handlers to avoid duplicate output
+    root.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.addFilter(RequestIdFilter())
+
+    if json_output:
+        formatter = JsonFormatter(
+            fmt="%(asctime)s %(levelname)s %(module)s %(message)s %(request_id)s",
+            rename_fields={"levelname": "level", "asctime": "timestamp"},
+            datefmt="%Y-%m-%dT%H:%M:%S%z",
+        )
+    else:
+        formatter = logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s",
+            defaults={"request_id": "-"},
+        )
+
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    # Suppress uvicorn access logs — our middleware replaces them
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,6 +14,8 @@ from fastapi.responses import JSONResponse
 
 from app.auth import get_current_user
 from app.config import settings as app_settings
+from app.logging_config import setup_logging
+from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
 from app.routers import assets, data, health, journal, options, regression, sessions, settings
 from app.services.backup import create_backup
@@ -51,6 +53,7 @@ def _pre_cache_common_assets():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    setup_logging()
     init_db()
 
     # Security checks first — must run before backup to avoid
@@ -138,8 +141,11 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[o.strip() for o in app_settings.cors_origins.split(",") if o.strip()],
     allow_methods=["GET", "POST", "PUT", "DELETE"],
-    allow_headers=["Content-Type", "Authorization"],
+    allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
+    expose_headers=["X-Request-ID"],
 )
+
+app.add_middleware(RequestLoggingMiddleware)
 
 # Include routers — health is public, all others require authentication
 app.include_router(health.router)

--- a/backend/app/middleware.py
+++ b/backend/app/middleware.py
@@ -1,0 +1,50 @@
+import logging
+import re
+import time
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.logging_config import request_id_ctx
+
+logger = logging.getLogger(__name__)
+
+_REQUEST_ID_RE = re.compile(r"^[\w\-]{1,128}$")
+
+
+class RequestLoggingMiddleware(BaseHTTPMiddleware):
+    """Logs every request with method, path, status, duration, and request_id."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        raw_id = request.headers.get("X-Request-ID", "")
+        request_id = raw_id if _REQUEST_ID_RE.match(raw_id) else str(uuid.uuid4())
+        token = request_id_ctx.set(request_id)
+
+        try:
+            start = time.perf_counter()
+            response = await call_next(request)
+            duration_ms = round((time.perf_counter() - start) * 1000, 2)
+
+            client_ip = request.client.host if request.client else "-"
+
+            logger.info(
+                "%s %s %s %.2fms",
+                request.method,
+                request.url.path,
+                response.status_code,
+                duration_ms,
+                extra={
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status_code": response.status_code,
+                    "duration_ms": duration_ms,
+                    "client_ip": client_ip,
+                },
+            )
+
+            response.headers["X-Request-ID"] = request_id
+            return response
+        finally:
+            request_id_ctx.reset(token)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ tenacity==9.0.0
 certifi
 requests
 python-dotenv==1.0.1
+python-json-logger==3.2.1
 httpx==0.28.1
 pytest==8.3.4
 pytest-asyncio==0.25.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,9 +8,16 @@ from sqlalchemy.pool import StaticPool
 from unittest.mock import patch
 
 from app.auth import get_current_user
+from app.logging_config import setup_logging
 from app.models.database import Base, get_db
 from app.models.schemas import DataMeta, DateRange
 from app.services.data_fetcher import DataFetcher
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _configure_test_logging():
+    """Use plain text logging in tests for readable output."""
+    setup_logging(json_output=False)
 
 
 def _make_price_df(seed=42, n=60):
@@ -65,6 +72,7 @@ def client():
     # Bypass auth for integration tests — auth logic is tested separately
     app.dependency_overrides[get_current_user] = lambda: {"sub": "test", "username": "testuser"}
     with patch("app.main.init_db"), \
+         patch("app.main.setup_logging"), \
          patch("app.main.create_backup", return_value=""), \
          patch("app.main._run_security_checks"):
         with TestClient(app) as c:

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -1,0 +1,253 @@
+import json
+import logging
+from datetime import datetime
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.auth import get_current_user
+from app.logging_config import RequestIdFilter, request_id_ctx, setup_logging
+from app.models.database import Base, get_db
+
+
+@pytest.fixture()
+def json_log_capture():
+    """Set up JSON logging and capture output."""
+    stream = StringIO()
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    original_level = root.level
+
+    # Use setup_logging to get the correct formatter, then redirect to our stream
+    setup_logging(json_output=True)
+    # Steal the formatter from the handler that setup_logging created
+    formatter = root.handlers[0].formatter
+
+    root.handlers.clear()
+    handler = logging.StreamHandler(stream)
+    handler.addFilter(RequestIdFilter())
+    handler.setFormatter(formatter)
+    root.addHandler(handler)
+
+    yield stream
+
+    root.handlers = original_handlers
+    root.level = original_level
+
+
+@pytest.fixture()
+def app_client():
+    """TestClient for middleware tests."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    TestSessionLocal = sessionmaker(bind=engine)
+
+    def override_get_db():
+        db = TestSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    from app.main import app
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = lambda: {
+        "sub": "test",
+        "username": "testuser",
+    }
+    with patch("app.main.init_db"), \
+         patch("app.main.setup_logging"), \
+         patch("app.main.create_backup", return_value=""), \
+         patch("app.main._run_security_checks"):
+        with TestClient(app) as c:
+            yield c
+    app.dependency_overrides.clear()
+
+
+class TestJsonLogging:
+    """Tests for JSON log output format."""
+
+    def test_json_output_contains_required_keys(self, json_log_capture):
+        logger = logging.getLogger("test.required_keys")
+        logger.info("test message")
+
+        output = json_log_capture.getvalue().strip()
+        record = json.loads(output)
+
+        assert "timestamp" in record
+        assert "level" in record
+        assert "module" in record
+        assert "message" in record
+        assert "request_id" in record
+
+    def test_timestamp_is_iso8601(self, json_log_capture):
+        logger = logging.getLogger("test.iso8601")
+        logger.info("timestamp check")
+
+        output = json_log_capture.getvalue().strip()
+        record = json.loads(output)
+
+        # Should parse without error as ISO 8601
+        datetime.fromisoformat(record["timestamp"])
+
+    def test_request_id_propagates_from_context_var(self, json_log_capture):
+        token = request_id_ctx.set("test-req-123")
+        try:
+            logger = logging.getLogger("test.propagation")
+            logger.info("propagation test")
+
+            output = json_log_capture.getvalue().strip()
+            record = json.loads(output)
+            assert record["request_id"] == "test-req-123"
+        finally:
+            request_id_ctx.reset(token)
+
+    def test_existing_logger_calls_produce_valid_json(self, json_log_capture):
+        logger = logging.getLogger("test.existing")
+        logger.info("value is %s and count is %d", "foo", 42)
+
+        output = json_log_capture.getvalue().strip()
+        record = json.loads(output)
+        assert "value is foo and count is 42" in record["message"]
+
+    def test_extra_fields_included_in_json(self, json_log_capture):
+        logger = logging.getLogger("test.extras")
+        logger.info("with extras", extra={"custom_field": "custom_value"})
+
+        output = json_log_capture.getvalue().strip()
+        record = json.loads(output)
+        assert record["custom_field"] == "custom_value"
+
+
+class TestPlainTextLogging:
+    """Tests for plain text (non-JSON) logging mode."""
+
+    def test_plain_text_output_is_not_json(self):
+        stream = StringIO()
+        root = logging.getLogger()
+        original_handlers = root.handlers[:]
+
+        try:
+            setup_logging(json_output=False)
+            formatter = root.handlers[0].formatter
+
+            root.handlers.clear()
+            handler = logging.StreamHandler(stream)
+            handler.addFilter(RequestIdFilter())
+            handler.setFormatter(formatter)
+            root.addHandler(handler)
+
+            logger = logging.getLogger("test.plaintext")
+            logger.info("plain text message")
+
+            output = stream.getvalue().strip()
+            # Should NOT be valid JSON
+            with pytest.raises(json.JSONDecodeError):
+                json.loads(output)
+
+            # Should contain the message as plain text
+            assert "plain text message" in output
+        finally:
+            root.handlers = original_handlers
+
+
+class TestRequestLoggingMiddleware:
+    """Tests for the request logging middleware."""
+
+    def test_middleware_logs_request_fields(self, app_client, json_log_capture):
+        app_client.get("/api/health")
+
+        output = json_log_capture.getvalue().strip()
+        # Find the middleware log line (may have multiple lines)
+        lines = output.split("\n")
+        middleware_line = None
+        for line in lines:
+            try:
+                record = json.loads(line)
+                if record.get("method") == "GET" and record.get("path") == "/api/health":
+                    middleware_line = record
+                    break
+            except json.JSONDecodeError:
+                continue
+
+        assert middleware_line is not None, f"No middleware log found in: {output}"
+        assert middleware_line["method"] == "GET"
+        assert middleware_line["path"] == "/api/health"
+        assert middleware_line["status_code"] == 200
+        assert "duration_ms" in middleware_line
+        assert isinstance(middleware_line["duration_ms"], (int, float))
+        assert "client_ip" in middleware_line
+
+    def test_custom_request_id_accepted_and_echoed(self, app_client):
+        response = app_client.get(
+            "/api/health", headers={"X-Request-ID": "custom-id-abc"}
+        )
+        assert response.status_code == 200
+        assert response.headers["X-Request-ID"] == "custom-id-abc"
+
+    def test_generated_request_id_in_response(self, app_client):
+        response = app_client.get("/api/health")
+        assert response.status_code == 200
+        request_id = response.headers.get("X-Request-ID")
+        assert request_id is not None
+        assert len(request_id) > 0
+        assert request_id != "-"
+
+    def test_malicious_request_id_is_rejected(self, app_client):
+        response = app_client.get(
+            "/api/health",
+            headers={"X-Request-ID": "evil\nX-Injected: true"},
+        )
+        assert response.status_code == 200
+        # Malicious value should be replaced with a generated UUID
+        echoed = response.headers["X-Request-ID"]
+        assert "\n" not in echoed
+        assert "evil" not in echoed
+
+    def test_oversized_request_id_is_rejected(self, app_client):
+        response = app_client.get(
+            "/api/health",
+            headers={"X-Request-ID": "a" * 200},
+        )
+        assert response.status_code == 200
+        echoed = response.headers["X-Request-ID"]
+        assert len(echoed) <= 128
+
+    def test_custom_request_id_propagates_to_logs(
+        self, app_client, json_log_capture
+    ):
+        app_client.get(
+            "/api/health", headers={"X-Request-ID": "trace-xyz-789"}
+        )
+
+        output = json_log_capture.getvalue().strip()
+        lines = output.split("\n")
+        found = False
+        for line in lines:
+            try:
+                record = json.loads(line)
+                if record.get("request_id") == "trace-xyz-789":
+                    found = True
+                    break
+            except json.JSONDecodeError:
+                continue
+
+        assert found, f"request_id 'trace-xyz-789' not found in logs: {output}"


### PR DESCRIPTION
## Summary
- Add structured JSON logging via `python-json-logger` with ISO 8601 timestamps, level, module, message, and request_id fields
- Add `RequestLoggingMiddleware` that generates/accepts `X-Request-ID` headers and logs method, path, status_code, duration_ms, client_ip per request
- Request IDs propagate via `contextvars` — all loggers in a request scope automatically include the correlation ID with zero changes to existing log calls
- Sanitize `X-Request-ID` input (alphanumeric + hyphens, max 128 chars) to prevent log injection
- Suppress uvicorn access logs (`--no-access-log`) since middleware replaces them with richer fields
- Plain text fallback (`json_output=False`) for readable test output

Closes #65

## Test plan
- [x] JSON output contains required keys (timestamp, level, module, message, request_id)
- [x] Timestamp is ISO 8601
- [x] request_id propagates from context var to log records
- [x] Existing `logger.info("msg %s", arg)` calls produce valid JSON
- [x] Extra fields included in JSON output
- [x] `json_output=False` produces plain text (not JSON)
- [x] Middleware logs method, path, status_code, duration_ms, client_ip
- [x] Custom X-Request-ID accepted and echoed in response
- [x] Generated request_id in response when no header sent
- [x] Malicious X-Request-ID (newlines, injection) is rejected
- [x] Oversized X-Request-ID (>128 chars) is rejected
- [x] Custom request_id propagates to log output
- [x] All 367 tests pass (12 new + 355 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)