### PR TITLE
Fix Schwab import: use /accounts/accountNumbers endpoint for hash

### DIFF
--- a/backend/app/services/schwab_client.py
+++ b/backend/app/services/schwab_client.py
@@ -228,6 +228,28 @@ class SchwabClient:
         retry=retry_if_exception_type(SchwabClientError),
         reraise=True,
     )
+    def get_account_numbers(self) -> list[dict]:
+        """Get account numbers and hashes from Trader API.
+
+        Returns list of dicts with 'accountNumber' and 'hashValue' keys.
+        The hashValue is required for transaction endpoints.
+        """
+        url = f"{self.TRADER_BASE_URL}/accounts/accountNumbers"
+        try:
+            resp = httpx.get(url, headers=self._headers(), timeout=15)
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                SchwabTokenManager().invalidate_token()
+                raise SchwabAuthError("Schwab API returned 401 — token may be invalid", code=SchwabAuthCode.API_401) from e
+            logger.error("Schwab accountNumbers API error: %s — response body: %s", e, e.response.text)
+            raise SchwabClientError("Schwab accountNumbers API error") from e
+        except httpx.RequestError as e:
+            logger.error("Schwab accountNumbers request error: %s", e)
+            raise SchwabClientError(SCHWAB_TRANSPORT_ERROR_MSG) from e
+
+        return resp.json()
+
     def get_accounts(self) -> list[dict]:
         """Get linked brokerage accounts from Trader API."""
         url = f"{self.TRADER_BASE_URL}/accounts"

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -137,9 +137,9 @@ def preview_import(db: Session, start_date: str, end_date: str) -> dict:
     Returns dict with account info, trade list, and duplicate counts.
     """
     client = SchwabClient()
-    accounts = client.get_accounts()
+    account_numbers = client.get_account_numbers()
 
-    if not accounts:
+    if not account_numbers:
         return {
             "account_number": "",
             "trades": [],
@@ -148,9 +148,9 @@ def preview_import(db: Session, start_date: str, end_date: str) -> dict:
             "new_count": 0,
         }
 
-    account = accounts[0]
+    account = account_numbers[0]
     account_hash = account.get("hashValue", "")
-    account_number = account.get("securitiesAccount", {}).get("accountNumber", "")
+    account_number = account.get("accountNumber", "")
     masked_account = f"****{account_number[-4:]}" if len(account_number) >= 4 else account_number
 
     transactions = client.get_transactions(account_hash, start_date, end_date)
@@ -186,12 +186,12 @@ def execute_import(db: Session, start_date: str, end_date: str, position_strateg
     Creates positions as needed and logs trades.
     """
     client = SchwabClient()
-    accounts = client.get_accounts()
+    account_numbers = client.get_account_numbers()
 
-    if not accounts:
+    if not account_numbers:
         return {"imported": 0, "skipped_duplicates": 0, "positions_created": 0}
 
-    account = accounts[0]
+    account = account_numbers[0]
     account_hash = account.get("hashValue", "")
     transactions = client.get_transactions(account_hash, start_date, end_date)
 

--- a/backend/tests/test_integration_import.py
+++ b/backend/tests/test_integration_import.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 
-MOCK_ACCOUNTS = [{"hashValue": "abc123", "securitiesAccount": {"accountNumber": "12345678"}}]
+MOCK_ACCOUNT_NUMBERS = [{"accountNumber": "12345678", "hashValue": "abc123"}]
 
 MOCK_TRANSACTIONS = [
     {
@@ -49,7 +49,7 @@ MOCK_TRANSACTIONS = [
 
 def _mock_schwab_client():
     mock = MagicMock()
-    mock.get_accounts.return_value = MOCK_ACCOUNTS
+    mock.get_account_numbers.return_value = MOCK_ACCOUNT_NUMBERS
     mock.get_transactions.return_value = MOCK_TRANSACTIONS
     return mock
 
@@ -82,7 +82,7 @@ class TestImportPreview:
     def test_preview_no_auth_returns_401(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError("no token", code=SchwabAuthCode.TOKEN_MISSING)
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError("no token", code=SchwabAuthCode.TOKEN_MISSING)
             resp = client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
         assert resp.status_code == 401
 
@@ -190,7 +190,7 @@ class TestImportAuthErrors:
     def test_preview_expired_token_returns_specific_detail(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError(
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError(
                 "expired", code=SchwabAuthCode.TOKEN_EXPIRED,
             )
             resp = client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
@@ -201,7 +201,7 @@ class TestImportAuthErrors:
     def test_preview_no_token_returns_not_connected(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError(
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError(
                 "no token", code=SchwabAuthCode.TOKEN_MISSING,
             )
             resp = client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
@@ -211,7 +211,7 @@ class TestImportAuthErrors:
     def test_preview_not_configured_returns_setup_message(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError(
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError(
                 "not configured", code=SchwabAuthCode.NOT_CONFIGURED,
             )
             resp = client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
@@ -221,7 +221,7 @@ class TestImportAuthErrors:
     def test_import_expired_token_returns_specific_detail(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError(
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError(
                 "expired", code=SchwabAuthCode.TOKEN_EXPIRED,
             )
             resp = client.post("/api/journal/import", json={
@@ -234,7 +234,7 @@ class TestImportAuthErrors:
     def test_generic_auth_error_returns_fallback_detail(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError(
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError(
                 "refresh failed", code=SchwabAuthCode.REFRESH_FAILED,
             )
             resp = client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
@@ -244,7 +244,7 @@ class TestImportAuthErrors:
     def test_auth_error_is_logged(self, client, caplog):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
-            mock_cls.return_value.get_accounts.side_effect = SchwabAuthError(
+            mock_cls.return_value.get_account_numbers.side_effect = SchwabAuthError(
                 "expired", code=SchwabAuthCode.TOKEN_EXPIRED,
             )
             with caplog.at_level(logging.WARNING, logger="app.routers.journal"):


### PR DESCRIPTION
## Summary

Closes #98

The Schwab import was calling `/accounts` to get the account hash, but that endpoint doesn't return `hashValue`. The hash is only available from `/accounts/accountNumbers`.

## Changes

- Added `get_account_numbers()` method to `SchwabClient` that calls `/accounts/accountNumbers`
- Updated `preview_import()` and `execute_import()` in `schwab_import.py` to use the new method
- `get_accounts()` is preserved for other uses (account details, balances)

## Test plan

- [ ] CI passes
- [ ] Schwab import preview returns transactions on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)