### PR TITLE
Fix dark-mode toggle: re-bind Tailwind v4 dark variant to class strategy (#117)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,5 +1,12 @@
 @import "tailwindcss";
 
+/* Issue #117: Tailwind v4's default `dark:` variant is media-query-based
+   (`prefers-color-scheme: dark`). The in-app toggle in
+   `context/ThemeContext.jsx` is class-based — it adds `.dark` to <html>.
+   This declaration re-binds the `dark:` variant to the class strategy so
+   the toggle actually drives every `dark:` utility in the codebase. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @layer base {
   body {
     @apply m-0 min-h-screen bg-white text-slate-900 antialiased;

--- a/frontend/components/layout/Header.jsx
+++ b/frontend/components/layout/Header.jsx
@@ -82,6 +82,7 @@ export default function Header({ sessions, onLoadSession }) {
 
         {/* Dark mode toggle */}
         <button
+          data-testid="dark-mode-toggle"
           onClick={toggle}
           className="p-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300"
           aria-label="Toggle dark mode"

--- a/frontend/e2e/dark-mode-toggle.spec.js
+++ b/frontend/e2e/dark-mode-toggle.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #117 — verifies the in-app dark-mode toggle actually drives Tailwind
+ * `dark:` variants across the UI.
+ *
+ * The bug fixed by this test: Tailwind v4's default `dark:` variant is
+ * media-query-based (`prefers-color-scheme: dark`), but `ThemeContext.jsx`
+ * is class-based (toggles `.dark` on <html>). Without the
+ * `@custom-variant dark (.dark, .dark *)` declaration in `globals.css`,
+ * the body would change but every component-level `dark:bg-*` etc. stayed
+ * in its light style.
+ *
+ * Test strategy: pin the browser to OS-light preference (so `prefers-color
+ * -scheme: dark` is false) and verify the toggle still drives the variants.
+ */
+
+/**
+ * Returns the perceived brightness (0..255) of an element's computed
+ * background-color. Robust to whether the browser serializes the value as
+ * `rgb(...)` or the newer `lab(...)` / `oklch(...)` color-managed forms.
+ *
+ * Strategy: render the element's bg into an off-screen canvas and read
+ * back the pixel — sidesteps every CSS color string format.
+ */
+async function bgLuminance(locator) {
+  return locator.evaluate((el) => {
+    const bg = getComputedStyle(el).backgroundColor;
+    const canvas = document.createElement('canvas');
+    canvas.width = 1; canvas.height = 1;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    return 0.299 * r + 0.587 * g + 0.114 * b;
+  });
+}
+
+test.describe('Dark mode toggle (#117)', () => {
+  test('toggles every dark: variant when OS prefers light', async ({ browser }) => {
+    const ctx = await browser.newContext({ colorScheme: 'light' });
+    const page = await ctx.newPage();
+
+    // Clear any stored theme so initial state is purely OS-driven (light).
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('theme'); } catch {}
+    });
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const html = page.locator('html');
+    const header = page.locator('header').first();
+    await expect(header).toBeVisible();
+
+    // Initial: OS light + no localStorage → ThemeContext computes `dark=false`.
+    await expect(html).not.toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    expect(await bgLuminance(header)).toBeGreaterThan(200);
+
+    // Toggle to dark.
+    await page.getByTestId('dark-mode-toggle').click();
+    await expect(html).toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    // The dark: variant must fire — header swaps to slate-800. This is the
+    // assertion that catches the original bug; without `@custom-variant dark`
+    // the header stays bg-white even though `<html class="dark">`.
+    expect(await bgLuminance(header)).toBeLessThan(80);
+
+    // Toggle back to light.
+    await page.getByTestId('dark-mode-toggle').click();
+    await expect(html).not.toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    expect(await bgLuminance(header)).toBeGreaterThan(200);
+
+    await ctx.close();
+  });
+
+  test('toggle works in the reverse direction when OS prefers dark', async ({ browser }) => {
+    const ctx = await browser.newContext({ colorScheme: 'dark' });
+    const page = await ctx.newPage();
+
+    await page.addInitScript(() => {
+      try { window.localStorage.removeItem('theme'); } catch {}
+    });
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const html = page.locator('html');
+    const header = page.locator('header').first();
+    await expect(header).toBeVisible();
+
+    // Initial: OS dark + no localStorage → ThemeContext computes `dark=true`.
+    await expect(html).toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    expect(await bgLuminance(header)).toBeLessThan(80);
+
+    // Toggle to light — must override the OS dark preference because
+    // `dark:` variants are now class-keyed, not media-query-keyed.
+    await page.getByTestId('dark-mode-toggle').click();
+    await expect(html).not.toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    expect(await bgLuminance(header)).toBeGreaterThan(200);
+
+    await ctx.close();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #117. One-line CSS fix that wires Tailwind v4's `dark:` variant to match the class-based strategy used by `ThemeContext.jsx`. Without it, all 512 component-level `dark:` variants in the codebase ignored the in-app toggle and only responded to the OS `prefers-color-scheme` preference.

## What changed

| File | Change |
|---|---|
| `frontend/app/globals.css` | Added `@custom-variant dark (&:where(.dark, .dark *));` so `dark:bg-*`, `dark:text-*`, etc. fire on the `.dark` class that `ThemeContext` adds to `<html>` |
| `frontend/components/layout/Header.jsx` | Added `data-testid="dark-mode-toggle"` to the toggle button (otherwise unchanged) |
| `frontend/e2e/dark-mode-toggle.spec.js` | New — 2 e2e tests covering both OS-light and OS-dark cases, asserting the header background swaps with the toggle |

No component code changed. No JavaScript runtime change. The visual UI was always there — the styles just weren't wiring through.

## Why this is one line

Investigation in #117 traced the bug to a strategy mismatch: Tailwind v4 defaults `dark:` to `@media (prefers-color-scheme: dark)`, while `ThemeContext.jsx` was written for the class strategy (`<html class="dark">`). The fix is to declare the custom variant explicitly. Tailwind v3 inferred the strategy from `darkMode: 'class'` in `tailwind.config.js`; v4's CSS-only config requires the `@custom-variant` declaration to opt in.

## Tests

Per CLAUDE.md, every AC has automated coverage:

| AC | Test |
|---|---|
| Toggle drives every `dark:` variant when OS is light (the broken case) | `dark-mode-toggle.spec.js` — pins `colorScheme: 'light'`, clicks toggle, asserts header bg luminance flips from >200 to <80 and back |
| Toggle still works when OS is dark | `dark-mode-toggle.spec.js` reverse case — `colorScheme: 'dark'`, click toggle, header brightens |
| OS preference still drives initial state when no `localStorage.theme` | Both tests start from no-localStorage and assert initial `<html>` class matches OS |
| No regressions | Full e2e: **80 passed, 6 skipped** (was 78 + 2 new) |

The luminance assertion uses a canvas pixel readback so it's robust to whether Chrome serializes the computed color as `rgb()` or the newer `lab()` / `oklch()` forms.

## Out of scope

- Visual redesign of any component — this is a wiring fix.
- Refactoring `ThemeContext` to use a different storage scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)