### PR TITLE
Add CSV upload import for historical Schwab trades (closes #104)

### DIFF
--- a/backend/app/routers/journal.py
+++ b/backend/app/routers/journal.py
@@ -1,12 +1,13 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import get_db
 from app.models.schemas import (
     POSITION_STATUS,
+    STRATEGY_TYPES,
     ImportPreviewResponse,
     ImportRequest,
     ImportResultResponse,
@@ -29,7 +30,21 @@ from app.services.journal import (
 )
 from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
 from app.services.schwab_client import SchwabClientError
-from app.services.schwab_import import execute_import, preview_import
+from app.services.schwab_csv import parse_schwab_csv
+from app.services.schwab_import import (
+    build_preview,
+    execute_import,
+    execute_mapped_import,
+    preview_import,
+)
+
+# Maximum CSV upload size; chosen to comfortably hold a year of transactions
+# for an active wheel trader (~5,000 rows averaging well under 1 KB each).
+_MAX_CSV_BYTES = 5 * 1024 * 1024
+_CSV_SIZE_DETAIL = "CSV file is larger than the 5 MB limit"
+_CSV_EXT_DETAIL = "Only .csv files are accepted"
+_CSV_EMPTY_DETAIL = "Uploaded file is empty"
+_CSV_PARSE_DETAIL = "Could not parse the uploaded CSV file"
 
 logger = logging.getLogger(__name__)
 
@@ -130,6 +145,62 @@ def import_transactions(req: ImportRequest, db: DBSession = Depends(get_db)):
     except Exception:
         logger.exception("Unexpected error during import")
         raise HTTPException(status_code=500, detail="An unexpected error occurred")
+
+
+@router.post("/import/csv/preview", response_model=ImportPreviewResponse)
+async def import_csv_preview(
+    file: UploadFile = File(...),
+    db: DBSession = Depends(get_db),
+):
+    """Preview options trades from a Schwab transaction CSV export.
+
+    Mirrors the Schwab API preview path but reads from an uploaded CSV file.
+    Use this when historical transactions predate the developer-app creation
+    date and are therefore not returned by ``/api/journal/import/preview``.
+    """
+    file_bytes = await _read_csv_upload(file)
+    try:
+        mapped = parse_schwab_csv(file_bytes)
+    except Exception:
+        logger.exception("Failed to parse uploaded Schwab CSV")
+        raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL)
+    return build_preview(db, mapped, account_number="")
+
+
+@router.post("/import/csv", response_model=ImportResultResponse)
+async def import_csv(
+    file: UploadFile = File(...),
+    position_strategy: STRATEGY_TYPES = Form("wheel"),
+    db: DBSession = Depends(get_db),
+):
+    """Import options trades from a Schwab transaction CSV export."""
+    file_bytes = await _read_csv_upload(file)
+    try:
+        mapped = parse_schwab_csv(file_bytes)
+    except Exception:
+        logger.exception("Failed to parse uploaded Schwab CSV")
+        raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL)
+    return execute_mapped_import(db, mapped, position_strategy=position_strategy)
+
+
+async def _read_csv_upload(file: UploadFile) -> bytes:
+    """Validate and read a CSV upload, enforcing size + extension limits.
+
+    Raises ``HTTPException`` 422 with a generic, user-safe detail if the file
+    is missing, has the wrong extension, or exceeds the 5 MB cap. Never logs
+    or returns the raw filename or contents.
+    """
+    if file is None or not file.filename:
+        raise HTTPException(status_code=422, detail=_CSV_EXT_DETAIL)
+    if not file.filename.lower().endswith(".csv"):
+        raise HTTPException(status_code=422, detail=_CSV_EXT_DETAIL)
+
+    contents = await file.read()
+    if not contents:
+        raise HTTPException(status_code=422, detail=_CSV_EMPTY_DETAIL)
+    if len(contents) > _MAX_CSV_BYTES:
+        raise HTTPException(status_code=422, detail=_CSV_SIZE_DETAIL)
+    return contents
 
 
 _AUTH_DETAIL_MAP: dict[SchwabAuthCode, str] = {

--- a/backend/app/routers/journal.py
+++ b/backend/app/routers/journal.py
@@ -163,7 +163,7 @@ async def import_csv_preview(
         mapped = parse_schwab_csv(file_bytes)
     except Exception:
         logger.exception("Failed to parse uploaded Schwab CSV")
-        raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL)
+        raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL) from None
     return build_preview(db, mapped, account_number="")
 
 
@@ -179,7 +179,7 @@ async def import_csv(
         mapped = parse_schwab_csv(file_bytes)
     except Exception:
         logger.exception("Failed to parse uploaded Schwab CSV")
-        raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL)
+        raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL) from None
     return execute_mapped_import(db, mapped, position_strategy=position_strategy)
 
 

--- a/backend/app/services/schwab_csv.py
+++ b/backend/app/services/schwab_csv.py
@@ -197,6 +197,9 @@ def _parse_option_symbol(symbol: str) -> tuple[str, str, float, str] | None:
 
     occ = _OCC_SYMBOL_RE.match(symbol)
     if occ:
+        # OCC symbols encode year as 2 digits; we hardcode the 21st-century
+        # prefix. Schwab journals containing options expiring in 2100+ would
+        # need revisiting then.
         try:
             exp = datetime.strptime(
                 f"20{occ.group('yy')}-{occ.group('mm')}-{occ.group('dd')}",

--- a/backend/app/services/schwab_csv.py
+++ b/backend/app/services/schwab_csv.py
@@ -1,0 +1,271 @@
+"""Parse Schwab transaction CSV exports into journal-ready trade dicts.
+
+Schwab.com's *Activity & Statements -> Transactions -> Export* feature produces a
+CSV file with the following columns (any order, header row is required):
+
+    Date, Action, Symbol, Description, Quantity, Price, Fees & Comm, Amount
+
+Example option rows (taken from real Schwab exports):
+
+    "03/27/2026", "Sell to Open", "F 03/27/2026 13.50 P", ...
+    "03/20/2026", "Buy to Close", "SOFI 03/20/2026 31.00 C", ...
+    "03/21/2026", "Assigned",     "AAPL 03/21/2026 150.00 P", ...
+
+The exact symbol layout varies by account/export — older exports may use the
+canonical OCC format (``AAPL240315P00185000``) instead of the human-readable
+``TICKER MM/DD/YYYY STRIKE P|C`` form. Both shapes are handled here.
+
+This module produces dicts in the **same shape** as
+:func:`app.services.schwab_import.map_schwab_transaction`, so the existing
+preview/execute import pipeline can consume them unchanged.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import re
+from datetime import datetime
+
+from app.services.schwab_import import _INSTRUCTION_MAP
+
+logger = logging.getLogger(__name__)
+
+
+# Map Schwab CSV "Action" column values to the (instruction, putCall) pair the
+# rest of the import pipeline uses. The putCall component is filled in from the
+# parsed Symbol; the keys below are case-insensitive and always trimmed.
+_ACTION_TO_INSTRUCTION: dict[str, str] = {
+    "sell to open": "SELL_TO_OPEN",
+    "buy to close": "BUY_TO_CLOSE",
+    "assigned": "RECEIVE_DELIVER",
+    "expired": "RECEIVE_DELIVER",
+    # Schwab uses different phrasing for called-away exercises depending on
+    # account type. Both map to RECEIVE_DELIVER on the call side.
+    "exercised": "RECEIVE_DELIVER",
+}
+
+
+# Human-readable option symbol: "F 03/27/2026 13.50 P" / "AAPL 03/21/2026 150.00 P"
+_HUMAN_SYMBOL_RE = re.compile(
+    r"^\s*(?P<ticker>[A-Z][A-Z0-9.\-]{0,9})\s+"
+    r"(?P<expiration>\d{2}/\d{2}/\d{4})\s+"
+    r"(?P<strike>\d+(?:\.\d+)?)\s+"
+    r"(?P<putcall>[PCpc])\s*$"
+)
+
+# Canonical OCC option symbol: "AAPL  240315C00185000"
+# Ticker (1-6 chars) + YYMMDD + C/P + strike-price * 1000 padded to 8 digits.
+_OCC_SYMBOL_RE = re.compile(
+    r"^\s*(?P<ticker>[A-Z][A-Z0-9.\-]{0,9})\s*"
+    r"(?P<yy>\d{2})(?P<mm>\d{2})(?P<dd>\d{2})"
+    r"(?P<putcall>[CP])"
+    r"(?P<strike>\d{8})\s*$"
+)
+
+
+def parse_schwab_csv(file_bytes: bytes) -> list[dict]:
+    """Parse a Schwab transaction CSV export into journal trade dicts.
+
+    Non-options rows (stock buys/sells, dividends, ACH transfers, etc.) and
+    rows whose Action does not map to a known options instruction are silently
+    skipped. Malformed rows that fail to parse are also skipped — the parser
+    never raises on a single bad row, so a partially valid file still yields
+    the rows that did parse.
+
+    Args:
+        file_bytes: Raw CSV file content. UTF-8 with BOM is tolerated; other
+            encodings are best-effort decoded as latin-1 fallback.
+
+    Returns:
+        A list of dicts matching the shape of
+        :func:`app.services.schwab_import.map_schwab_transaction`:
+
+        ``ticker``, ``trade_type``, ``strike``, ``expiration`` (YYYY-MM-DD),
+        ``premium`` (per-share, signed), ``fees``, ``quantity``, ``opened_at``.
+    """
+    text = _decode_csv_bytes(file_bytes)
+    if not text.strip():
+        return []
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        return []
+
+    # Build a case-insensitive header lookup so subtle variations like
+    # "Fees & Comm" vs "Fees & Comm." don't break parsing.
+    header_map = {(h or "").strip().lower(): h for h in reader.fieldnames}
+    required = {"date", "action", "symbol", "quantity", "amount"}
+    if not required.issubset(header_map.keys()):
+        logger.info("Schwab CSV missing required columns; got %s", reader.fieldnames)
+        return []
+
+    trades: list[dict] = []
+    for raw_row in reader:
+        try:
+            mapped = _map_csv_row(raw_row, header_map)
+        except Exception:  # noqa: BLE001 — defensive: never crash on a single row
+            logger.debug("Skipping malformed CSV row", exc_info=True)
+            continue
+        if mapped is not None:
+            trades.append(mapped)
+    return trades
+
+
+def _decode_csv_bytes(file_bytes: bytes) -> str:
+    """Decode CSV bytes to text, tolerating BOM and non-UTF-8 inputs."""
+    try:
+        return file_bytes.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return file_bytes.decode("latin-1", errors="replace")
+
+
+def _map_csv_row(raw_row: dict, header_map: dict[str, str]) -> dict | None:
+    """Map a single CSV row dict to a journal trade dict, or None to skip."""
+    action_raw = (raw_row.get(header_map.get("action", ""), "") or "").strip().lower()
+    instruction = _ACTION_TO_INSTRUCTION.get(action_raw)
+    if instruction is None:
+        return None
+
+    symbol = (raw_row.get(header_map.get("symbol", ""), "") or "").strip()
+    parsed = _parse_option_symbol(symbol)
+    if parsed is None:
+        return None
+
+    ticker, expiration, strike, put_call = parsed
+    trade_type = _INSTRUCTION_MAP.get((instruction, put_call))
+    if trade_type is None:
+        return None
+
+    quantity = _parse_int(raw_row.get(header_map.get("quantity", ""), ""))
+    if quantity is None or quantity <= 0:
+        return None
+
+    amount = _parse_float(raw_row.get(header_map.get("amount", ""), ""))
+    fees = _parse_float(raw_row.get(header_map.get("fees & comm", ""), "")) or 0.0
+
+    if amount is None:
+        amount = 0.0
+
+    # Premium per share: abs(Amount) / (quantity * 100). Schwab's "Amount"
+    # column is signed (positive = credit, negative = debit) and already net of
+    # fees, mirroring the API's `netAmount` field.
+    premium_per_share = abs(amount) / (quantity * 100) if quantity > 0 else 0.0
+    if instruction == "BUY_TO_CLOSE":
+        premium_per_share = -premium_per_share
+
+    opened_at = _normalize_csv_date(
+        raw_row.get(header_map.get("date", ""), "")
+    )
+    if not opened_at:
+        return None
+
+    return {
+        "ticker": ticker,
+        "trade_type": trade_type,
+        "strike": float(strike),
+        "expiration": expiration,
+        "premium": round(premium_per_share, 4),
+        "fees": round(abs(fees), 2),
+        "quantity": int(quantity),
+        "opened_at": opened_at,
+    }
+
+
+def _parse_option_symbol(symbol: str) -> tuple[str, str, float, str] | None:
+    """Parse a Schwab option symbol into (ticker, expiration, strike, putCall).
+
+    Returns None if the symbol is empty, malformed, or not an option (e.g.
+    plain equity tickers like "AAPL").
+    """
+    if not symbol:
+        return None
+
+    human = _HUMAN_SYMBOL_RE.match(symbol)
+    if human:
+        try:
+            exp = datetime.strptime(human.group("expiration"), "%m/%d/%Y").strftime("%Y-%m-%d")
+        except ValueError:
+            return None
+        return (
+            human.group("ticker").upper(),
+            exp,
+            float(human.group("strike")),
+            "PUT" if human.group("putcall").upper() == "P" else "CALL",
+        )
+
+    occ = _OCC_SYMBOL_RE.match(symbol)
+    if occ:
+        try:
+            exp = datetime.strptime(
+                f"20{occ.group('yy')}-{occ.group('mm')}-{occ.group('dd')}",
+                "%Y-%m-%d",
+            ).strftime("%Y-%m-%d")
+        except ValueError:
+            return None
+        strike = int(occ.group("strike")) / 1000.0
+        return (
+            occ.group("ticker").upper(),
+            exp,
+            strike,
+            "PUT" if occ.group("putcall") == "P" else "CALL",
+        )
+
+    return None
+
+
+def _normalize_csv_date(date_str: str) -> str:
+    """Normalize a Schwab CSV Date cell to YYYY-MM-DD.
+
+    Schwab exports use ``MM/DD/YYYY``. Some rows include an action suffix in
+    parentheses (e.g. ``"03/01/2026 as of 02/28/2026"``); we use the first
+    parseable date in the cell.
+    """
+    if not date_str:
+        return ""
+    candidate = date_str.strip().split(" as of ")[0].strip()
+    for fmt in ("%m/%d/%Y", "%Y-%m-%d", "%m/%d/%y"):
+        try:
+            return datetime.strptime(candidate, fmt).strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return ""
+
+
+def _parse_int(value: str | None) -> int | None:
+    """Parse an integer from a Schwab CSV cell. Returns None on failure."""
+    if value is None:
+        return None
+    cleaned = str(value).replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return int(float(cleaned))
+    except ValueError:
+        return None
+
+
+def _parse_float(value: str | None) -> float | None:
+    """Parse a float from a Schwab CSV cell, stripping ``$``/``,`` and parens.
+
+    Schwab uses parentheses for negatives in some exports (``"($1,234.56)"``).
+    Returns None on failure.
+    """
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    if not cleaned:
+        return None
+    negative = False
+    if cleaned.startswith("(") and cleaned.endswith(")"):
+        negative = True
+        cleaned = cleaned[1:-1]
+    cleaned = cleaned.replace("$", "").replace(",", "").strip()
+    if not cleaned or cleaned == "-":
+        return None
+    try:
+        result = float(cleaned)
+    except ValueError:
+        return None
+    return -result if negative else result

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -131,44 +131,33 @@ def is_duplicate(
     return result is not None
 
 
-def preview_import(db: Session, start_date: str, end_date: str) -> dict:
-    """Preview Schwab transactions for import.
+def build_preview(
+    db: Session,
+    mapped_trades: list[dict],
+    account_number: str = "",
+) -> dict:
+    """Build a preview response from a list of pre-mapped trade dicts.
 
-    Returns dict with account info, trade list, and duplicate counts.
+    Shared between the API preview path (``preview_import``) and the CSV
+    preview path so both produce identical response shapes and apply the same
+    duplicate-detection logic.
     """
-    client = SchwabClient()
-    account_numbers = client.get_account_numbers()
-
-    if not account_numbers:
-        return {
-            "account_number": "",
-            "trades": [],
-            "total": 0,
-            "duplicates": 0,
-            "new_count": 0,
-        }
-
-    account = account_numbers[0]
-    account_hash = account.get("hashValue", "")
-    account_number = account.get("accountNumber", "")
-    masked_account = f"****{account_number[-4:]}" if len(account_number) >= 4 else account_number
-
-    transactions = client.get_transactions(account_hash, start_date, end_date)
-
-    trades = []
+    masked_account = (
+        f"****{account_number[-4:]}" if len(account_number) >= 4 else account_number
+    )
+    trades: list[dict] = []
     duplicates = 0
-    for txn in transactions:
-        mapped = map_schwab_transaction(txn)
-        if mapped is None:
-            continue
-
+    for mapped in mapped_trades:
         dup = is_duplicate(
-            db, mapped["ticker"], mapped["strike"], mapped["expiration"],
-            mapped["trade_type"], mapped["opened_at"],
+            db,
+            mapped["ticker"],
+            mapped["strike"],
+            mapped["expiration"],
+            mapped["trade_type"],
+            mapped["opened_at"],
         )
         if dup:
             duplicates += 1
-
         trades.append({**mapped, "is_duplicate": dup})
 
     return {
@@ -180,38 +169,33 @@ def preview_import(db: Session, start_date: str, end_date: str) -> dict:
     }
 
 
-def execute_import(db: Session, start_date: str, end_date: str, position_strategy: str = "wheel") -> dict:
-    """Import Schwab transactions into the journal.
+def execute_mapped_import(
+    db: Session,
+    mapped_trades: list[dict],
+    position_strategy: str = "wheel",
+) -> dict:
+    """Persist a list of pre-mapped trade dicts to the journal.
 
-    Creates positions as needed and logs trades.
+    Reuses ``is_duplicate`` for skip detection and creates open positions on
+    demand for tickers without one. Shared between the Schwab API import path
+    and the CSV upload import path.
     """
-    client = SchwabClient()
-    account_numbers = client.get_account_numbers()
-
-    if not account_numbers:
-        return {"imported": 0, "skipped_duplicates": 0, "positions_created": 0}
-
-    account = account_numbers[0]
-    account_hash = account.get("hashValue", "")
-    transactions = client.get_transactions(account_hash, start_date, end_date)
-
     imported = 0
     skipped = 0
     positions_created = 0
 
-    for txn in transactions:
-        mapped = map_schwab_transaction(txn)
-        if mapped is None:
-            continue
-
+    for mapped in mapped_trades:
         if is_duplicate(
-            db, mapped["ticker"], mapped["strike"], mapped["expiration"],
-            mapped["trade_type"], mapped["opened_at"],
+            db,
+            mapped["ticker"],
+            mapped["strike"],
+            mapped["expiration"],
+            mapped["trade_type"],
+            mapped["opened_at"],
         ):
             skipped += 1
             continue
 
-        # Find or create position for this ticker
         position = (
             db.query(Position)
             .filter(Position.ticker == mapped["ticker"], Position.status == "open")
@@ -247,3 +231,47 @@ def execute_import(db: Session, start_date: str, end_date: str, position_strateg
         "skipped_duplicates": skipped,
         "positions_created": positions_created,
     }
+
+
+def preview_import(db: Session, start_date: str, end_date: str) -> dict:
+    """Preview Schwab transactions for import.
+
+    Returns dict with account info, trade list, and duplicate counts.
+    """
+    client = SchwabClient()
+    account_numbers = client.get_account_numbers()
+
+    if not account_numbers:
+        return {
+            "account_number": "",
+            "trades": [],
+            "total": 0,
+            "duplicates": 0,
+            "new_count": 0,
+        }
+
+    account = account_numbers[0]
+    account_hash = account.get("hashValue", "")
+    account_number = account.get("accountNumber", "")
+
+    transactions = client.get_transactions(account_hash, start_date, end_date)
+    mapped_trades = [m for m in (map_schwab_transaction(t) for t in transactions) if m]
+    return build_preview(db, mapped_trades, account_number=account_number)
+
+
+def execute_import(db: Session, start_date: str, end_date: str, position_strategy: str = "wheel") -> dict:
+    """Import Schwab transactions into the journal.
+
+    Creates positions as needed and logs trades.
+    """
+    client = SchwabClient()
+    account_numbers = client.get_account_numbers()
+
+    if not account_numbers:
+        return {"imported": 0, "skipped_duplicates": 0, "positions_created": 0}
+
+    account = account_numbers[0]
+    account_hash = account.get("hashValue", "")
+    transactions = client.get_transactions(account_hash, start_date, end_date)
+    mapped_trades = [m for m in (map_schwab_transaction(t) for t in transactions) if m]
+    return execute_mapped_import(db, mapped_trades, position_strategy=position_strategy)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.6
+python-multipart==0.0.27
 uvicorn[standard]==0.34.0
 pydantic==2.10.4
 pydantic-settings==2.7.1

--- a/backend/tests/test_schwab_csv_import.py
+++ b/backend/tests/test_schwab_csv_import.py
@@ -1,0 +1,361 @@
+"""Unit + integration tests for Schwab CSV import (issue #104).
+
+Covers ``app.services.schwab_csv.parse_schwab_csv`` and the matching
+``POST /api/journal/import/csv/preview`` and ``POST /api/journal/import/csv``
+endpoints. The fixtures here intentionally mirror real Schwab transaction
+exports so any regression in symbol/date parsing is caught early.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services.schwab_csv import parse_schwab_csv
+
+
+# --- Fixtures ---------------------------------------------------------------
+
+
+def _csv(rows: list[str]) -> bytes:
+    """Build a Schwab-style CSV from a list of pre-formatted lines."""
+    header = "Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount"
+    return ("\n".join([header, *rows]) + "\n").encode("utf-8")
+
+
+SELL_PUT_ROW = (
+    '03/01/2026,Sell to Open,F 03/27/2026 13.50 P,'
+    'PUT FORD MOTOR CO $13.50 EXP 03/27/26,1,0.30,0.65,29.35'
+)
+SELL_CALL_ROW = (
+    '03/02/2026,Sell to Open,SOFI 03/20/2026 31.00 C,'
+    'CALL SOFI TECHNOLOGIES INC $31 EXP 03/20/26,2,0.50,1.30,98.70'
+)
+BUY_TO_CLOSE_ROW = (
+    '03/05/2026,Buy to Close,F 03/27/2026 13.50 P,'
+    'PUT FORD MOTOR CO $13.50 EXP 03/27/26,1,0.10,0.65,(10.65)'
+)
+ASSIGNED_PUT_ROW = (
+    '03/27/2026,Assigned,F 03/27/2026 13.50 P,'
+    'PUT FORD MOTOR CO ASSIGNMENT,1,,0.00,0.00'
+)
+EXPIRED_CALL_ROW = (
+    '03/20/2026,Expired,SOFI 03/20/2026 31.00 C,'
+    'CALL SOFI EXPIRATION,2,,0.00,0.00'
+)
+
+# Non-options noise that must be silently skipped.
+STOCK_BUY_ROW = '03/01/2026,Buy,AAPL,APPLE INC,100,150.00,0.00,(15000.00)'
+DIVIDEND_ROW = '03/15/2026,Cash Dividend,AAPL,APPLE INC DIVIDEND,,,,25.00'
+ACH_ROW = '03/01/2026,Funds Received,,ACH RECEIPT,,,,1000.00'
+
+# Canonical OCC symbol — older Schwab exports use this layout.
+OCC_SELL_PUT_ROW = (
+    '03/10/2026,Sell to Open,AAPL  260315P00185000,'
+    'PUT AAPL $185 EXP 03/15/26,1,1.20,0.65,119.35'
+)
+
+
+# --- parse_schwab_csv unit tests --------------------------------------------
+
+
+class TestParseSchwabCsv:
+    """Cover the happy-path mappings, skip rules, and malformed input."""
+
+    def test_sell_to_open_put_human_symbol(self):
+        result = parse_schwab_csv(_csv([SELL_PUT_ROW]))
+        assert len(result) == 1
+        row = result[0]
+        assert row["ticker"] == "F"
+        assert row["trade_type"] == "sell_put"
+        assert row["strike"] == 13.50
+        assert row["expiration"] == "2026-03-27"
+        assert row["quantity"] == 1
+        # Premium per share = 29.35 / (1 * 100) = 0.2935, positive for sells.
+        assert row["premium"] == pytest.approx(0.2935, abs=1e-4)
+        assert row["fees"] == 0.65
+        assert row["opened_at"] == "2026-03-01"
+
+    def test_sell_to_open_call_multi_contract(self):
+        result = parse_schwab_csv(_csv([SELL_CALL_ROW]))
+        assert len(result) == 1
+        row = result[0]
+        assert row["ticker"] == "SOFI"
+        assert row["trade_type"] == "sell_call"
+        assert row["quantity"] == 2
+        # 98.70 / (2 * 100) = 0.4935
+        assert row["premium"] == pytest.approx(0.4935, abs=1e-4)
+
+    def test_buy_to_close_premium_is_negative(self):
+        result = parse_schwab_csv(_csv([BUY_TO_CLOSE_ROW]))
+        assert len(result) == 1
+        row = result[0]
+        assert row["trade_type"] == "buy_put_close"
+        # Schwab uses parentheses for negatives; abs(amount) used for premium,
+        # but the buy side flips the sign.
+        assert row["premium"] == pytest.approx(-0.1065, abs=1e-4)
+
+    def test_assigned_maps_to_assignment(self):
+        result = parse_schwab_csv(_csv([ASSIGNED_PUT_ROW]))
+        assert len(result) == 1
+        assert result[0]["trade_type"] == "assignment"
+
+    def test_expired_call_maps_to_called_away(self):
+        result = parse_schwab_csv(_csv([EXPIRED_CALL_ROW]))
+        assert len(result) == 1
+        assert result[0]["trade_type"] == "called_away"
+
+    def test_occ_format_symbol_parses(self):
+        result = parse_schwab_csv(_csv([OCC_SELL_PUT_ROW]))
+        assert len(result) == 1
+        row = result[0]
+        assert row["ticker"] == "AAPL"
+        assert row["strike"] == 185.0
+        assert row["expiration"] == "2026-03-15"
+        assert row["trade_type"] == "sell_put"
+
+    def test_full_mix_round_trip(self):
+        rows = [
+            SELL_PUT_ROW,
+            SELL_CALL_ROW,
+            BUY_TO_CLOSE_ROW,
+            ASSIGNED_PUT_ROW,
+            EXPIRED_CALL_ROW,
+            STOCK_BUY_ROW,
+            DIVIDEND_ROW,
+            ACH_ROW,
+        ]
+        result = parse_schwab_csv(_csv(rows))
+        # Five options rows survive; three non-options skipped silently.
+        assert len(result) == 5
+        trade_types = sorted(r["trade_type"] for r in result)
+        assert trade_types == [
+            "assignment",
+            "buy_put_close",
+            "called_away",
+            "sell_call",
+            "sell_put",
+        ]
+
+    def test_non_options_rows_skipped(self):
+        result = parse_schwab_csv(_csv([STOCK_BUY_ROW, DIVIDEND_ROW, ACH_ROW]))
+        assert result == []
+
+    def test_unknown_action_skipped(self):
+        # "Journal" / "Wire Transfer" / etc. should never crash the parser.
+        rows = [
+            '03/01/2026,Journal,F 03/27/2026 13.50 P,JOURNAL,1,,0.00,0.00',
+            '03/01/2026,Wire Transfer,,,,,,5000.00',
+        ]
+        assert parse_schwab_csv(_csv(rows)) == []
+
+    @pytest.mark.parametrize(
+        "bad_symbol",
+        [
+            "F GARBAGE 13.50 P",   # wrong date layout
+            "F 03/27/2026 P",       # missing strike
+            "F 13/40/2026 13.50 P",  # invalid date
+            "AAPL 99X9999P00000000",  # OCC-shaped but malformed
+            "",                       # empty
+        ],
+    )
+    def test_malformed_symbols_skipped(self, bad_symbol):
+        row = (
+            f'03/01/2026,Sell to Open,{bad_symbol},'
+            f'JUNK,1,1.00,0.65,99.35'
+        )
+        assert parse_schwab_csv(_csv([row])) == []
+
+    def test_missing_required_columns_returns_empty(self):
+        # No "Symbol" column at all — entire file rejected.
+        body = (
+            "Date,Action,Quantity,Amount\n"
+            "03/01/2026,Sell to Open,1,29.35\n"
+        ).encode("utf-8")
+        assert parse_schwab_csv(body) == []
+
+    def test_empty_file_returns_empty(self):
+        assert parse_schwab_csv(b"") == []
+        assert parse_schwab_csv(b"\n") == []
+
+    def test_utf8_bom_tolerated(self):
+        body = b"\xef\xbb\xbf" + _csv([SELL_PUT_ROW])
+        assert len(parse_schwab_csv(body)) == 1
+
+    def test_zero_quantity_row_skipped(self):
+        row = (
+            '03/01/2026,Sell to Open,F 03/27/2026 13.50 P,'
+            'JUNK,0,0.30,0.65,29.35'
+        )
+        assert parse_schwab_csv(_csv([row])) == []
+
+    def test_amount_with_dollar_and_comma(self):
+        # Schwab sometimes formats Amount as "$1,234.56".
+        row = (
+            '03/01/2026,Sell to Open,SOFI 03/20/2026 31.00 C,'
+            'JUNK,2,5.00,1.30,"$998.70"'
+        )
+        result = parse_schwab_csv(_csv([row]))
+        assert len(result) == 1
+        # 998.70 / (2 * 100) = 4.9935
+        assert result[0]["premium"] == pytest.approx(4.9935, abs=1e-4)
+
+
+# --- API endpoint integration tests -----------------------------------------
+
+
+def _csv_file(content: bytes, filename: str = "schwab.csv") -> dict:
+    """Build the multipart `files` payload for TestClient.post."""
+    return {"file": (filename, content, "text/csv")}
+
+
+class TestImportCsvPreviewEndpoint:
+    """Cover ``POST /api/journal/import/csv/preview`` validation + happy path."""
+
+    def test_preview_rejects_wrong_extension(self, client):
+        resp = client.post(
+            "/api/journal/import/csv/preview",
+            files=_csv_file(_csv([SELL_PUT_ROW]), filename="trades.txt"),
+        )
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Only .csv files are accepted"
+
+    def test_preview_rejects_oversized_file(self, client):
+        # 6 MB synthetic body — header byte + filler. Body content is irrelevant
+        # because size is checked before parsing.
+        oversized = b"Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount\n"
+        oversized += b"x" * (6 * 1024 * 1024)
+        resp = client.post(
+            "/api/journal/import/csv/preview",
+            files=_csv_file(oversized),
+        )
+        assert resp.status_code == 422
+        assert "5 MB" in resp.json()["detail"]
+
+    def test_preview_rejects_empty_file(self, client):
+        resp = client.post(
+            "/api/journal/import/csv/preview",
+            files=_csv_file(b""),
+        )
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "Uploaded file is empty"
+
+    def test_preview_returns_correct_shape(self, client):
+        resp = client.post(
+            "/api/journal/import/csv/preview",
+            files=_csv_file(_csv([SELL_PUT_ROW, SELL_CALL_ROW, STOCK_BUY_ROW])),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 2
+        assert data["new_count"] == 2
+        assert data["duplicates"] == 0
+        # CSV path has no account number — UI handles the empty value.
+        assert data["account_number"] == ""
+        tickers = sorted(t["ticker"] for t in data["trades"])
+        assert tickers == ["F", "SOFI"]
+        for trade in data["trades"]:
+            assert trade["is_duplicate"] is False
+
+    def test_preview_with_only_non_options_returns_empty(self, client):
+        resp = client.post(
+            "/api/journal/import/csv/preview",
+            files=_csv_file(_csv([STOCK_BUY_ROW, DIVIDEND_ROW, ACH_ROW])),
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {
+            "account_number": "",
+            "trades": [],
+            "total": 0,
+            "duplicates": 0,
+            "new_count": 0,
+        }
+
+    def test_preview_does_not_leak_exception_message(self, client):
+        # If parsing somehow crashes (defensive, since parse_schwab_csv catches
+        # per-row errors), the endpoint must return a generic 422.
+        with patch(
+            "app.routers.journal.parse_schwab_csv",
+            side_effect=RuntimeError("internal secret"),
+        ):
+            resp = client.post(
+                "/api/journal/import/csv/preview",
+                files=_csv_file(_csv([SELL_PUT_ROW])),
+            )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert "internal secret" not in detail
+        assert detail == "Could not parse the uploaded CSV file"
+
+
+class TestImportCsvEndpoint:
+    """Cover ``POST /api/journal/import/csv`` write path + duplicate handling."""
+
+    def test_import_creates_trades_and_positions(self, client):
+        resp = client.post(
+            "/api/journal/import/csv",
+            files=_csv_file(_csv([SELL_PUT_ROW, SELL_CALL_ROW])),
+            data={"position_strategy": "wheel"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["imported"] == 2
+        assert data["positions_created"] == 2
+        assert data["skipped_duplicates"] == 0
+
+        positions = client.get("/api/journal/positions").json()["positions"]
+        tickers = {p["ticker"] for p in positions}
+        assert tickers == {"F", "SOFI"}
+
+    def test_import_default_strategy_is_wheel(self, client):
+        # `position_strategy` form field omitted — should default to "wheel".
+        resp = client.post(
+            "/api/journal/import/csv",
+            files=_csv_file(_csv([SELL_PUT_ROW])),
+        )
+        assert resp.status_code == 200
+        positions = client.get("/api/journal/positions").json()["positions"]
+        assert positions[0]["strategy"] == "wheel"
+
+    def test_import_skips_duplicates_on_second_upload(self, client):
+        body = _csv([SELL_PUT_ROW, SELL_CALL_ROW])
+        first = client.post("/api/journal/import/csv", files=_csv_file(body))
+        assert first.json()["imported"] == 2
+
+        second = client.post("/api/journal/import/csv", files=_csv_file(body))
+        data = second.json()
+        assert data["imported"] == 0
+        assert data["skipped_duplicates"] == 2
+        assert data["positions_created"] == 0
+
+    def test_import_rejects_invalid_strategy(self, client):
+        resp = client.post(
+            "/api/journal/import/csv",
+            files=_csv_file(_csv([SELL_PUT_ROW])),
+            data={"position_strategy": "not-a-strategy"},
+        )
+        # Pydantic Literal validation -> 422 before any DB writes.
+        assert resp.status_code == 422
+
+    def test_import_rejects_oversized_file(self, client):
+        oversized = b"Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount\n"
+        oversized += b"x" * (6 * 1024 * 1024)
+        resp = client.post(
+            "/api/journal/import/csv",
+            files=_csv_file(oversized),
+        )
+        assert resp.status_code == 422
+
+    def test_import_does_not_leak_exception_message(self, client):
+        with patch(
+            "app.routers.journal.parse_schwab_csv",
+            side_effect=RuntimeError("internal secret"),
+        ):
+            resp = client.post(
+                "/api/journal/import/csv",
+                files=_csv_file(_csv([SELL_PUT_ROW])),
+            )
+        assert resp.status_code == 422
+        assert "internal secret" not in resp.json()["detail"]

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -281,6 +281,21 @@ export async function executeSchwabImport(startDate, endDate, positionStrategy =
   return data;
 }
 
+export async function previewSchwabCsvImport(file) {
+  const form = new FormData();
+  form.append('file', file);
+  const { data } = await api.post('/api/journal/import/csv/preview', form);
+  return data;
+}
+
+export async function executeSchwabCsvImport(file, positionStrategy = 'wheel') {
+  const form = new FormData();
+  form.append('file', file);
+  form.append('position_strategy', positionStrategy);
+  const { data } = await api.post('/api/journal/import/csv', form);
+  return data;
+}
+
 // --- Dashboard ---
 
 export async function getDashboard() {

--- a/frontend/components/journal/ImportModal.jsx
+++ b/frontend/components/journal/ImportModal.jsx
@@ -50,6 +50,8 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
   const [csvError, setCsvError] = useState(null);
   const [result, setResult] = useState(null);
   const fileInputRef = useRef(null);
+  const apiTabRef = useRef(null);
+  const csvTabRef = useRef(null);
 
   const handlePreview = async () => {
     await onPreview(startDate, endDate);
@@ -101,11 +103,28 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
     await onPreviewCsv(csvFile);
   };
 
-  const handleSwitchMode = (next) => {
-    if (next === mode) return;
+  const handleSwitchMode = (next, { focus = false } = {}) => {
+    if (next === mode) {
+      if (focus) {
+        const ref = next === MODES.API ? apiTabRef : csvTabRef;
+        ref.current?.focus();
+      }
+      return;
+    }
     setMode(next);
     setCsvError(null);
     setCsvFile(null);
+    if (focus) {
+      const ref = next === MODES.API ? apiTabRef : csvTabRef;
+      ref.current?.focus();
+    }
+  };
+
+  const handleTabKeyDown = (e) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const next = mode === MODES.API ? MODES.CSV : MODES.API;
+    handleSwitchMode(next, { focus: true });
   };
 
   const allDuplicates = preview && preview.new_count === 0;
@@ -241,10 +260,14 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
           </div>
         ) : (
           <div className="space-y-4">
-            <div role="tablist" aria-label="Import source" data-testid="import-mode-toggle" className="flex gap-2">
+            <div role="tablist" aria-label="Import source" data-testid="import-mode-toggle" className="flex gap-2" onKeyDown={handleTabKeyDown}>
               <button
+                ref={apiTabRef}
+                id="import-tab-api"
                 role="tab"
                 aria-selected={mode === MODES.API}
+                aria-controls="import-panel-api"
+                tabIndex={mode === MODES.API ? 0 : -1}
                 data-testid="import-mode-api"
                 onClick={() => handleSwitchMode(MODES.API)}
                 className={`${tabBaseClass} ${mode === MODES.API ? tabActiveClass : tabInactiveClass}`}
@@ -252,8 +275,12 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
                 Schwab API
               </button>
               <button
+                ref={csvTabRef}
+                id="import-tab-csv"
                 role="tab"
                 aria-selected={mode === MODES.CSV}
+                aria-controls="import-panel-csv"
+                tabIndex={mode === MODES.CSV ? 0 : -1}
                 data-testid="import-mode-csv"
                 onClick={() => handleSwitchMode(MODES.CSV)}
                 className={`${tabBaseClass} ${mode === MODES.CSV ? tabActiveClass : tabInactiveClass}`}
@@ -263,7 +290,7 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
             </div>
 
             {mode === MODES.API ? (
-              <>
+              <div id="import-panel-api" role="tabpanel" aria-labelledby="import-tab-api" tabIndex={0}>
                 <div data-testid="import-api-fields" className="grid grid-cols-2 gap-4">
                   <div>
                     <label className={labelClass}>Start Date</label>
@@ -287,9 +314,9 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
                     Cancel
                   </button>
                 </div>
-              </>
+              </div>
             ) : (
-              <>
+              <div id="import-panel-csv" role="tabpanel" aria-labelledby="import-tab-csv" tabIndex={0}>
                 <div data-testid="import-csv-fields" className="space-y-2">
                   <label className={labelClass} htmlFor="csv-file-input">Schwab CSV export</label>
                   <input
@@ -328,7 +355,7 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
                     Cancel
                   </button>
                 </div>
-              </>
+              </div>
             )}
           </div>
         )}

--- a/frontend/components/journal/ImportModal.jsx
+++ b/frontend/components/journal/ImportModal.jsx
@@ -1,10 +1,15 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 const STRATEGIES = [
   { value: 'csp', label: 'Cash Secured Put' },
   { value: 'cc', label: 'Covered Call' },
   { value: 'wheel', label: 'Wheel' },
 ];
+
+const MODES = {
+  API: 'api',
+  CSV: 'csv',
+};
 
 function toLocalDate(d) {
   const tzOffsetMs = d.getTimezoneOffset() * 60_000;
@@ -15,6 +20,7 @@ function toLocalDate(d) {
 // without exceeding the server-side 365-day cap from issue #75.
 const DEFAULT_LOOKBACK_DAYS = 90;
 const MAX_LOOKBACK_DAYS = 365;
+const MAX_CSV_BYTES = 5 * 1024 * 1024;
 
 function defaultDates() {
   const end = new Date();
@@ -26,7 +32,7 @@ function defaultDates() {
   };
 }
 
-export default function ImportModal({ onClose, onPreview, onImport, preview, loading }) {
+export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv, onImportCsv, preview, loading }) {
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'Escape' && !loading) onClose();
@@ -36,10 +42,14 @@ export default function ImportModal({ onClose, onPreview, onImport, preview, loa
   }, [onClose, loading]);
 
   const defaults = defaultDates();
+  const [mode, setMode] = useState(MODES.API);
   const [startDate, setStartDate] = useState(defaults.startDate);
   const [endDate, setEndDate] = useState(defaults.endDate);
   const [strategy, setStrategy] = useState('wheel');
+  const [csvFile, setCsvFile] = useState(null);
+  const [csvError, setCsvError] = useState(null);
   const [result, setResult] = useState(null);
+  const fileInputRef = useRef(null);
 
   const handlePreview = async () => {
     await onPreview(startDate, endDate);
@@ -57,8 +67,44 @@ export default function ImportModal({ onClose, onPreview, onImport, preview, loa
   };
 
   const handleImport = async () => {
-    const res = await onImport(startDate, endDate, strategy);
+    let res = null;
+    if (mode === MODES.CSV && csvFile && onImportCsv) {
+      res = await onImportCsv(csvFile, strategy);
+    } else {
+      res = await onImport(startDate, endDate, strategy);
+    }
     if (res) setResult(res);
+  };
+
+  const handleCsvChange = (e) => {
+    const file = e.target.files?.[0] || null;
+    setCsvError(null);
+    if (!file) {
+      setCsvFile(null);
+      return;
+    }
+    if (!file.name.toLowerCase().endsWith('.csv')) {
+      setCsvError('Only .csv files are accepted');
+      setCsvFile(null);
+      return;
+    }
+    if (file.size > MAX_CSV_BYTES) {
+      setCsvError('CSV file is larger than the 5 MB limit');
+      setCsvFile(null);
+      return;
+    }
+    setCsvFile(file);
+  };
+
+  const handleCsvPreview = async () => {
+    if (!csvFile || !onPreviewCsv) return;
+    await onPreviewCsv(csvFile);
+  };
+
+  const handleSwitchMode = (next) => {
+    if (next === mode) return;
+    setMode(next);
+    setCsvError(null);
   };
 
   const allDuplicates = preview && preview.new_count === 0;
@@ -66,6 +112,9 @@ export default function ImportModal({ onClose, onPreview, onImport, preview, loa
 
   const inputClass = 'w-full border border-slate-300 dark:border-slate-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-slate-700 text-slate-900 dark:text-white';
   const labelClass = 'block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1';
+  const tabBaseClass = 'px-3 py-1.5 text-sm font-medium rounded-lg border';
+  const tabActiveClass = 'bg-blue-600 text-white border-blue-600';
+  const tabInactiveClass = 'bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-600';
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" data-testid="import-backdrop" aria-label="Close modal" onClick={loading ? undefined : onClose}>
@@ -89,10 +138,11 @@ export default function ImportModal({ onClose, onPreview, onImport, preview, loa
         ) : preview ? (
           <div data-testid="import-preview" className="space-y-4">
             <p className="text-sm text-slate-600 dark:text-slate-400">
-              Account: {preview.account_number} | {preview.total} trades found | {preview.duplicates} duplicates | {preview.new_count} new
+              {preview.account_number ? `Account: ${preview.account_number} | ` : ''}
+              {preview.total} trades found | {preview.duplicates} duplicates | {preview.new_count} new
             </p>
 
-            {emptyPreview && (
+            {emptyPreview && mode === MODES.API && (
               <div
                 data-testid="empty-preview-banner"
                 className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4 space-y-2"
@@ -109,6 +159,18 @@ export default function ImportModal({ onClose, onPreview, onImport, preview, loa
                 >
                   {loading ? 'Loading...' : 'Look back 365 days'}
                 </button>
+              </div>
+            )}
+
+            {emptyPreview && mode === MODES.CSV && (
+              <div
+                data-testid="empty-csv-banner"
+                className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4"
+              >
+                <p className="text-sm text-amber-800 dark:text-amber-200">
+                  No options trades found in this CSV. Make sure the export is from
+                  Schwab.com Activity & Statements and includes options activity.
+                </p>
               </div>
             )}
 
@@ -178,29 +240,95 @@ export default function ImportModal({ onClose, onPreview, onImport, preview, loa
           </div>
         ) : (
           <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className={labelClass}>Start Date</label>
-                <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className={inputClass} />
-              </div>
-              <div>
-                <label className={labelClass}>End Date</label>
-                <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className={inputClass} />
-              </div>
-            </div>
-            <div className="flex gap-2">
+            <div role="tablist" aria-label="Import source" data-testid="import-mode-toggle" className="flex gap-2">
               <button
-                data-testid="preview-import-btn"
-                onClick={handlePreview}
-                disabled={loading}
-                className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                role="tab"
+                aria-selected={mode === MODES.API}
+                data-testid="import-mode-api"
+                onClick={() => handleSwitchMode(MODES.API)}
+                className={`${tabBaseClass} ${mode === MODES.API ? tabActiveClass : tabInactiveClass}`}
               >
-                {loading ? 'Loading...' : 'Preview'}
+                Schwab API
               </button>
-              <button onClick={onClose} className="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-300 dark:hover:bg-slate-600">
-                Cancel
+              <button
+                role="tab"
+                aria-selected={mode === MODES.CSV}
+                data-testid="import-mode-csv"
+                onClick={() => handleSwitchMode(MODES.CSV)}
+                className={`${tabBaseClass} ${mode === MODES.CSV ? tabActiveClass : tabInactiveClass}`}
+              >
+                CSV Upload
               </button>
             </div>
+
+            {mode === MODES.API ? (
+              <>
+                <div data-testid="import-api-fields" className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className={labelClass}>Start Date</label>
+                    <input type="date" value={startDate} onChange={(e) => setStartDate(e.target.value)} className={inputClass} />
+                  </div>
+                  <div>
+                    <label className={labelClass}>End Date</label>
+                    <input type="date" value={endDate} onChange={(e) => setEndDate(e.target.value)} className={inputClass} />
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    data-testid="preview-import-btn"
+                    onClick={handlePreview}
+                    disabled={loading}
+                    className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50"
+                  >
+                    {loading ? 'Loading...' : 'Preview'}
+                  </button>
+                  <button onClick={onClose} className="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-300 dark:hover:bg-slate-600">
+                    Cancel
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div data-testid="import-csv-fields" className="space-y-2">
+                  <label className={labelClass} htmlFor="csv-file-input">Schwab CSV export</label>
+                  <input
+                    id="csv-file-input"
+                    ref={fileInputRef}
+                    data-testid="csv-file-input"
+                    type="file"
+                    accept=".csv,text/csv"
+                    onChange={handleCsvChange}
+                    className="block text-sm text-slate-700 dark:text-slate-300 file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100 dark:file:bg-slate-700 dark:file:text-slate-300"
+                  />
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Export from Schwab.com -&gt; Activity &amp; Statements -&gt; Transactions -&gt; Export. Maximum 5 MB.
+                  </p>
+                  {csvFile && (
+                    <p data-testid="csv-file-name" className="text-xs text-slate-700 dark:text-slate-300">
+                      Selected: {csvFile.name} ({Math.round(csvFile.size / 1024)} KB)
+                    </p>
+                  )}
+                  {csvError && (
+                    <p data-testid="csv-error" className="text-xs text-red-600 dark:text-red-400">
+                      {csvError}
+                    </p>
+                  )}
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    data-testid="preview-csv-btn"
+                    onClick={handleCsvPreview}
+                    disabled={loading || !csvFile}
+                    className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {loading ? 'Loading...' : 'Preview'}
+                  </button>
+                  <button onClick={onClose} className="px-4 py-2 bg-slate-200 dark:bg-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-300 dark:hover:bg-slate-600">
+                    Cancel
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         )}
       </div>

--- a/frontend/components/journal/ImportModal.jsx
+++ b/frontend/components/journal/ImportModal.jsx
@@ -105,6 +105,7 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
     if (next === mode) return;
     setMode(next);
     setCsvError(null);
+    setCsvFile(null);
   };
 
   const allDuplicates = preview && preview.new_count === 0;

--- a/frontend/components/journal/JournalPage.jsx
+++ b/frontend/components/journal/JournalPage.jsx
@@ -102,6 +102,8 @@ export default function JournalPage() {
             onClose={handleCloseImport}
             onPreview={journal.previewImport}
             onImport={journal.confirmImport}
+            onPreviewCsv={journal.previewCsvImport}
+            onImportCsv={journal.confirmCsvImport}
             preview={journal.importPreview}
             loading={journal.importLoading}
           />

--- a/frontend/e2e/import-csv.spec.js
+++ b/frontend/e2e/import-csv.spec.js
@@ -1,0 +1,204 @@
+import { test, expect } from '@playwright/test';
+
+const SAMPLE_CSV = [
+  'Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount',
+  '"03/01/2026","Sell to Open","F 03/27/2026 13.50 P","PUT FORD",1,0.30,0.65,29.35',
+  '"03/02/2026","Sell to Open","SOFI 03/20/2026 31.00 C","CALL SOFI",2,0.50,1.30,98.70',
+].join('\n');
+
+const MOCK_CSV_PREVIEW = {
+  account_number: '',
+  trades: [
+    {
+      ticker: 'F',
+      trade_type: 'sell_put',
+      strike: 13.5,
+      expiration: '2026-03-27',
+      premium: 0.2935,
+      fees: 0.65,
+      quantity: 1,
+      opened_at: '2026-03-01',
+      is_duplicate: false,
+    },
+    {
+      ticker: 'SOFI',
+      trade_type: 'sell_call',
+      strike: 31.0,
+      expiration: '2026-03-20',
+      premium: 0.4935,
+      fees: 1.3,
+      quantity: 2,
+      opened_at: '2026-03-02',
+      is_duplicate: false,
+    },
+  ],
+  total: 2,
+  duplicates: 0,
+  new_count: 2,
+};
+
+const MOCK_CSV_IMPORT_RESULT = {
+  imported: 2,
+  skipped_duplicates: 0,
+  positions_created: 2,
+};
+
+function setupMocks(page) {
+  return Promise.all([
+    page.route('**/api/journal/positions', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ positions: [] }),
+        });
+      }
+      return route.continue();
+    }),
+    page.route('**/api/journal/import/csv/preview', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CSV_PREVIEW),
+      })
+    ),
+    page.route('**/api/journal/import/csv', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_CSV_IMPORT_RESULT),
+        });
+      }
+      return route.continue();
+    }),
+  ]);
+}
+
+test.describe('Schwab CSV Import (issue #104)', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/journal');
+  });
+
+  test('mode toggle is visible and switches the input UI', async ({ page }) => {
+    await page.getByTestId('import-schwab-btn').click();
+    await expect(page.getByTestId('import-modal')).toBeVisible();
+
+    // Default mode is API — date inputs visible, file input hidden.
+    await expect(page.getByTestId('import-mode-toggle')).toBeVisible();
+    await expect(page.getByTestId('import-api-fields')).toBeVisible();
+    await expect(page.getByTestId('import-csv-fields')).toHaveCount(0);
+
+    // Switch to CSV — file input visible, date inputs hidden.
+    await page.getByTestId('import-mode-csv').click();
+    await expect(page.getByTestId('import-csv-fields')).toBeVisible();
+    await expect(page.getByTestId('import-api-fields')).toHaveCount(0);
+    await expect(page.getByTestId('csv-file-input')).toBeVisible();
+
+    // And back to API.
+    await page.getByTestId('import-mode-api').click();
+    await expect(page.getByTestId('import-api-fields')).toBeVisible();
+    await expect(page.getByTestId('import-csv-fields')).toHaveCount(0);
+  });
+
+  test('preview button is disabled until a CSV file is selected', async ({ page }) => {
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+    await expect(page.getByTestId('preview-csv-btn')).toBeDisabled();
+  });
+
+  test('selecting a CSV file then previewing renders trade rows', async ({ page }) => {
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+
+    await page.getByTestId('csv-file-input').setInputFiles({
+      name: 'schwab-trades.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(SAMPLE_CSV, 'utf-8'),
+    });
+
+    await expect(page.getByTestId('csv-file-name')).toContainText('schwab-trades.csv');
+    await expect(page.getByTestId('preview-csv-btn')).toBeEnabled();
+    await page.getByTestId('preview-csv-btn').click();
+
+    await expect(page.getByTestId('import-preview')).toBeVisible();
+    await expect(page.getByText('F', { exact: true })).toBeVisible();
+    await expect(page.getByText('SOFI', { exact: true })).toBeVisible();
+  });
+
+  test('full CSV import flow shows success state', async ({ page }) => {
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+
+    await page.getByTestId('csv-file-input').setInputFiles({
+      name: 'schwab-trades.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(SAMPLE_CSV, 'utf-8'),
+    });
+    await page.getByTestId('preview-csv-btn').click();
+    await expect(page.getByTestId('import-preview')).toBeVisible();
+
+    await page.getByTestId('confirm-import-btn').click();
+    await expect(page.getByTestId('import-result')).toBeVisible();
+    await expect(page.getByText('Imported: 2 trades')).toBeVisible();
+    await expect(page.getByText('Positions created: 2')).toBeVisible();
+  });
+
+  test('non-CSV file shows client-side validation error', async ({ page }) => {
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+
+    await page.getByTestId('csv-file-input').setInputFiles({
+      name: 'nope.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('hello'),
+    });
+
+    await expect(page.getByTestId('csv-error')).toContainText('.csv');
+    await expect(page.getByTestId('preview-csv-btn')).toBeDisabled();
+  });
+
+  test('confirm posts to CSV endpoint, not API endpoint', async ({ page }) => {
+    const csvCalls = [];
+    const apiCalls = [];
+    await page.unroute('**/api/journal/import/csv');
+    await page.route('**/api/journal/import/csv', (route) => {
+      if (route.request().method() === 'POST') {
+        csvCalls.push(route.request().url());
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_CSV_IMPORT_RESULT),
+        });
+      }
+      return route.continue();
+    });
+    await page.route('**/api/journal/import', (route) => {
+      if (route.request().method() === 'POST') {
+        apiCalls.push(route.request().url());
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ imported: 0, skipped_duplicates: 0, positions_created: 0 }),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+    await page.getByTestId('csv-file-input').setInputFiles({
+      name: 'schwab-trades.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(SAMPLE_CSV, 'utf-8'),
+    });
+    await page.getByTestId('preview-csv-btn').click();
+    await expect(page.getByTestId('import-preview')).toBeVisible();
+    await page.getByTestId('confirm-import-btn').click();
+    await expect(page.getByTestId('import-result')).toBeVisible();
+
+    expect(csvCalls.length).toBe(1);
+    expect(apiCalls.length).toBe(0);
+  });
+});

--- a/frontend/hooks/useJournal.js
+++ b/frontend/hooks/useJournal.js
@@ -10,6 +10,8 @@ import {
   deleteTrade,
   previewSchwabImport,
   executeSchwabImport,
+  previewSchwabCsvImport,
+  executeSchwabCsvImport,
 } from '../api/client';
 
 export function useJournal() {
@@ -151,6 +153,38 @@ export function useJournal() {
     }
   }, [fetchPositions]);
 
+  const previewCsvImport = useCallback(async (file) => {
+    setImportLoading(true);
+    try {
+      const data = await previewSchwabCsvImport(file);
+      setImportPreview(data);
+      return data;
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      toast.error(detail || 'Failed to preview CSV import');
+      return null;
+    } finally {
+      setImportLoading(false);
+    }
+  }, []);
+
+  const confirmCsvImport = useCallback(async (file, positionStrategy = 'wheel') => {
+    setImportLoading(true);
+    try {
+      const result = await executeSchwabCsvImport(file, positionStrategy);
+      toast.success(`Imported ${result.imported} trades`);
+      setImportPreview(null);
+      await fetchPositions();
+      return result;
+    } catch (err) {
+      const detail = err?.response?.data?.detail;
+      toast.error(detail || 'Failed to import CSV trades');
+      return null;
+    } finally {
+      setImportLoading(false);
+    }
+  }, [fetchPositions]);
+
   const clearImportPreview = useCallback(() => {
     setImportPreview(null);
   }, []);
@@ -176,6 +210,8 @@ export function useJournal() {
     removeTrade,
     previewImport,
     confirmImport,
+    previewCsvImport,
+    confirmCsvImport,
     clearImportPreview,
   };
 }


### PR DESCRIPTION
## Summary

Closes #104.

Adds a parallel CSV-based import path so users can populate the journal with options trades that predate the Schwab developer-app creation date and are therefore unreachable via `/transactions`.

## Context

The Schwab `/transactions` API only returns transactions made after the developer-app creation date — historical trades are permanently inaccessible. This is also the practical workaround for the broader issue tracked in #125 (Schwab API returning empty arrays for confirmed-active accounts; reproduced independently with `schwab-py`). CSV import bypasses Schwab's API entirely, so it works regardless of what the support ticket eventually finds.

## Backend

- `POST /api/journal/import/csv/preview` and `POST /api/journal/import/csv` accept `multipart/form-data` with a `file` field and (for the import endpoint) `position_strategy` form value.
- New `parse_schwab_csv` in `app/services/schwab_csv.py` handles both:
  - Human-readable symbols: `F 03/27/2026 13.50 P`
  - Canonical OCC symbols: `AAPL  260315P00185000`
  Non-options rows (stocks, dividends, ACH) and rows with unrecognized Action / Symbol values are silently skipped — malformed rows never crash the parser.
- Validates file extension (`.csv` only) and 5 MB size cap before parsing; raw file bytes are never logged or persisted.
- Refactored `preview_import` / `execute_import` to delegate to new `build_preview` and `execute_mapped_import` helpers so the API path and CSV path share duplicate detection (`is_duplicate`) and position-creation logic.
- Errors return `HTTP 422` with a generic, user-safe `detail` — no `str(e)` leakage.
- Added `python-multipart==0.0.27` to `backend/requirements.txt` (FastAPI runtime dep for `UploadFile`; the parser itself uses only `csv` stdlib).

## Frontend

- `ImportModal.jsx` gains a "Schwab API" / "CSV Upload" mode toggle. CSV mode replaces the date-range inputs with a file picker that does client-side `.csv`-extension and 5 MB checks before upload. Preview table, duplicate badges, strategy selector, and confirm button are all reused — no fork.
- `useJournal` exposes `previewCsvImport` / `confirmCsvImport`. The CSV-aware confirm button posts to `/api/journal/import/csv` while the existing date-range path stays on `/api/journal/import`.

## Out of scope

- Non-Schwab CSV formats (TD Ameritrade, Fidelity, etc.)
- Batch upload of multiple files
- Editing individual rows before import
- Storing or re-downloading the uploaded CSV

## Tests

Backend pytest: **595 passed -> 626 passed** (+31 new in `test_schwab_csv_import.py`).
- Parser unit tests: happy path for all 5 trade types, multi-contract premium math, OCC + human symbol formats, BOM tolerance, dollar/comma formatting, malformed-symbol skip rules, empty-file handling.
- Endpoint integration tests: extension/size/empty validation, preview shape, default strategy, full import + duplicate detection on second upload, generic-error path verifying internal exception messages don't leak in `detail`.

Frontend Playwright: **11 import e2e -> 17 import e2e** (+6 new in `import-csv.spec.js`).
- Mode toggle visibility and bidirectional switching
- Preview button gated on file selection
- Full preview -> confirm round trip with mocked backend
- Client-side `.csv` validation
- Confirm posts to CSV endpoint, not API endpoint

## CodeRabbit watch

Will monitor for CodeRabbit AI inline review after open. If it hits a rate limit (we've seen this), I'll note it here and proceed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)