### PR TITLE
Fix position lifecycle: state machine, equity capture, share aggregation (closes #127)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: reconcile-positions test-backend test-frontend
+
+# Re-derive Position lifecycle state from each position's trade ledger.
+# Defaults to a dry-run; pass ARGS=--apply to commit changes.
+#
+#   make reconcile-positions
+#   make reconcile-positions ARGS=--apply
+reconcile-positions:
+	cd backend && python -m scripts.reconcile_positions $(ARGS)
+
+# Run the backend pytest suite (in-memory SQLite via conftest fixtures).
+test-backend:
+	cd backend && python -m pytest
+
+# Run the frontend Playwright e2e suite.
+test-frontend:
+	cd frontend && npx playwright test

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -61,7 +61,7 @@ class Trade(Base):
 
     id = Column(String, primary_key=True)  # UUID4
     position_id = Column(String, ForeignKey("positions.id"), nullable=False)
-    trade_type = Column(String, nullable=False)  # "sell_put" | "buy_put_close" | "assignment" | "sell_call" | "buy_call_close" | "called_away"
+    trade_type = Column(String, nullable=False)  # "sell_put" | "buy_put_close" | "assignment" | "sell_call" | "buy_call_close" | "called_away" | "expired"
     strike = Column(Float, nullable=False)
     expiration = Column(String, nullable=False)  # date string
     premium = Column(Float, nullable=False)  # per-share, positive for credits, negative for debits

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -293,7 +293,15 @@ class OptionScanResponse(BaseModel):
 
 STRATEGY_TYPES = Literal["csp", "cc", "wheel"]
 POSITION_STATUS = Literal["open", "closed"]
-TRADE_TYPES = Literal["sell_put", "buy_put_close", "assignment", "sell_call", "buy_call_close", "called_away"]
+TRADE_TYPES = Literal[
+    "sell_put",
+    "buy_put_close",
+    "assignment",
+    "sell_call",
+    "buy_call_close",
+    "called_away",
+    "expired",
+]
 CLOSE_REASONS = Literal["fifty_pct_target", "full_expiration", "rolled", "closed_early", "assigned", "called_away"]
 
 

--- a/backend/app/services/positions.py
+++ b/backend/app/services/positions.py
@@ -1,0 +1,269 @@
+"""Derive position lifecycle state from a position's trade ledger.
+
+The journal stores positions and the trades attached to them as an append-only
+ledger. ``status`` / ``shares`` / ``broker_cost_basis`` / ``closed_at`` on the
+``Position`` row are *derived* values: they are whatever the trade ledger says
+they should be. This module is the single source of truth for that derivation.
+
+The function :func:`recompute_position_state` is called from two places:
+
+* :mod:`app.services.schwab_import` after a Schwab import (CSV or API path)
+  inserts trades, so the touched positions are immediately consistent with the
+  ledger they just received.
+* :mod:`backend.scripts.reconcile_positions`, which lets a user re-derive every
+  position in their journal in case earlier imports (pre-fix) left stale state.
+
+The recomputer is **idempotent** — running it twice on the same ledger yields
+the same final state. That property is what makes the reconciliation script
+safe to re-run.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.database import Position, Trade
+
+logger = logging.getLogger(__name__)
+
+
+# Trade types that close out an existing option leg. Each consumes one open leg
+# of the matching (option_type, strike, expiration) when it appears.
+_OPTION_CLOSE_TYPES = {
+    "buy_put_close",
+    "buy_call_close",
+    "assignment",
+    "called_away",
+    "expired",
+}
+
+
+@dataclass(frozen=True)
+class _LegKey:
+    """Identifies an open option leg for matching against a closing trade."""
+
+    option_type: str  # "put" or "call"
+    strike: float
+    expiration: str
+
+
+def _option_type_for_open(trade_type: str) -> str | None:
+    """Return ``"put"`` / ``"call"`` for an opening trade, else ``None``."""
+    if trade_type == "sell_put":
+        return "put"
+    if trade_type == "sell_call":
+        return "call"
+    return None
+
+
+def _option_type_for_close(trade_type: str) -> str | None:
+    """Return the option side that this closing trade consumes, else ``None``.
+
+    ``assignment`` consumes a put leg (the put that was assigned). ``called_away``
+    consumes a call leg. ``expired`` is ambiguous on its own, but the matching
+    pass tries put-then-call so the worthless-expired side is cleared either way.
+    """
+    if trade_type == "buy_put_close" or trade_type == "assignment":
+        return "put"
+    if trade_type == "buy_call_close" or trade_type == "called_away":
+        return "call"
+    if trade_type == "expired":
+        return None  # try both sides
+    return None
+
+
+def _consume_leg(
+    open_legs: list[_LegKey],
+    option_type: str | None,
+    strike: float,
+    expiration: str,
+    ticker: str,
+    trade_type: str,
+) -> bool:
+    """Remove the first matching open leg from ``open_legs``.
+
+    Match is by (option_type, strike, expiration); when ``option_type`` is None
+    (``expired`` trade type — see :func:`_option_type_for_close`) either side
+    is accepted, put first. FIFO for ties.
+
+    Returns ``True`` if a leg was consumed, ``False`` if no match was found
+    (which we tolerate but log — see the partial-ledger discussion in the
+    module docstring).
+    """
+    candidates: list[str]
+    if option_type is None:
+        candidates = ["put", "call"]
+    else:
+        candidates = [option_type]
+
+    for candidate in candidates:
+        for idx, leg in enumerate(open_legs):
+            if (
+                leg.option_type == candidate
+                and leg.strike == strike
+                and leg.expiration == expiration
+            ):
+                del open_legs[idx]
+                return True
+
+    logger.warning(
+        "recompute_position_state: no matching open leg for %s on %s "
+        "(strike=%s, expiration=%s); ledger may be incomplete",
+        trade_type,
+        ticker,
+        strike,
+        expiration,
+    )
+    return False
+
+
+def recompute_position_state(
+    db: Session, position_id: str, commit: bool = True
+) -> Position | None:
+    """Walk a position's trade ledger and derive its lifecycle state.
+
+    Sorts trades by ``(opened_at, id)`` and replays them, tracking shares,
+    broker_cost_basis, and the list of currently-open option legs. At the end:
+
+    * ``status`` is ``"closed"`` if and only if shares == 0 and no open option
+      legs remain. ``closed_at`` is set to the ``opened_at`` of the last trade
+      that drove the position to a closed state (cleared again if it later
+      reopens within the same Position — though "reopen-after-close" creates a
+      new Position elsewhere, so this clearing path is mostly defensive).
+    * ``shares`` and ``broker_cost_basis`` are recomputed from scratch.
+
+    Per-trade-type semantics:
+
+    ====================  ============  ===================================  ============
+    trade_type            shares delta  basis delta                          legs delta
+    ====================  ============  ===================================  ============
+    sell_put              0             0                                    +1 put
+    sell_call             0             0                                    +1 call
+    buy_put_close         0             0                                    -1 put leg
+    buy_call_close        0             0                                    -1 call leg
+    assignment (PUT)      + qty*100     + strike * qty * 100                 -1 put leg
+    called_away (CALL)    - qty*100     - basis * (qty*100 / shares)         -1 call leg
+    expired               0             0                                    -1 leg (any)
+    ====================  ============  ===================================  ============
+
+    **Partial called-away basis rule:** if the user holds 200 shares and a
+    single call (100 shares' worth) is exercised, basis is reduced
+    *proportionally* (``basis * 100 / 200``); shares go to 100, position stays
+    open. This is simpler than tracking lot-FIFO and matches typical broker
+    journal display closely enough; the trade-off is documented in the module
+    docstring of the issue plan.
+
+    The function is idempotent: running it twice on the same trade ledger
+    yields the same Position state.
+
+    Args:
+        db: SQLAlchemy session bound to the journal database.
+        position_id: ID of the Position to recompute.
+        commit: If True (default), commit the derived state to the database.
+            Pass False from a dry-run / preview caller that wants to inspect
+            the result without persisting it.
+
+    Returns:
+        The refreshed Position ORM object, or None if no Position with that ID
+        exists. Never raises on per-trade ledger inconsistencies (orphan close,
+        missing leg) — those are logged as warnings so the recomputer keeps
+        running across the rest of the journal.
+    """
+    position = db.query(Position).filter(Position.id == position_id).first()
+    if position is None:
+        return None
+
+    trades: list[Trade] = sorted(
+        position.trades,
+        key=lambda t: (t.opened_at or "", t.id or ""),
+    )
+
+    shares = 0
+    basis = 0.0
+    open_legs: list[_LegKey] = []
+    last_close_at: str | None = None
+
+    for trade in trades:
+        ttype = trade.trade_type
+        qty = int(trade.quantity or 1)
+        contract_shares = qty * 100
+
+        # Opening a new option leg.
+        opening_side = _option_type_for_open(ttype)
+        if opening_side is not None:
+            for _ in range(qty):
+                open_legs.append(
+                    _LegKey(
+                        option_type=opening_side,
+                        strike=float(trade.strike),
+                        expiration=trade.expiration,
+                    )
+                )
+            continue
+
+        # Closing trade types: consume one matching open leg per contract.
+        if ttype in _OPTION_CLOSE_TYPES:
+            close_side = _option_type_for_close(ttype)
+            for _ in range(qty):
+                _consume_leg(
+                    open_legs,
+                    close_side,
+                    float(trade.strike),
+                    trade.expiration,
+                    position.ticker,
+                    ttype,
+                )
+
+            if ttype == "assignment":
+                # Put assigned: acquire shares at strike.
+                shares += contract_shares
+                basis += float(trade.strike) * contract_shares
+            elif ttype == "called_away":
+                # Call exercised: shares are removed at the option's strike;
+                # broker basis is reduced proportionally to the shares removed.
+                if shares > 0:
+                    removed = min(contract_shares, shares)
+                    if shares > 0 and basis != 0.0:
+                        basis = basis * (1 - removed / shares)
+                    shares -= removed
+                else:
+                    logger.warning(
+                        "recompute_position_state: called_away on %s with no "
+                        "shares held; treating as no-op",
+                        position.ticker,
+                    )
+
+            # If this trade brought the position to a fully-closed state,
+            # remember its opened_at as the close timestamp.
+            if shares == 0 and not open_legs:
+                last_close_at = trade.opened_at
+
+            continue
+
+        logger.warning(
+            "recompute_position_state: unknown trade_type %r on %s; ignoring",
+            ttype,
+            position.ticker,
+        )
+
+    # Apply the derived state to the Position row.
+    position.shares = shares
+    position.broker_cost_basis = round(basis, 4)
+    if shares == 0 and not open_legs:
+        position.status = "closed"
+        position.closed_at = last_close_at or position.closed_at
+    else:
+        position.status = "open"
+        position.closed_at = None
+
+    if commit:
+        try:
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+        db.refresh(position)
+    return position

--- a/backend/app/services/positions.py
+++ b/backend/app/services/positions.py
@@ -226,6 +226,15 @@ def recompute_position_state(
                 # broker basis is reduced proportionally to the shares removed.
                 if shares > 0:
                     removed = min(contract_shares, shares)
+                    if removed < contract_shares:
+                        logger.warning(
+                            "recompute_position_state: called_away on %s "
+                            "requested %d shares but only %d held; "
+                            "truncating removal (ledger may be incomplete)",
+                            position.ticker,
+                            contract_shares,
+                            shares,
+                        )
                     if shares > 0 and basis != 0.0:
                         basis = basis * (1 - removed / shares)
                     shares -= removed

--- a/backend/app/services/schwab_csv.py
+++ b/backend/app/services/schwab_csv.py
@@ -36,14 +36,26 @@ logger = logging.getLogger(__name__)
 # Map Schwab CSV "Action" column values to the (instruction, putCall) pair the
 # rest of the import pipeline uses. The putCall component is filled in from the
 # parsed Symbol; the keys below are case-insensitive and always trimmed.
+#
+# ``Expired`` is intentionally absent here — :func:`_map_csv_row` short-circuits
+# the literal action ``"expired"`` to ``trade_type="expired"`` regardless of
+# putCall. That fixes a Schwab CSV bug where an expired-worthless put would
+# otherwise be mapped to ``RECEIVE_DELIVER`` → ``assignment``, incorrectly
+# moving shares and broker basis on the position. See issue #127.
 _ACTION_TO_INSTRUCTION: dict[str, str] = {
     "sell to open": "SELL_TO_OPEN",
     "buy to close": "BUY_TO_CLOSE",
     "assigned": "RECEIVE_DELIVER",
-    "expired": "RECEIVE_DELIVER",
     # Schwab uses different phrasing for called-away exercises depending on
     # account type. Both map to RECEIVE_DELIVER on the call side.
     "exercised": "RECEIVE_DELIVER",
+}
+
+# CSV ``Action`` values that should bypass the (instruction, putCall) lookup
+# because their journal trade_type is determined by the Action alone, not by
+# the option side.
+_ACTION_DIRECT_TRADE_TYPE: dict[str, str] = {
+    "expired": "expired",
 }
 
 
@@ -122,10 +134,23 @@ def _decode_csv_bytes(file_bytes: bytes) -> str:
 
 
 def _map_csv_row(raw_row: dict, header_map: dict[str, str]) -> dict | None:
-    """Map a single CSV row dict to a journal trade dict, or None to skip."""
+    """Map a single CSV row dict to a journal trade dict, or None to skip.
+
+    Equity-leg rows that pair with an option assignment (e.g. ``Action="Buy"``
+    on the underlying ticker) are silently skipped because their Action does
+    not appear in :data:`_ACTION_TO_INSTRUCTION` / :data:`_ACTION_DIRECT_TRADE_TYPE`.
+    Broker cost basis is therefore derived from the option's strike at the
+    finalizer (see :mod:`app.services.positions`), not parsed from the equity
+    row.
+    """
     action_raw = (raw_row.get(header_map.get("action", ""), "") or "").strip().lower()
-    instruction = _ACTION_TO_INSTRUCTION.get(action_raw)
-    if instruction is None:
+
+    # Action values whose journal trade_type is determined by the Action alone
+    # (currently just "Expired"). These bypass the (instruction, putCall) lookup
+    # because, for example, an expired-worthless put must NOT map to assignment.
+    direct_trade_type = _ACTION_DIRECT_TRADE_TYPE.get(action_raw)
+    instruction = _ACTION_TO_INSTRUCTION.get(action_raw) if direct_trade_type is None else None
+    if direct_trade_type is None and instruction is None:
         return None
 
     symbol = (raw_row.get(header_map.get("symbol", ""), "") or "").strip()
@@ -134,7 +159,10 @@ def _map_csv_row(raw_row: dict, header_map: dict[str, str]) -> dict | None:
         return None
 
     ticker, expiration, strike, put_call = parsed
-    trade_type = _INSTRUCTION_MAP.get((instruction, put_call))
+    if direct_trade_type is not None:
+        trade_type: str | None = direct_trade_type
+    else:
+        trade_type = _INSTRUCTION_MAP.get((instruction, put_call))
     if trade_type is None:
         return None
 

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -6,14 +6,22 @@ import re
 from sqlalchemy.orm import Session
 
 from app.models.database import Position, Trade
-from app.models.schemas import TradeCreate
-from app.services.journal import create_trade, create_position
-from app.models.schemas import PositionCreate
+from app.models.schemas import PositionCreate, TradeCreate
+from app.services.journal import create_position, create_trade
+from app.services.positions import recompute_position_state
 from app.services.schwab_client import SchwabClient
 
 logger = logging.getLogger(__name__)
 
-# Schwab instruction + putCall → journal trade_type
+# Schwab instruction + putCall → journal trade_type.
+#
+# Note: the API path does **not** currently emit ``"expired"`` — Schwab's API
+# delivers expired-worthless options as a ``RECEIVE_DELIVER`` transaction with
+# ``netAmount == 0``, which we still surface as ``assignment`` / ``called_away``.
+# Distinguishing expired from assigned on the API path requires inspecting the
+# paired equity transferItem and is deferred to a follow-up issue. The CSV path
+# (see :mod:`app.services.schwab_csv`) uses the literal ``Action="Expired"`` and
+# already maps to ``"expired"`` for both puts and calls.
 _INSTRUCTION_MAP = {
     ("SELL_TO_OPEN", "PUT"): "sell_put",
     ("SELL_TO_OPEN", "CALL"): "sell_call",
@@ -176,13 +184,20 @@ def execute_mapped_import(
 ) -> dict:
     """Persist a list of pre-mapped trade dicts to the journal.
 
-    Reuses ``is_duplicate`` for skip detection and creates open positions on
-    demand for tickers without one. Shared between the Schwab API import path
-    and the CSV upload import path.
+    Inserts trades onto an existing open Position for the ticker, or creates a
+    new Position with neutral initial state (``shares=0``, ``broker_cost_basis=0``)
+    that the recomputer will overwrite. After all trades are inserted, the
+    finalizer calls :func:`app.services.positions.recompute_position_state` once
+    per touched ticker to derive ``status`` / ``shares`` / ``broker_cost_basis``
+    / ``closed_at`` from the trade ledger.
+
+    Shared between the Schwab API import path and the CSV upload import path.
     """
     imported = 0
     skipped = 0
     positions_created = 0
+    touched_position_ids: list[str] = []
+    seen_position_ids: set[str] = set()
 
     for mapped in mapped_trades:
         if is_duplicate(
@@ -199,12 +214,15 @@ def execute_mapped_import(
         position = (
             db.query(Position)
             .filter(Position.ticker == mapped["ticker"], Position.status == "open")
+            .order_by(Position.opened_at.desc())
             .first()
         )
         if position is None:
+            # Neutral initial state — the recomputer below overwrites these
+            # from the trade ledger once the batch finishes inserting.
             pos_data = PositionCreate(
                 ticker=mapped["ticker"],
-                shares=100,
+                shares=1,  # ge=1 schema constraint; real value comes from recomputer
                 broker_cost_basis=0.0,
                 strategy=position_strategy,
                 opened_at=mapped["opened_at"],
@@ -225,6 +243,18 @@ def execute_mapped_import(
         )
         create_trade(db, trade_data)
         imported += 1
+
+        if position.id not in seen_position_ids:
+            seen_position_ids.add(position.id)
+            touched_position_ids.append(position.id)
+
+    # Finalizer: recompute lifecycle state for every touched position so the
+    # journal reflects the trade ledger we just appended (closed cycles flip
+    # to status="closed", assignments set broker_cost_basis = strike * shares,
+    # double assignments aggregate share counts, etc.). See
+    # :mod:`app.services.positions` for the full state machine.
+    for pos_id in touched_position_ids:
+        recompute_position_state(db, pos_id)
 
     return {
         "imported": imported,

--- a/backend/scripts/reconcile_positions.py
+++ b/backend/scripts/reconcile_positions.py
@@ -1,0 +1,169 @@
+"""One-shot reconciliation tool: re-derive every Position's lifecycle state.
+
+Walks the entire ``positions`` table and runs
+:func:`app.services.positions.recompute_position_state` against each row, then
+prints a per-ticker before/after diff. Provides a fix path for journals that
+were imported before issue #127 was fixed (every imported position stuck at
+``status="open"``, ``shares=100``, ``broker_cost_basis=0.0``).
+
+Usage::
+
+    python -m scripts.reconcile_positions               # dry run (default)
+    python -m scripts.reconcile_positions --apply       # commit changes
+    make reconcile-positions ARGS=--apply               # via Makefile
+
+The script is **opt-in** — it is never invoked automatically. Running it with
+``--apply`` rewrites the ``status`` / ``shares`` / ``broker_cost_basis`` /
+``closed_at`` columns of every Position; review the dry-run diff first.
+
+Exit codes:
+    0  success (or dry-run completed)
+    1  one or more positions raised during recomputation; details logged
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.database import Position, SessionLocal
+from app.services.positions import recompute_position_state
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Snapshot:
+    """Capture of a Position's derived state at a point in time."""
+
+    status: str
+    shares: int
+    broker_cost_basis: float
+    closed_at: str | None
+
+
+def _snapshot(position: Position) -> _Snapshot:
+    """Capture the derived columns of a Position into a comparable record."""
+    return _Snapshot(
+        status=position.status,
+        shares=int(position.shares or 0),
+        broker_cost_basis=float(position.broker_cost_basis or 0.0),
+        closed_at=position.closed_at,
+    )
+
+
+def _format_diff(ticker: str, before: _Snapshot, after: _Snapshot) -> str | None:
+    """Return a one-line diff string, or None if the snapshots are equal."""
+    if before == after:
+        return None
+    parts: list[str] = []
+    if before.status != after.status:
+        parts.append(f"status {before.status} -> {after.status}")
+    if before.shares != after.shares:
+        parts.append(f"shares {before.shares} -> {after.shares}")
+    if before.broker_cost_basis != after.broker_cost_basis:
+        parts.append(
+            f"basis ${before.broker_cost_basis:.2f} -> ${after.broker_cost_basis:.2f}"
+        )
+    if before.closed_at != after.closed_at:
+        parts.append(f"closed_at {before.closed_at!r} -> {after.closed_at!r}")
+    return f"  {ticker:<8} {', '.join(parts)}"
+
+
+def reconcile_all(db: Session, apply: bool) -> tuple[int, int, int]:
+    """Recompute every Position and report changes.
+
+    Args:
+        db: SQLAlchemy session bound to the journal database.
+        apply: If True, commit all changes. If False, roll back at the end so
+            the database is untouched.
+
+    Returns:
+        ``(total, changed, errors)`` — count of positions walked, count whose
+        derived state differed from before, and count that raised during
+        recomputation.
+    """
+    positions = db.query(Position).all()
+    total = len(positions)
+    changed = 0
+    errors = 0
+
+    print(f"Reconciling {total} positions{' (DRY RUN)' if not apply else ''}...")
+
+    for position in positions:
+        ticker = position.ticker
+        before = _snapshot(position)
+        try:
+            recompute_position_state(db, position.id, commit=apply)
+        except Exception:
+            errors += 1
+            logger.exception(
+                "Failed to recompute position %s (%s)", position.id, ticker
+            )
+            continue
+        # In dry-run mode the recomputer left the changes uncommitted on the
+        # ORM object; we can read them directly. In apply mode it already
+        # refreshed the row.
+        after = _snapshot(position)
+        diff = _format_diff(ticker, before, after)
+        if diff is not None:
+            changed += 1
+            print(diff)
+
+    if apply:
+        print(f"\n{total} positions, {changed} changed, {errors} errors. Applied.")
+    else:
+        # Discard all uncommitted in-memory mutations so the database is
+        # untouched. Each recompute call set position.shares / .status / ...
+        # without committing — rollback drops them.
+        db.rollback()
+        print(
+            f"\n{total} positions, {changed} would change, {errors} errors.\n"
+            "Re-run with --apply to commit."
+        )
+    return total, changed, errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-derive Position lifecycle state (status / shares / "
+            "broker_cost_basis / closed_at) from the trade ledger."
+        )
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--apply",
+        action="store_true",
+        help="Commit changes. Without this flag, the script runs in dry-run mode.",
+    )
+    group.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Default. Print diff without committing.",
+    )
+    args = parser.parse_args(argv)
+
+    apply = bool(args.apply)
+
+    logging.basicConfig(
+        level=logging.WARNING,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    db = SessionLocal()
+    try:
+        _total, _changed, errors = reconcile_all(db, apply=apply)
+    finally:
+        db.close()
+    return 0 if errors == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -341,6 +341,52 @@ class TestLifecycleScenarios:
         assert result.shares == 0
         assert result.closed_at is None
 
+    def test_covered_call_expires_keeps_shares(self, db_session):
+        # Wheel mid-cycle: assigned 100 shares from a put, then sold a covered
+        # call that expired worthless. Position must stay open with shares and
+        # basis intact — closing this would silently delete shares the trader
+        # still holds.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+                # Now 100 shares held at $1350 basis.
+                {
+                    "trade_type": "sell_call",
+                    "strike": 15.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-01",
+                },
+                {
+                    "trade_type": "expired",
+                    "strike": 15.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        # Covered call expired worthless → shares and basis unchanged from
+        # post-assignment state, position stays open, no closed_at stamp.
+        assert result.status == "open"
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(1350.0)
+        assert result.closed_at is None
+
     def test_partial_called_away_keeps_position_open(self, db_session):
         # 200 shares held (two assignments at $20), 1 call exercised at $22.
         # Expectation: 100 shares remain, basis halved, status stays open.

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -1,0 +1,551 @@
+"""Unit tests for ``app.services.positions.recompute_position_state``.
+
+Each test seeds a Position with a hand-crafted Trade ledger, calls the
+recomputer, and asserts the derived state matches the truth table in the
+module docstring. The tests bypass the import pipeline entirely so a regression
+in the recomputer is caught in isolation from the Schwab parsing/mapping code.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import Base, Position, Trade
+from app.services.positions import recompute_position_state
+
+
+# --- Fixtures ----------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_session():
+    """In-memory SQLite session for isolated recomputer tests."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _make_trade(
+    position_id: str,
+    *,
+    trade_type: str,
+    strike: float,
+    expiration: str,
+    opened_at: str,
+    quantity: int = 1,
+    premium: float = 0.0,
+    fees: float = 0.0,
+) -> Trade:
+    """Build a Trade ORM row with sensible defaults for the recomputer tests."""
+    return Trade(
+        id=str(uuid.uuid4()),
+        position_id=position_id,
+        trade_type=trade_type,
+        strike=strike,
+        expiration=expiration,
+        premium=premium,
+        fees=fees,
+        quantity=quantity,
+        opened_at=opened_at,
+    )
+
+
+def _seed_position(
+    db,
+    *,
+    ticker: str,
+    trades: Iterable[dict],
+    initial_shares: int = 1,
+    initial_basis: float = 0.0,
+    status: str = "open",
+) -> Position:
+    """Create a Position + Trade ledger from a compact dict spec."""
+    position = Position(
+        id=str(uuid.uuid4()),
+        ticker=ticker,
+        shares=initial_shares,
+        broker_cost_basis=initial_basis,
+        status=status,
+        strategy="wheel",
+        opened_at="2026-01-01T00:00:00Z",
+    )
+    db.add(position)
+    db.flush()
+    for spec in trades:
+        db.add(_make_trade(position.id, **spec))
+    db.commit()
+    db.refresh(position)
+    return position
+
+
+# --- Per-trade-type semantics ------------------------------------------------
+
+
+class TestSingleTrades:
+    """Recomputer applied to ledgers with a single trade type."""
+
+    def test_sell_put_only_stays_open_zero_shares(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                }
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result is not None
+        assert result.status == "open"
+        assert result.shares == 0
+        assert result.broker_cost_basis == 0.0
+        assert result.closed_at is None
+
+    def test_sell_call_only_stays_open(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="AAPL",
+            trades=[
+                {
+                    "trade_type": "sell_call",
+                    "strike": 200.0,
+                    "expiration": "2026-04-18",
+                    "opened_at": "2026-03-01",
+                }
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 0
+
+
+# --- Lifecycle scenarios -----------------------------------------------------
+
+
+class TestLifecycleScenarios:
+    """End-to-end cycles a wheel trader actually walks through."""
+
+    def test_sell_put_then_buy_to_close_closes_position(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "buy_put_close",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-05",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "closed"
+        assert result.shares == 0
+        assert result.broker_cost_basis == 0.0
+        assert result.closed_at == "2026-03-05"
+
+    def test_sell_put_then_assignment_acquires_shares(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 100
+        assert result.broker_cost_basis == 1350.0
+
+    def test_full_wheel_cycle_called_away(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-02-25",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "closed"
+        assert result.shares == 0
+        assert result.broker_cost_basis == 0.0
+        assert result.closed_at == "2026-03-20"
+
+    def test_sell_put_then_expired_closes_position(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="HPE",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 18.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-03-15",
+                },
+                {
+                    "trade_type": "expired",
+                    "strike": 18.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "closed"
+        assert result.shares == 0
+        assert result.broker_cost_basis == 0.0
+        assert result.closed_at == "2026-04-17"
+
+    def test_double_assignment_aggregates_shares_and_basis(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="SOFI",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 28.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 28.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 30.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 30.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 200
+        assert result.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
+
+    def test_two_open_legs_one_closed_position_stays_open(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="AAPL",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 200.0,
+                    "expiration": "2026-04-18",
+                    "opened_at": "2026-03-15",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 195.0,
+                    "expiration": "2026-04-18",
+                    "opened_at": "2026-03-16",
+                },
+                {
+                    "trade_type": "buy_put_close",
+                    "strike": 200.0,
+                    "expiration": "2026-04-18",
+                    "opened_at": "2026-03-17",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 0
+        assert result.closed_at is None
+
+    def test_partial_called_away_keeps_position_open(self, db_session):
+        # 200 shares held (two assignments at $20), 1 call exercised at $22.
+        # Expectation: 100 shares remain, basis halved, status stays open.
+        pos = _seed_position(
+            db_session,
+            ticker="DVN",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+                # Now 200 shares, basis $4000.
+                {
+                    "trade_type": "sell_call",
+                    "strike": 22.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-03-25",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 22.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 100
+        # Basis was $4000 across 200 shares; removing 100 shares proportionally
+        # halves the basis to $2000.
+        assert result.broker_cost_basis == pytest.approx(2000.0)
+
+
+# --- Edge cases --------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Defensive behavior when the trade ledger is unusual or partially valid."""
+
+    def test_returns_none_for_unknown_position_id(self, db_session):
+        assert recompute_position_state(db_session, "nonexistent-id") is None
+
+    def test_orphan_buy_to_close_does_not_raise(self, db_session, caplog):
+        # Closing trade with no matching open leg; recomputer must not raise.
+        pos = _seed_position(
+            db_session,
+            ticker="ZZZ",
+            trades=[
+                {
+                    "trade_type": "buy_put_close",
+                    "strike": 50.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-01",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        # No shares, no open legs → closed.
+        assert result.status == "closed"
+        assert result.shares == 0
+        # Warning should have been logged.
+        assert any(
+            "no matching open leg" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_idempotent_two_runs_same_state(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        first = recompute_position_state(db_session, pos.id)
+        snapshot = (first.status, first.shares, first.broker_cost_basis, first.closed_at)
+        second = recompute_position_state(db_session, pos.id)
+        assert (second.status, second.shares, second.broker_cost_basis, second.closed_at) == snapshot
+
+    def test_out_of_order_trades_sorted_by_opened_at(self, db_session):
+        # Insert assignment first (chronologically later), then sell_put.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        # Even with reversed insert order, chronological replay yields the
+        # same final state as the in-order ledger.
+        assert result.status == "open"
+        assert result.shares == 100
+        assert result.broker_cost_basis == 1350.0
+
+    def test_dry_run_does_not_commit(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            initial_shares=999,
+            initial_basis=12345.67,
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+        original_id = pos.id
+
+        # commit=False: in-memory mutations only.
+        result = recompute_position_state(db_session, original_id, commit=False)
+        assert result.shares == 100
+        assert result.broker_cost_basis == 1350.0
+
+        # Roll back to discard the uncommitted mutations.
+        db_session.rollback()
+        reloaded = db_session.query(Position).filter(Position.id == original_id).first()
+        assert reloaded.shares == 999
+        assert reloaded.broker_cost_basis == 12345.67
+
+    def test_quantity_two_assignment_acquires_two_lots(self, db_session):
+        # A single assignment row with quantity=2 should acquire 200 shares
+        # at strike, and consume 2 open put legs at the same strike/expiration.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                    "quantity": 2,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                    "quantity": 2,
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 200
+        assert result.broker_cost_basis == pytest.approx(2700.0)

--- a/backend/tests/test_reconcile_positions.py
+++ b/backend/tests/test_reconcile_positions.py
@@ -1,0 +1,264 @@
+"""Tests for the ``reconcile_positions`` CLI script.
+
+The script is the user-visible fix path for journals imported before issue
+#127 was patched (every position stuck at ``shares=100`` / ``basis=0`` /
+``status="open"``). These tests exercise both ``--dry-run`` and ``--apply``
+modes through the function-level entry point so we don't shell out.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import Base, Position, Trade
+from scripts.reconcile_positions import main, reconcile_all
+
+
+@pytest.fixture()
+def db_session():
+    """In-memory SQLite session shared by reconcile + caller."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _seed_ghost_open_position(
+    db,
+    ticker: str,
+    *,
+    bad_shares: int = 100,
+    bad_basis: float = 0.0,
+    trades: list[dict],
+) -> Position:
+    """Seed a Position with intentionally wrong derived state + a trade ledger.
+
+    Mirrors the bug repro from issue #127 — pre-fix imports left
+    ``shares=100`` and ``broker_cost_basis=0.0`` even when the trade ledger
+    showed something different.
+    """
+    position = Position(
+        id=str(uuid.uuid4()),
+        ticker=ticker,
+        shares=bad_shares,
+        broker_cost_basis=bad_basis,
+        status="open",
+        strategy="wheel",
+        opened_at="2026-01-01T00:00:00Z",
+    )
+    db.add(position)
+    db.flush()
+    for spec in trades:
+        db.add(
+            Trade(
+                id=str(uuid.uuid4()),
+                position_id=position.id,
+                premium=0.0,
+                fees=0.0,
+                quantity=spec.get("quantity", 1),
+                **{k: v for k, v in spec.items() if k != "quantity"},
+            )
+        )
+    db.commit()
+    db.refresh(position)
+    return position
+
+
+class TestReconcileAll:
+    def test_dry_run_makes_no_writes(self, db_session, capsys):
+        pos = _seed_ghost_open_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+            ],
+        )
+        original_id = pos.id
+
+        total, changed, errors = reconcile_all(db_session, apply=False)
+
+        assert total == 1
+        assert changed == 1
+        assert errors == 0
+
+        # Re-query to confirm DB was not written.
+        db_session.expire_all()
+        reloaded = db_session.query(Position).filter(Position.id == original_id).first()
+        assert reloaded.status == "open"  # unchanged from the bad seed
+        assert reloaded.shares == 100  # unchanged
+
+        captured = capsys.readouterr()
+        assert "DRY RUN" in captured.out
+        assert "MARA" in captured.out
+
+    def test_apply_corrects_ghost_open_positions(self, db_session, capsys):
+        # Bad state: shares=100, status=open. Real ledger: full cycle ending
+        # in called_away → should be closed with 0 shares.
+        pos = _seed_ghost_open_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-02-25",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+        original_id = pos.id
+
+        total, changed, errors = reconcile_all(db_session, apply=True)
+
+        assert total == 1
+        assert changed == 1
+        assert errors == 0
+
+        db_session.expire_all()
+        reloaded = db_session.query(Position).filter(Position.id == original_id).first()
+        assert reloaded.status == "closed"
+        assert reloaded.shares == 0
+        assert reloaded.closed_at == "2026-03-20"
+
+        captured = capsys.readouterr()
+        assert "Applied" in captured.out
+
+    def test_apply_aggregates_double_assignment(self, db_session):
+        # Bad state: shares=100. Real ledger: two assignments → 200 shares.
+        pos = _seed_ghost_open_position(
+            db_session,
+            ticker="SOFI",
+            bad_shares=100,
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 28.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 28.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 30.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 30.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+        original_id = pos.id
+
+        reconcile_all(db_session, apply=True)
+
+        db_session.expire_all()
+        reloaded = db_session.query(Position).filter(Position.id == original_id).first()
+        assert reloaded.shares == 200
+        assert reloaded.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
+
+    def test_no_changes_when_state_already_correct(self, db_session, capsys):
+        # Seed with correct state for a simple sell_put leg: 0 shares, open.
+        _seed_ghost_open_position(
+            db_session,
+            ticker="F",
+            bad_shares=0,
+            bad_basis=0.0,
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+            ],
+        )
+
+        total, changed, errors = reconcile_all(db_session, apply=True)
+
+        assert total == 1
+        assert changed == 0
+        assert errors == 0
+
+
+class TestMainCli:
+    """Argparse-driven entry point for the script (``python -m scripts...``)."""
+
+    def test_main_dry_run_default(self, db_session):
+        # Patch SessionLocal so the CLI uses the test engine.
+        with patch(
+            "scripts.reconcile_positions.SessionLocal",
+            return_value=db_session,
+        ):
+            # SessionLocal() is called inside main(); patching the class so
+            # main()'s `SessionLocal()` call returns our pre-built session.
+            with patch.object(db_session, "close"):
+                exit_code = main([])
+
+        assert exit_code == 0
+
+    def test_main_apply_returns_zero_with_no_errors(self, db_session):
+        with patch(
+            "scripts.reconcile_positions.SessionLocal",
+            return_value=db_session,
+        ):
+            with patch.object(db_session, "close"):
+                exit_code = main(["--apply"])
+
+        assert exit_code == 0

--- a/backend/tests/test_schwab_csv_import.py
+++ b/backend/tests/test_schwab_csv_import.py
@@ -101,10 +101,33 @@ class TestParseSchwabCsv:
         assert len(result) == 1
         assert result[0]["trade_type"] == "assignment"
 
-    def test_expired_call_maps_to_called_away(self):
+    def test_expired_call_maps_to_expired(self):
+        """An expired call must map to ``trade_type="expired"``, not ``called_away``.
+
+        Pre-#127, ``Action="Expired"`` was conflated with ``Assigned`` /
+        ``Exercised`` and incorrectly moved shares + broker basis on the
+        position. The recomputer treats ``expired`` as a leg-only close: no
+        share movement, no basis change.
+        """
         result = parse_schwab_csv(_csv([EXPIRED_CALL_ROW]))
         assert len(result) == 1
-        assert result[0]["trade_type"] == "called_away"
+        assert result[0]["trade_type"] == "expired"
+
+    def test_expired_put_maps_to_expired(self):
+        """An expired put also maps to ``trade_type="expired"`` — not ``assignment``.
+
+        This is the real-world repro from issue #127 (HPE / INTC / VZ on
+        Schwab ****885): pre-fix, expired-worthless puts were silently
+        recorded as assignments and moved nonexistent shares onto the position.
+        """
+        expired_put_row = (
+            '03/20/2026,Expired,SOFI 03/20/2026 28.00 P,'
+            'PUT SOFI EXPIRATION,1,,0.00,0.00'
+        )
+        result = parse_schwab_csv(_csv([expired_put_row]))
+        assert len(result) == 1
+        assert result[0]["trade_type"] == "expired"
+        assert result[0]["ticker"] == "SOFI"
 
     def test_occ_format_symbol_parses(self):
         result = parse_schwab_csv(_csv([OCC_SELL_PUT_ROW]))
@@ -130,10 +153,12 @@ class TestParseSchwabCsv:
         # Five options rows survive; three non-options skipped silently.
         assert len(result) == 5
         trade_types = sorted(r["trade_type"] for r in result)
+        # "Expired" now maps to its own trade_type (issue #127); previously
+        # an expired call was conflated with called_away.
         assert trade_types == [
             "assignment",
             "buy_put_close",
-            "called_away",
+            "expired",
             "sell_call",
             "sell_put",
         ]

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -12,6 +12,7 @@ from app.services.schwab_import import (
     map_schwab_transaction,
     is_duplicate,
     _extract_fees,
+    execute_mapped_import,
     preview_import,
 )
 
@@ -240,3 +241,187 @@ class TestPreviewImportReceiveAndDeliver:
         assert result["total"] == 2
         assert result["new_count"] == 2
         assert result["account_number"] == "****5678"
+
+
+# --- Position lifecycle integration (issue #127 acceptance criteria) --------
+
+
+def _mapped(
+    ticker: str,
+    trade_type: str,
+    strike: float,
+    expiration: str,
+    opened_at: str,
+    *,
+    quantity: int = 1,
+    premium: float = 0.0,
+    fees: float = 0.0,
+) -> dict:
+    """Build the dict shape that ``execute_mapped_import`` consumes.
+
+    Mirrors the output of :func:`map_schwab_transaction` /
+    :func:`app.services.schwab_csv.parse_schwab_csv` so these integration
+    tests don't need to round-trip through the parsers.
+    """
+    return {
+        "ticker": ticker,
+        "trade_type": trade_type,
+        "strike": strike,
+        "expiration": expiration,
+        "premium": premium,
+        "fees": fees,
+        "quantity": quantity,
+        "opened_at": opened_at,
+    }
+
+
+class TestPositionLifecycleOnImport:
+    """End-to-end coverage of issue #127's four acceptance criteria.
+
+    Each test drives ``execute_mapped_import`` with a crafted mapped-trade
+    list (no Schwab parsing involved) and asserts the resulting Position has
+    the expected lifecycle state. The recomputer is invoked as part of the
+    import finalizer.
+    """
+
+    def test_ac1_called_away_closes_position(self, db_session):
+        """AC #1: full wheel cycle ending in called_away → status=closed."""
+        mapped = [
+            _mapped("MARA", "sell_put", 20.0, "2026-02-20", "2026-02-01"),
+            _mapped("MARA", "assignment", 20.0, "2026-02-20", "2026-02-20"),
+            _mapped("MARA", "sell_call", 22.0, "2026-03-20", "2026-02-25"),
+            _mapped("MARA", "called_away", 22.0, "2026-03-20", "2026-03-20"),
+        ]
+
+        result = execute_mapped_import(db_session, mapped)
+
+        assert result["imported"] == 4
+        assert result["positions_created"] == 1
+        position = db_session.query(Position).filter(Position.ticker == "MARA").first()
+        assert position is not None
+        assert position.status == "closed"
+        assert position.shares == 0
+        assert position.closed_at == "2026-03-20"
+
+    def test_ac1_expired_closes_position(self, db_session):
+        """AC #1: sell_put → expired → status=closed (no shares acquired)."""
+        mapped = [
+            _mapped("HPE", "sell_put", 18.0, "2026-04-17", "2026-03-15"),
+            _mapped("HPE", "expired", 18.0, "2026-04-17", "2026-04-17"),
+        ]
+
+        result = execute_mapped_import(db_session, mapped)
+        assert result["imported"] == 2
+
+        position = db_session.query(Position).filter(Position.ticker == "HPE").first()
+        assert position.status == "closed"
+        assert position.shares == 0
+        assert position.broker_cost_basis == 0.0
+        assert position.closed_at == "2026-04-17"
+
+    def test_ac2_assignment_sets_broker_cost_basis(self, db_session):
+        """AC #2: after assignment, broker_cost_basis = strike * shares."""
+        mapped = [
+            _mapped("F", "sell_put", 13.50, "2026-03-27", "2026-03-01"),
+            _mapped("F", "assignment", 13.50, "2026-03-27", "2026-03-27"),
+        ]
+
+        execute_mapped_import(db_session, mapped)
+
+        position = db_session.query(Position).filter(Position.ticker == "F").first()
+        assert position.status == "open"
+        assert position.shares == 100
+        assert position.broker_cost_basis == pytest.approx(13.50 * 100)
+
+    def test_ac3_double_assignment_aggregates_shares_and_basis(self, db_session):
+        """AC #3: a second assignment increments shares (no silent no-op)."""
+        mapped = [
+            _mapped("SOFI", "sell_put", 28.0, "2026-02-20", "2026-02-01"),
+            _mapped("SOFI", "assignment", 28.0, "2026-02-20", "2026-02-20"),
+            _mapped("SOFI", "sell_put", 30.0, "2026-03-20", "2026-03-01"),
+            _mapped("SOFI", "assignment", 30.0, "2026-03-20", "2026-03-20"),
+        ]
+
+        execute_mapped_import(db_session, mapped)
+
+        position = db_session.query(Position).filter(Position.ticker == "SOFI").first()
+        assert position is not None
+        assert position.status == "open"
+        assert position.shares == 200
+        assert position.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
+
+    def test_ac4_buy_to_close_closes_position(self, db_session):
+        """AC #4: sell_put → buy_to_close (no reopen) → status=closed."""
+        mapped = [
+            _mapped("INTC", "sell_put", 25.0, "2026-04-17", "2026-03-15"),
+            _mapped("INTC", "buy_put_close", 25.0, "2026-04-17", "2026-03-25"),
+        ]
+
+        execute_mapped_import(db_session, mapped)
+
+        position = db_session.query(Position).filter(Position.ticker == "INTC").first()
+        assert position.status == "closed"
+        assert position.shares == 0
+        assert position.closed_at == "2026-03-25"
+
+    def test_reopen_after_close_creates_new_position(self, db_session):
+        """A new sell_put on a previously-closed ticker creates a new Position.
+
+        The closed cycle's history (trades, dates, P&L) must remain immutable.
+        """
+        first_cycle = [
+            _mapped("F", "sell_put", 13.50, "2026-03-27", "2026-03-01"),
+            _mapped("F", "buy_put_close", 13.50, "2026-03-27", "2026-03-05"),
+        ]
+        execute_mapped_import(db_session, first_cycle)
+
+        second_cycle = [
+            _mapped("F", "sell_put", 13.50, "2026-04-17", "2026-04-01"),
+        ]
+        execute_mapped_import(db_session, second_cycle)
+
+        positions = (
+            db_session.query(Position)
+            .filter(Position.ticker == "F")
+            .order_by(Position.opened_at.asc())
+            .all()
+        )
+        assert len(positions) == 2
+        assert positions[0].status == "closed"
+        assert positions[1].status == "open"
+
+    def test_ghost_open_positions_no_longer_appear_after_called_away(self, db_session):
+        """Regression for the real-world repro in issue #127 (Schwab ****885).
+
+        Tickers MARA / HPE / INTC whose full cycles end in called_away or
+        expired must NOT appear in ``status=open`` queries, and only F (still
+        open with 100 shares from assignment) should remain.
+        """
+        mapped = [
+            # F: assigned, still open with 100 shares.
+            _mapped("F", "sell_put", 13.50, "2026-03-27", "2026-03-01"),
+            _mapped("F", "assignment", 13.50, "2026-03-27", "2026-03-27"),
+            # MARA: full wheel cycle ending in called_away.
+            _mapped("MARA", "sell_put", 20.0, "2026-02-20", "2026-02-01"),
+            _mapped("MARA", "assignment", 20.0, "2026-02-20", "2026-02-20"),
+            _mapped("MARA", "sell_call", 22.0, "2026-03-20", "2026-02-25"),
+            _mapped("MARA", "called_away", 22.0, "2026-03-20", "2026-03-20"),
+            # HPE: expired worthless.
+            _mapped("HPE", "sell_put", 18.0, "2026-04-17", "2026-03-15"),
+            _mapped("HPE", "expired", 18.0, "2026-04-17", "2026-04-17"),
+            # INTC: closed via buy-to-close.
+            _mapped("INTC", "sell_put", 25.0, "2026-04-17", "2026-03-15"),
+            _mapped("INTC", "buy_put_close", 25.0, "2026-04-17", "2026-03-25"),
+        ]
+
+        execute_mapped_import(db_session, mapped)
+
+        open_positions = (
+            db_session.query(Position).filter(Position.status == "open").all()
+        )
+        open_tickers = {p.ticker for p in open_positions}
+        assert open_tickers == {"F"}
+
+        f_position = next(p for p in open_positions if p.ticker == "F")
+        assert f_position.shares == 100
+        assert f_position.broker_cost_basis == pytest.approx(1350.0)


### PR DESCRIPTION
Closes #127

## Summary

Position state (`status` / `shares` / `broker_cost_basis` / `closed_at`) is now derived from the trade ledger by a new `recompute_position_state()` function called once per touched ticker at the end of every Schwab import (CSV or API). A `make reconcile-positions` script applies the same logic to fix journals that were imported before this lands.

Pre-fix, `import_mapped_trades()` never closed positions, hard-coded `shares=100` and `broker_cost_basis=0.0`, and silently no-oped on a second assignment for the same ticker — every imported journal was misleading.

## Acceptance criteria

- [x] After importing a wheel cycle ending in `called_away` or `expired`, the position is `status="closed"` and does not appear in `GET /api/journal/positions?status=open`.
- [x] After importing an `assignment` event, `broker_cost_basis = strike × shares` (strike-derived; equity-leg parsing deferred — see decision matrix in plan).
- [x] A second assignment on the same ticker increments `shares` and updates `broker_cost_basis` (no silent no-op).
- [x] A `buy_to_close` without a subsequent `sell_to_open` flips the position to `status="closed"`.
- [x] One-shot reconciliation script (`make reconcile-positions`, defaults to `--dry-run`, `--apply` to commit).
- [x] Backend tests cover full wheel cycle, CSP-closed-without-assignment, expired-worthless, and double-assignment.

## What changed

- **New module:** `backend/app/services/positions.py` — `recompute_position_state(db, position_id)` is the single source of truth for deriving Position state from a Trade ledger. Idempotent; tolerates orphan close trades by logging a warning.
- **New trade type `expired`** — distinct from `assignment` / `called_away`. CSV `Action="Expired"` now maps to it, fixing the bug where expired-worthless puts were silently recorded as assignments.
- **API-path `expired` detection deferred** to a follow-up — the API doesn't carry the disambiguator that the CSV's `Action` column provides. Documented in code comment in `schwab_import.py`.
- **New script:** `backend/scripts/reconcile_positions.py` with a `Makefile` target (`make reconcile-positions`, `make reconcile-positions ARGS=--apply`). Opt-in only — never auto-runs.
- **Partial `called_away` rule:** basis is reduced proportionally to the shares removed; position stays open if shares remain.
- **Close-then-reopen** creates a new Position (preserving cycle history) rather than reopening the closed one.

## Files

| File | Change |
|------|--------|
| `backend/app/services/positions.py` | NEW — recomputer module |
| `backend/scripts/reconcile_positions.py` | NEW — CLI |
| `backend/scripts/__init__.py` | NEW — package marker |
| `Makefile` | NEW — `reconcile-positions`, `test-backend`, `test-frontend` |
| `backend/app/services/schwab_import.py` | Wire recomputer into `execute_mapped_import` finalizer; remove hard-coded shares=100 / basis=0.0 |
| `backend/app/services/schwab_csv.py` | Map `Action="Expired"` directly to `trade_type="expired"` regardless of put/call |
| `backend/app/models/schemas.py` | Add `"expired"` to `TRADE_TYPES` literal |
| `backend/app/models/database.py` | Update `Trade.trade_type` comment |
| `backend/tests/test_position_state.py` | NEW — 15 unit tests over recomputer |
| `backend/tests/test_reconcile_positions.py` | NEW — 6 tests covering dry-run / apply |
| `backend/tests/test_schwab_import.py` | +7 lifecycle integration tests |
| `backend/tests/test_schwab_csv_import.py` | +1 test for expired-put; updated expired-call expectation |

## Test plan

- [x] `cd backend && python -m pytest` — **655 passed, 7 skipped**
- [x] Recomputer unit tests: `tests/test_position_state.py` (15 passed)
- [x] Lifecycle integration tests: `tests/test_schwab_import.py` (23 passed, 7 new)
- [x] Reconcile script tests: `tests/test_reconcile_positions.py` (6 passed)
- [x] CSV import tests still green: `tests/test_schwab_csv_import.py` (32 passed)
- [ ] Manual smoke test: run `make reconcile-positions` against the user's Schwab ****885 journal, verify F=$1320.66 / SOFI 300 sh / 6 ghost positions closed

## Migration note for existing users

If you imported a Schwab CSV before this lands, your journal has the bug. After upgrading:

```bash
make reconcile-positions          # see what would change
make reconcile-positions ARGS=--apply   # commit the fix
```

The script overwrites `status` / `shares` / `broker_cost_basis` / `closed_at` on every Position from its trade ledger — trades themselves are never modified. Daily backups in `backend/app/services/backup.py` provide a recovery path if you regret it.

## Deferred follow-ups

- API-path `expired` detection (currently `RECEIVE_DELIVER` with `netAmount=0` still maps to `assignment` / `called_away` for API imports). Requires inspecting paired equity transferItems; a separate issue.
- Equity-leg basis cross-check: today we derive basis from option strike on `assignment`. Future enhancement could parse the equity-leg row as a verification cross-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)