### PR TITLE
Derive position label from state; remove Strategy dropdown from import + form (closes #131)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -291,7 +291,13 @@ class OptionScanResponse(BaseModel):
 # --- Journal ---
 
 
-STRATEGY_TYPES = Literal["csp", "cc", "wheel"]
+# Strategy values are *derived* from a position's lifecycle state by
+# :func:`app.services.positions.recompute_position_state` (see issue #131).
+# ``"holding"`` joins the original {csp, cc, wheel} set to label positions
+# that hold shares with no open option legs. The literal still drives request
+# validation on legacy back-compat fields (e.g. ``ImportRequest``) but is no
+# longer accepted on position-create or position-update payloads.
+STRATEGY_TYPES = Literal["csp", "cc", "wheel", "holding"]
 POSITION_STATUS = Literal["open", "closed"]
 TRADE_TYPES = Literal[
     "sell_put",
@@ -306,17 +312,31 @@ CLOSE_REASONS = Literal["fifty_pct_target", "full_expiration", "rolled", "closed
 
 
 class PositionCreate(BaseModel):
+    """Payload for creating a position.
+
+    Per issue #131 the strategy label is derived from the position's
+    lifecycle state by ``recompute_position_state`` and is no longer
+    accepted from the client. New positions are seeded with ``"csp"``
+    server-side; the recomputer overwrites that as soon as the first
+    trade is logged.
+    """
+
     ticker: str
     shares: int = Field(default=100, ge=1)
     broker_cost_basis: float
-    strategy: STRATEGY_TYPES
     opened_at: str
     notes: Optional[str] = None
 
 
 class PositionUpdate(BaseModel):
+    """Partial-update payload for a position.
+
+    Per issue #131 ``strategy`` is no longer accepted — the recomputer is
+    authoritative. Status / closed_at / notes / shares / broker_cost_basis
+    can still be patched directly for manual corrections.
+    """
+
     status: Optional[POSITION_STATUS] = None
-    strategy: Optional[STRATEGY_TYPES] = None
     closed_at: Optional[str] = None
     notes: Optional[str] = None
     broker_cost_basis: Optional[float] = None
@@ -406,9 +426,17 @@ class ImportPreviewResponse(BaseModel):
 
 
 class ImportRequest(BaseModel):
+    """Request body for ``POST /api/journal/import``.
+
+    ``position_strategy`` is **deprecated** as of issue #131 — the recomputer
+    derives the displayed label from each position's state. The field is
+    retained on the request schema so older clients that still send it do
+    not 422; the value is silently ignored by the handler.
+    """
+
     start_date: str
     end_date: str
-    position_strategy: STRATEGY_TYPES = "wheel"
+    position_strategy: Optional[STRATEGY_TYPES] = None  # deprecated; ignored
 
     @field_validator("start_date", "end_date")
     @classmethod
@@ -470,10 +498,20 @@ class DashboardStatus(BaseModel):
 
 
 class DashboardOpenPositionsBreakdown(BaseModel):
+    """Open-positions count split by derived strategy label.
+
+    ``stock`` is a vestigial bucket from before #131 that is never
+    incremented (no position has ``strategy="stock"``); kept here for
+    response-shape stability while the frontend consumers are tracked into
+    a follow-up. ``holding`` was added in #131 for positions that hold
+    shares with no open option legs.
+    """
+
     stock: int
     csp: int
     cc: int
     wheel: int
+    holding: int
 
 
 class DashboardOpenLegsBreakdown(BaseModel):

--- a/backend/app/routers/journal.py
+++ b/backend/app/routers/journal.py
@@ -1,13 +1,12 @@
 import logging
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import get_db
 from app.models.schemas import (
     POSITION_STATUS,
-    STRATEGY_TYPES,
     ClearJournalResponse,
     ImportPreviewResponse,
     ImportRequest,
@@ -165,7 +164,10 @@ def import_transactions(req: ImportRequest, db: DBSession = Depends(get_db)):
     if _date_range_exceeds_limit(req.start_date, req.end_date):
         raise HTTPException(status_code=422, detail="Date range cannot exceed 1 year (365 days)")
     try:
-        return execute_import(db, req.start_date, req.end_date, req.position_strategy)
+        # ``req.position_strategy`` is accepted on the request body for
+        # backwards compatibility with old clients but ignored — the
+        # recomputer derives the label per issue #131.
+        return execute_import(db, req.start_date, req.end_date)
     except SchwabAuthError as e:
         logger.warning("Schwab auth failed during import: %s", e)
         raise HTTPException(status_code=401, detail=_schwab_auth_detail(e)) from e
@@ -200,17 +202,22 @@ async def import_csv_preview(
 @router.post("/import/csv", response_model=ImportResultResponse)
 async def import_csv(
     file: UploadFile = File(...),
-    position_strategy: STRATEGY_TYPES = Form("wheel"),
     db: DBSession = Depends(get_db),
 ):
-    """Import options trades from a Schwab transaction CSV export."""
+    """Import options trades from a Schwab transaction CSV export.
+
+    Per issue #131 the previously-required ``position_strategy`` form field
+    has been removed; the strategy label is derived from each position's
+    state by the recomputer. Stale clients that still post the field are
+    tolerated — FastAPI ignores unrecognized form parameters.
+    """
     file_bytes = await _read_csv_upload(file)
     try:
         mapped = parse_schwab_csv(file_bytes)
     except Exception:
         logger.exception("Failed to parse uploaded Schwab CSV")
         raise HTTPException(status_code=422, detail=_CSV_PARSE_DETAIL) from None
-    return execute_mapped_import(db, mapped, position_strategy=position_strategy)
+    return execute_mapped_import(db, mapped)
 
 
 async def _read_csv_upload(file: UploadFile) -> bytes:

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -209,7 +209,11 @@ def _build_kpis(
 ) -> dict:
     """Aggregate KPI tiles from already-built row data."""
     open_positions_count = len(position_rows)
-    breakdown = {"stock": 0, "csp": 0, "cc": 0, "wheel": 0}
+    # ``stock`` is a vestigial bucket retained for response-shape stability
+    # (see DashboardOpenPositionsBreakdown docstring); ``holding`` is the
+    # new bucket added for issue #131. Unknown labels (closed positions or
+    # raw values from pre-recompute imports) are silently dropped.
+    breakdown = {"stock": 0, "csp": 0, "cc": 0, "wheel": 0, "holding": 0}
     for position in open_positions:
         strategy = position["strategy"]
         if strategy in breakdown:

--- a/backend/app/services/journal.py
+++ b/backend/app/services/journal.py
@@ -93,14 +93,21 @@ def get_position(db: Session, position_id: str) -> dict | None:
 
 
 def create_position(db: Session, data: PositionCreate) -> dict:
-    """Create a new Position."""
+    """Create a new Position.
+
+    The ``strategy`` column is seeded with the placeholder ``"csp"``; the
+    label is *derived* from each position's lifecycle state by
+    ``recompute_position_state`` (issue #131). The placeholder is overwritten
+    as soon as the first trade is logged and the recomputer runs — until
+    then, manually-created positions display as "csp" by default.
+    """
     position = Position(
         id=str(uuid.uuid4()),
         ticker=data.ticker,
         shares=data.shares,
         broker_cost_basis=data.broker_cost_basis,
         status="open",
-        strategy=data.strategy,
+        strategy="csp",
         opened_at=data.opened_at,
         notes=data.notes,
     )

--- a/backend/app/services/positions.py
+++ b/backend/app/services/positions.py
@@ -120,6 +120,66 @@ def _consume_leg(
     return False
 
 
+def _derive_strategy_label(shares: int, open_legs: list[_LegKey]) -> str:
+    """Derive the displayed strategy label from a position's current state.
+
+    Maps ``(shares, open_put_count, open_call_count)`` to one of
+    ``"csp" | "cc" | "wheel" | "holding"`` per issue #131:
+
+    ====================================  =========
+    state                                 label
+    ====================================  =========
+    0 shares, only open puts              ``csp``
+    shares held, only open calls          ``cc``
+    shares held, open puts AND calls      ``wheel``
+    shares held, no open option legs      ``holding``
+    0 shares, no open option legs         ``csp`` (caller-handled "closed")
+    0 shares, only open calls (anomaly)   ``cc`` (logged warning — naked
+                                          call has no place in a wheel flow
+                                          but the label that matches the
+                                          live legs is the least-misleading
+                                          choice)
+    0 shares, both open puts and calls    ``csp`` (puts dominate when no
+                                          shares are held)
+    ====================================  =========
+
+    Pure function — no DB access — to keep the mapping unit-testable in
+    isolation from the trade-replay machinery in
+    :func:`recompute_position_state`. The caller is responsible for
+    short-circuiting on the closed state (``shares == 0`` and no open legs);
+    this function still returns a defensible label for that input so it is
+    safe to call unconditionally.
+    """
+    open_puts = sum(1 for leg in open_legs if leg.option_type == "put")
+    open_calls = sum(1 for leg in open_legs if leg.option_type == "call")
+
+    if shares > 0:
+        if open_puts > 0 and open_calls > 0:
+            return "wheel"
+        if open_calls > 0:
+            return "cc"
+        if open_puts > 0:
+            # Short put while holding shares — uncommon (mid-cycle layered
+            # entry) but valid; csp is the closest single-side label.
+            return "csp"
+        return "holding"
+
+    # shares == 0 below
+    if open_calls > 0 and open_puts == 0:
+        # Naked calls without shares should not occur in a wheel-only flow.
+        # Surface the anomaly via a warning but return ``"cc"`` because that
+        # is the label that best matches the live legs — the alternative
+        # ("csp") would directly contradict what the user is looking at.
+        logger.warning(
+            "_derive_strategy_label: 0 shares with %d open call leg(s) and "
+            "no open puts; returning 'cc' but this state is anomalous in a "
+            "wheel-only journal",
+            open_calls,
+        )
+        return "cc"
+    return "csp"
+
+
 def recompute_position_state(
     db: Session, position_id: str, commit: bool = True
 ) -> Position | None:
@@ -134,6 +194,13 @@ def recompute_position_state(
       reopens within the same Position — though "reopen-after-close" creates a
       new Position elsewhere, so this clearing path is mostly defensive).
     * ``shares`` and ``broker_cost_basis`` are recomputed from scratch.
+    * ``strategy`` is derived from ``(shares, open_legs)`` per issue #131 —
+      see :func:`_derive_strategy_label` for the truth table. This makes the
+      label authoritative on what the position is actually doing right now
+      (csp / cc / wheel / holding) instead of trusting whatever the import
+      pipeline guessed at row-creation time. Closed positions retain their
+      last-derived label for historical reading; the dashboard suppresses
+      the label for closed positions.
 
     Per-trade-type semantics:
 
@@ -261,6 +328,7 @@ def recompute_position_state(
     # Apply the derived state to the Position row.
     position.shares = shares
     position.broker_cost_basis = round(basis, 4)
+    position.strategy = _derive_strategy_label(shares, open_legs)
     if shares == 0 and not open_legs:
         position.status = "closed"
         position.closed_at = last_close_at or position.closed_at

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -180,16 +180,20 @@ def build_preview(
 def execute_mapped_import(
     db: Session,
     mapped_trades: list[dict],
-    position_strategy: str = "wheel",
 ) -> dict:
     """Persist a list of pre-mapped trade dicts to the journal.
 
     Inserts trades onto an existing open Position for the ticker, or creates a
     new Position with neutral initial state (``shares=0``, ``broker_cost_basis=0``)
-    that the recomputer will overwrite. After all trades are inserted, the
-    finalizer calls :func:`app.services.positions.recompute_position_state` once
-    per touched ticker to derive ``status`` / ``shares`` / ``broker_cost_basis``
-    / ``closed_at`` from the trade ledger.
+    that the recomputer will overwrite. New positions are seeded with a
+    ``"csp"`` placeholder strategy; the recomputer overwrites that with the
+    correct derived label (csp / cc / wheel / holding) before this function
+    returns — see issue #131 for the truth table.
+
+    After all trades are inserted, the finalizer calls
+    :func:`app.services.positions.recompute_position_state` once per touched
+    ticker to derive ``status`` / ``shares`` / ``broker_cost_basis`` /
+    ``closed_at`` / ``strategy`` from the trade ledger.
 
     Shared between the Schwab API import path and the CSV upload import path.
     """
@@ -220,11 +224,12 @@ def execute_mapped_import(
         if position is None:
             # Neutral initial state — the recomputer below overwrites these
             # from the trade ledger once the batch finishes inserting.
+            # ``strategy`` is seeded with the journal-service default in
+            # ``create_position`` and recomputed in the finalizer.
             pos_data = PositionCreate(
                 ticker=mapped["ticker"],
                 shares=1,  # ge=1 schema constraint; real value comes from recomputer
                 broker_cost_basis=0.0,
-                strategy=position_strategy,
                 opened_at=mapped["opened_at"],
             )
             pos_result = create_position(db, pos_data)
@@ -289,10 +294,11 @@ def preview_import(db: Session, start_date: str, end_date: str) -> dict:
     return build_preview(db, mapped_trades, account_number=account_number)
 
 
-def execute_import(db: Session, start_date: str, end_date: str, position_strategy: str = "wheel") -> dict:
+def execute_import(db: Session, start_date: str, end_date: str) -> dict:
     """Import Schwab transactions into the journal.
 
-    Creates positions as needed and logs trades.
+    Creates positions as needed and logs trades. Strategy labels are derived
+    by the recomputer (issue #131) — there is no per-import strategy override.
     """
     client = SchwabClient()
     account_numbers = client.get_account_numbers()
@@ -304,4 +310,4 @@ def execute_import(db: Session, start_date: str, end_date: str, position_strateg
     account_hash = account.get("hashValue", "")
     transactions = client.get_transactions(account_hash, start_date, end_date)
     mapped_trades = [m for m in (map_schwab_transaction(t) for t in transactions) if m]
-    return execute_mapped_import(db, mapped_trades, position_strategy=position_strategy)
+    return execute_mapped_import(db, mapped_trades)

--- a/backend/scripts/reconcile_positions.py
+++ b/backend/scripts/reconcile_positions.py
@@ -4,7 +4,9 @@ Walks the entire ``positions`` table and runs
 :func:`app.services.positions.recompute_position_state` against each row, then
 prints a per-ticker before/after diff. Provides a fix path for journals that
 were imported before issue #127 was fixed (every imported position stuck at
-``status="open"``, ``shares=100``, ``broker_cost_basis=0.0``).
+``status="open"``, ``shares=100``, ``broker_cost_basis=0.0``) and for journals
+imported before issue #131 (every imported position stuck on the
+batch-applied strategy label rather than a derived one).
 
 Usage::
 
@@ -14,7 +16,8 @@ Usage::
 
 The script is **opt-in** — it is never invoked automatically. Running it with
 ``--apply`` rewrites the ``status`` / ``shares`` / ``broker_cost_basis`` /
-``closed_at`` columns of every Position; review the dry-run diff first.
+``closed_at`` / ``strategy`` columns of every Position; review the dry-run
+diff first.
 
 Exit codes:
     0  success (or dry-run completed)
@@ -44,6 +47,7 @@ class _Snapshot:
     shares: int
     broker_cost_basis: float
     closed_at: str | None
+    strategy: str
 
 
 def _snapshot(position: Position) -> _Snapshot:
@@ -53,6 +57,7 @@ def _snapshot(position: Position) -> _Snapshot:
         shares=int(position.shares or 0),
         broker_cost_basis=float(position.broker_cost_basis or 0.0),
         closed_at=position.closed_at,
+        strategy=position.strategy or "",
     )
 
 
@@ -71,6 +76,8 @@ def _format_diff(ticker: str, before: _Snapshot, after: _Snapshot) -> str | None
         )
     if before.closed_at != after.closed_at:
         parts.append(f"closed_at {before.closed_at!r} -> {after.closed_at!r}")
+    if before.strategy != after.strategy:
+        parts.append(f"strategy {before.strategy} -> {after.strategy}")
     return f"  {ticker:<8} {', '.join(parts)}"
 
 

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -49,12 +49,17 @@ def _make_schwab_mgr(*, configured: bool, expires_at: str | None = None):
 
 
 def _seed_position(client, **overrides) -> str:
-    """Create a position via the API and return its id."""
+    """Create a position via the API and return its id.
+
+    Per issue #131 ``strategy`` is no longer accepted on PositionCreate;
+    the recomputer derives the label from the trade ledger. Callers that
+    need a specific strategy on the seeded row should add a trade after
+    creation so the recomputer derives the desired label.
+    """
     payload = {
         "ticker": "AAPL",
         "shares": 100,
         "broker_cost_basis": 17000.0,
-        "strategy": "wheel",
         "opened_at": "2026-04-01T10:00:00Z",
     }
     payload.update(overrides)
@@ -139,7 +144,6 @@ def test_dashboard_populated(client, monkeypatch):
         ticker="TSLA",
         broker_cost_basis=20000.0,
         shares=100,
-        strategy="cc",
     )
 
     # AAPL short put 175 expires in 3 days → ITM → roll-or-assign
@@ -186,6 +190,10 @@ def test_dashboard_populated(client, monkeypatch):
     assert data["kpis"]["open_positions"] == 2
     assert data["kpis"]["open_legs"] == 2
     assert data["kpis"]["open_legs_breakdown"] == {"puts": 1, "calls": 1}
+    # Issue #131: ``holding`` is part of the additive breakdown shape.
+    # Both seeded positions retain the create-time "csp" placeholder
+    # because the manual trade flow does not invoke the recomputer.
+    assert "holding" in data["kpis"]["open_positions_breakdown"]
 
     # Unrealized P/L is computed because both quotes resolved.
     assert data["kpis"]["unrealized_pl"] is not None

--- a/backend/tests/test_integration_import.py
+++ b/backend/tests/test_integration_import.py
@@ -96,10 +96,11 @@ class TestImportExecute:
         assert resp.status_code == 422
 
     def test_import_creates_trades(self, client, mock_schwab):
+        # Body omits ``position_strategy`` — the field is deprecated under
+        # issue #131 and the recomputer derives the label from state.
         resp = client.post("/api/journal/import", json={
             "start_date": "2025-03-01",
             "end_date": "2025-03-31",
-            "position_strategy": "wheel",
         })
         assert resp.status_code == 200
         data = resp.json()
@@ -113,6 +114,28 @@ class TestImportExecute:
         assert len(positions) == 2
         tickers = {p["ticker"] for p in positions}
         assert tickers == {"AAPL", "MSFT"}
+        # Both mock transactions are short-only legs (no shares ever
+        # acquired), so the derived label is "csp" for both — the
+        # AAPL sell_put has 0 shares + 1 open put, and the MSFT
+        # sell_call has 0 shares + 1 open call (anomaly path → "cc").
+        labels = {p["ticker"]: p["strategy"] for p in positions}
+        assert labels["AAPL"] == "csp"
+        assert labels["MSFT"] == "cc"
+
+    def test_import_accepts_legacy_strategy_field_but_ignores_it(self, client, mock_schwab):
+        """Backwards-compat: old clients sending ``position_strategy`` still
+        get a 200, but the value is ignored and the recomputer wins."""
+        resp = client.post("/api/journal/import", json={
+            "start_date": "2025-03-01",
+            "end_date": "2025-03-31",
+            "position_strategy": "wheel",  # legacy — ignored
+        })
+        assert resp.status_code == 200
+        positions = client.get("/api/journal/positions").json()["positions"]
+        # Even though the client requested "wheel", the derived labels win.
+        labels = {p["ticker"]: p["strategy"] for p in positions}
+        assert labels["AAPL"] == "csp"
+        assert labels["MSFT"] == "cc"
 
     def test_import_skips_duplicates(self, client, mock_schwab):
         # First import
@@ -132,12 +155,13 @@ class TestImportExecute:
         assert data["positions_created"] == 0
 
     def test_import_reuses_existing_position(self, client, mock_schwab):
-        # Create a position for AAPL first
+        # Create a position for AAPL first.
+        # ``strategy`` is no longer accepted on PositionCreate (#131); it
+        # gets derived/seeded server-side.
         client.post("/api/journal/positions", json={
             "ticker": "AAPL",
             "shares": 100,
             "broker_cost_basis": 15000.0,
-            "strategy": "wheel",
             "opened_at": "2025-01-01T00:00:00Z",
         })
 

--- a/backend/tests/test_integration_journal.py
+++ b/backend/tests/test_integration_journal.py
@@ -50,12 +50,17 @@ def db_session():
 
 
 def _create_sample_position(db_session, **overrides):
-    """Helper to create a position with sensible defaults."""
+    """Helper to create a position with sensible defaults.
+
+    ``strategy`` was dropped from PositionCreate in #131 — the recomputer
+    derives the displayed label, and manual creates seed with "csp" until
+    a trade is logged. Callers passing a ``strategy`` override are silently
+    ignored by Pydantic (extras-allowed by default).
+    """
     defaults = {
         "ticker": "AAPL",
         "shares": 100,
         "broker_cost_basis": 5000.0,
-        "strategy": "csp",
         "opened_at": "2025-01-15T10:00:00Z",
         "notes": None,
     }
@@ -281,15 +286,20 @@ def test_min_compliant_cc_strike(db_session):
 # --- Input validation ---
 
 
-def test_invalid_strategy_rejected():
-    """Invalid strategy value should be rejected by Pydantic."""
-    with pytest.raises(ValidationError):
-        PositionCreate(
-            ticker="AAPL",
-            broker_cost_basis=5000.0,
-            strategy="invalid",
-            opened_at="2025-01-15T10:00:00Z",
-        )
+def test_strategy_field_silently_ignored_on_create():
+    """Issue #131: ``strategy`` is no longer a PositionCreate field.
+
+    Pydantic v2 ignores unknown fields by default, so a payload that still
+    includes ``strategy`` must build cleanly — proving the back-compat
+    contract for stale clients.
+    """
+    pos = PositionCreate(
+        ticker="AAPL",
+        broker_cost_basis=5000.0,
+        strategy="invalid",  # silently dropped — no longer a declared field
+        opened_at="2025-01-15T10:00:00Z",
+    )
+    assert not hasattr(pos, "strategy")
 
 
 def test_invalid_trade_type_rejected():
@@ -312,7 +322,6 @@ def test_zero_shares_rejected():
             ticker="AAPL",
             shares=0,
             broker_cost_basis=5000.0,
-            strategy="csp",
             opened_at="2025-01-15T10:00:00Z",
         )
 

--- a/backend/tests/test_integration_journal_api.py
+++ b/backend/tests/test_integration_journal_api.py
@@ -2,12 +2,17 @@
 
 
 def _create_position(client, **overrides):
-    """Helper to POST a position with sensible defaults."""
+    """Helper to POST a position with sensible defaults.
+
+    Per issue #131 the ``strategy`` field is no longer accepted on
+    PositionCreate; the server seeds it with "csp" and the recomputer
+    overwrites it on the first import. Tests that still want to override
+    the seeded strategy can do so via direct ORM manipulation.
+    """
     payload = {
         "ticker": "AAPL",
         "shares": 100,
         "broker_cost_basis": 5000.0,
-        "strategy": "csp",
         "opened_at": "2025-01-15T10:00:00Z",
     }
     payload.update(overrides)
@@ -95,14 +100,22 @@ def test_create_position(client):
     assert data["ticker"] == "AAPL"
     assert data["shares"] == 100
     assert data["broker_cost_basis"] == 5000.0
+    # Per #131, manually-created positions seed with "csp" until a trade
+    # is logged and the recomputer derives the real label.
     assert data["strategy"] == "csp"
     assert data["status"] == "open"
     assert len(data["id"]) == 36
 
 
-def test_create_position_invalid_strategy(client):
-    resp = _create_position(client, strategy="invalid")
-    assert resp.status_code == 422
+def test_create_position_ignores_strategy_field(client):
+    """Issue #131: ``strategy`` is no longer accepted on PositionCreate.
+
+    Pydantic ignores unknown fields by default, so a payload that still
+    sends ``strategy`` must succeed and the seeded "csp" label must win.
+    """
+    resp = _create_position(client, strategy="wheel")
+    assert resp.status_code == 201
+    assert resp.json()["strategy"] == "csp"
 
 
 def test_create_position_zero_shares(client):
@@ -387,20 +400,17 @@ def test_update_trade_zero_quantity(client):
     assert resp.status_code == 422
 
 
-def test_update_position_strategy(client):
-    """Strategy can be corrected via update."""
-    pos = _create_position(client, strategy="csp").json()
+def test_update_position_ignores_strategy_field(client):
+    """Issue #131: ``strategy`` is no longer accepted on PositionUpdate.
+
+    The recomputer is authoritative for the displayed label, so a PUT that
+    still includes ``strategy`` must succeed (Pydantic ignores unknown
+    fields) and the existing strategy must remain unchanged.
+    """
+    pos = _create_position(client).json()
     resp = client.put(
         f"/api/journal/positions/{pos['id']}", json={"strategy": "wheel"}
     )
     assert resp.status_code == 200
-    assert resp.json()["strategy"] == "wheel"
-
-
-def test_update_position_invalid_strategy(client):
-    """Invalid strategy in update should return 422."""
-    pos = _create_position(client).json()
-    resp = client.put(
-        f"/api/journal/positions/{pos['id']}", json={"strategy": "invalid"}
-    )
-    assert resp.status_code == 422
+    # Seeded label persists because recomputer was not invoked from PUT.
+    assert resp.json()["strategy"] == "csp"

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.models.database import Base, Position, Trade
-from app.services.positions import recompute_position_state
+from app.services.positions import _derive_strategy_label, _LegKey, recompute_position_state
 
 
 # --- Fixtures ----------------------------------------------------------------
@@ -595,3 +595,252 @@ class TestEdgeCases:
         assert result.status == "open"
         assert result.shares == 200
         assert result.broker_cost_basis == pytest.approx(2700.0)
+
+
+# --- Strategy label derivation (issue #131) ----------------------------------
+
+
+class TestDeriveStrategyLabel:
+    """Pure-function unit tests for ``_derive_strategy_label``.
+
+    Each test maps one row of the issue #131 truth table to its expected
+    label. The recomputer wraps this helper; the integration cases below
+    confirm the wiring.
+    """
+
+    def _put_leg(self) -> _LegKey:
+        return _LegKey(option_type="put", strike=20.0, expiration="2026-03-20")
+
+    def _call_leg(self) -> _LegKey:
+        return _LegKey(option_type="call", strike=22.0, expiration="2026-03-20")
+
+    def test_zero_shares_only_open_puts_is_csp(self):
+        assert _derive_strategy_label(0, [self._put_leg()]) == "csp"
+
+    def test_shares_held_only_open_calls_is_cc(self):
+        assert _derive_strategy_label(100, [self._call_leg()]) == "cc"
+
+    def test_shares_held_open_puts_and_calls_is_wheel(self):
+        assert (
+            _derive_strategy_label(100, [self._put_leg(), self._call_leg()])
+            == "wheel"
+        )
+
+    def test_shares_held_no_open_legs_is_holding(self):
+        assert _derive_strategy_label(100, []) == "holding"
+
+    def test_zero_shares_no_open_legs_is_csp(self):
+        # The closed-position case: status is closed and the label is not
+        # rendered on the dashboard, but the helper still returns a defined
+        # label so callers can use it unconditionally.
+        assert _derive_strategy_label(0, []) == "csp"
+
+    def test_zero_shares_only_open_calls_is_cc_with_warning(self, caplog):
+        # Anomalous (naked-call) case: derive ``cc`` and log a warning
+        # because no shares + open calls should not occur in a wheel-only
+        # journal. The label still matches the live legs — calling this
+        # "csp" would directly contradict what the user is looking at.
+        with caplog.at_level("WARNING", logger="app.services.positions"):
+            label = _derive_strategy_label(0, [self._call_leg()])
+        assert label == "cc"
+        assert any(
+            "anomalous" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_shares_held_only_open_puts_is_csp(self):
+        # Layered-entry edge case: short put while holding shares (e.g.
+        # selling a deeper put after assignment but before the next call).
+        # csp is the closest single-side label.
+        assert _derive_strategy_label(100, [self._put_leg()]) == "csp"
+
+
+class TestRecomputeWritesDerivedStrategy:
+    """Integration: ``recompute_position_state`` must persist the derived label."""
+
+    def test_csp_flow_writes_csp_label(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                }
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.shares == 0
+        assert result.strategy == "csp"
+
+    def test_holding_flow_writes_holding_label(self, db_session):
+        # sell_put → assignment leaves 100 shares, no open legs → holding.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.shares == 100
+        assert result.strategy == "holding"
+
+    def test_cc_flow_writes_cc_label(self, db_session):
+        # Hold shares + open call leg → cc.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 15.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-01",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.shares == 100
+        assert result.strategy == "cc"
+
+    def test_wheel_flow_writes_wheel_label(self, db_session):
+        # Hold shares + open call AND open put → wheel.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 15.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-01",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 12.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-02",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.shares == 100
+        assert result.strategy == "wheel"
+
+    def test_closed_position_retains_last_derived_label(self, db_session):
+        # Full round trip → shares back to 0, no open legs → status closed.
+        # The label is whatever the helper says for ``(0, [])`` — currently
+        # "csp" — and the row's status flag tells the dashboard not to
+        # bucket it.
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-02-25",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "closed"
+        assert result.shares == 0
+        assert result.strategy == "csp"
+
+    def test_recompute_overwrites_stale_label(self, db_session):
+        # Seeded with "wheel" but real ledger derives "holding". The
+        # recomputer must overwrite the stale value — this is the user-
+        # facing fix that ``make reconcile-positions`` relies on for
+        # already-imported journals.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+        # Confirm seed had stale "wheel" label.
+        assert pos.strategy == "wheel"
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.strategy == "holding"

--- a/backend/tests/test_reconcile_positions.py
+++ b/backend/tests/test_reconcile_positions.py
@@ -215,7 +215,9 @@ class TestReconcileAll:
 
     def test_no_changes_when_state_already_correct(self, db_session, capsys):
         # Seed with correct state for a simple sell_put leg: 0 shares, open.
-        _seed_ghost_open_position(
+        # Strategy must already match the derived "csp" label, otherwise the
+        # reconciler will record a change for the label fix.
+        pos = _seed_ghost_open_position(
             db_session,
             ticker="F",
             bad_shares=0,
@@ -229,12 +231,56 @@ class TestReconcileAll:
                 },
             ],
         )
+        # Override the seed's "wheel" label to the derived value so this
+        # truly represents an "already correct" row.
+        pos.strategy = "csp"
+        db_session.commit()
 
         total, changed, errors = reconcile_all(db_session, apply=True)
 
         assert total == 1
         assert changed == 0
         assert errors == 0
+
+    def test_apply_re_derives_strategy_label(self, db_session):
+        # Bad state: stored as "wheel" but the ledger shows held shares with
+        # no open option legs → the derived label is "holding". This
+        # mirrors the real-world repro from the issue (wheel-imported batch
+        # left two equity-only positions stuck on "wheel" on the dashboard).
+        pos = _seed_ghost_open_position(
+            db_session,
+            ticker="F",
+            bad_shares=100,
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+        original_id = pos.id
+        assert pos.strategy == "wheel"  # stale seed
+
+        total, changed, errors = reconcile_all(db_session, apply=True)
+
+        assert total == 1
+        assert changed == 1
+        assert errors == 0
+
+        db_session.expire_all()
+        reloaded = (
+            db_session.query(Position).filter(Position.id == original_id).first()
+        )
+        assert reloaded.strategy == "holding"
+        assert reloaded.shares == 100
 
 
 class TestMainCli:

--- a/backend/tests/test_schwab_csv_import.py
+++ b/backend/tests/test_schwab_csv_import.py
@@ -319,6 +319,8 @@ class TestImportCsvEndpoint:
     """Cover ``POST /api/journal/import/csv`` write path + duplicate handling."""
 
     def test_import_creates_trades_and_positions(self, client):
+        # Stale clients may still post `position_strategy`; the field is
+        # ignored by FastAPI under #131 but the request must still succeed.
         resp = client.post(
             "/api/journal/import/csv",
             files=_csv_file(_csv([SELL_PUT_ROW, SELL_CALL_ROW])),
@@ -334,15 +336,20 @@ class TestImportCsvEndpoint:
         tickers = {p["ticker"] for p in positions}
         assert tickers == {"F", "SOFI"}
 
-    def test_import_default_strategy_is_wheel(self, client):
-        # `position_strategy` form field omitted — should default to "wheel".
+    def test_import_derives_strategy_label(self, client):
+        # `position_strategy` form field is no longer accepted under #131.
+        # The recomputer derives the label per position state. F has a single
+        # short put with no shares → "csp". SOFI has a single short call
+        # with no shares → "cc" (anomaly path; logged warning).
         resp = client.post(
             "/api/journal/import/csv",
-            files=_csv_file(_csv([SELL_PUT_ROW])),
+            files=_csv_file(_csv([SELL_PUT_ROW, SELL_CALL_ROW])),
         )
         assert resp.status_code == 200
         positions = client.get("/api/journal/positions").json()["positions"]
-        assert positions[0]["strategy"] == "wheel"
+        labels = {p["ticker"]: p["strategy"] for p in positions}
+        assert labels["F"] == "csp"
+        assert labels["SOFI"] == "cc"
 
     def test_import_skips_duplicates_on_second_upload(self, client):
         body = _csv([SELL_PUT_ROW, SELL_CALL_ROW])
@@ -355,14 +362,17 @@ class TestImportCsvEndpoint:
         assert data["skipped_duplicates"] == 2
         assert data["positions_created"] == 0
 
-    def test_import_rejects_invalid_strategy(self, client):
+    def test_import_ignores_legacy_strategy_field(self, client):
+        # Stale clients may still post `position_strategy`; under #131 the
+        # field is no longer declared on the handler so FastAPI silently
+        # ignores it. A bogus value must therefore *succeed*, not 422 — this
+        # locks in the back-compat contract called out in the issue.
         resp = client.post(
             "/api/journal/import/csv",
             files=_csv_file(_csv([SELL_PUT_ROW])),
             data={"position_strategy": "not-a-strategy"},
         )
-        # Pydantic Literal validation -> 422 before any DB writes.
-        assert resp.status_code == 422
+        assert resp.status_code == 200
 
     def test_import_rejects_oversized_file(self, client):
         oversized = b"Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount\n"

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -281,11 +281,12 @@ export async function previewSchwabImport(startDate, endDate) {
   return data;
 }
 
-export async function executeSchwabImport(startDate, endDate, positionStrategy = 'wheel') {
+export async function executeSchwabImport(startDate, endDate) {
+  // ``position_strategy`` is no longer sent — issue #131 derives the
+  // displayed label from each position's lifecycle state.
   const { data } = await api.post('/api/journal/import', {
     start_date: startDate,
     end_date: endDate,
-    position_strategy: positionStrategy,
   });
   return data;
 }
@@ -297,10 +298,10 @@ export async function previewSchwabCsvImport(file) {
   return data;
 }
 
-export async function executeSchwabCsvImport(file, positionStrategy = 'wheel') {
+export async function executeSchwabCsvImport(file) {
+  // ``position_strategy`` form field removed in issue #131.
   const form = new FormData();
   form.append('file', file);
-  form.append('position_strategy', positionStrategy);
   const { data } = await api.post('/api/journal/import/csv', form);
   return data;
 }

--- a/frontend/components/dashboard/KpiRow.jsx
+++ b/frontend/components/dashboard/KpiRow.jsx
@@ -25,11 +25,16 @@ function plColor(value) {
 export default function KpiRow({ kpis }) {
   if (!kpis) return null;
   const breakdown = kpis.open_positions_breakdown || {};
+  // Issue #131 added the ``holding`` bucket — equity-only positions with no
+  // open option legs. Order: csp -> cc -> wheel -> holding mirrors the
+  // wheel lifecycle progression. ``stock`` remains for response-shape
+  // stability; cleanup is tracked as a follow-up.
   const positionSubtext = [
     breakdown.stock ? `${breakdown.stock} stock` : null,
     breakdown.csp ? `${breakdown.csp} CSP` : null,
     breakdown.cc ? `${breakdown.cc} CC` : null,
     breakdown.wheel ? `${breakdown.wheel} wheel` : null,
+    breakdown.holding ? `${breakdown.holding} holding` : null,
   ]
     .filter(Boolean)
     .join(' · ');

--- a/frontend/components/journal/ImportModal.jsx
+++ b/frontend/components/journal/ImportModal.jsx
@@ -1,11 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 
-const STRATEGIES = [
-  { value: 'csp', label: 'Cash Secured Put' },
-  { value: 'cc', label: 'Covered Call' },
-  { value: 'wheel', label: 'Wheel' },
-];
-
 const MODES = {
   API: 'api',
   CSV: 'csv',
@@ -45,7 +39,6 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
   const [mode, setMode] = useState(MODES.API);
   const [startDate, setStartDate] = useState(defaults.startDate);
   const [endDate, setEndDate] = useState(defaults.endDate);
-  const [strategy, setStrategy] = useState('wheel');
   const [csvFile, setCsvFile] = useState(null);
   const [csvError, setCsvError] = useState(null);
   const [result, setResult] = useState(null);
@@ -71,9 +64,9 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
   const handleImport = async () => {
     let res = null;
     if (mode === MODES.CSV && csvFile && onImportCsv) {
-      res = await onImportCsv(csvFile, strategy);
+      res = await onImportCsv(csvFile);
     } else {
-      res = await onImport(startDate, endDate, strategy);
+      res = await onImport(startDate, endDate);
     }
     if (res) setResult(res);
   };
@@ -234,15 +227,6 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
                 </table>
               </div>
             )}
-
-            <div className="flex items-center gap-4">
-              <div>
-                <label className={labelClass}>Position Strategy</label>
-                <select value={strategy} onChange={(e) => setStrategy(e.target.value)} className={inputClass}>
-                  {STRATEGIES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
-                </select>
-              </div>
-            </div>
 
             <div className="flex gap-2">
               <button

--- a/frontend/components/journal/PositionForm.jsx
+++ b/frontend/components/journal/PositionForm.jsx
@@ -1,17 +1,15 @@
 import { useState } from 'react';
 
-const STRATEGIES = [
-  { value: 'csp', label: 'Cash Secured Put' },
-  { value: 'cc', label: 'Covered Call' },
-  { value: 'wheel', label: 'Wheel' },
-];
+// Strategy is no longer set by the user — issue #131 made it a derived
+// label that ``recompute_position_state`` writes from the trade ledger.
+// Manually-created positions are seeded as "csp" server-side and the
+// recomputer overwrites that on the first import / trade.
 
 export default function PositionForm({ onSubmit, onCancel }) {
   const [form, setForm] = useState({
     ticker: '',
     shares: '100',
     broker_cost_basis: '',
-    strategy: 'csp',
     opened_at: new Date().toISOString().split('T')[0],
     notes: '',
   });
@@ -28,7 +26,6 @@ export default function PositionForm({ onSubmit, onCancel }) {
       ticker: form.ticker.toUpperCase().trim(),
       shares: parseInt(form.shares) || 100,
       broker_cost_basis: parseFloat(form.broker_cost_basis),
-      strategy: form.strategy,
       opened_at: date.toISOString(),
       notes: form.notes || null,
     });
@@ -55,17 +52,9 @@ export default function PositionForm({ onSubmit, onCancel }) {
             <input name="broker_cost_basis" type="number" step="0.01" value={form.broker_cost_basis} onChange={handleChange} required placeholder="15000.00" className={inputClass} />
           </div>
         </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className={labelClass}>Strategy</label>
-            <select name="strategy" value={form.strategy} onChange={handleChange} className={inputClass}>
-              {STRATEGIES.map((s) => <option key={s.value} value={s.value}>{s.label}</option>)}
-            </select>
-          </div>
-          <div>
-            <label className={labelClass}>Opened Date</label>
-            <input name="opened_at" type="date" value={form.opened_at} onChange={handleChange} required className={inputClass} />
-          </div>
+        <div>
+          <label className={labelClass}>Opened Date</label>
+          <input name="opened_at" type="date" value={form.opened_at} onChange={handleChange} required className={inputClass} />
         </div>
         <div>
           <label className={labelClass}>Notes (optional)</label>

--- a/frontend/e2e/dashboard.spec.js
+++ b/frontend/e2e/dashboard.spec.js
@@ -22,7 +22,7 @@ const POPULATED_PAYLOAD = {
   },
   kpis: {
     open_positions: 3,
-    open_positions_breakdown: { stock: 2, csp: 0, cc: 0, wheel: 1 },
+    open_positions_breakdown: { stock: 0, csp: 1, cc: 0, wheel: 1, holding: 1 },
     notional_value: 48210.0,
     notional_change_pct: 0.021,
     open_legs: 3,
@@ -155,7 +155,7 @@ const EMPTY_PAYLOAD = {
   },
   kpis: {
     open_positions: 0,
-    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 0 },
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 0, holding: 0 },
     notional_value: 0,
     notional_change_pct: null,
     open_legs: 0,
@@ -234,6 +234,12 @@ test.describe('Dashboard route', () => {
     const kpis = page.getByTestId('dashboard-kpi-row');
     await expect(kpis.getByTestId('kpi-open-positions')).toContainText('3');
     await expect(kpis.getByTestId('kpi-open-legs')).toContainText('3');
+    // Issue #131 — derived breakdown subtext renders the new "holding"
+    // bucket alongside csp / wheel.
+    const openPosTile = kpis.getByTestId('kpi-open-positions');
+    await expect(openPosTile).toContainText('1 CSP');
+    await expect(openPosTile).toContainText('1 wheel');
+    await expect(openPosTile).toContainText('1 holding');
 
     // Decision row — AAPL roll-or-assign
     const expirationCard = page.getByTestId('dashboard-expirations-card');

--- a/frontend/e2e/import-csv.spec.js
+++ b/frontend/e2e/import-csv.spec.js
@@ -145,6 +145,57 @@ test.describe('Schwab CSV Import (issue #104)', () => {
     await expect(page.getByText('Positions created: 2')).toBeVisible();
   });
 
+  test('Position Strategy dropdown is removed in CSV mode (issue #131)', async ({ page }) => {
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+    const modal = page.getByTestId('import-modal');
+    await expect(modal.getByText('Position Strategy')).toHaveCount(0);
+
+    await page.getByTestId('csv-file-input').setInputFiles({
+      name: 'schwab-trades.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(SAMPLE_CSV, 'utf-8'),
+    });
+    await page.getByTestId('preview-csv-btn').click();
+    await expect(page.getByTestId('import-preview')).toBeVisible();
+    // Still gone after preview (the dropdown previously appeared on this view).
+    await expect(modal.getByText('Position Strategy')).toHaveCount(0);
+  });
+
+  test('CSV import POST omits position_strategy form field (issue #131)', async ({ page }) => {
+    const csvBodies = [];
+    await page.unroute('**/api/journal/import/csv');
+    await page.route('**/api/journal/import/csv', (route) => {
+      const req = route.request();
+      if (req.method() === 'POST') {
+        const raw = req.postData() || '';
+        csvBodies.push(raw);
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_CSV_IMPORT_RESULT),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('import-mode-csv').click();
+    await page.getByTestId('csv-file-input').setInputFiles({
+      name: 'schwab-trades.csv',
+      mimeType: 'text/csv',
+      buffer: Buffer.from(SAMPLE_CSV, 'utf-8'),
+    });
+    await page.getByTestId('preview-csv-btn').click();
+    await expect(page.getByTestId('import-preview')).toBeVisible();
+    await page.getByTestId('confirm-import-btn').click();
+    await expect(page.getByTestId('import-result')).toBeVisible();
+
+    expect(csvBodies.length).toBe(1);
+    // The multipart body should not contain a `position_strategy` part.
+    expect(csvBodies[0]).not.toMatch(/name="position_strategy"/);
+  });
+
   test('non-CSV file shows client-side validation error', async ({ page }) => {
     await page.getByTestId('import-schwab-btn').click();
     await page.getByTestId('import-mode-csv').click();

--- a/frontend/e2e/import.spec.js
+++ b/frontend/e2e/import.spec.js
@@ -99,6 +99,49 @@ test.describe('Schwab Import', () => {
     await expect(page.getByText('MSFT')).toBeVisible();
   });
 
+  test('Position Strategy dropdown is removed (issue #131)', async ({ page }) => {
+    // Issue #131 removed the user-facing strategy picker; the recomputer
+    // derives the label from each position's lifecycle state. The label
+    // (and its select) must not appear in the modal in either pre-preview
+    // or post-preview state.
+    await page.getByTestId('import-schwab-btn').click();
+    const modal = page.getByTestId('import-modal');
+    await expect(modal.getByText('Position Strategy')).toHaveCount(0);
+
+    await page.getByTestId('preview-import-btn').click();
+    await expect(modal.getByTestId('import-preview')).toBeVisible();
+    await expect(modal.getByText('Position Strategy')).toHaveCount(0);
+  });
+
+  test('confirm import POST body omits position_strategy (issue #131)', async ({ page }) => {
+    const importBodies = [];
+    await page.unroute('**/api/journal/import');
+    await page.route('**/api/journal/import', (route) => {
+      const req = route.request();
+      if (req.method() === 'POST') {
+        try {
+          importBodies.push(JSON.parse(req.postData() || '{}'));
+        } catch {
+          importBodies.push({});
+        }
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_IMPORT_RESULT),
+        });
+      }
+      return route.continue();
+    });
+
+    await page.getByTestId('import-schwab-btn').click();
+    await page.getByTestId('preview-import-btn').click();
+    await page.getByTestId('confirm-import-btn').click();
+    await expect(page.getByTestId('import-result')).toBeVisible();
+
+    expect(importBodies.length).toBe(1);
+    expect(importBodies[0]).not.toHaveProperty('position_strategy');
+  });
+
   test('duplicate badge is visible', async ({ page }) => {
     await page.getByTestId('import-schwab-btn').click();
     await page.getByTestId('preview-import-btn').click();

--- a/frontend/hooks/useJournal.js
+++ b/frontend/hooks/useJournal.js
@@ -164,10 +164,10 @@ export function useJournal() {
     }
   }, []);
 
-  const confirmImport = useCallback(async (startDate, endDate, positionStrategy = 'wheel') => {
+  const confirmImport = useCallback(async (startDate, endDate) => {
     setImportLoading(true);
     try {
-      const result = await executeSchwabImport(startDate, endDate, positionStrategy);
+      const result = await executeSchwabImport(startDate, endDate);
       toast.success(`Imported ${result.imported} trades`);
       setImportPreview(null);
       await fetchPositions();
@@ -200,10 +200,10 @@ export function useJournal() {
     }
   }, []);
 
-  const confirmCsvImport = useCallback(async (file, positionStrategy = 'wheel') => {
+  const confirmCsvImport = useCallback(async (file) => {
     setImportLoading(true);
     try {
-      const result = await executeSchwabCsvImport(file, positionStrategy);
+      const result = await executeSchwabCsvImport(file);
       toast.success(`Imported ${result.imported} trades`);
       setImportPreview(null);
       await fetchPositions();


### PR DESCRIPTION
Closes #131.

## Summary

The "Position Strategy" picker on the import modal applied a single user-chosen label to every position in a batch and never recomputed it. The dashboard then showed labels that didn't match reality (e.g. "Open positions: 2 (2 wheel)" for two equity-only holdings). This PR makes the displayed label *derived*: ``recompute_position_state`` now writes ``Position.strategy`` alongside the other lifecycle columns it maintains, mapping ``(shares, open_put_count, open_call_count)`` to ``csp / cc / wheel / holding`` per the issue truth table.

## Acceptance criteria

- [x] The "Position Strategy" dropdown is removed from `frontend/components/journal/ImportModal.jsx` (also removed from `PositionForm.jsx` per the user's "remove it entirely" instruction).
- [x] The frontend import flow no longer sends a `strategy` field to `/api/journal/import` or `/api/journal/import/csv` (e2e assertions added).
- [x] The backend import endpoints accept the absence of `strategy` (back-compat: `ImportRequest.position_strategy` retained on the schema and silently ignored; CSV form param removed and FastAPI tolerates extras).
- [x] `recompute_position_state` derives a label from `(shares, open_put_count, open_call_count)` per the table.
- [x] The Position response schema includes the derived label (still `PositionResponse.strategy`, no migration).
- [x] Dashboard KPI reflects the derived breakdown — `DashboardOpenPositionsBreakdown` gained a `holding` field; `KpiRow` renders the new chip.
- [x] Existing positions transition cleanly via `make reconcile-positions ARGS=--apply` (script now diffs and writes `strategy`; new test in `test_reconcile_positions.py` confirms re-derivation on stale rows).
- [x] Backend tests cover all 5 state-to-label mappings (`TestDeriveStrategyLabel` covers csp / cc / wheel / holding / closed plus the two off-table edge cases; `TestRecomputeWritesDerivedStrategy` covers the end-to-end persistence path).
- [x] Frontend e2e confirms the modal no longer shows the dropdown and the dashboard subtext renders the new `holding` bucket (`import.spec.js`, `import-csv.spec.js`, `dashboard.spec.js`).

## Decisions called out in the plan

**Backwards compat — POST `/api/journal/import`:** `ImportRequest.position_strategy` stays on the schema as `Optional[STRATEGY_TYPES] = None` and is silently ignored by the handler. Old clients continue to 200.

**Backwards compat — POST `/api/journal/import/csv`:** form field removed; FastAPI ignores unrecognized form parameters so stale clients still 200. The `test_import_ignores_legacy_strategy_field` test locks this in (asserts a bogus legacy value succeeds rather than 422-ing).

**`PositionCreate` / `PositionUpdate`:** `strategy` removed from both schemas. Pydantic v2 default is `extras=ignore`, so old payloads that include `strategy` succeed and the seeded "csp" placeholder wins. Tests (`test_create_position_ignores_strategy_field`, `test_update_position_ignores_strategy_field`) cover this.

**Edge case — 0 shares + only open calls:** derive `cc` (matches the live legs) and emit a `logger.warning(...)` since this is anomalous in a wheel-only flow. Covered by `test_zero_shares_only_open_calls_is_cc_with_warning`.

**Vestigial `stock` bucket on `DashboardOpenPositionsBreakdown`:** left as-is per the locked-in decision. Cleanup is tracked as a follow-up.

## Migration path for existing data

Running deployments need to re-derive labels for previously-imported positions:

```
make reconcile-positions ARGS=--apply
```

The script already shipped in #127 and called `recompute_position_state`; this PR extends the recomputer to write `strategy` and updates the script's snapshot/diff to surface label changes. Operators should dry-run first (`make reconcile-positions`, no flag) to review the per-position diff.

## Test plan

- [x] `cd backend && python -m pytest` — 681 passed, 7 skipped (full suite green)
- [x] `cd frontend && npm run lint` — 0 errors (1 pre-existing image-element warning unrelated to this change)
- [x] `cd frontend && npm run build` — clean Turbopack production build
- [ ] Playwright e2e tests (`import.spec.js`, `import-csv.spec.js`, `dashboard.spec.js`) — run on CI
- [ ] Manual: run `make reconcile-positions` against a populated DB to verify the label transitions print as expected

## Files touched

Backend (8): `app/models/schemas.py`, `app/routers/journal.py`, `app/services/dashboard.py`, `app/services/journal.py`, `app/services/positions.py`, `app/services/schwab_import.py`, `scripts/reconcile_positions.py`, plus 7 test files.

Frontend (8): `api/client.js`, `components/dashboard/KpiRow.jsx`, `components/journal/ImportModal.jsx`, `components/journal/PositionForm.jsx`, `hooks/useJournal.js`, plus 3 e2e specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)