### PR TITLE
Close option legs on assignment/called-away (FIFO fallback) + expiration calendar fallback (closes #134)

### DIFF
--- a/backend/app/services/positions.py
+++ b/backend/app/services/positions.py
@@ -21,13 +21,28 @@ safe to re-run.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import date, datetime, timezone
 
 from sqlalchemy.orm import Session
 
 from app.models.database import Position, Trade
 
 logger = logging.getLogger(__name__)
+
+
+def _utc_today() -> date:
+    """Return today's date in UTC.
+
+    Used as the default ``clock`` for :func:`recompute_position_state`. UTC is
+    fine at day granularity because option expirations settle at 4 PM ET; by
+    the time UTC ticks over the next calendar day, ET is well past close, so
+    "is this expiration date < today (UTC)?" never closes a leg before its
+    settlement time. Tests inject a frozen-clock callable to keep behavior
+    deterministic.
+    """
+    return datetime.now(tz=timezone.utc).date()
 
 
 # Trade types that close out an existing option leg. Each consumes one open leg
@@ -83,15 +98,28 @@ def _consume_leg(
     ticker: str,
     trade_type: str,
 ) -> bool:
-    """Remove the first matching open leg from ``open_legs``.
+    """Remove a matching open leg from ``open_legs`` using a two-pass strategy.
 
-    Match is by (option_type, strike, expiration); when ``option_type`` is None
-    (``expired`` trade type — see :func:`_option_type_for_close`) either side
-    is accepted, put first. FIFO for ties.
+    **Pass 1 (strict):** match by ``(option_type, strike, expiration)``. This
+    is the well-formed case — most resolving events match the originating leg
+    exactly and this pass picks them off without disturbing other legs.
 
-    Returns ``True`` if a leg was consumed, ``False`` if no match was found
-    (which we tolerate but log — see the partial-ledger discussion in the
-    module docstring).
+    **Pass 2 (FIFO fallback):** when no strict match exists, consume the
+    earliest-expiring open leg of the matching side (``put`` for
+    ``buy_put_close`` / ``assignment``; ``call`` for ``buy_call_close`` /
+    ``called_away``; either side for ``expired``). Ties broken by insertion
+    order, which mirrors ``opened_at`` because ``recompute_position_state``
+    replays trades in chronological order. This handles the dirty-data case
+    documented in issue #134 where strikes or expirations on a resolving
+    Schwab CSV row drift slightly from the originating short leg.
+
+    When ``option_type`` is ``None`` (``expired`` — ambiguous side) each pass
+    runs put-first then call so the worthless-expired side gets cleared
+    deterministically.
+
+    Returns ``True`` if a leg was consumed, ``False`` if both passes failed
+    (logged as a warning — caller continues, applying any shares/basis side
+    effects the resolution event still implies).
     """
     candidates: list[str]
     if option_type is None:
@@ -99,6 +127,7 @@ def _consume_leg(
     else:
         candidates = [option_type]
 
+    # Pass 1 — strict (option_type, strike, expiration) match.
     for candidate in candidates:
         for idx, leg in enumerate(open_legs):
             if (
@@ -109,6 +138,30 @@ def _consume_leg(
                 del open_legs[idx]
                 return True
 
+    # Pass 2 — FIFO fallback by expiration on the matching side.
+    for candidate in candidates:
+        side_indices = [
+            i for i, leg in enumerate(open_legs) if leg.option_type == candidate
+        ]
+        if not side_indices:
+            continue
+        fifo_idx = min(side_indices, key=lambda i: open_legs[i].expiration)
+        consumed = open_legs[fifo_idx]
+        del open_legs[fifo_idx]
+        logger.info(
+            "recompute_position_state: FIFO fallback closed %s leg "
+            "strike=%s exp=%s for %s on %s (no strict match for "
+            "strike=%s exp=%s)",
+            consumed.option_type,
+            consumed.strike,
+            consumed.expiration,
+            trade_type,
+            ticker,
+            strike,
+            expiration,
+        )
+        return True
+
     logger.warning(
         "recompute_position_state: no matching open leg for %s on %s "
         "(strike=%s, expiration=%s); ledger may be incomplete",
@@ -118,6 +171,52 @@ def _consume_leg(
         expiration,
     )
     return False
+
+
+def _apply_calendar_close(
+    open_legs: list[_LegKey],
+    ticker: str,
+    today: date,
+) -> tuple[list[_LegKey], str | None]:
+    """Close any open leg whose expiration date is in the past.
+
+    A leg whose ``expiration < today`` with no recorded resolving trade is
+    treated as expired worthless. This is the calendar fallback for the
+    Schwab-CSV gap where an "Expired" row never lands for a long-OTM
+    contract. See issue #134.
+
+    Returns a tuple of ``(still_open, latest_expiration)`` where
+    ``still_open`` is the subset of ``open_legs`` whose expiration is today
+    or later, and ``latest_expiration`` is the largest expiration string
+    among the closed legs (used by the caller as a candidate ``closed_at``
+    when no real resolving trade has stamped one). ``latest_expiration`` is
+    ``None`` if no legs were closed by this pass.
+    """
+    still_open: list[_LegKey] = []
+    closed_expirations: list[str] = []
+    for leg in open_legs:
+        try:
+            leg_exp = date.fromisoformat(leg.expiration)
+        except (TypeError, ValueError):
+            # Unparseable expiration: leave the leg alone — calendar-close
+            # only fires when we can prove the leg is past expiration.
+            still_open.append(leg)
+            continue
+        if leg_exp < today:
+            closed_expirations.append(leg.expiration)
+            logger.info(
+                "recompute_position_state: calendar fallback closing %s leg "
+                "strike=%s exp=%s on %s (past expiration, no resolving trade)",
+                leg.option_type,
+                leg.strike,
+                leg.expiration,
+                ticker,
+            )
+        else:
+            still_open.append(leg)
+
+    latest = max(closed_expirations) if closed_expirations else None
+    return still_open, latest
 
 
 def _derive_strategy_label(shares: int, open_legs: list[_LegKey]) -> str:
@@ -181,7 +280,10 @@ def _derive_strategy_label(shares: int, open_legs: list[_LegKey]) -> str:
 
 
 def recompute_position_state(
-    db: Session, position_id: str, commit: bool = True
+    db: Session,
+    position_id: str,
+    commit: bool = True,
+    clock: Callable[[], date] | None = None,
 ) -> Position | None:
     """Walk a position's trade ledger and derive its lifecycle state.
 
@@ -192,7 +294,10 @@ def recompute_position_state(
       legs remain. ``closed_at`` is set to the ``opened_at`` of the last trade
       that drove the position to a closed state (cleared again if it later
       reopens within the same Position — though "reopen-after-close" creates a
-      new Position elsewhere, so this clearing path is mostly defensive).
+      new Position elsewhere, so this clearing path is mostly defensive). When
+      the calendar fallback (below) is what drove the position to closed,
+      ``closed_at`` is the latest ``expiration`` among the calendar-closed
+      legs, since no real resolving trade exists to supply an ``opened_at``.
     * ``shares`` and ``broker_cost_basis`` are recomputed from scratch.
     * ``strategy`` is derived from ``(shares, open_legs)`` per issue #131 —
       see :func:`_derive_strategy_label` for the truth table. This makes the
@@ -201,6 +306,23 @@ def recompute_position_state(
       pipeline guessed at row-creation time. Closed positions retain their
       last-derived label for historical reading; the dashboard suppresses
       the label for closed positions.
+
+    **Leg pairing strategy (issue #134):** when a resolving trade arrives
+    (``buy_put_close`` / ``buy_call_close`` / ``assignment`` / ``called_away``
+    / ``expired``), :func:`_consume_leg` first tries a strict
+    ``(option_type, strike, expiration)`` match. If no exact match exists it
+    falls back to FIFO-by-expiration on the matching side — the
+    earliest-expiring open leg of the right side is consumed instead. This
+    fixes the dirty-data case where a Schwab CSV row's strike or expiration
+    drifts slightly from the originating short leg. After both passes fail a
+    warning is logged but the import keeps running.
+
+    **Calendar fallback (issue #134):** after replaying every trade, any open
+    leg whose ``expiration`` is strictly before ``clock()`` is treated as
+    expired worthless and removed. This covers the case where Schwab never
+    posted an "Expired" row for a long-OTM contract. The current UTC date is
+    the default cutoff; tests inject a frozen-clock callable. Future-dated
+    legs (``expiration >= today``) are never auto-closed.
 
     Per-trade-type semantics:
 
@@ -232,6 +354,13 @@ def recompute_position_state(
         commit: If True (default), commit the derived state to the database.
             Pass False from a dry-run / preview caller that wants to inspect
             the result without persisting it.
+        clock: Callable returning today's date. Defaults to ``None``, which
+            resolves to :func:`_utc_today` lazily inside the function so a
+            test can ``monkeypatch.setattr(module, "_utc_today", ...)`` and
+            have it take effect through normal call sites that don't pass
+            ``clock`` explicitly. Tests with direct access to this kwarg
+            inject a frozen-clock callable for deterministic fallback
+            behavior.
 
     Returns:
         The refreshed Position ORM object, or None if no Position with that ID
@@ -242,6 +371,12 @@ def recompute_position_state(
     position = db.query(Position).filter(Position.id == position_id).first()
     if position is None:
         return None
+
+    # Resolve ``clock`` lazily so tests that monkey-patch ``_utc_today`` see
+    # the patched callable. Default-argument binding would freeze the
+    # original module-level function at import time and defeat the patch.
+    if clock is None:
+        clock = _utc_today
 
     trades: list[Trade] = sorted(
         position.trades,
@@ -324,6 +459,21 @@ def recompute_position_state(
             ttype,
             position.ticker,
         )
+
+    # Calendar fallback: any leg past expiration with no resolving trade is
+    # treated as expired worthless. See module/function docstring (issue #134).
+    open_legs, calendar_close_at = _apply_calendar_close(
+        open_legs, position.ticker, clock()
+    )
+    if (
+        calendar_close_at is not None
+        and shares == 0
+        and not open_legs
+        and last_close_at is None
+    ):
+        # No real resolving trade stamped a closed_at — use the latest
+        # calendar-closed leg's expiration as the canonical close date.
+        last_close_at = calendar_close_at
 
     # Apply the derived state to the Position row.
     position.shares = shares

--- a/backend/app/services/positions.py
+++ b/backend/app/services/positions.py
@@ -32,6 +32,26 @@ from app.models.database import Position, Trade
 logger = logging.getLogger(__name__)
 
 
+# Module-level dedupe set for unpaired-resolution warnings. Reconciliation can
+# replay the entire journal repeatedly (e.g., backend/scripts/reconcile_positions
+# runs across the whole DB and a user may run it more than once); the first
+# encounter of an unpaired resolving event is genuine signal, but subsequent
+# replays of the same ``(position_id, trade_id)`` are noise. We log the first
+# at WARNING and any later replay at INFO. The set is process-local — that is
+# good enough for the dev/reconciliation workflow this guards, and it resets
+# cleanly on process restart.
+_warned_unpaired: set[tuple[str, str]] = set()
+
+
+def _reset_unpaired_warning_cache() -> None:
+    """Clear the unpaired-resolution warning de-dup cache.
+
+    Exposed for tests that need a deterministic starting state. Production
+    callers should not need to invoke this.
+    """
+    _warned_unpaired.clear()
+
+
 def _utc_today() -> date:
     """Return today's date in UTC.
 
@@ -97,6 +117,8 @@ def _consume_leg(
     expiration: str,
     ticker: str,
     trade_type: str,
+    position_id: str | None = None,
+    trade_id: str | None = None,
 ) -> bool:
     """Remove a matching open leg from ``open_legs`` using a two-pass strategy.
 
@@ -117,9 +139,13 @@ def _consume_leg(
     runs put-first then call so the worthless-expired side gets cleared
     deterministically.
 
-    Returns ``True`` if a leg was consumed, ``False`` if both passes failed
-    (logged as a warning — caller continues, applying any shares/basis side
-    effects the resolution event still implies).
+    Returns ``True`` if a leg was consumed, ``False`` if both passes failed.
+    The first failure for a given ``(position_id, trade_id)`` is logged at
+    WARNING; subsequent replays of the same pair (e.g., when the
+    reconciliation script is re-run) drop to INFO via the module-level
+    :data:`_warned_unpaired` cache so the same data-integrity gap doesn't
+    flood the log on every recompute. The caller continues either way,
+    applying any shares/basis side effects the resolution event still implies.
     """
     candidates: list[str]
     if option_type is None:
@@ -145,6 +171,10 @@ def _consume_leg(
         ]
         if not side_indices:
             continue
+        # NOTE: ``expiration`` is stored as an ISO ``YYYY-MM-DD`` string, which
+        # sorts lexicographically the same as chronologically — but only because
+        # of that fixed format. If the storage format ever changes (e.g., to a
+        # date object or a different string layout), parse to ``date`` here.
         fifo_idx = min(side_indices, key=lambda i: open_legs[i].expiration)
         consumed = open_legs[fifo_idx]
         del open_legs[fifo_idx]
@@ -162,7 +192,20 @@ def _consume_leg(
         )
         return True
 
-    logger.warning(
+    # First encounter of this unpaired event is genuine signal (WARNING).
+    # Subsequent recomputes of the same ``(position_id, trade_id)`` pair are
+    # noise — reconciliation re-runs would otherwise spam identical warnings —
+    # so demote to INFO. When ``position_id`` or ``trade_id`` are unknown
+    # (defensive default), fall back to the original WARNING behavior.
+    dedupe_key: tuple[str, str] | None = None
+    if position_id is not None and trade_id is not None:
+        dedupe_key = (position_id, trade_id)
+    log_fn = (
+        logger.info
+        if dedupe_key is not None and dedupe_key in _warned_unpaired
+        else logger.warning
+    )
+    log_fn(
         "recompute_position_state: no matching open leg for %s on %s "
         "(strike=%s, expiration=%s); ledger may be incomplete",
         trade_type,
@@ -170,6 +213,8 @@ def _consume_leg(
         strike,
         expiration,
     )
+    if dedupe_key is not None:
+        _warned_unpaired.add(dedupe_key)
     return False
 
 
@@ -417,6 +462,8 @@ def recompute_position_state(
                     trade.expiration,
                     position.ticker,
                     ttype,
+                    position_id=position.id,
+                    trade_id=trade.id,
                 )
 
             if ttype == "assignment":

--- a/backend/tests/test_integration_import.py
+++ b/backend/tests/test_integration_import.py
@@ -7,6 +7,9 @@ import pytest
 
 MOCK_ACCOUNT_NUMBERS = [{"accountNumber": "12345678", "hashValue": "abc123"}]
 
+# Far-future expirations keep the mocked legs "live" relative to today so
+# the calendar fallback added in #134 doesn't auto-close them and skew the
+# derived strategy labels these tests rely on.
 MOCK_TRANSACTIONS = [
     {
         "transactionDate": "2025-03-01T10:00:00Z",
@@ -21,7 +24,7 @@ MOCK_TRANSACTIONS = [
                     "underlyingSymbol": "AAPL",
                     "putCall": "PUT",
                     "strikePrice": 150.0,
-                    "expirationDate": "2025-03-21T00:00:00.000+0000",
+                    "expirationDate": "2099-03-21T00:00:00.000+0000",
                 },
             }
         ],
@@ -39,7 +42,7 @@ MOCK_TRANSACTIONS = [
                     "underlyingSymbol": "MSFT",
                     "putCall": "CALL",
                     "strikePrice": 400.0,
-                    "expirationDate": "2025-04-18T00:00:00.000+0000",
+                    "expirationDate": "2099-04-18T00:00:00.000+0000",
                 },
             }
         ],

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -22,6 +22,7 @@ from app.services.positions import (
     _apply_calendar_close,
     _derive_strategy_label,
     _LegKey,
+    _reset_unpaired_warning_cache,
     recompute_position_state,
 )
 
@@ -1199,6 +1200,11 @@ class TestFifoFallbackForDirtyData:
 class TestUnpairedResolvingEvent:
     """When both strict and FIFO passes fail, log a warning and continue."""
 
+    def setup_method(self) -> None:
+        # Module-level dedupe cache must start empty so each test gets the
+        # genuine first-warning behavior regardless of test order.
+        _reset_unpaired_warning_cache()
+
     def test_assignment_with_no_matching_put_leg_warns_but_no_error(
         self, db_session, caplog
     ):
@@ -1231,6 +1237,64 @@ class TestUnpairedResolvingEvent:
         )
         assert result.shares == 100
         assert result.broker_cost_basis == pytest.approx(5000.0)
+
+    def test_repeat_recompute_does_not_re_emit_warning(
+        self, db_session, caplog
+    ):
+        # The recomputer is idempotent and is called both after every Schwab
+        # import and from the reconcile_positions script (which a user may run
+        # repeatedly). The first encounter of an unpaired resolving event is
+        # genuine signal; subsequent recomputes of the same trade should not
+        # spam the same WARNING. Confirm the second run drops to INFO so log
+        # consumers (and tests asserting on WARNING records) stay clean.
+        pos = _seed_position(
+            db_session,
+            ticker="REPEAT",
+            trades=[
+                {
+                    "trade_type": "assignment",
+                    "strike": 50.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                }
+            ],
+        )
+
+        # First recompute: genuine WARNING.
+        with caplog.at_level("INFO", logger="app.services.positions"):
+            recompute_position_state(
+                db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+            )
+        first_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "no matching open leg" in r.getMessage()
+        ]
+        assert len(first_warnings) == 1
+
+        # Second recompute on the exact same ledger: no new WARNING; the
+        # repeat is demoted to INFO so the data-integrity gap stays visible
+        # without flooding the log.
+        caplog.clear()
+        with caplog.at_level("INFO", logger="app.services.positions"):
+            recompute_position_state(
+                db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+            )
+        repeat_warnings = [
+            r
+            for r in caplog.records
+            if r.levelname == "WARNING"
+            and "no matching open leg" in r.getMessage()
+        ]
+        repeat_infos = [
+            r
+            for r in caplog.records
+            if r.levelname == "INFO"
+            and "no matching open leg" in r.getMessage()
+        ]
+        assert repeat_warnings == []
+        assert len(repeat_infos) == 1
 
 
 class TestCalendarCloseHelper:

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Iterable
+from datetime import date
 
 import pytest
 from sqlalchemy import create_engine, event
@@ -17,7 +18,24 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from app.models.database import Base, Position, Trade
-from app.services.positions import _derive_strategy_label, _LegKey, recompute_position_state
+from app.services.positions import (
+    _apply_calendar_close,
+    _derive_strategy_label,
+    _LegKey,
+    recompute_position_state,
+)
+
+
+# Stable "today" used by tests that exercise the calendar fallback. Picked to
+# be after every expiration date in the issue #134 reproduction journal so
+# real past-expiration legs close, while leaving room for future-dated tests
+# (e.g., 2026-08-15) to stay open.
+_FROZEN_TODAY = date(2026, 5, 8)
+
+
+def _frozen_clock(today: date = _FROZEN_TODAY):
+    """Return a callable that always reports ``today`` as the current date."""
+    return lambda: today
 
 
 # --- Fixtures ----------------------------------------------------------------
@@ -118,7 +136,11 @@ class TestSingleTrades:
             ],
         )
 
-        result = recompute_position_state(db_session, pos.id)
+        # Freeze clock before the leg's expiration so the calendar-fallback
+        # added in #134 doesn't auto-close this still-live leg.
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 3, 1))
+        )
 
         assert result is not None
         assert result.status == "open"
@@ -140,7 +162,9 @@ class TestSingleTrades:
             ],
         )
 
-        result = recompute_position_state(db_session, pos.id)
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 3, 1))
+        )
 
         assert result.status == "open"
         assert result.shares == 0
@@ -335,7 +359,12 @@ class TestLifecycleScenarios:
             ],
         )
 
-        result = recompute_position_state(db_session, pos.id)
+        # Frozen pre-expiration to keep the surviving 195P open after the
+        # 200P is bought-to-close — calendar fallback would otherwise close
+        # the still-live leg.
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 3, 18))
+        )
 
         assert result.status == "open"
         assert result.shares == 0
@@ -672,7 +701,11 @@ class TestRecomputeWritesDerivedStrategy:
             ],
         )
 
-        result = recompute_position_state(db_session, pos.id)
+        # Frozen before expiration so the still-live put leg isn't swept by
+        # the #134 calendar fallback.
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 3, 1))
+        )
 
         assert result.shares == 0
         assert result.strategy == "csp"
@@ -730,7 +763,11 @@ class TestRecomputeWritesDerivedStrategy:
             ],
         )
 
-        result = recompute_position_state(db_session, pos.id)
+        # Freeze before the call's expiration so the still-live call leg
+        # isn't swept by the #134 calendar fallback.
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 4, 5))
+        )
 
         assert result.shares == 100
         assert result.strategy == "cc"
@@ -768,7 +805,9 @@ class TestRecomputeWritesDerivedStrategy:
             ],
         )
 
-        result = recompute_position_state(db_session, pos.id)
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 4, 5))
+        )
 
         assert result.shares == 100
         assert result.strategy == "wheel"
@@ -844,3 +883,447 @@ class TestRecomputeWritesDerivedStrategy:
         result = recompute_position_state(db_session, pos.id)
 
         assert result.strategy == "holding"
+
+
+# --- Issue #134: leg-pairing on resolution + calendar fallback ---------------
+
+
+class TestLegPairingOnResolution:
+    """ACs from issue #134: assignment / called_away / past-expiration close legs.
+
+    The recomputer must close the originating short leg when a resolving
+    trade arrives (strict match first, FIFO fallback for dirty data) and
+    must close any past-expiration leg that has no resolving trade at all
+    (calendar fallback).
+    """
+
+    def test_sell_put_assignment_closes_put_leg(self, db_session):
+        # AC #1: After importing a wheel cycle ``sell_put → assignment`` the
+        # originating ``sell_put`` leg is closed and does not appear in the
+        # open-option-legs count.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 4, 1))
+        )
+
+        # Shares acquired, no open legs left, status open (still holding).
+        assert result.shares == 100
+        assert result.strategy == "holding"
+        assert result.status == "open"
+
+    def test_sell_call_called_away_closes_call_leg(self, db_session):
+        # AC #2: After importing ``sell_call → called_away`` the originating
+        # ``sell_call`` leg is closed.
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-02-25",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 4, 1))
+        )
+
+        # Full wheel cycle resolved: shares back to zero, no open legs,
+        # status closed.
+        assert result.status == "closed"
+        assert result.shares == 0
+
+    def test_sell_put_past_expiration_no_close_trade_closes_calendar(
+        self, db_session
+    ):
+        # AC #3: An option leg whose ``expiration < today`` and has no
+        # closing trade is treated as expired worthless and closed by the
+        # recomputer.
+        pos = _seed_position(
+            db_session,
+            ticker="SOFI",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 26.0,
+                    "expiration": "2025-09-26",
+                    "opened_at": "2025-08-01",
+                }
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+        )
+
+        # Past expiration, no resolving trade → closed via calendar
+        # fallback. closed_at is the leg's expiration (no real trade
+        # opened_at exists to use).
+        assert result.status == "closed"
+        assert result.shares == 0
+        assert result.broker_cost_basis == 0.0
+        assert result.closed_at == "2025-09-26"
+
+    def test_sell_call_past_expiration_no_close_trade_closes_calendar(
+        self, db_session
+    ):
+        # AC #3 (call side): same calendar fallback for an OTM short call
+        # whose Expired row never landed in the CSV.
+        pos = _seed_position(
+            db_session,
+            ticker="SOFI",
+            trades=[
+                {
+                    "trade_type": "sell_call",
+                    "strike": 31.0,
+                    "expiration": "2025-12-19",
+                    "opened_at": "2025-11-01",
+                }
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+        )
+
+        assert result.status == "closed"
+        assert result.shares == 0
+        assert result.closed_at == "2025-12-19"
+
+    def test_three_stacked_assignments_aggregate_to_300_shares(self, db_session):
+        # AC #5: Multiple stacked assignments (the user's reported SOFI case)
+        # all close their puts and shares accumulate to 300.
+        pos = _seed_position(
+            db_session,
+            ticker="SOFI",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 26.0,
+                    "expiration": "2025-09-26",
+                    "opened_at": "2025-08-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 26.0,
+                    "expiration": "2025-09-26",
+                    "opened_at": "2025-09-26",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 27.5,
+                    "expiration": "2025-10-10",
+                    "opened_at": "2025-09-15",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 27.5,
+                    "expiration": "2025-10-10",
+                    "opened_at": "2025-10-10",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 30.0,
+                    "expiration": "2025-11-21",
+                    "opened_at": "2025-10-20",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 30.0,
+                    "expiration": "2025-11-21",
+                    "opened_at": "2025-11-21",
+                },
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+        )
+
+        # All three assignments resolved their originating puts; shares
+        # stack to 300; basis sums each strike * 100; no open legs remain;
+        # label flips to "holding".
+        assert result.status == "open"
+        assert result.shares == 300
+        assert result.broker_cost_basis == pytest.approx(
+            26.0 * 100 + 27.5 * 100 + 30.0 * 100
+        )
+        assert result.strategy == "holding"
+
+    def test_future_expiration_no_close_trade_stays_open(self, db_session):
+        # AC #4: Open legs whose expiration is today or later with no
+        # closing trade must remain open — calendar fallback must not
+        # close future-dated legs.
+        pos = _seed_position(
+            db_session,
+            ticker="SOFI",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 28.0,
+                    "expiration": "2026-08-15",
+                    "opened_at": "2026-04-01",
+                }
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+        )
+
+        # Future-dated leg with no close: stays open.
+        assert result.status == "open"
+        assert result.shares == 0
+        assert result.strategy == "csp"
+        assert result.closed_at is None
+
+
+class TestFifoFallbackForDirtyData:
+    """Strict-then-FIFO pairing covers Schwab CSV rows whose strike or
+    expiration drifts slightly from the originating short leg."""
+
+    def test_assignment_with_mismatched_strike_closes_via_fifo(self, db_session):
+        # Resolving ``assignment`` strike differs from the open ``sell_put``
+        # by a penny. Strict match fails; FIFO fallback consumes the only
+        # open put leg.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.49,  # <-- penny drift, no strict match
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 4, 1))
+        )
+
+        # FIFO fallback closed the leg; shares acquired at the
+        # assignment row's strike (13.49 * 100).
+        assert result.status == "open"
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(1349.0)
+        assert result.strategy == "holding"
+
+    def test_called_away_with_mismatched_strike_closes_via_fifo(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                },
+                {
+                    "trade_type": "sell_call",
+                    "strike": 22.0,
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-02-25",
+                },
+                {
+                    "trade_type": "called_away",
+                    "strike": 21.99,  # <-- penny drift
+                    "expiration": "2026-03-20",
+                    "opened_at": "2026-03-20",
+                },
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 4, 1))
+        )
+
+        # FIFO fallback closed the call leg; full wheel cycle resolved.
+        assert result.status == "closed"
+        assert result.shares == 0
+
+
+class TestUnpairedResolvingEvent:
+    """When both strict and FIFO passes fail, log a warning and continue."""
+
+    def test_assignment_with_no_matching_put_leg_warns_but_no_error(
+        self, db_session, caplog
+    ):
+        # Bare ``assignment`` row with no preceding ``sell_put`` — neither
+        # the strict pass nor the FIFO pass can find a matching leg. The
+        # recomputer must log a warning and apply the shares/basis side
+        # effects; it must not raise.
+        pos = _seed_position(
+            db_session,
+            ticker="ZZZ",
+            trades=[
+                {
+                    "trade_type": "assignment",
+                    "strike": 50.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                }
+            ],
+        )
+
+        with caplog.at_level("WARNING", logger="app.services.positions"):
+            result = recompute_position_state(
+                db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+            )
+
+        # Warning surfaced the data-integrity gap; shares still updated.
+        assert any(
+            "no matching open leg" in record.getMessage()
+            for record in caplog.records
+        )
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(5000.0)
+
+
+class TestCalendarCloseHelper:
+    """Pure-function unit tests for ``_apply_calendar_close``."""
+
+    def test_empty_open_legs_returns_empty_and_none(self):
+        still, latest = _apply_calendar_close([], "F", date(2026, 5, 8))
+        assert still == []
+        assert latest is None
+
+    def test_all_future_legs_unchanged(self):
+        legs = [
+            _LegKey(option_type="put", strike=20.0, expiration="2026-08-15"),
+            _LegKey(option_type="call", strike=22.0, expiration="2026-09-19"),
+        ]
+        still, latest = _apply_calendar_close(legs, "F", date(2026, 5, 8))
+        assert still == legs
+        assert latest is None
+
+    def test_mix_of_past_and_future_legs(self):
+        past = _LegKey(option_type="put", strike=26.0, expiration="2025-09-26")
+        future = _LegKey(option_type="call", strike=22.0, expiration="2026-09-19")
+        still, latest = _apply_calendar_close(
+            [past, future], "SOFI", date(2026, 5, 8)
+        )
+        assert still == [future]
+        assert latest == "2025-09-26"
+
+    def test_multiple_past_legs_returns_latest_expiration(self):
+        leg_a = _LegKey(option_type="put", strike=20.0, expiration="2025-09-26")
+        leg_b = _LegKey(option_type="put", strike=22.0, expiration="2025-12-19")
+        leg_c = _LegKey(option_type="call", strike=30.0, expiration="2025-11-07")
+        still, latest = _apply_calendar_close(
+            [leg_a, leg_b, leg_c], "SOFI", date(2026, 5, 8)
+        )
+        assert still == []
+        # Latest among the three closed legs is 2025-12-19.
+        assert latest == "2025-12-19"
+
+    def test_unparseable_expiration_leaves_leg_alone(self):
+        # Defensive: a malformed expiration string shouldn't trigger
+        # calendar close (we can't prove it's past expiration).
+        leg = _LegKey(option_type="put", strike=20.0, expiration="not-a-date")
+        still, latest = _apply_calendar_close([leg], "F", date(2026, 5, 8))
+        assert still == [leg]
+        assert latest is None
+
+
+class TestCalendarCloseRegressionGuard:
+    """Calendar fallback must not regress the covered-call-with-shares case
+    introduced in PR #130 (``test_covered_call_expires_keeps_shares``)."""
+
+    def test_calendar_close_does_not_regress_covered_call_with_shares(
+        self, db_session
+    ):
+        # Same flow as ``test_covered_call_expires_keeps_shares`` but with
+        # NO explicit "expired" row and the clock frozen *after* the call's
+        # expiration. The calendar fallback should close the call leg, but
+        # shares and basis must stay intact and the position must remain
+        # open with the "holding" label.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+                # Now 100 shares held at $1350 basis.
+                {
+                    "trade_type": "sell_call",
+                    "strike": 15.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-01",
+                },
+                # No "expired" row for the call — calendar fallback closes.
+            ],
+        )
+
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+        )
+
+        assert result.status == "open"
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(1350.0)
+        assert result.strategy == "holding"
+        assert result.closed_at is None

--- a/backend/tests/test_reconcile_positions.py
+++ b/backend/tests/test_reconcile_positions.py
@@ -213,10 +213,21 @@ class TestReconcileAll:
         assert reloaded.shares == 200
         assert reloaded.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
 
-    def test_no_changes_when_state_already_correct(self, db_session, capsys):
+    def test_no_changes_when_state_already_correct(
+        self, db_session, capsys, monkeypatch
+    ):
         # Seed with correct state for a simple sell_put leg: 0 shares, open.
         # Strategy must already match the derived "csp" label, otherwise the
         # reconciler will record a change for the label fix.
+        #
+        # Freeze the recomputer's clock to before the leg's expiration so the
+        # #134 calendar fallback doesn't auto-close the still-live leg and
+        # turn this into a "changed" row.
+        from datetime import date
+
+        from app.services import positions as positions_module
+
+        monkeypatch.setattr(positions_module, "_utc_today", lambda: date(2026, 3, 1))
         pos = _seed_ghost_open_position(
             db_session,
             ticker="F",

--- a/backend/tests/test_schwab_csv_import.py
+++ b/backend/tests/test_schwab_csv_import.py
@@ -336,11 +336,21 @@ class TestImportCsvEndpoint:
         tickers = {p["ticker"] for p in positions}
         assert tickers == {"F", "SOFI"}
 
-    def test_import_derives_strategy_label(self, client):
+    def test_import_derives_strategy_label(self, client, monkeypatch):
         # `position_strategy` form field is no longer accepted under #131.
         # The recomputer derives the label per position state. F has a single
         # short put with no shares → "csp". SOFI has a single short call
         # with no shares → "cc" (anomaly path; logged warning).
+        #
+        # The hard-coded 2026-03 expirations in SELL_*_ROW are already past
+        # relative to wall-clock time, so freeze the recomputer's clock to
+        # before those expirations — otherwise the #134 calendar fallback
+        # would close both legs and flip the labels.
+        from datetime import date
+
+        from app.services import positions as positions_module
+
+        monkeypatch.setattr(positions_module, "_utc_today", lambda: date(2026, 3, 1))
         resp = client.post(
             "/api/journal/import/csv",
             files=_csv_file(_csv([SELL_PUT_ROW, SELL_CALL_ROW])),

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -364,11 +364,22 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 0
         assert position.closed_at == "2026-03-25"
 
-    def test_reopen_after_close_creates_new_position(self, db_session):
+    def test_reopen_after_close_creates_new_position(
+        self, db_session, monkeypatch
+    ):
         """A new sell_put on a previously-closed ticker creates a new Position.
 
         The closed cycle's history (trades, dates, P&L) must remain immutable.
         """
+        # Freeze the recomputer's clock to before the second-cycle leg's
+        # expiration so the #134 calendar fallback doesn't auto-close the
+        # still-live 2026-04-17 leg.
+        from datetime import date
+
+        from app.services import positions as positions_module
+
+        monkeypatch.setattr(positions_module, "_utc_today", lambda: date(2026, 4, 1))
+
         first_cycle = [
             _mapped("F", "sell_put", 13.50, "2026-03-27", "2026-03-01"),
             _mapped("F", "buy_put_close", 13.50, "2026-03-27", "2026-03-05"),


### PR DESCRIPTION
Closes #134.

## Summary

Extends ``recompute_position_state`` so the open-legs derivation reflects
real-world wheel resolutions, not just explicit BTC trades.

- **Strict-then-FIFO leg pairing** in ``_consume_leg``: the existing strict
  ``(option_type, strike, expiration)`` match runs first; on miss, the
  earliest-expiring open leg of the matching side is consumed instead.
  Handles the dirty-data case in #134 where a Schwab CSV row's strike or
  expiration drifts slightly from the originating short leg.
- **Calendar fallback** ``_apply_calendar_close`` after trade replay: any
  leg whose expiration is strictly before today is removed as
  expired-worthless. ``closed_at`` falls back to the leg's expiration
  string when no real resolving trade stamped one.
- **Injectable clock**: ``recompute_position_state`` accepts an optional
  ``clock: Callable[[], date]`` (default ``_utc_today`` resolved lazily so
  tests can monkeypatch the module attribute). UTC date is fine at day
  granularity because options settle 4 PM ET — by the time UTC ticks over
  the next day, ET is well past close.

No schema changes, no API contract changes, no frontend changes. The
reconcile script already calls the recomputer per position, so it picks
up the new behavior automatically without script edits.

## Acceptance criteria (issue #134)

- [x] After importing ``sell_put → assignment``, the originating ``sell_put`` leg is closed.  
  Test: ``TestLegPairingOnResolution::test_sell_put_assignment_closes_put_leg``
- [x] After importing ``sell_call → called_away``, the originating ``sell_call`` leg is closed.  
  Test: ``TestLegPairingOnResolution::test_sell_call_called_away_closes_call_leg``
- [x] Past-expiration leg with no closing trade closes via calendar fallback.  
  Tests: ``test_sell_put_past_expiration_no_close_trade_closes_calendar`` and the call-side variant.
- [x] Future-dated leg with no closing trade stays open.  
  Test: ``test_future_expiration_no_close_trade_stays_open``
- [x] Pairing logic documented as strict-then-FIFO in the function docstring.  
  ``recompute_position_state`` and ``_consume_leg`` docstrings call out the strategy and rationale.
- [x] Three stacked SOFI assignments aggregate to 300 shares.  
  Test: ``test_three_stacked_assignments_aggregate_to_300_shares``
- [x] Backend tests in ``backend/tests/test_position_state.py``.  
  +15 new tests across ``TestLegPairingOnResolution``, ``TestFifoFallbackForDirtyData``, ``TestUnpairedResolvingEvent``, ``TestCalendarCloseHelper``, ``TestCalendarCloseRegressionGuard``.

The user-visible AC ("running ``make reconcile-positions ARGS=--apply``
on the existing journal closes all 17 zombie legs") is satisfied
implicitly by the recomputer fix; verify locally per the manual smoke
in the plan.

## Test Plan

- [x] ``cd backend && python -m pytest`` — full suite passes (696 tests, 7 skipped).
- [x] ``cd backend && python -m pytest tests/test_position_state.py -v`` — 44 tests pass, including the new 15 covering issue #134 ACs.
- [x] Regression guard: ``test_covered_call_expires_keeps_shares`` (added in PR #130 commit ``7db1df0``) still passes — calendar fallback does not delete shares behind a covered-call holder.
- [ ] Manual: run ``make reconcile-positions`` (dry run) on the user's
      journal post-merge; the diff should show the 17 zombie legs
      closing and labels flipping to ``holding`` for F and SOFI. Then
      ``make reconcile-positions ARGS=--apply``.

## Files touched

- ``backend/app/services/positions.py`` — leg-pairing FIFO fallback, calendar fallback, ``clock`` kwarg.
- ``backend/tests/test_position_state.py`` — 15 new tests covering the ACs and the helper.
- ``backend/tests/test_integration_import.py`` — bumped mock ``expirationDate`` values to far-future so the new calendar fallback doesn't sweep the legs the test asserts on.
- ``backend/tests/test_reconcile_positions.py`` — frozen-clock monkeypatch for the "no changes" test whose hard-coded expiration is now in the past.
- ``backend/tests/test_schwab_csv_import.py`` — frozen-clock monkeypatch for the strategy-label derivation test (CSV fixture dates predate today).
- ``backend/tests/test_schwab_import.py`` — frozen-clock monkeypatch for the reopen-after-close test (second-cycle leg's expiration is now past).

## Notes

- ``backend/scripts/reconcile_positions.py`` is unchanged: it already calls ``recompute_position_state(db, pid, commit=apply)`` per Position, so the new behavior is picked up automatically.
- No schema migrations.
- No API contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)