### PR TITLE
V0.5.4: Backend foundation — action engine, KPI extensions, signal fields (closes #146)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -515,6 +515,27 @@ DASHBOARD_OPTION_TYPE = Literal["put", "call"]
 DASHBOARD_MONEYNESS_STATE = Literal["ITM", "ATM", "OTM"]
 DASHBOARD_DECISION_TAG = Literal["roll-or-assign", "manage", "watch", "hold"]
 DASHBOARD_ACTIVITY_KIND = Literal["session_saved", "trade_added"]
+DASHBOARD_PROFIT_TARGET_STATE = Literal[
+    "captured_50", "in_progress", "underwater", "unknown"
+]
+DASHBOARD_ASSIGNMENT_RISK = Literal["high", "watch", "low"]
+# Per spec §14.5: V0.5 never emits "close" (live option-chain integration
+# deferred). Frontend renders "—" when state == "unknown". The Literal
+# enumerates every legal value the field may eventually carry.
+DASHBOARD_SUGGESTED_ACTION = Literal["roll", "close", "hold", "manage"]
+DASHBOARD_WHEEL_STATUS = Literal["CSP", "CC", "Wheel", "Holding"]
+DASHBOARD_ACTION_ID = Literal[
+    "data.schwab_disconnected",
+    "data.cache_very_stale",
+    "data.schwab_token_expiring",
+    "position.large_loser",
+    "expiration.itm_short_dte",
+    "expiration.short_dte",
+    "position.cc_candidate",
+    "journal.no_open_legs",
+]
+DASHBOARD_ACTION_PRIORITY = Literal["P0", "P1", "P2"]
+DASHBOARD_ACTION_CTA_KIND = Literal["link", "inline"]
 
 
 class DashboardSchwabStatus(BaseModel):
@@ -568,6 +589,22 @@ class DashboardOpenLegsBreakdown(BaseModel):
     calls: int
 
 
+class DashboardKpiLargestRisk(BaseModel):
+    """Tile payload for the "Largest risk" KPI (worst unrealized loser)."""
+
+    ticker: str
+    unrealized_pl: float
+    unrealized_pl_pct: Optional[float] = None
+
+
+class DashboardKpiLargestLoser(BaseModel):
+    """Tile payload for the largest realized loser across closed positions."""
+
+    ticker: str
+    realized_pl: float
+    realized_pl_pct: Optional[float] = None
+
+
 class DashboardKpis(BaseModel):
     open_positions: int
     open_positions_breakdown: DashboardOpenPositionsBreakdown
@@ -577,6 +614,14 @@ class DashboardKpis(BaseModel):
     open_legs_breakdown: DashboardOpenLegsBreakdown
     unrealized_pl: Optional[float] = None
     unrealized_pl_pct: Optional[float] = None
+    # New in V0.5.4 — see decision-dashboard-v05.md §2.3 / §14.4
+    largest_risk: Optional[DashboardKpiLargestRisk] = None
+    largest_loser: Optional[DashboardKpiLargestLoser] = None
+    premium_collected_total: float = 0.0
+    premium_collected_ytd: float = 0.0
+    premium_collected_trades: int = 0
+    realized_pl: float = 0.0
+    realized_pl_pct: Optional[float] = None
 
 
 class DashboardPositionRow(BaseModel):
@@ -589,12 +634,28 @@ class DashboardPositionRow(BaseModel):
     notional: Optional[float] = None
     unrealized_pl: Optional[float] = None
     open_legs_count: int
+    # New in V0.5.4 — see decision-dashboard-v05.md §14.6
+    wheel_status: DASHBOARD_WHEEL_STATUS
+    next_suggested_action: str = "hold"
+    pl_pct: Optional[float] = None
 
 
 class DashboardMoneyness(BaseModel):
     state: DASHBOARD_MONEYNESS_STATE
     distance_pct: float
     distance_dollars: float
+
+
+class DashboardProfitTargetStatus(BaseModel):
+    """Per-leg profit-target signal.
+
+    V0.5 always sets ``state == "unknown"`` because live option-chain data
+    is not yet integrated. The field shape ships so frontend renderers and
+    the V0.7 live-chain work have a stable contract.
+    """
+
+    captured_pct: Optional[float] = None
+    state: DASHBOARD_PROFIT_TARGET_STATE
 
 
 class DashboardOpenLeg(BaseModel):
@@ -606,11 +667,52 @@ class DashboardOpenLeg(BaseModel):
     dte: int
     moneyness: Optional[DashboardMoneyness] = None
     position_id: str
+    # New in V0.5.4 — see decision-dashboard-v05.md §14.5
+    profit_target_status: DashboardProfitTargetStatus
+    assignment_risk: DASHBOARD_ASSIGNMENT_RISK
+    suggested_action: DASHBOARD_SUGGESTED_ACTION
+    earnings_in_window: bool = False
 
 
 class DashboardUpcomingExpiration(DashboardOpenLeg):
     decision_tag: DASHBOARD_DECISION_TAG
     decision_reason: str
+
+
+class DashboardNextActionSubject(BaseModel):
+    """Structured subject identifier for a Next Action card.
+
+    Both fields are optional — the engine emits whichever signals are
+    available for the action type. ``amount`` is a preformatted display
+    string (e.g. ``"-$1,420 (-7.2%)"``) so the frontend renders it verbatim.
+    """
+
+    ticker: Optional[str] = None
+    amount: Optional[str] = None
+
+
+class DashboardNextActionCta(BaseModel):
+    """CTA on a Next Action card.
+
+    ``kind == "link"`` navigates to ``href``; ``kind == "inline"`` invokes
+    a known client-side handler keyed by ``action_id`` (e.g. cache-refresh).
+    """
+
+    label: str
+    href: str
+    kind: DASHBOARD_ACTION_CTA_KIND = "link"
+
+
+class DashboardNextAction(BaseModel):
+    """One entry in the dashboard's ranked action engine output."""
+
+    id: str  # stable React key, derived from "{action_id}.{subject_id}"
+    action_id: DASHBOARD_ACTION_ID
+    priority: DASHBOARD_ACTION_PRIORITY
+    title: str
+    subject: DashboardNextActionSubject = DashboardNextActionSubject()
+    reason: str
+    cta: DashboardNextActionCta
 
 
 class DashboardActivity(BaseModel):
@@ -640,3 +742,6 @@ class DashboardResponse(BaseModel):
     upcoming_expirations: list[DashboardUpcomingExpiration]
     recent_activity: list[DashboardActivity]
     data_meta: DashboardDataMeta
+    # New in V0.5.4 — server-side ranked action engine output. See
+    # decision-dashboard-v05.md §2.2 / §14.7.
+    next_actions: list[DashboardNextAction] = []

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -1,0 +1,495 @@
+"""Decision Dashboard action engine — Next Actions ranking.
+
+The engine is a pure function: given the already-composed status, KPI,
+positions, and open-legs slices of a dashboard payload, it returns a
+deterministically ranked list of action cards for the frontend to render.
+
+Determinism matters because the section is e2e-tested and the rendering
+order is part of the user-visible contract. Sort keys (see
+``_sort_key_for``) include the action's stable ``id`` as the final tie
+breaker so the engine is bit-for-bit reproducible across runs.
+
+Design rules (per ``frontend/design-specs/decision-dashboard-v05.md`` §2.2
+and §14.7):
+- Server-side; the frontend renders what it receives.
+- No memoization — recomputed on every dashboard load. Cost is one pass
+  over already-loaded arrays.
+- Cap the output at 8 entries; the frontend hides past 3 behind
+  ``[Show N more]``.
+- Each action's ``id`` is ``"{action_id}.{subject_id}"`` so React keys are
+  stable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable
+
+# Cap from spec §2.2: anything beyond 8 cards is noise; the user should
+# triage in the destination tool.
+MAX_ACTIONS = 8
+
+# How soon a Schwab refresh-token expiry should trigger a P1 warning
+# action. Aligns with the 7-day token lifetime documented in
+# ``schwab_auth.py``.
+TOKEN_EXPIRING_DAYS = 7
+
+# Large-loser thresholds (spec §2.2 / Q1). Whichever fires first.
+LARGE_LOSER_PCT_THRESHOLD = -0.05  # -5%
+LARGE_LOSER_DOLLAR_THRESHOLD = -1000.0  # -$1,000
+
+# Cap on per-leg ITM short-DTE cards. Spec §2.2: "one card per leg, capped
+# at 3 most-urgent".
+ITM_SHORT_DTE_CAP = 3
+ITM_SHORT_DTE_MAX_DTE = 7
+
+# Sort priority bases per spec §14.7. Lower number = ranked first inside
+# the priority bucket. Two sub-bucket keys live alongside these to break
+# ties within a single severity bucket (see ``_sub_bucket_for``).
+_PRIORITY_RANK: dict[str, int] = {"P0": 0, "P1": 1, "P2": 2}
+
+
+def _slugify_ticker(ticker: str | None) -> str:
+    """Lowercase ticker stub used in stable action IDs."""
+    return (ticker or "unknown").lower()
+
+
+def _format_dollar(amount: float) -> str:
+    """Render a signed dollar amount with comma grouping (e.g. ``-$1,420``)."""
+    sign = "-" if amount < 0 else "+"
+    return f"{sign}${abs(amount):,.0f}"
+
+
+def _format_signed_pct(pct: float) -> str:
+    """Render a signed percentage at one decimal place (e.g. ``-7.2%``)."""
+    return f"{pct * 100:+.1f}%"
+
+
+def _parse_iso_to_utc(value: str | None) -> datetime | None:
+    """Best-effort ISO timestamp parser; returns ``None`` on failure."""
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _sub_bucket_for(action: dict) -> int:
+    """Within-bucket ordering key. Lower sorts first.
+
+    Rules per spec §14.7:
+    - Within P0: ``data.*`` ranks above ``position.*`` (trust data before
+      losses).
+    - Within P1: data issues rank above expiration issues, which rank
+      above other position issues.
+    - Within P2: covered-call candidates rank above the no-open-legs
+      scanner card (revenue before lowest-urgency).
+    """
+    action_id = action["action_id"]
+    if action_id.startswith("data."):
+        return 0
+    if action_id.startswith("expiration."):
+        return 1
+    if action_id == "position.cc_candidate":
+        # P2 tiebreaker: CC candidates outrank the scanner.
+        return 0
+    if action_id == "journal.no_open_legs":
+        return 9
+    return 5
+
+
+def _tie_breaker_for(action: dict) -> tuple:
+    """Tail-end deterministic ordering tuple.
+
+    - P1 expiration cards sort by DTE ascending (closest deadline first).
+    - P2 covered-call candidates sort by ticker A→Z.
+    - All others fall back to the action ID for a stable lexical order.
+    """
+    action_id = action["action_id"]
+    subject_ticker = (action.get("subject") or {}).get("ticker") or ""
+    if action_id == "expiration.itm_short_dte":
+        return (action.get("_dte", 0), subject_ticker)
+    if action_id == "expiration.short_dte":
+        return (action.get("_dte", 0), subject_ticker)
+    if action_id == "position.cc_candidate":
+        return (0, subject_ticker)
+    return (0, action["id"])
+
+
+def _sort_key_for(action: dict) -> tuple:
+    """Composite deterministic sort key. Lower sorts first.
+
+    Components, in priority order:
+    1. priority bucket (P0 < P1 < P2)
+    2. within-bucket sub-bucket (e.g. data > position inside P0)
+    3. action-type tie breaker (DTE asc / ticker A→Z)
+    4. action id (final lexical fallback so equal-priority duplicates
+       remain stable)
+    """
+    return (
+        _PRIORITY_RANK[action["priority"]],
+        _sub_bucket_for(action),
+        _tie_breaker_for(action),
+        action["id"],
+    )
+
+
+# --- Action builders --------------------------------------------------------
+
+
+def _schwab_disconnected_action(schwab_status: dict) -> dict | None:
+    """Build a ``data.schwab_disconnected`` card when Schwab is unusable."""
+    configured = schwab_status.get("configured")
+    valid = schwab_status.get("valid")
+    if configured is False or valid is False:
+        return {
+            "id": "data.schwab_disconnected.schwab",
+            "action_id": "data.schwab_disconnected",
+            "priority": "P0",
+            "title": "Reconnect Schwab",
+            "subject": {},
+            "reason": (
+                "Schwab is disconnected — live prices and trade import are unavailable."
+            ),
+            "cta": {
+                "label": "Open Schwab settings",
+                "href": "/settings#schwab",
+                "kind": "link",
+            },
+        }
+    return None
+
+
+def _cache_very_stale_action(cache_status: dict) -> dict | None:
+    """Build a ``data.cache_very_stale`` card when very-stale entries exist."""
+    very_stale = int(cache_status.get("very_stale") or 0)
+    if very_stale <= 0:
+        return None
+    return {
+        "id": "data.cache_very_stale.cache",
+        "action_id": "data.cache_very_stale",
+        "priority": "P0",
+        "title": "Refresh stale market data",
+        "subject": {"amount": f"{very_stale} item{'s' if very_stale != 1 else ''}"},
+        "reason": (
+            f"{very_stale} cached item{'s are' if very_stale != 1 else ' is'} "
+            f"over 90 days old. Refresh before trusting downstream metrics."
+        ),
+        "cta": {
+            "label": "Refresh stale data",
+            "href": "#refresh-stale-cache",
+            "kind": "inline",
+        },
+    }
+
+
+def _schwab_token_expiring_action(
+    schwab_status: dict, now: datetime | None = None
+) -> dict | None:
+    """Build a ``data.schwab_token_expiring`` card when expiry is < 7 days."""
+    if schwab_status.get("configured") is not True or schwab_status.get("valid") is False:
+        # Disconnected cases are handled by the P0 card above; don't
+        # double-emit.
+        return None
+    expiry_iso = schwab_status.get("expires_at")
+    expires_at = _parse_iso_to_utc(expiry_iso)
+    if expires_at is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    delta = expires_at - now
+    if delta.total_seconds() < 0:
+        # Already expired — `data.schwab_disconnected` handles that case
+        # via `valid == False`; this builder is for soon-to-expire only.
+        return None
+    if delta.days > TOKEN_EXPIRING_DAYS:
+        return None
+    days = max(delta.days, 0)
+    when = "today" if days == 0 else f"in {days} day{'s' if days != 1 else ''}"
+    return {
+        "id": "data.schwab_token_expiring.schwab",
+        "action_id": "data.schwab_token_expiring",
+        "priority": "P1",
+        "title": "Renew Schwab token",
+        "subject": {"amount": when},
+        "reason": (
+            f"Schwab refresh token expires {when} — renew before the next session."
+        ),
+        "cta": {
+            "label": "Open Schwab settings",
+            "href": "/settings#schwab",
+            "kind": "link",
+        },
+    }
+
+
+def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
+    """Build a ``position.large_loser`` card for the single worst loser.
+
+    Spec §2.2: surface only the single largest loser per cycle, even when
+    multiple positions breach the threshold. Trigger is whichever-fires-first
+    between ``unrealized_pl_pct <= -5%`` and ``unrealized_pl <= -$1,000``.
+    """
+    candidates: list[tuple[float, dict]] = []
+    for row in positions:
+        unrealized_pl = row.get("unrealized_pl")
+        if unrealized_pl is None or unrealized_pl >= 0:
+            continue
+        pct = row.get("pl_pct")
+        triggered = unrealized_pl <= LARGE_LOSER_DOLLAR_THRESHOLD or (
+            pct is not None and pct <= LARGE_LOSER_PCT_THRESHOLD
+        )
+        if not triggered:
+            continue
+        candidates.append((unrealized_pl, row))
+    if not candidates:
+        return None
+    # Most negative unrealized_pl wins; ticker A→Z is the deterministic tie
+    # breaker so equal-loss positions don't shuffle between runs.
+    candidates.sort(key=lambda pair: (pair[0], pair[1]["ticker"]))
+    _, worst = candidates[0]
+    ticker = worst["ticker"]
+    amount_dollars = _format_dollar(worst["unrealized_pl"])
+    pct = worst.get("pl_pct")
+    amount_pct = _format_signed_pct(pct) if pct is not None else ""
+    amount = (
+        f"{ticker}  {amount_dollars} ({amount_pct})"
+        if amount_pct
+        else f"{ticker}  {amount_dollars}"
+    )
+    return {
+        "id": f"position.large_loser.{worst['id']}",
+        "action_id": "position.large_loser",
+        "priority": "P0",
+        "title": f"Review {ticker}",
+        "subject": {"ticker": ticker, "amount": amount},
+        "reason": "Position is below your review threshold (-5% or -$1,000).",
+        "cta": {
+            "label": f"Review {ticker}",
+            "href": f"/journal?position={worst['id']}",
+            "kind": "link",
+        },
+    }
+
+
+def _itm_short_dte_actions(open_legs: Iterable[dict]) -> list[dict]:
+    """Build up to ``ITM_SHORT_DTE_CAP`` per-leg ``expiration.itm_short_dte`` cards."""
+    cards: list[dict] = []
+    for leg in open_legs:
+        dte = leg.get("dte")
+        moneyness = leg.get("moneyness") or {}
+        if dte is None or dte > ITM_SHORT_DTE_MAX_DTE:
+            continue
+        if moneyness.get("state") != "ITM":
+            continue
+        ticker = leg["ticker"]
+        strike = leg["strike"]
+        option_letter = "P" if leg.get("type") == "put" else "C"
+        cards.append(
+            {
+                "id": f"expiration.itm_short_dte.{leg['id']}",
+                "action_id": "expiration.itm_short_dte",
+                "priority": "P1",
+                "title": f"Roll {ticker} {strike:g}{option_letter}",
+                "subject": {
+                    "ticker": ticker,
+                    "amount": f"{int(dte)} DTE · ITM",
+                },
+                "reason": (
+                    f"Short {leg.get('type', 'put')} is ITM with {int(dte)} day"
+                    f"{'s' if dte != 1 else ''} to expiration."
+                ),
+                "cta": {
+                    "label": "Manage in Journal",
+                    "href": f"/journal?position={leg['position_id']}",
+                    "kind": "link",
+                },
+                # Sort metadata consumed by `_tie_breaker_for`.
+                "_dte": int(dte),
+            }
+        )
+    cards.sort(key=lambda c: (c["_dte"], c["subject"]["ticker"], c["id"]))
+    return cards[:ITM_SHORT_DTE_CAP]
+
+
+def _short_dte_aggregate_actions(open_legs: Iterable[dict]) -> list[dict]:
+    """Build aggregated ``expiration.short_dte`` cards — one per ticker.
+
+    Aggregated because a 7-DTE OTM book often contains the same ticker
+    repeatedly, and per-leg cards would crowd out higher-priority signals.
+    """
+    by_ticker: dict[str, dict] = {}
+    for leg in open_legs:
+        dte = leg.get("dte")
+        moneyness = leg.get("moneyness") or {}
+        if dte is None or dte > ITM_SHORT_DTE_MAX_DTE:
+            continue
+        if moneyness.get("state") == "ITM":
+            # ITM legs are handled by the per-leg card.
+            continue
+        ticker = leg["ticker"]
+        entry = by_ticker.get(ticker)
+        if entry is None or dte < entry["min_dte"]:
+            by_ticker[ticker] = {
+                "ticker": ticker,
+                "min_dte": int(dte),
+                "position_id": leg["position_id"],
+                "leg_count": (entry["leg_count"] + 1) if entry else 1,
+            }
+        else:
+            entry["leg_count"] += 1
+    cards: list[dict] = []
+    for ticker, entry in by_ticker.items():
+        count = entry["leg_count"]
+        leg_word = "leg" if count == 1 else "legs"
+        cards.append(
+            {
+                "id": f"expiration.short_dte.{ticker.lower()}",
+                "action_id": "expiration.short_dte",
+                "priority": "P1",
+                "title": f"Review {ticker} legs",
+                "subject": {
+                    "ticker": ticker,
+                    "amount": f"{count} {leg_word} ≤ {ITM_SHORT_DTE_MAX_DTE} DTE",
+                },
+                "reason": (
+                    f"{count} open {leg_word} on {ticker} expire within "
+                    f"{ITM_SHORT_DTE_MAX_DTE} days."
+                ),
+                "cta": {
+                    "label": f"Manage {ticker}",
+                    "href": f"/journal?position={entry['position_id']}",
+                    "kind": "link",
+                },
+                "_dte": entry["min_dte"],
+            }
+        )
+    cards.sort(key=lambda c: (c["_dte"], c["subject"]["ticker"], c["id"]))
+    return cards
+
+
+def _cc_candidate_actions(
+    positions: Iterable[dict],
+    open_legs: Iterable[dict],
+) -> list[dict]:
+    """Build ``position.cc_candidate`` cards for unsold-call positions.
+
+    Trigger per spec §2.2: ``shares >= 100`` AND no open call leg on that
+    ticker. V0.5 assumes every ticker is options-tradable (spec §10 Q6).
+    """
+    tickers_with_open_calls = {
+        leg["ticker"] for leg in open_legs if leg.get("type") == "call"
+    }
+    cards: list[dict] = []
+    for row in positions:
+        if (row.get("shares") or 0) < 100:
+            continue
+        ticker = row["ticker"]
+        if ticker in tickers_with_open_calls:
+            continue
+        cards.append(
+            {
+                "id": f"position.cc_candidate.{_slugify_ticker(ticker)}",
+                "action_id": "position.cc_candidate",
+                "priority": "P2",
+                "title": f"Consider covered call on {ticker}",
+                "subject": {
+                    "ticker": ticker,
+                    "amount": f"{int(row['shares'])} shares",
+                },
+                "reason": (
+                    f"You hold {int(row['shares'])} {ticker} shares with no open "
+                    "call leg — consider writing a covered call."
+                ),
+                "cta": {
+                    "label": f"Scan {ticker}",
+                    "href": f"/options?ticker={ticker}",
+                    "kind": "link",
+                },
+            }
+        )
+    cards.sort(key=lambda c: c["subject"]["ticker"] or "")
+    return cards
+
+
+def _no_open_legs_action(kpis: dict) -> dict | None:
+    """Build the single ``journal.no_open_legs`` card when no legs are open.
+
+    Per locked decision: emit even when there are no positions at all — the
+    scanner card directs the user to start there.
+    """
+    if int(kpis.get("open_legs") or 0) != 0:
+        return None
+    return {
+        "id": "journal.no_open_legs.scanner",
+        "action_id": "journal.no_open_legs",
+        "priority": "P2",
+        "title": "Run scanner — no open legs",
+        "subject": {},
+        "reason": "No open option legs across the journal — run the scanner to find new ideas.",
+        "cta": {
+            "label": "Open Options",
+            "href": "/options",
+            "kind": "link",
+        },
+    }
+
+
+def _strip_internal_keys(action: dict) -> dict:
+    """Drop sort-only metadata (``_dte`` etc.) before emitting to the client."""
+    return {k: v for k, v in action.items() if not k.startswith("_")}
+
+
+def compute_next_actions(
+    *,
+    status: dict,
+    kpis: dict,
+    positions: list[dict],
+    open_legs: list[dict],
+    now: datetime | None = None,
+) -> list[dict]:
+    """Compute the ranked Next Actions list for the dashboard payload.
+
+    Pure function: every input is plain in-memory data already loaded by
+    :func:`app.services.dashboard.build_dashboard_payload`. Output is
+    deterministic for any given input — same input, same order, byte for
+    byte.
+
+    Returns at most :data:`MAX_ACTIONS` entries.
+    """
+    candidates: list[dict] = []
+
+    schwab = status.get("schwab", {}) or {}
+    cache = status.get("cache", {}) or {}
+
+    schwab_card = _schwab_disconnected_action(schwab)
+    if schwab_card is not None:
+        candidates.append(schwab_card)
+
+    cache_card = _cache_very_stale_action(cache)
+    if cache_card is not None:
+        candidates.append(cache_card)
+
+    # Token-expiring is only meaningful when Schwab is otherwise healthy —
+    # the builder short-circuits the disconnected case.
+    token_card = _schwab_token_expiring_action(schwab, now=now)
+    if token_card is not None:
+        candidates.append(token_card)
+
+    loser_card = _largest_loser_action(positions)
+    if loser_card is not None:
+        candidates.append(loser_card)
+
+    candidates.extend(_itm_short_dte_actions(open_legs))
+    candidates.extend(_short_dte_aggregate_actions(open_legs))
+    candidates.extend(_cc_candidate_actions(positions, open_legs))
+
+    no_legs_card = _no_open_legs_action(kpis)
+    if no_legs_card is not None:
+        candidates.append(no_legs_card)
+
+    candidates.sort(key=_sort_key_for)
+    return [_strip_internal_keys(card) for card in candidates[:MAX_ACTIONS]]

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Iterable
+from urllib.parse import quote
 
 # Cap from spec §2.2: anything beyond 8 cards is noise; the user should
 # triage in the destination tool.
@@ -269,7 +270,7 @@ def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
         "reason": "Position is below your review threshold (-5% or -$1,000).",
         "cta": {
             "label": f"Review {ticker}",
-            "href": f"/journal?position={worst['id']}",
+            "href": f"/journal?position={quote(str(worst['id']), safe='')}",
             "kind": "link",
         },
     }
@@ -304,7 +305,7 @@ def _itm_short_dte_actions(open_legs: Iterable[dict]) -> list[dict]:
                 ),
                 "cta": {
                     "label": "Manage in Journal",
-                    "href": f"/journal?position={leg['position_id']}",
+                    "href": f"/journal?position={quote(str(leg['position_id']), safe='')}",
                     "kind": "link",
                 },
                 # Sort metadata consumed by `_tie_breaker_for`.
@@ -361,7 +362,7 @@ def _short_dte_aggregate_actions(open_legs: Iterable[dict]) -> list[dict]:
                 ),
                 "cta": {
                     "label": f"Manage {ticker}",
-                    "href": f"/journal?position={entry['position_id']}",
+                    "href": f"/journal?position={quote(str(entry['position_id']), safe='')}",
                     "kind": "link",
                 },
                 "_dte": entry["min_dte"],
@@ -406,7 +407,7 @@ def _cc_candidate_actions(
                 ),
                 "cta": {
                     "label": f"Scan {ticker}",
-                    "href": f"/options?ticker={ticker}",
+                    "href": f"/options?ticker={quote(ticker, safe='')}",
                     "kind": "link",
                 },
             }

--- a/backend/app/services/alpha_vantage_client.py
+++ b/backend/app/services/alpha_vantage_client.py
@@ -167,6 +167,39 @@ def get_next_earnings_date(symbol: str) -> Optional[str]:
         return None
 
 
+def get_cached_next_earnings_date(symbol: str) -> Optional[str]:
+    """Return a cached earnings date for ``symbol`` without making a network call.
+
+    Looks at the in-memory hot cache first, then the SQLite durable cache.
+    Returns ``None`` when no fresh cache entry exists. By contract this
+    function NEVER triggers a network round-trip — callers (e.g. the
+    dashboard composition path) rely on cache-hit-only semantics so the
+    request path is not blocked on Alpha Vantage rate limits.
+
+    See ``frontend/design-specs/decision-dashboard-v05.md`` §14.5: the
+    dashboard surfaces ``earnings_in_window`` only when a fresh cache hit
+    is available; otherwise the field defaults to ``false`` and the
+    earnings glyph is suppressed.
+    """
+    now = datetime.now(timezone.utc)
+
+    if symbol in _cache:
+        cached_date, fetched_at = _cache[symbol]
+        if now - fetched_at < _CACHE_TTL:
+            return cached_date
+
+    db_entry = _read_db_cache(symbol)
+    if db_entry:
+        cached_date, fetched_at = db_entry
+        if now - fetched_at < _CACHE_TTL:
+            # Backfill the hot cache so subsequent lookups in the same
+            # process skip the DB hit.
+            _cache[symbol] = (cached_date, fetched_at)
+            return cached_date
+
+    return None
+
+
 def clear_cache() -> None:
     """Clear the in-memory earnings cache (for testing)."""
     _cache.clear()

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -20,6 +20,8 @@ from sqlalchemy.orm import Session as DBSession
 from app.config import get_fred_api_key
 from app.models.database import CacheEntry, Position, Session as SessionModel, Trade
 from app.services import journal as journal_service
+from app.services.action_engine import compute_next_actions
+from app.services.alpha_vantage_client import get_cached_next_earnings_date
 from app.services.dashboard_legs import (
     derive_open_legs,
     filter_upcoming,
@@ -160,17 +162,57 @@ def _fetch_quotes_parallel(
     return prices, schwab_failed
 
 
+# Maps the derived ``position.strategy`` lifecycle label to the V0.5 wheel
+# status pill (spec §14.6). Unknown values collapse to "Holding" so a
+# pre-recompute import doesn't crash the dashboard.
+_STRATEGY_TO_WHEEL_STATUS: dict[str, str] = {
+    "csp": "CSP",
+    "cc": "CC",
+    "wheel": "Wheel",
+    "holding": "Holding",
+}
+
+
+def _derive_wheel_status(strategy: str, has_open_call: bool, has_open_put: bool) -> str:
+    """Translate a position's derived strategy + open-leg presence into a
+    user-facing wheel status pill (``CSP`` / ``CC`` / ``Wheel`` / ``Holding``).
+
+    The strategy label is already recomputed authoritatively by
+    :func:`app.services.positions.recompute_position_state`. We layer the
+    open-call/open-put presence on top only to keep the pill in sync when
+    the strategy column is out of date (pre-recompute imports). When both
+    a put and a call are open on the same ticker, that's a wheel.
+    """
+    if has_open_call and has_open_put:
+        return "Wheel"
+    base = _STRATEGY_TO_WHEEL_STATUS.get(strategy)
+    if base is not None:
+        return base
+    return "Holding"
+
+
 def _build_position_rows(
     open_positions: list[dict],
     quotes_by_ticker: dict[str, float | None],
     open_legs: list[dict],
 ) -> list[dict]:
-    """Convert journal positions into dashboard row shape, sorted by notional."""
-    leg_count_by_position = {}
+    """Convert journal positions into dashboard row shape, sorted by notional.
+
+    Each row also carries the V0.5 signal fields ``wheel_status`` and
+    ``pl_pct``. The ``next_suggested_action`` field is populated later by
+    :func:`_attach_next_suggested_actions` after the action engine runs.
+    """
+    leg_count_by_position: dict[str, int] = {}
+    has_open_put_by_ticker: dict[str, bool] = {}
+    has_open_call_by_ticker: dict[str, bool] = {}
     for leg in open_legs:
         leg_count_by_position[leg["position_id"]] = (
             leg_count_by_position.get(leg["position_id"], 0) + 1
         )
+        if leg.get("type") == "call":
+            has_open_call_by_ticker[leg["ticker"]] = True
+        elif leg.get("type") == "put":
+            has_open_put_by_ticker[leg["ticker"]] = True
 
     rows: list[dict] = []
     for position in open_positions:
@@ -180,10 +222,18 @@ def _build_position_rows(
         current_price = quotes_by_ticker.get(ticker)
         notional: float | None = None
         unrealized_pl: float | None = None
+        pl_pct: float | None = None
         if shares > 0 and current_price is not None:
             notional = current_price * shares
             cost_per_share = adjusted_cost_basis / shares if shares else 0.0
             unrealized_pl = (current_price - cost_per_share) * shares
+            if adjusted_cost_basis > 0:
+                pl_pct = (current_price * shares - adjusted_cost_basis) / adjusted_cost_basis
+        wheel_status = _derive_wheel_status(
+            position["strategy"],
+            has_open_call=has_open_call_by_ticker.get(ticker, False),
+            has_open_put=has_open_put_by_ticker.get(ticker, False),
+        )
         rows.append(
             {
                 "id": position["id"],
@@ -195,6 +245,9 @@ def _build_position_rows(
                 "notional": notional,
                 "unrealized_pl": unrealized_pl,
                 "open_legs_count": leg_count_by_position.get(position["id"], 0),
+                "wheel_status": wheel_status,
+                "next_suggested_action": "hold",  # overwritten after the engine runs
+                "pl_pct": pl_pct,
             }
         )
     # Sort by notional desc (None last), then ticker asc.
@@ -202,12 +255,192 @@ def _build_position_rows(
     return rows
 
 
+# Maps each action_id to a short display label used in the per-position
+# "next action" column. The action engine title is intentionally
+# action-oriented (e.g. "Roll AAPL 175P"); this label is the *summary*
+# rendered in the table cell.
+_NEXT_ACTION_TABLE_LABEL: dict[str, str] = {
+    "data.schwab_disconnected": "Reconnect",
+    "data.cache_very_stale": "Refresh data",
+    "data.schwab_token_expiring": "Renew token",
+    "position.large_loser": "Review",
+    "expiration.itm_short_dte": "Roll",
+    "expiration.short_dte": "Manage",
+    "position.cc_candidate": "Cover",
+    "journal.no_open_legs": "Run scanner",
+}
+
+
+def _attach_next_suggested_actions(
+    rows: list[dict],
+    next_actions: list[dict],
+    open_legs: list[dict],
+) -> None:
+    """Stamp each position row with the highest-priority targeted action label.
+
+    Position-targeted actions point straight to a position by id (e.g.
+    ``position.large_loser`` carries the position id in its action id).
+    Leg-targeted actions resolve via ``open_legs`` → ``position_id``. The
+    first matching action wins because :func:`compute_next_actions`
+    already sorted by priority. Positions without a match keep the default
+    ``"hold"``.
+    """
+    position_id_by_leg = {leg["id"]: leg["position_id"] for leg in open_legs}
+    label_by_position: dict[str, str] = {}
+    for action in next_actions:
+        action_id = action["action_id"]
+        label = _NEXT_ACTION_TABLE_LABEL.get(action_id)
+        if label is None:
+            continue
+        prefix = f"{action_id}."
+        subject_id = (
+            action["id"][len(prefix):] if action["id"].startswith(prefix) else ""
+        )
+        if action_id == "position.large_loser":
+            # Subject id is the position uuid.
+            if subject_id and subject_id not in label_by_position:
+                label_by_position[subject_id] = label
+        elif action_id == "expiration.itm_short_dte":
+            # Subject id is the leg/trade uuid — resolve via the legs map.
+            position_id = position_id_by_leg.get(subject_id)
+            if position_id and position_id not in label_by_position:
+                label_by_position[position_id] = label
+        elif action_id in {"position.cc_candidate", "expiration.short_dte"}:
+            # Subject is a ticker slug — resolve through the row scan so the
+            # label lands on every open position for that ticker.
+            ticker = (action.get("subject") or {}).get("ticker")
+            if not ticker:
+                continue
+            for row in rows:
+                if row["ticker"] == ticker and row["id"] not in label_by_position:
+                    label_by_position[row["id"]] = label
+
+    for row in rows:
+        row["next_suggested_action"] = label_by_position.get(row["id"], "hold")
+
+
+def _compute_largest_risk(position_rows: list[dict]) -> dict | None:
+    """Return the worst loser among open positions, or ``None``.
+
+    Picks the most-negative ``unrealized_pl``; positions without a price
+    or with non-negative P/L are skipped. Ties are broken by ticker A→Z
+    so the engine output is deterministic.
+    """
+    losers: list[tuple[float, str, dict]] = []
+    for row in position_rows:
+        pl = row.get("unrealized_pl")
+        if pl is None or pl >= 0:
+            continue
+        losers.append((pl, row["ticker"], row))
+    if not losers:
+        return None
+    losers.sort(key=lambda triple: (triple[0], triple[1]))
+    _, _, worst = losers[0]
+    return {
+        "ticker": worst["ticker"],
+        "unrealized_pl": worst["unrealized_pl"],
+        "unrealized_pl_pct": worst.get("pl_pct"),
+    }
+
+
+def _sum_premium_for_positions(positions: list[dict]) -> tuple[float, int]:
+    """Sum ``total_premiums`` and trade counts across positions.
+
+    Trade counts include every trade attached to the supplied positions,
+    not just leg-opening trades — the KPI tile is "trades that contributed
+    to the premium total".
+    """
+    total = 0.0
+    count = 0
+    for position in positions:
+        total += float(position.get("total_premiums") or 0.0)
+        count += len(position.get("trades") or [])
+    return total, count
+
+
+def _sum_premium_ytd(positions: list[dict], today: date) -> float:
+    """Sum credit/debit premium across trades closed in the current year.
+
+    Uses ``closed_at`` when present, falling back to ``opened_at``; per
+    the locked spec the YTD field is not rendered as a tile in V0.5 but
+    is emitted for downstream analytics. Trades without parseable timestamps
+    are skipped silently.
+    """
+    year = today.year
+    total = 0.0
+    for position in positions:
+        for trade in position.get("trades") or []:
+            anchor = trade.get("closed_at") or trade.get("opened_at")
+            parsed = parse_iso_to_utc(anchor)
+            if parsed is None:
+                continue
+            if parsed.year != year:
+                continue
+            premium = float(trade.get("premium") or 0.0)
+            qty = int(trade.get("quantity") or 0)
+            total += premium * qty * 100
+    return total
+
+
+def _compute_realized_pl(closed_positions: list[dict]) -> tuple[float, float | None]:
+    """Compute lifetime realized P/L and percent across closed positions.
+
+    Per the locked architectural decision in issue #146, V0.5 uses the
+    "simple" formula: ``realized_pl = sum(total_premiums)`` across closed
+    positions. Assignment / called-away cash flows are not yet tracked
+    explicitly — a follow-up issue will model close-out proceeds.
+
+    Percent is ``realized_pl / sum(broker_cost_basis)``; returns ``None``
+    when the denominator is zero or negative (no comparable basis).
+    """
+    if not closed_positions:
+        return 0.0, None
+    realized_pl = sum(
+        float(p.get("total_premiums") or 0.0) for p in closed_positions
+    )
+    cost_basis_total = sum(
+        float(p.get("broker_cost_basis") or 0.0) for p in closed_positions
+    )
+    if cost_basis_total <= 0:
+        return realized_pl, None
+    return realized_pl, realized_pl / cost_basis_total
+
+
+def _compute_largest_loser(closed_positions: list[dict]) -> dict | None:
+    """Return the worst realized loser among closed positions, or ``None``."""
+    if not closed_positions:
+        return None
+    losers: list[tuple[float, str, dict]] = []
+    for position in closed_positions:
+        realized = float(position.get("total_premiums") or 0.0)
+        if realized >= 0:
+            continue
+        losers.append((realized, position["ticker"], position))
+    if not losers:
+        return None
+    losers.sort(key=lambda triple: (triple[0], triple[1]))
+    realized, ticker, worst = losers[0]
+    basis = float(worst.get("broker_cost_basis") or 0.0)
+    pct = realized / basis if basis > 0 else None
+    return {
+        "ticker": ticker,
+        "realized_pl": realized,
+        "realized_pl_pct": pct,
+    }
+
+
 def _build_kpis(
     position_rows: list[dict],
     open_legs: list[dict],
     open_positions: list[dict],
+    closed_positions: list[dict],
+    today: date,
 ) -> dict:
-    """Aggregate KPI tiles from already-built row data."""
+    """Aggregate KPI tiles from already-built row data.
+
+    ``closed_positions`` powers the realized-P/L and largest-loser tiles.
+    ``today`` is threaded through so YTD scopes are deterministic in tests.
+    """
     open_positions_count = len(position_rows)
     # ``stock`` is a vestigial bucket retained for response-shape stability
     # (see DashboardOpenPositionsBreakdown docstring); ``holding`` is the
@@ -234,6 +467,12 @@ def _build_kpis(
     if unrealized_pl is not None and cost_basis_total > 0:
         unrealized_pl_pct = unrealized_pl / cost_basis_total
 
+    all_positions = list(open_positions) + list(closed_positions)
+    premium_total, premium_trades = _sum_premium_for_positions(all_positions)
+    premium_ytd = _sum_premium_ytd(all_positions, today=today)
+
+    realized_pl, realized_pl_pct = _compute_realized_pl(closed_positions)
+
     return {
         "open_positions": open_positions_count,
         "open_positions_breakdown": breakdown,
@@ -243,6 +482,13 @@ def _build_kpis(
         "open_legs_breakdown": {"puts": puts, "calls": calls},
         "unrealized_pl": unrealized_pl,
         "unrealized_pl_pct": unrealized_pl_pct,
+        "largest_risk": _compute_largest_risk(position_rows),
+        "largest_loser": _compute_largest_loser(closed_positions),
+        "premium_collected_total": premium_total,
+        "premium_collected_ytd": premium_ytd,
+        "premium_collected_trades": premium_trades,
+        "realized_pl": realized_pl,
+        "realized_pl_pct": realized_pl_pct,
     }
 
 
@@ -328,8 +574,10 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
     fred_status = _build_fred_status()
     cache_status = _bucket_cache_freshness(db)
 
-    # Positions
+    # Positions — fetch both open and closed in one go so realized-P/L
+    # KPIs and the action engine see the same snapshot.
     open_positions = journal_service.get_positions(db, status="open")
+    closed_positions = journal_service.get_positions(db, status="closed")
     journal_status = {"positions_count": len(open_positions)}
 
     # Quotes (parallelized; deduped by ticker)
@@ -338,13 +586,39 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         tickers, schwab_configured=schwab_configured
     )
 
-    # Legs derive purely from in-memory data + the quote map.
-    open_legs = derive_open_legs(open_positions, quotes_by_ticker, today=today)
+    # Legs derive purely from in-memory data + the quote map. Earnings
+    # lookup is cache-hit-only — the request path must not block on AV.
+    open_legs = derive_open_legs(
+        open_positions,
+        quotes_by_ticker,
+        today=today,
+        earnings_lookup=get_cached_next_earnings_date,
+    )
     upcoming = filter_upcoming(open_legs, horizon_days=14)
 
     # Position rows + KPIs piggyback on the same data — no extra DB hits.
     position_rows = _build_position_rows(open_positions, quotes_by_ticker, open_legs)
-    kpis = _build_kpis(position_rows, open_legs, open_positions)
+    kpis = _build_kpis(
+        position_rows,
+        open_legs,
+        open_positions,
+        closed_positions=closed_positions,
+        today=today,
+    )
+
+    # Action engine — pure, deterministic, recomputed every call (spec §2.2).
+    next_actions = compute_next_actions(
+        status={
+            "schwab": schwab_status,
+            "fred": fred_status,
+            "cache": cache_status,
+            "journal": journal_status,
+        },
+        kpis=kpis,
+        positions=position_rows,
+        open_legs=open_legs,
+    )
+    _attach_next_suggested_actions(position_rows, next_actions, open_legs)
 
     # Activity feed
     recent_activity = _build_recent_activity(db)
@@ -376,4 +650,5 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
             "fetched_at": now,
             "sources_unavailable": sources_unavailable,
         },
+        "next_actions": next_actions,
     }

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -23,6 +23,20 @@ TRADE_TYPE_TO_OPTION_TYPE: dict[str, Literal["put", "call"]] = {
 
 MoneynessState = Literal["ITM", "ATM", "OTM"]
 DecisionTag = Literal["roll-or-assign", "manage", "watch", "hold"]
+AssignmentRisk = Literal["high", "watch", "low"]
+SuggestedAction = Literal["roll", "close", "hold", "manage"]
+ProfitTargetState = Literal["captured_50", "in_progress", "underwater", "unknown"]
+
+# Maps the four existing decision-tag buckets to the V0.5 suggested-action
+# vocabulary. Spec §14.5 locks this mapping; "close" is intentionally absent
+# because the 50% target signal requires live option-chain data (deferred to
+# V0.7).
+_DECISION_TAG_TO_SUGGESTED_ACTION: dict[DecisionTag, SuggestedAction] = {
+    "roll-or-assign": "roll",
+    "manage": "manage",
+    "watch": "hold",
+    "hold": "hold",
+}
 
 
 def compute_dte(expiration_iso: str, today: date | None = None) -> int:
@@ -134,21 +148,108 @@ def format_decision_reason(
     return f"OTM {moneyness['distance_pct'] * 100:.1f}%"
 
 
+def compute_assignment_risk(
+    dte: int,
+    moneyness_state: str | None,
+) -> AssignmentRisk:
+    """Classify the short option's assignment risk into three buckets.
+
+    Per spec §14.5:
+    - ``dte <= 7 AND ITM``  → ``"high"`` (acute risk; review today)
+    - ``dte <= 14 AND ITM`` → ``"watch"`` (watch the next 1–2 sessions)
+    - otherwise             → ``"low"``
+
+    Non-ITM legs and legs with unknown moneyness (no live price) collapse to
+    ``"low"`` so the dashboard never flags a risk it cannot justify.
+    """
+    if moneyness_state != "ITM":
+        return "low"
+    if dte <= 7:
+        return "high"
+    if dte <= 14:
+        return "watch"
+    return "low"
+
+
+def compute_suggested_action(decision_tag: DecisionTag) -> SuggestedAction:
+    """Map an existing decision tag to a V0.5 suggested-action label.
+
+    Per spec §14.5 the V0.5 vocabulary is ``"roll" | "hold" | "manage"``.
+    The ``"close"`` value (50%-profit-target hit) is intentionally never
+    emitted because the underlying signal requires live option-chain data.
+    """
+    return _DECISION_TAG_TO_SUGGESTED_ACTION.get(decision_tag, "hold")
+
+
+def build_profit_target_status() -> dict:
+    """Return the V0.5 profit-target status payload.
+
+    Always ``{"captured_pct": None, "state": "unknown"}`` because the live
+    option-chain integration is deferred. The shape ships so the frontend
+    contract is stable for the V0.7 expansion.
+    """
+    return {"captured_pct": None, "state": "unknown"}
+
+
+def compute_earnings_in_window(
+    ticker: str,
+    dte: int,
+    earnings_lookup,
+) -> bool:
+    """Determine whether a cached earnings date falls inside the leg's DTE window.
+
+    ``earnings_lookup`` is a callable ``(ticker: str) -> str | None`` that
+    must NEVER make a network call — typically
+    :func:`app.services.alpha_vantage_client.get_cached_next_earnings_date`.
+
+    Returns ``False`` when:
+    - the lookup returns ``None`` (cache miss),
+    - the cached date cannot be parsed,
+    - the DTE is non-positive (the leg has already expired or expires today),
+    - the cached earnings date falls outside ``[today, today + dte]``.
+
+    The window is intentionally inclusive on both ends.
+    """
+    if dte <= 0:
+        return False
+    earnings_iso = earnings_lookup(ticker)
+    if not earnings_iso:
+        return False
+    try:
+        earnings_date = date.fromisoformat(str(earnings_iso)[:10])
+    except (TypeError, ValueError):
+        return False
+    today_d = date.today()
+    delta_days = (earnings_date - today_d).days
+    return 0 <= delta_days <= dte
+
+
 def derive_open_legs(
     positions: Iterable[dict],
     quotes_by_ticker: dict[str, float | None],
     today: date | None = None,
+    earnings_lookup=None,
 ) -> list[dict]:
     """Flatten open option legs across the given positions.
 
     A leg is "open" when it was an opening trade (`sell_put` / `sell_call`)
     AND its `closed_at` is None on the trade row. Each leg is enriched with
-    DTE and moneyness using `quotes_by_ticker` (per-ticker live price).
+    DTE, moneyness, and the V0.5 per-leg signal fields:
+    ``profit_target_status`` (always ``state="unknown"``),
+    ``assignment_risk``, ``suggested_action``, and ``earnings_in_window``.
+
+    ``earnings_lookup`` is an optional callable used to populate
+    ``earnings_in_window``. It MUST be cache-hit-only — defaults to a
+    sentinel that returns ``None`` so the dashboard never blocks on
+    Alpha Vantage in the request path.
 
     Returns a list ordered by (dte ASC, ticker ASC) — callers that need
     other orderings should re-sort.
     """
     today = today or date.today()
+    if earnings_lookup is None:
+        # Defensive default: cache miss-only sentinel. Never trigger network.
+        earnings_lookup = lambda _ticker: None  # noqa: E731 — small inline default
     legs: list[dict] = []
     for position in positions:
         ticker = position["ticker"]
@@ -163,6 +264,8 @@ def derive_open_legs(
             strike = float(trade["strike"])
             dte = compute_dte(trade["expiration"], today=today)
             moneyness = compute_moneyness(option_type, strike, current_price)
+            moneyness_state = moneyness["state"] if moneyness else None
+            decision_tag = compute_decision_tag(dte, moneyness_state)
             legs.append(
                 {
                     "id": trade["id"],
@@ -173,6 +276,12 @@ def derive_open_legs(
                     "dte": dte,
                     "moneyness": moneyness,
                     "position_id": position_id,
+                    "profit_target_status": build_profit_target_status(),
+                    "assignment_risk": compute_assignment_risk(dte, moneyness_state),
+                    "suggested_action": compute_suggested_action(decision_tag),
+                    "earnings_in_window": compute_earnings_in_window(
+                        ticker, dte, earnings_lookup
+                    ),
                 }
             )
     legs.sort(key=lambda x: (x["dte"], x["ticker"]))

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -195,12 +195,16 @@ def compute_earnings_in_window(
     ticker: str,
     dte: int,
     earnings_lookup,
+    today: date | None = None,
 ) -> bool:
     """Determine whether a cached earnings date falls inside the leg's DTE window.
 
     ``earnings_lookup`` is a callable ``(ticker: str) -> str | None`` that
     must NEVER make a network call — typically
     :func:`app.services.alpha_vantage_client.get_cached_next_earnings_date`.
+
+    ``today`` is injected so the rest of the dashboard pipeline can stay
+    deterministic; when omitted it falls back to :func:`date.today`.
 
     Returns ``False`` when:
     - the lookup returns ``None`` (cache miss),
@@ -219,7 +223,7 @@ def compute_earnings_in_window(
         earnings_date = date.fromisoformat(str(earnings_iso)[:10])
     except (TypeError, ValueError):
         return False
-    today_d = date.today()
+    today_d = today or date.today()
     delta_days = (earnings_date - today_d).days
     return 0 <= delta_days <= dte
 
@@ -280,7 +284,7 @@ def derive_open_legs(
                     "assignment_risk": compute_assignment_risk(dte, moneyness_state),
                     "suggested_action": compute_suggested_action(decision_tag),
                     "earnings_in_window": compute_earnings_in_window(
-                        ticker, dte, earnings_lookup
+                        ticker, dte, earnings_lookup, today=today
                     ),
                 }
             )

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -1,0 +1,545 @@
+"""Unit tests for the dashboard Next Actions engine.
+
+The engine is a pure function. These tests exercise:
+- each trigger fires only when its precondition holds (positive + negative);
+- deterministic ranking across the priority buckets and tie-breakers;
+- the cap at 8 entries;
+- the no-position scanner-card emit-when-empty rule.
+
+No DB, no HTTP — all data is constructed in-memory.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.services.action_engine import (
+    ITM_SHORT_DTE_CAP,
+    MAX_ACTIONS,
+    compute_next_actions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _status(
+    *,
+    schwab_configured: bool = True,
+    schwab_valid: bool = True,
+    schwab_expires_at: str | None = None,
+    cache_very_stale: int = 0,
+) -> dict:
+    return {
+        "schwab": {
+            "configured": schwab_configured,
+            "valid": schwab_valid,
+            "expires_at": schwab_expires_at,
+        },
+        "cache": {
+            "fresh": 0,
+            "stale": 0,
+            "very_stale": cache_very_stale,
+            "total": cache_very_stale,
+        },
+        "fred": {"configured": True, "valid": True},
+        "journal": {"positions_count": 0},
+    }
+
+
+def _kpis(open_legs: int = 0) -> dict:
+    return {"open_legs": open_legs, "open_positions": 0}
+
+
+def _position(
+    position_id: str = "p-1",
+    ticker: str = "AAPL",
+    *,
+    shares: int = 100,
+    unrealized_pl: float | None = None,
+    pl_pct: float | None = None,
+) -> dict:
+    return {
+        "id": position_id,
+        "ticker": ticker,
+        "shares": shares,
+        "unrealized_pl": unrealized_pl,
+        "pl_pct": pl_pct,
+    }
+
+
+def _leg(
+    leg_id: str,
+    *,
+    ticker: str = "AAPL",
+    type_: str = "put",
+    strike: float = 175.0,
+    dte: int,
+    moneyness_state: str | None = "ITM",
+    position_id: str = "p-1",
+) -> dict:
+    moneyness = None
+    if moneyness_state is not None:
+        moneyness = {
+            "state": moneyness_state,
+            "distance_pct": 0.01,
+            "distance_dollars": 0.5,
+        }
+    return {
+        "id": leg_id,
+        "ticker": ticker,
+        "type": type_,
+        "strike": strike,
+        "expiration": "2026-05-08",
+        "dte": dte,
+        "moneyness": moneyness,
+        "position_id": position_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Per-trigger tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchwabDisconnectedTrigger:
+    def test_emits_when_not_configured(self):
+        actions = compute_next_actions(
+            status=_status(schwab_configured=False, schwab_valid=False),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_disconnected" in ids
+
+    def test_emits_when_invalid(self):
+        actions = compute_next_actions(
+            status=_status(schwab_configured=True, schwab_valid=False),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_disconnected" in ids
+
+    def test_does_not_emit_when_healthy(self):
+        actions = compute_next_actions(
+            status=_status(schwab_configured=True, schwab_valid=True),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_disconnected" not in ids
+
+
+class TestCacheVeryStaleTrigger:
+    def test_emits_when_very_stale_positive(self):
+        actions = compute_next_actions(
+            status=_status(cache_very_stale=3),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        action = next(a for a in actions if a["action_id"] == "data.cache_very_stale")
+        assert action["priority"] == "P0"
+        assert action["cta"]["kind"] == "inline"
+
+    def test_does_not_emit_when_no_very_stale(self):
+        actions = compute_next_actions(
+            status=_status(cache_very_stale=0),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.cache_very_stale" not in ids
+
+
+class TestSchwabTokenExpiringTrigger:
+    def test_emits_within_seven_days(self):
+        soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+        actions = compute_next_actions(
+            status=_status(schwab_expires_at=soon),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_token_expiring" in ids
+
+    def test_does_not_emit_when_more_than_seven_days(self):
+        far = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+        actions = compute_next_actions(
+            status=_status(schwab_expires_at=far),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_token_expiring" not in ids
+
+    def test_does_not_emit_when_disconnected(self):
+        # Disconnected case is handled by `data.schwab_disconnected`. No
+        # double-emit when both conditions hold.
+        soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+        actions = compute_next_actions(
+            status=_status(schwab_configured=False, schwab_expires_at=soon),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_token_expiring" not in ids
+
+
+class TestLargeLoserTrigger:
+    def test_emits_at_pct_threshold_minus_five_pct(self):
+        # Whichever-fires-first: -5% trips even when dollars are small.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-loser", "TSLA", unrealized_pl=-50.0, pl_pct=-0.05),
+            ],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.large_loser" in ids
+
+    def test_emits_at_dollar_threshold_minus_1000(self):
+        # Whichever-fires-first: -$1000 trips even at -1% basis.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-loser", "AMZN", unrealized_pl=-1000.0, pl_pct=-0.01),
+            ],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.large_loser" in ids
+
+    def test_does_not_emit_just_below_thresholds(self):
+        # -4.9% and -$999 should NOT trigger.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-ok", "MSFT", unrealized_pl=-999.0, pl_pct=-0.049),
+            ],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.large_loser" not in ids
+
+    def test_only_single_largest_loser_emitted(self):
+        # Three losers — engine surfaces only the worst.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-a", "AAA", unrealized_pl=-500.0, pl_pct=-0.10),
+                _position("p-b", "BBB", unrealized_pl=-2000.0, pl_pct=-0.20),
+                _position("p-c", "CCC", unrealized_pl=-1500.0, pl_pct=-0.15),
+            ],
+            open_legs=[],
+        )
+        loser_cards = [a for a in actions if a["action_id"] == "position.large_loser"]
+        assert len(loser_cards) == 1
+        assert loser_cards[0]["subject"]["ticker"] == "BBB"
+
+
+class TestItmShortDteTrigger:
+    def test_emits_when_itm_and_short_dte(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=3, moneyness_state="ITM")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "expiration.itm_short_dte" in ids
+
+    def test_does_not_emit_at_exact_boundary_eight_dte(self):
+        # 8 DTE is outside the ≤ 7 window — no per-leg ITM card.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=8, moneyness_state="ITM")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "expiration.itm_short_dte" not in ids
+
+    def test_capped_at_three(self):
+        legs = [
+            _leg(f"l-{i}", dte=i, moneyness_state="ITM", position_id=f"p-{i}")
+            for i in range(1, 7)
+        ]
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=len(legs)),
+            positions=[],
+            open_legs=legs,
+        )
+        cards = [a for a in actions if a["action_id"] == "expiration.itm_short_dte"]
+        assert len(cards) == ITM_SHORT_DTE_CAP
+
+
+class TestShortDteAggregateTrigger:
+    def test_aggregates_one_per_ticker_when_otm(self):
+        # Two OTM short-DTE legs on AAPL → one card.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=[],
+            open_legs=[
+                _leg("l-1", dte=3, moneyness_state="OTM"),
+                _leg("l-2", dte=5, moneyness_state="OTM"),
+            ],
+        )
+        cards = [a for a in actions if a["action_id"] == "expiration.short_dte"]
+        assert len(cards) == 1
+        # Carries leg count in the subject amount.
+        assert "2 legs" in cards[0]["subject"]["amount"]
+
+    def test_does_not_emit_when_itm(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=3, moneyness_state="ITM")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "expiration.short_dte" not in ids
+
+
+class TestCcCandidateTrigger:
+    def test_emits_for_position_with_shares_and_no_open_call(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[_position("p-aapl", "AAPL", shares=100)],
+            open_legs=[_leg("l-1", ticker="AAPL", type_="put", dte=30, moneyness_state="OTM")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.cc_candidate" in ids
+
+    def test_does_not_emit_when_open_call_exists(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[_position("p-aapl", "AAPL", shares=100)],
+            open_legs=[_leg("l-1", ticker="AAPL", type_="call", dte=30, moneyness_state="OTM")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.cc_candidate" not in ids
+
+    def test_does_not_emit_for_less_than_100_shares(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[_position("p-aapl", "AAPL", shares=50)],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.cc_candidate" not in ids
+
+
+class TestNoOpenLegsTrigger:
+    def test_emits_when_zero_open_legs(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=0),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "journal.no_open_legs" in ids
+
+    def test_emits_when_positions_exist_but_zero_legs(self):
+        # Locked decision: emit even when positions exist but kpis.open_legs == 0.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=0),
+            positions=[_position("p-1", "AAPL")],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "journal.no_open_legs" in ids
+
+    def test_does_not_emit_when_legs_exist(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=10, moneyness_state="OTM")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "journal.no_open_legs" not in ids
+
+
+# ---------------------------------------------------------------------------
+# Ranking / determinism
+# ---------------------------------------------------------------------------
+
+
+class TestRanking:
+    def test_p0_data_above_p0_position(self):
+        # Spec §14.7: within P0, `data.*` outranks `position.*`.
+        actions = compute_next_actions(
+            status=_status(cache_very_stale=2),
+            kpis=_kpis(open_legs=1),
+            positions=[_position("p-1", "AAA", unrealized_pl=-2000.0, pl_pct=-0.10)],
+            open_legs=[],
+        )
+        # The first P0 action is the cache card.
+        first_p0 = next(a for a in actions if a["priority"] == "P0")
+        assert first_p0["action_id"] == "data.cache_very_stale"
+
+    def test_p0_above_p1(self):
+        actions = compute_next_actions(
+            status=_status(schwab_configured=False, schwab_valid=False),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=3, moneyness_state="ITM")],
+        )
+        priorities = [a["priority"] for a in actions]
+        # Once we see a P1 the remaining actions must not be P0.
+        seen_p1 = False
+        for p in priorities:
+            if p == "P1":
+                seen_p1 = True
+            if seen_p1 and p == "P0":
+                raise AssertionError("P0 found after a P1 — ranking is broken")
+
+    def test_p1_expiration_sorted_by_dte_ascending(self):
+        legs = [
+            _leg("l-7", dte=7, moneyness_state="ITM", position_id="p-7"),
+            _leg("l-3", dte=3, moneyness_state="ITM", position_id="p-3"),
+            _leg("l-5", dte=5, moneyness_state="ITM", position_id="p-5"),
+        ]
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=3),
+            positions=[],
+            open_legs=legs,
+        )
+        cards = [a for a in actions if a["action_id"] == "expiration.itm_short_dte"]
+        leg_ids = [a["id"].split(".")[-1] for a in cards]
+        assert leg_ids == ["l-3", "l-5", "l-7"]
+
+    def test_p2_cc_before_scanner(self):
+        # Both P2 cards in the same payload — covered call ranks first.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=0),
+            positions=[_position("p-aapl", "AAPL", shares=100)],
+            open_legs=[],
+        )
+        p2_ids = [a["action_id"] for a in actions if a["priority"] == "P2"]
+        assert p2_ids.index("position.cc_candidate") < p2_ids.index(
+            "journal.no_open_legs"
+        )
+
+    def test_p2_cc_candidates_sorted_alphabetically(self):
+        positions = [
+            _position("p-tsla", "TSLA", shares=100),
+            _position("p-aapl", "AAPL", shares=100),
+            _position("p-msft", "MSFT", shares=100),
+        ]
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=positions,
+            open_legs=[],
+        )
+        tickers = [
+            a["subject"]["ticker"]
+            for a in actions
+            if a["action_id"] == "position.cc_candidate"
+        ]
+        assert tickers == ["AAPL", "MSFT", "TSLA"]
+
+    def test_deterministic_across_runs(self):
+        # Same inputs → same outputs across 100 runs.
+        positions = [
+            _position("p-loser", "TSLA", unrealized_pl=-2000.0, pl_pct=-0.10),
+            _position("p-aapl", "AAPL", shares=100),
+        ]
+        legs = [
+            _leg("l-1", ticker="AAPL", dte=3, moneyness_state="ITM", position_id="p-aapl"),
+            _leg("l-2", ticker="TSLA", dte=10, moneyness_state="OTM", position_id="p-loser"),
+        ]
+        first = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=positions,
+            open_legs=legs,
+        )
+        for _ in range(99):
+            again = compute_next_actions(
+                status=_status(),
+                kpis=_kpis(open_legs=2),
+                positions=positions,
+                open_legs=legs,
+            )
+            assert again == first
+
+    def test_capped_at_max(self):
+        # Stuff every bucket; ensure the engine truncates at MAX_ACTIONS.
+        legs = [
+            _leg(f"l-{i}", ticker=f"T{i}", dte=i, moneyness_state="ITM", position_id=f"p-{i}")
+            for i in range(1, 8)
+        ]
+        positions = [
+            _position(f"p-cc-{i}", f"CC{i}", shares=100) for i in range(20)
+        ]
+        actions = compute_next_actions(
+            status=_status(schwab_configured=False, schwab_valid=False, cache_very_stale=4),
+            kpis=_kpis(open_legs=len(legs)),
+            positions=positions,
+            open_legs=legs,
+        )
+        assert len(actions) <= MAX_ACTIONS
+
+
+class TestActionShape:
+    def test_id_is_action_id_dot_subject_id(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=0),
+            positions=[],
+            open_legs=[],
+        )
+        scanner = next(a for a in actions if a["action_id"] == "journal.no_open_legs")
+        assert scanner["id"].startswith("journal.no_open_legs.")
+
+    def test_cta_kind_inline_only_for_cache_refresh(self):
+        actions = compute_next_actions(
+            status=_status(cache_very_stale=1),
+            kpis=_kpis(open_legs=0),
+            positions=[],
+            open_legs=[],
+        )
+        for action in actions:
+            if action["action_id"] == "data.cache_very_stale":
+                assert action["cta"]["kind"] == "inline"
+            else:
+                assert action["cta"]["kind"] == "link"
+
+    def test_priority_is_string_label(self):
+        actions = compute_next_actions(
+            status=_status(schwab_configured=False, schwab_valid=False),
+            kpis=_kpis(open_legs=0),
+            positions=[],
+            open_legs=[],
+        )
+        for action in actions:
+            assert action["priority"] in {"P0", "P1", "P2"}
+
+

--- a/backend/tests/test_alpha_vantage_client.py
+++ b/backend/tests/test_alpha_vantage_client.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch, MagicMock
 
 import pytest
 
 from app.services.alpha_vantage_client import (
+    get_cached_next_earnings_date,
     get_next_earnings_date,
     clear_cache,
 )
@@ -214,3 +215,53 @@ class TestNoYfinanceImportsAnywhere:
             if isinstance(node, ast.ImportFrom):
                 if node.module and "yfinance" in node.module:
                     raise AssertionError("health.py still imports from yfinance")
+
+
+class TestGetCachedNextEarningsDate:
+    """Cache-hit-only helper (issue #146).
+
+    Must never trigger a network call. The dashboard composition path relies
+    on this guarantee to avoid blocking the request on Alpha Vantage.
+    """
+
+    def test_returns_none_when_cache_miss(self):
+        # No in-memory entry; _read_db_cache is stubbed to None via the
+        # module-level autouse fixture. The helper MUST NOT call requests.get.
+        with patch("app.services.alpha_vantage_client.requests.get") as mock_get:
+            result = get_cached_next_earnings_date("AAPL")
+        assert result is None
+        mock_get.assert_not_called()
+
+    def test_returns_value_from_hot_cache(self):
+        # Pre-populate the hot cache.
+        from app.services import alpha_vantage_client as av
+
+        av._cache["AAPL"] = ("2026-06-15", datetime.now(timezone.utc))
+        with patch("app.services.alpha_vantage_client.requests.get") as mock_get:
+            result = get_cached_next_earnings_date("AAPL")
+        assert result == "2026-06-15"
+        mock_get.assert_not_called()
+
+    def test_returns_none_when_hot_cache_expired(self):
+        from app.services import alpha_vantage_client as av
+
+        # Stamp the entry as more than 24h old so the TTL check fails.
+        old = datetime.now(timezone.utc) - timedelta(days=2)
+        av._cache["AAPL"] = ("2026-06-15", old)
+        with patch("app.services.alpha_vantage_client.requests.get") as mock_get:
+            result = get_cached_next_earnings_date("AAPL")
+        assert result is None
+        mock_get.assert_not_called()
+
+    def test_falls_back_to_db_cache(self):
+        from app.services import alpha_vantage_client as av
+
+        fresh = datetime.now(timezone.utc)
+        with patch(
+            "app.services.alpha_vantage_client._read_db_cache",
+            return_value=("2026-07-01", fresh),
+        ):
+            with patch("app.services.alpha_vantage_client.requests.get") as mock_get:
+                result = get_cached_next_earnings_date("AAPL")
+        assert result == "2026-07-01"
+        mock_get.assert_not_called()

--- a/backend/tests/test_dashboard_kpis.py
+++ b/backend/tests/test_dashboard_kpis.py
@@ -1,0 +1,397 @@
+"""Unit tests for the dashboard KPI extension helpers (issue #146).
+
+Covers:
+- ``largest_risk`` picks the worst loser among open positions.
+- ``premium_collected_total`` sums correctly across all positions.
+- ``premium_collected_ytd`` scopes to the current calendar year only.
+- ``realized_pl`` and ``realized_pl_pct`` aggregate closed positions.
+- ``largest_loser`` picks the worst closed-position outcome.
+- Null-safety paths: no losers, no closed positions, zero basis.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.dashboard import (
+    _build_kpis,
+    _compute_largest_loser,
+    _compute_largest_risk,
+    _compute_realized_pl,
+    _sum_premium_for_positions,
+    _sum_premium_ytd,
+)
+
+
+def _row(
+    *,
+    position_id: str = "p-1",
+    ticker: str = "AAPL",
+    shares: int = 100,
+    adjusted_cost_basis: float = 17000.0,
+    current_price: float | None = None,
+    notional: float | None = None,
+    unrealized_pl: float | None = None,
+    pl_pct: float | None = None,
+) -> dict:
+    return {
+        "id": position_id,
+        "ticker": ticker,
+        "shares": shares,
+        "strategy": "csp",
+        "adjusted_cost_basis": adjusted_cost_basis,
+        "current_price": current_price,
+        "notional": notional,
+        "unrealized_pl": unrealized_pl,
+        "open_legs_count": 0,
+        "wheel_status": "Holding",
+        "next_suggested_action": "hold",
+        "pl_pct": pl_pct,
+    }
+
+
+def _closed_position(
+    *,
+    ticker: str = "AAPL",
+    total_premiums: float = 0.0,
+    broker_cost_basis: float = 17000.0,
+    trades: list[dict] | None = None,
+) -> dict:
+    return {
+        "id": f"pc-{ticker}",
+        "ticker": ticker,
+        "shares": 0,
+        "broker_cost_basis": broker_cost_basis,
+        "status": "closed",
+        "strategy": "holding",
+        "opened_at": "2024-01-01T00:00:00Z",
+        "closed_at": "2025-06-30T00:00:00Z",
+        "notes": None,
+        "total_premiums": total_premiums,
+        "adjusted_cost_basis": broker_cost_basis - total_premiums,
+        "min_compliant_cc_strike": 0.0,
+        "trades": trades or [],
+    }
+
+
+def _open_position_with_trades(
+    *,
+    ticker: str = "AAPL",
+    trades: list[dict],
+    broker_cost_basis: float = 17000.0,
+    total_premiums: float | None = None,
+) -> dict:
+    if total_premiums is None:
+        total_premiums = sum(
+            (t.get("premium") or 0.0) * (t.get("quantity") or 0) * 100 for t in trades
+        )
+    return {
+        "id": f"po-{ticker}",
+        "ticker": ticker,
+        "shares": 100,
+        "broker_cost_basis": broker_cost_basis,
+        "status": "open",
+        "strategy": "csp",
+        "opened_at": "2026-01-01T00:00:00Z",
+        "closed_at": None,
+        "notes": None,
+        "total_premiums": total_premiums,
+        "adjusted_cost_basis": broker_cost_basis - total_premiums,
+        "min_compliant_cc_strike": 0.0,
+        "trades": trades,
+    }
+
+
+class TestComputeLargestRisk:
+    def test_picks_worst_negative_pl(self):
+        rows = [
+            _row(position_id="p-a", ticker="AAA", unrealized_pl=-100.0, pl_pct=-0.01),
+            _row(position_id="p-b", ticker="BBB", unrealized_pl=-1500.0, pl_pct=-0.10),
+            _row(position_id="p-c", ticker="CCC", unrealized_pl=200.0, pl_pct=0.02),
+        ]
+        result = _compute_largest_risk(rows)
+        assert result is not None
+        assert result["ticker"] == "BBB"
+        assert result["unrealized_pl"] == -1500.0
+        assert result["unrealized_pl_pct"] == pytest.approx(-0.10)
+
+    def test_returns_none_when_no_losers(self):
+        rows = [
+            _row(position_id="p-a", ticker="AAA", unrealized_pl=100.0, pl_pct=0.01),
+            _row(position_id="p-b", ticker="BBB", unrealized_pl=0.0, pl_pct=0.0),
+        ]
+        assert _compute_largest_risk(rows) is None
+
+    def test_returns_none_when_empty(self):
+        assert _compute_largest_risk([]) is None
+
+    def test_skips_rows_without_pl(self):
+        # Rows with unrealized_pl=None (quote failed) are excluded.
+        rows = [
+            _row(position_id="p-a", ticker="AAA", unrealized_pl=None),
+            _row(position_id="p-b", ticker="BBB", unrealized_pl=-50.0, pl_pct=-0.01),
+        ]
+        assert _compute_largest_risk(rows)["ticker"] == "BBB"
+
+    def test_breaks_ties_alphabetically(self):
+        # Equal-loss positions should sort alphabetically — deterministic
+        # output is part of the contract.
+        rows = [
+            _row(position_id="p-z", ticker="ZZZ", unrealized_pl=-100.0, pl_pct=-0.01),
+            _row(position_id="p-a", ticker="AAA", unrealized_pl=-100.0, pl_pct=-0.01),
+        ]
+        assert _compute_largest_risk(rows)["ticker"] == "AAA"
+
+
+class TestSumPremiumForPositions:
+    def test_sums_total_premiums(self):
+        positions = [
+            _open_position_with_trades(
+                ticker="AAPL",
+                trades=[
+                    {"premium": 1.50, "quantity": 1, "trade_type": "sell_put",
+                     "opened_at": "2026-01-15T00:00:00Z"},
+                    {"premium": 2.25, "quantity": 1, "trade_type": "sell_call",
+                     "opened_at": "2026-02-10T00:00:00Z"},
+                ],
+            ),
+            _closed_position(ticker="TSLA", total_premiums=300.0),
+        ]
+        total, count = _sum_premium_for_positions(positions)
+        assert total == pytest.approx(150.0 + 225.0 + 300.0)
+        assert count == 2  # only AAPL has trade rows
+
+    def test_zero_when_no_positions(self):
+        total, count = _sum_premium_for_positions([])
+        assert total == 0.0
+        assert count == 0
+
+
+class TestSumPremiumYtd:
+    def test_only_current_year_trades_count(self):
+        positions = [
+            _open_position_with_trades(
+                ticker="AAPL",
+                trades=[
+                    {"premium": 1.0, "quantity": 1, "trade_type": "sell_put",
+                     "opened_at": "2024-06-01T00:00:00Z"},  # prior year
+                    {"premium": 2.0, "quantity": 1, "trade_type": "sell_put",
+                     "opened_at": "2026-03-01T00:00:00Z"},
+                ],
+            ),
+        ]
+        ytd = _sum_premium_ytd(positions, today=date(2026, 5, 1))
+        assert ytd == pytest.approx(200.0)
+
+    def test_uses_closed_at_when_present(self):
+        positions = [
+            _open_position_with_trades(
+                ticker="AAPL",
+                trades=[
+                    # Opened last year but closed this year — counts as YTD.
+                    {"premium": 1.5, "quantity": 1, "trade_type": "sell_put",
+                     "opened_at": "2025-12-15T00:00:00Z",
+                     "closed_at": "2026-01-10T00:00:00Z"},
+                ],
+            ),
+        ]
+        ytd = _sum_premium_ytd(positions, today=date(2026, 5, 1))
+        assert ytd == pytest.approx(150.0)
+
+
+class TestComputeRealizedPl:
+    def test_sums_total_premiums_for_closed_positions(self):
+        closed = [
+            _closed_position(ticker="A", total_premiums=500.0, broker_cost_basis=10000.0),
+            _closed_position(ticker="B", total_premiums=-200.0, broker_cost_basis=5000.0),
+        ]
+        realized, pct = _compute_realized_pl(closed)
+        assert realized == pytest.approx(300.0)
+        assert pct == pytest.approx(300.0 / 15000.0)
+
+    def test_returns_zero_and_none_when_empty(self):
+        realized, pct = _compute_realized_pl([])
+        assert realized == 0.0
+        assert pct is None
+
+    def test_returns_none_pct_when_basis_zero(self):
+        closed = [_closed_position(total_premiums=200.0, broker_cost_basis=0.0)]
+        realized, pct = _compute_realized_pl(closed)
+        assert realized == 200.0
+        assert pct is None
+
+
+class TestComputeLargestLoser:
+    def test_picks_worst_realized_loser(self):
+        closed = [
+            _closed_position(ticker="A", total_premiums=200.0, broker_cost_basis=10000.0),
+            _closed_position(ticker="B", total_premiums=-500.0, broker_cost_basis=10000.0),
+            _closed_position(ticker="C", total_premiums=-100.0, broker_cost_basis=5000.0),
+        ]
+        result = _compute_largest_loser(closed)
+        assert result is not None
+        assert result["ticker"] == "B"
+        assert result["realized_pl"] == -500.0
+        assert result["realized_pl_pct"] == pytest.approx(-0.05)
+
+    def test_returns_none_when_no_losers(self):
+        closed = [_closed_position(ticker="A", total_premiums=100.0)]
+        assert _compute_largest_loser(closed) is None
+
+    def test_returns_none_when_no_closed_positions(self):
+        assert _compute_largest_loser([]) is None
+
+
+class TestBuildKpis:
+    """Integration-level test on _build_kpis to assert the full payload shape."""
+
+    def test_includes_new_kpi_fields(self):
+        rows = [
+            _row(position_id="p-1", ticker="AAPL", unrealized_pl=-200.0, pl_pct=-0.02),
+        ]
+        open_legs: list[dict] = []
+        open_positions = [
+            _open_position_with_trades(
+                ticker="AAPL",
+                trades=[
+                    {"premium": 1.0, "quantity": 1, "trade_type": "sell_put",
+                     "opened_at": "2026-02-01T00:00:00Z"},
+                ],
+            ),
+        ]
+        closed_positions = [
+            _closed_position(ticker="TSLA", total_premiums=400.0, broker_cost_basis=20000.0),
+        ]
+        kpis = _build_kpis(
+            rows,
+            open_legs,
+            open_positions,
+            closed_positions=closed_positions,
+            today=date(2026, 5, 11),
+        )
+        # New fields present.
+        assert "largest_risk" in kpis
+        assert kpis["largest_risk"]["ticker"] == "AAPL"
+        assert "premium_collected_total" in kpis
+        assert kpis["premium_collected_total"] == pytest.approx(100.0 + 400.0)
+        assert "premium_collected_ytd" in kpis
+        assert kpis["premium_collected_ytd"] == pytest.approx(100.0)
+        assert "realized_pl" in kpis
+        assert kpis["realized_pl"] == pytest.approx(400.0)
+        assert kpis["realized_pl_pct"] == pytest.approx(400.0 / 20000.0)
+        assert "largest_loser" in kpis
+        # TSLA has positive premiums — no realized loser.
+        assert kpis["largest_loser"] is None
+        # Premium trade count: 1 open trade.
+        assert kpis["premium_collected_trades"] == 1
+
+    def test_null_safety_when_empty(self):
+        kpis = _build_kpis(
+            [], [], [], closed_positions=[], today=date(2026, 5, 11)
+        )
+        assert kpis["largest_risk"] is None
+        assert kpis["largest_loser"] is None
+        assert kpis["premium_collected_total"] == 0.0
+        assert kpis["premium_collected_ytd"] == 0.0
+        assert kpis["realized_pl"] == 0.0
+        assert kpis["realized_pl_pct"] is None
+        assert kpis["premium_collected_trades"] == 0
+
+
+class TestAttachNextSuggestedActions:
+    """The post-engine pass that stamps each position row with its action label."""
+
+    def test_position_with_no_matching_action_stays_hold(self):
+        from app.services.dashboard import _attach_next_suggested_actions
+
+        rows = [_row(position_id="p-1", ticker="AAPL")]
+        _attach_next_suggested_actions(rows, next_actions=[], open_legs=[])
+        assert rows[0]["next_suggested_action"] == "hold"
+
+    def test_large_loser_label_attaches_by_position_id(self):
+        from app.services.dashboard import _attach_next_suggested_actions
+
+        rows = [_row(position_id="p-1", ticker="TSLA", unrealized_pl=-2000.0)]
+        next_actions = [
+            {
+                "id": "position.large_loser.p-1",
+                "action_id": "position.large_loser",
+                "priority": "P0",
+                "title": "Review TSLA",
+                "subject": {"ticker": "TSLA"},
+                "reason": "below threshold",
+                "cta": {"label": "Review", "href": "/journal", "kind": "link"},
+            }
+        ]
+        _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=[])
+        assert rows[0]["next_suggested_action"] == "Review"
+
+    def test_itm_short_dte_label_attaches_via_leg_lookup(self):
+        from app.services.dashboard import _attach_next_suggested_actions
+
+        rows = [_row(position_id="p-1", ticker="AAPL")]
+        open_legs = [
+            {"id": "leg-7", "ticker": "AAPL", "position_id": "p-1", "type": "put"}
+        ]
+        next_actions = [
+            {
+                "id": "expiration.itm_short_dte.leg-7",
+                "action_id": "expiration.itm_short_dte",
+                "priority": "P1",
+                "title": "Roll AAPL",
+                "subject": {"ticker": "AAPL"},
+                "reason": "ITM",
+                "cta": {"label": "Manage", "href": "/journal", "kind": "link"},
+            }
+        ]
+        _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=open_legs)
+        assert rows[0]["next_suggested_action"] == "Roll"
+
+    def test_cc_candidate_label_attaches_by_ticker(self):
+        from app.services.dashboard import _attach_next_suggested_actions
+
+        rows = [_row(position_id="p-1", ticker="AAPL")]
+        next_actions = [
+            {
+                "id": "position.cc_candidate.aapl",
+                "action_id": "position.cc_candidate",
+                "priority": "P2",
+                "title": "Consider covered call on AAPL",
+                "subject": {"ticker": "AAPL"},
+                "reason": "100 shares, no open call",
+                "cta": {"label": "Scan", "href": "/options?ticker=AAPL", "kind": "link"},
+            }
+        ]
+        _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=[])
+        assert rows[0]["next_suggested_action"] == "Cover"
+
+    def test_highest_priority_action_wins(self):
+        """When two actions target the same position, the first one (highest
+        priority, since next_actions is pre-sorted) wins."""
+        from app.services.dashboard import _attach_next_suggested_actions
+
+        rows = [_row(position_id="p-1", ticker="AAPL")]
+        next_actions = [
+            {
+                "id": "position.large_loser.p-1",
+                "action_id": "position.large_loser",
+                "priority": "P0",
+                "title": "Review",
+                "subject": {"ticker": "AAPL"},
+                "reason": "loss",
+                "cta": {"label": "Review", "href": "/journal", "kind": "link"},
+            },
+            {
+                "id": "position.cc_candidate.aapl",
+                "action_id": "position.cc_candidate",
+                "priority": "P2",
+                "title": "Cover",
+                "subject": {"ticker": "AAPL"},
+                "reason": "100 shares",
+                "cta": {"label": "Scan", "href": "/options", "kind": "link"},
+            },
+        ]
+        _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=[])
+        assert rows[0]["next_suggested_action"] == "Review"

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -5,9 +5,13 @@ from datetime import date, timedelta
 import pytest
 
 from app.services.dashboard_legs import (
+    build_profit_target_status,
+    compute_assignment_risk,
     compute_decision_tag,
     compute_dte,
+    compute_earnings_in_window,
     compute_moneyness,
+    compute_suggested_action,
     derive_open_legs,
     filter_upcoming,
     format_decision_reason,
@@ -289,3 +293,177 @@ class TestFilterUpcoming:
         ]
         upcoming = filter_upcoming(legs)
         assert [leg["id"] for leg in upcoming] == ["itm", "otm"]
+
+
+# ---------------------------------------------------------------------------
+# V0.5 per-leg signal helpers (issue #146)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeAssignmentRisk:
+    def test_high_at_seven_dte_itm(self):
+        assert compute_assignment_risk(7, "ITM") == "high"
+        assert compute_assignment_risk(0, "ITM") == "high"
+
+    def test_watch_at_fourteen_dte_itm(self):
+        # At the boundary the spec rule "dte <= 14 AND ITM" still applies.
+        assert compute_assignment_risk(14, "ITM") == "watch"
+        assert compute_assignment_risk(8, "ITM") == "watch"
+
+    def test_low_at_fifteen_dte_itm(self):
+        # Outside both windows even when ITM.
+        assert compute_assignment_risk(15, "ITM") == "low"
+        assert compute_assignment_risk(30, "ITM") == "low"
+
+    def test_low_when_not_itm(self):
+        assert compute_assignment_risk(3, "OTM") == "low"
+        assert compute_assignment_risk(3, "ATM") == "low"
+
+    def test_low_when_moneyness_unknown(self):
+        assert compute_assignment_risk(3, None) == "low"
+
+
+class TestComputeSuggestedAction:
+    def test_roll_for_roll_or_assign(self):
+        assert compute_suggested_action("roll-or-assign") == "roll"
+
+    def test_manage_for_manage(self):
+        assert compute_suggested_action("manage") == "manage"
+
+    def test_hold_for_watch(self):
+        # Watch maps to hold because the V0.5 vocabulary is intentionally
+        # smaller; the frontend already shows a Watch pill via decision_tag.
+        assert compute_suggested_action("watch") == "hold"
+
+    def test_hold_for_hold(self):
+        assert compute_suggested_action("hold") == "hold"
+
+    def test_never_emits_close_in_v05(self):
+        # Locked architectural decision: V0.5 never emits "close" because
+        # the 50%-target signal requires live option-chain data.
+        values = {
+            compute_suggested_action(tag)
+            for tag in ("roll-or-assign", "manage", "watch", "hold")
+        }
+        assert "close" not in values
+
+
+class TestProfitTargetStatusBuilder:
+    def test_state_is_universally_unknown_in_v05(self):
+        result = build_profit_target_status()
+        assert result == {"captured_pct": None, "state": "unknown"}
+
+
+class TestComputeEarningsInWindow:
+    def test_false_when_lookup_returns_none(self):
+        assert (
+            compute_earnings_in_window("AAPL", dte=5, earnings_lookup=lambda _t: None)
+            is False
+        )
+
+    def test_false_when_dte_zero(self):
+        # Zero DTE means the leg expires today — no future window.
+        assert (
+            compute_earnings_in_window(
+                "AAPL", dte=0, earnings_lookup=lambda _t: "2099-01-01"
+            )
+            is False
+        )
+
+    def test_true_when_within_window(self):
+        future = (date.today() + timedelta(days=3)).isoformat()
+        assert (
+            compute_earnings_in_window(
+                "AAPL", dte=7, earnings_lookup=lambda _t: future
+            )
+            is True
+        )
+
+    def test_false_when_after_window(self):
+        future = (date.today() + timedelta(days=30)).isoformat()
+        assert (
+            compute_earnings_in_window(
+                "AAPL", dte=5, earnings_lookup=lambda _t: future
+            )
+            is False
+        )
+
+    def test_false_when_lookup_returns_garbage(self):
+        assert (
+            compute_earnings_in_window(
+                "AAPL", dte=5, earnings_lookup=lambda _t: "not-a-date"
+            )
+            is False
+        )
+
+
+class TestDeriveOpenLegsV05Signals:
+    """Signal fields added in V0.5 must always be present on each leg."""
+
+    def _position(self, ticker: str, position_id: str, trades: list[dict]) -> dict:
+        return {"id": position_id, "ticker": ticker, "trades": trades}
+
+    def test_includes_v05_signal_fields(self):
+        positions = [
+            self._position(
+                "AAPL",
+                "p-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_put",
+                        "strike": 175.0,
+                        "expiration": "2026-05-08",
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 174.50},
+            today=date(2026, 5, 5),
+        )
+        leg = legs[0]
+        assert leg["profit_target_status"] == {
+            "captured_pct": None,
+            "state": "unknown",
+        }
+        # 3 DTE + ITM → high risk
+        assert leg["assignment_risk"] == "high"
+        # 3 DTE + ITM → decision tag roll-or-assign → suggested_action "roll"
+        assert leg["suggested_action"] == "roll"
+        # Earnings lookup defaults to cache-miss → False.
+        assert leg["earnings_in_window"] is False
+
+    def test_earnings_lookup_must_not_be_called_with_network(self):
+        # Custom lookup proves derive_open_legs uses cache-only semantics
+        # via the injected callable. No real network is allowed.
+        calls: list[str] = []
+
+        def lookup(ticker: str) -> str | None:
+            calls.append(ticker)
+            return None
+
+        positions = [
+            self._position(
+                "AAPL",
+                "p-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_put",
+                        "strike": 175.0,
+                        "expiration": "2026-05-08",
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 174.50},
+            today=date(2026, 5, 5),
+            earnings_lookup=lookup,
+        )
+        assert calls == ["AAPL"]

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -387,3 +387,164 @@ def test_dashboard_500_does_not_leak_exception(client, monkeypatch):
     body = resp.text
     assert secret not in body
     assert "Failed to load dashboard" in body
+
+
+# ---------------------------------------------------------------------------
+# V0.5 contract — issue #146
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_payload_schema_v05_keys(client, monkeypatch):
+    """Snapshot test: assert every V0.5 top-level + nested key is present."""
+    _patch_status(monkeypatch, schwab_configured=False, fred_key="")
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Top-level keys — `next_actions` is the V0.5 addition.
+    expected_top_level = {
+        "generated_at",
+        "status",
+        "kpis",
+        "positions",
+        "open_legs",
+        "upcoming_expirations",
+        "recent_activity",
+        "data_meta",
+        "next_actions",
+    }
+    assert expected_top_level <= set(data.keys())
+
+    # KPI extensions per spec §14.4.
+    kpi_keys = set(data["kpis"].keys())
+    for new_field in (
+        "largest_risk",
+        "largest_loser",
+        "premium_collected_total",
+        "premium_collected_ytd",
+        "premium_collected_trades",
+        "realized_pl",
+        "realized_pl_pct",
+    ):
+        assert new_field in kpi_keys, f"missing kpis.{new_field}"
+
+    # Engine output is a list (empty on a fresh dashboard with no open legs
+    # the scanner card still fires — but the field shape must exist).
+    assert isinstance(data["next_actions"], list)
+
+
+def test_dashboard_scanner_card_when_no_open_legs(client, monkeypatch):
+    """`journal.no_open_legs` emits even when there are zero positions."""
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {a["action_id"] for a in data["next_actions"]}
+    assert "journal.no_open_legs" in ids
+
+
+def test_dashboard_schwab_disconnected_action(client, monkeypatch):
+    """`data.schwab_disconnected` fires when Schwab is not configured."""
+    _patch_status(monkeypatch, schwab_configured=False, fred_key="")
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {a["action_id"] for a in data["next_actions"]}
+    assert "data.schwab_disconnected" in ids
+
+
+def test_dashboard_itm_short_dte_action(client, monkeypatch):
+    """An ITM ≤ 7 DTE leg triggers the per-leg expiration card."""
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+
+    # Mock Schwab so the put is ITM (price 174 < strike 175).
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 174.0},
+    )
+
+    today = datetime(2026, 5, 5, tzinfo=timezone.utc).date()
+    monkeypatch.setattr(
+        "app.services.dashboard.date",
+        type("D", (), {"today": staticmethod(lambda: today)}),
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",  # 3 DTE
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {a["action_id"] for a in data["next_actions"]}
+    assert "expiration.itm_short_dte" in ids
+
+
+def test_dashboard_per_leg_signals_present(client, monkeypatch):
+    """Every open leg carries the V0.5 signal fields (issue #146 §14.5)."""
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 174.0},
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2099-12-31",  # far DTE so the card doesn't get truncated
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["open_legs"], "expected at least one open leg"
+    leg = data["open_legs"][0]
+    # V0.5 contract: every leg carries these fields.
+    assert leg["profit_target_status"] == {
+        "captured_pct": None,
+        "state": "unknown",
+    }
+    assert leg["assignment_risk"] in {"high", "watch", "low"}
+    assert leg["suggested_action"] in {"roll", "hold", "manage"}
+    # close is intentionally never emitted in V0.5.
+    assert leg["suggested_action"] != "close"
+    assert leg["earnings_in_window"] is False  # no AV cache hit in tests
+
+
+def test_dashboard_position_rows_have_v05_signals(client, monkeypatch):
+    """Position rows include `wheel_status`, `next_suggested_action`, and `pl_pct`."""
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 180.0},
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["positions"], "expected at least one position row"
+    row = data["positions"][0]
+    assert row["wheel_status"] in {"CSP", "CC", "Wheel", "Holding"}
+    assert "next_suggested_action" in row
+    # pl_pct is None when no price OR when basis is zero — here we have both.
+    assert "pl_pct" in row


### PR DESCRIPTION
Closes #146.

## Summary
Extends `/api/dashboard` with the V0.5 Decision Dashboard backend foundation — a server-side ranked action engine (`next_actions`), 4 new KPI aggregates, per-leg signal fields, and per-position signal fields. Pure additive — no breaking changes to existing payload fields. Issues #147–#152 (frontend cards) consume this payload.

## What changed
- **New** `backend/app/services/action_engine.py` — pure, deterministic ranking pass over the composed dashboard slices. Implements all 8 action types with the priority buckets and tie-breakers locked in spec §14.7. Output capped at 8 entries.
- **New** `backend/app/services/alpha_vantage_client.py::get_cached_next_earnings_date` — cache-hit-only sibling helper; never triggers a network call. Used by the dashboard composition path so first paint isn't blocked on Alpha Vantage rate limits.
- **Updated** `backend/app/services/dashboard.py` — wires up new KPI aggregates (`largest_risk`, `largest_loser`, `premium_collected_{total,ytd,trades}`, `realized_pl`, `realized_pl_pct`), per-position fields (`wheel_status`, `next_suggested_action`, `pl_pct`), and threads the engine output onto the response. Loads closed positions once for realized-P/L + largest-loser tiles.
- **Updated** `backend/app/services/dashboard_legs.py` — adds `profit_target_status` (always `state="unknown"` in V0.5), `assignment_risk`, `suggested_action`, and `earnings_in_window` to every open leg.
- **Updated** `backend/app/models/schemas.py` — adds `DashboardNextAction`, `DashboardKpiLargestRisk`, `DashboardKpiLargestLoser`, `DashboardProfitTargetStatus`; extends `DashboardKpis`, `DashboardOpenLeg`, `DashboardPositionRow`, `DashboardResponse` with the new fields.

## Locked architectural decisions (honored in this PR)
- **Realized P/L formula**: `sum(total_premiums for closed positions)` — no assignment-stock delta. Annotated in `_compute_realized_pl` so the V0.7 expansion knows where to plug in.
- **`suggested_action` vocabulary**: only `"roll" | "hold" | "manage"` in V0.5 — `"close"` is intentionally never emitted (live option-chain integration deferred).
- **`profit_target_status.state`**: universally `"unknown"` for every leg in V0.5.
- **`earnings_in_window`**: cache-hit only — uncached tickers default to `false`. No network call in the request path.
- **`journal.no_open_legs` action**: emitted whenever `kpis.open_legs === 0`, even when no positions exist.
- **Engine recomputes on every dashboard load** — no memoization.

## Tests (131 new test cases; full suite 804 passed / 7 skipped)
- `backend/tests/test_action_engine.py` — every trigger fires (and doesn't fire) on its threshold; deterministic ranking across 100 runs; cap at 8; within-bucket ordering rules; ITM short-DTE cap at 3; CC candidates A→Z then scanner.
- `backend/tests/test_dashboard_kpis.py` — `largest_risk` picks worst loser, alphabetic tie-break, null-safety; `realized_pl`/`largest_loser` only on closed positions; `_attach_next_suggested_actions` mapping (large-loser → position id, ITM-short-DTE → leg→position, CC candidate → ticker scan, highest-priority wins).
- `backend/tests/test_dashboard_legs.py` — assignment-risk thresholds at exactly 7 and 14 DTE; `state == "unknown"` for all legs; `earnings_in_window` false on cache miss; `suggested_action` never emits `"close"`; cache-only earnings lookup never calls network.
- `backend/tests/test_alpha_vantage_client.py` — `get_cached_next_earnings_date` never calls `requests.get`; respects hot-cache TTL; falls back to DB cache.
- `backend/tests/test_integration_dashboard.py` — payload-shape snapshot of new top-level + nested keys; live scenarios for `data.schwab_disconnected`, `expiration.itm_short_dte`, `journal.no_open_legs`; per-leg and per-position V0.5 signal fields render on the API response.

## API contract additions

### `kpis.*` (extended)
```jsonc
{
  "largest_risk": { "ticker": "TSLA", "unrealized_pl": -1420, "unrealized_pl_pct": -0.072 } | null,
  "largest_loser": { "ticker": "AMZN", "realized_pl": -350, "realized_pl_pct": -0.05 } | null,
  "premium_collected_total": 2847.0,
  "premium_collected_ytd": 950.0,
  "premium_collected_trades": 38,
  "realized_pl": 1932.0,
  "realized_pl_pct": 0.041 | null
}
```

### `open_legs[].*` (extended)
```jsonc
{
  "profit_target_status": { "captured_pct": null, "state": "unknown" },
  "assignment_risk": "high" | "watch" | "low",
  "suggested_action": "roll" | "hold" | "manage",   // never "close" in V0.5
  "earnings_in_window": false
}
```

### `positions[].*` (extended)
```jsonc
{
  "wheel_status": "CSP" | "CC" | "Wheel" | "Holding",
  "next_suggested_action": "Roll" | "Cover" | "Review" | "hold",
  "pl_pct": 0.0175 | null
}
```

### `next_actions[]` (new)
```jsonc
[
  {
    "id": "expiration.itm_short_dte.<leg_uuid>",
    "action_id": "expiration.itm_short_dte",
    "priority": "P1",
    "title": "Roll AAPL 175P",
    "subject": { "ticker": "AAPL", "amount": "3 DTE · ITM" },
    "reason": "Short put is ITM with 3 days to expiration.",
    "cta": { "label": "Manage in Journal", "href": "/journal?position=<id>", "kind": "link" }
  }
]
```

## Testing notes
- `cd backend && python -m pytest` — 804 passed, 7 skipped locally.
- Hit `/api/dashboard` with no Schwab credentials → expect `data.schwab_disconnected` and `journal.no_open_legs` cards in `next_actions`.
- Seed an ITM put within 7 DTE → expect `expiration.itm_short_dte` in `next_actions` and `assignment_risk === "high"` on the leg.

## Dependencies
No new packages; only existing pydantic v2 / SQLAlchemy / FastAPI stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)