### PR TITLE
V0.5.4: Add DataReadinessBanner with severity ranking and session dismiss (closes #147)

### DIFF
--- a/frontend/components/dashboard/DashboardPage.jsx
+++ b/frontend/components/dashboard/DashboardPage.jsx
@@ -2,6 +2,7 @@ import Header from '../layout/Header';
 import { useDashboard } from '../../hooks/useDashboard';
 import { formatDate } from '../../utils/formatters';
 import StatusStrip from './StatusStrip';
+import DataReadinessBanner from './DataReadinessBanner';
 import KpiRow from './KpiRow';
 import UpcomingExpirationsCard from './UpcomingExpirationsCard';
 import OpenLegsCard from './OpenLegsCard';
@@ -9,15 +10,6 @@ import DashboardPositionsCard from './DashboardPositionsCard';
 import RecentActivityCard from './RecentActivityCard';
 import DataReadinessDetail from './DataReadinessDetail';
 import OnboardingPanel from './OnboardingPanel';
-
-function StaleBanner({ meta }) {
-  if (!meta?.is_stale) return null;
-  return (
-    <div className="px-4 py-2 bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-lg text-sm text-yellow-800 dark:text-yellow-200">
-      Some data sources are unavailable — values shown may be cached or incomplete.
-    </div>
-  );
-}
 
 function lastSyncLabel(meta) {
   if (!meta?.fetched_at) return null;
@@ -69,7 +61,11 @@ export default function DashboardPage() {
           </div>
         ) : (
           <>
-            <StaleBanner meta={data?.data_meta} />
+            <DataReadinessBanner
+              status={data?.status}
+              loading={loading}
+              onRefreshed={refetch}
+            />
             <StatusStrip status={data?.status} />
 
             {isAllEmpty(data) ? (

--- a/frontend/components/dashboard/DataReadinessBanner.jsx
+++ b/frontend/components/dashboard/DataReadinessBanner.jsx
@@ -1,0 +1,230 @@
+import { useState } from 'react';
+import Link from 'next/link';
+import toast from 'react-hot-toast';
+import { refreshStaleCache } from '../../api/client';
+
+/**
+ * DataReadinessBanner — single-line, severity-ranked, page-level trust signal.
+ *
+ * Replaces ``StaleBanner`` from #114 as the dashboard's data-trust surface.
+ * Hidden entirely when all sources are healthy. Severity ranking (worst-wins)
+ * picks one of the following conditions to surface, per design-spec §2.1 and
+ * §14.1:
+ *
+ *   1. error — Schwab not configured / token invalid           (red)
+ *   2. error — Cache very-stale > 0                            (red)
+ *   3. warn  — Schwab token expiring within 7 days             (yellow)
+ *   4. warn  — Cache stale > 0                                 (yellow)
+ *   5. ok    — banner hidden
+ *
+ * FRED is deliberately NOT surfaced on the dashboard banner — it stays on
+ * `/analysis` only (spec §2.1 + §10 Q5).
+ *
+ * Dismissal is session-only (React state). Reloading the page restores the
+ * banner if the underlying condition still holds (spec §14.1).
+ */
+
+const TOKEN_EXPIRING_DAYS = 7;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function tokenExpiresSoon(expiresAt) {
+  if (!expiresAt) return false;
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) return false;
+  const diffMs = expiry.getTime() - Date.now();
+  return diffMs > 0 && diffMs <= TOKEN_EXPIRING_DAYS * MS_PER_DAY;
+}
+
+/**
+ * Resolve the worst-wins banner condition. Returns ``null`` when all-clear.
+ *
+ * Each condition carries the bits the banner renders: severity, glyph, the
+ * message clauses, and CTA descriptors. The CTA shape mirrors EmptyState —
+ * ``{ label, href }`` or ``{ label, onClick }``.
+ */
+function resolveBannerCondition(status) {
+  if (!status) return null;
+
+  const schwab = status.schwab || {};
+  const cache = status.cache || {};
+  const veryStale = Number(cache.very_stale || 0);
+  const stale = Number(cache.stale || 0);
+
+  // 1) Schwab disconnected / token invalid → error
+  if (schwab.configured === false || schwab.valid === false) {
+    return {
+      severity: 'error',
+      condition: 'schwab_disconnected',
+      glyph: '⛔',
+      prefix: 'Schwab disconnected',
+      message: 'live prices and trade import unavailable.',
+      primary: { label: 'Reconnect Schwab →', href: '/settings#schwab' },
+    };
+  }
+
+  // 2) Cache very-stale > 0 → error
+  if (veryStale > 0) {
+    return {
+      severity: 'error',
+      condition: 'cache_very_stale',
+      glyph: '⛔',
+      prefix: 'Market data very stale',
+      message: `${veryStale} cached item${veryStale === 1 ? '' : 's'} over 90 days old.`,
+      primary: { label: 'Refresh stale data →', kind: 'inline' },
+      secondary: { label: 'Open Settings →', href: '/settings#cache' },
+    };
+  }
+
+  // 3) Schwab token expiring within 7 days → warn
+  if (tokenExpiresSoon(schwab.expires_at)) {
+    return {
+      severity: 'warn',
+      condition: 'schwab_token_expiring',
+      glyph: '⚠',
+      prefix: 'Schwab token expiring',
+      message: 'renew before it lapses to keep imports running.',
+      primary: { label: 'Open Settings →', href: '/settings#schwab' },
+    };
+  }
+
+  // 4) Cache stale > 0 → warn
+  if (stale > 0) {
+    return {
+      severity: 'warn',
+      condition: 'cache_stale',
+      glyph: '⚠',
+      prefix: 'Quotes stale',
+      message: `${stale} cached item${stale === 1 ? '' : 's'} stale — review before trading.`,
+      primary: { label: 'Refresh stale data →', kind: 'inline' },
+      secondary: { label: 'Open Settings →', href: '/settings#cache' },
+    };
+  }
+
+  return null;
+}
+
+function severityClasses(severity) {
+  if (severity === 'error') {
+    return {
+      container:
+        'bg-red-50 dark:bg-red-900/30 border-red-200 dark:border-red-800 text-red-800 dark:text-red-200',
+      glyph: 'text-red-600 dark:text-red-300',
+      primary:
+        'inline-flex items-center text-sm font-medium text-red-700 dark:text-red-200 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded',
+      secondary:
+        'inline-flex items-center text-sm text-red-700 dark:text-red-200 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 rounded',
+      dismiss:
+        'text-red-700 dark:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/50 focus-visible:ring-red-500',
+    };
+  }
+  return {
+    container:
+      'bg-yellow-50 dark:bg-yellow-900/30 border-yellow-200 dark:border-yellow-800 text-yellow-800 dark:text-yellow-200',
+    glyph: 'text-yellow-700 dark:text-yellow-300',
+    primary:
+      'inline-flex items-center text-sm font-medium text-yellow-800 dark:text-yellow-100 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 rounded',
+    secondary:
+      'inline-flex items-center text-sm text-yellow-800 dark:text-yellow-100 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-yellow-500 rounded',
+    dismiss:
+      'text-yellow-800 dark:text-yellow-100 hover:bg-yellow-100 dark:hover:bg-yellow-900/50 focus-visible:ring-yellow-500',
+  };
+}
+
+function BannerCta({ cta, classes, busy, onInline, dataTestid }) {
+  if (!cta) return null;
+  if (cta.kind === 'inline') {
+    return (
+      <button
+        type="button"
+        onClick={onInline}
+        disabled={busy}
+        data-testid={dataTestid}
+        className={`${classes} disabled:opacity-60`}
+      >
+        {busy ? 'Refreshing…' : cta.label}
+      </button>
+    );
+  }
+  return (
+    <Link href={cta.href} data-testid={dataTestid} className={classes}>
+      {cta.label}
+    </Link>
+  );
+}
+
+export default function DataReadinessBanner({ status, loading, onRefreshed }) {
+  const [dismissed, setDismissed] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  if (loading) {
+    return (
+      <div
+        data-testid="data-readiness-banner-skeleton"
+        aria-hidden="true"
+        className="h-6 rounded-lg bg-slate-200 dark:bg-slate-700 animate-pulse"
+      />
+    );
+  }
+
+  const condition = resolveBannerCondition(status);
+  if (!condition || dismissed) return null;
+
+  const classes = severityClasses(condition.severity);
+  const role = condition.severity === 'error' ? 'alert' : 'status';
+
+  async function handleInlineRefresh() {
+    setBusy(true);
+    try {
+      await refreshStaleCache();
+      toast.success('Refreshed stale cache entries');
+      onRefreshed?.();
+    } catch {
+      toast.error('Failed to refresh stale cache');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div
+      role={role}
+      data-testid="data-readiness-banner"
+      data-severity={condition.severity}
+      data-condition={condition.condition}
+      className={`flex flex-wrap items-center gap-x-4 gap-y-1 px-4 py-2 border rounded-lg ${classes.container}`}
+    >
+      <span aria-hidden="true" className={`text-base leading-none ${classes.glyph}`}>
+        {condition.glyph}
+      </span>
+      <span className="text-sm font-medium">
+        {condition.prefix}
+        {condition.message ? `: ${condition.message}` : ''}
+      </span>
+      <div className="flex items-center gap-3 ml-auto">
+        <BannerCta
+          cta={condition.primary}
+          classes={classes.primary}
+          busy={busy}
+          onInline={handleInlineRefresh}
+          dataTestid="data-readiness-banner-cta-primary"
+        />
+        <BannerCta
+          cta={condition.secondary}
+          classes={classes.secondary}
+          busy={busy}
+          onInline={handleInlineRefresh}
+          dataTestid="data-readiness-banner-cta-secondary"
+        />
+        <button
+          type="button"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss banner"
+          data-testid="data-readiness-banner-dismiss"
+          className={`inline-flex items-center justify-center w-7 h-7 rounded-md text-base leading-none focus:outline-none focus-visible:ring-2 ${classes.dismiss}`}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/StatusStrip.jsx
+++ b/frontend/components/dashboard/StatusStrip.jsx
@@ -28,8 +28,11 @@ function fredPill(fred) {
 }
 
 function cachePill(cache) {
+  // Issue #147 / spec §2.1: ``cache.total === 0`` no longer renders a pill on
+  // the dashboard — the "Cache empty" surface moves to Settings → Data Sources.
+  // Returning ``null`` here is the signal to skip the pill entirely.
   if (!cache || cache.total === 0) {
-    return { state: 'neutral', label: 'Cache empty' };
+    return null;
   }
   if (cache.very_stale > 0) {
     return { state: 'error', label: `Cache very stale (${cache.very_stale})` };
@@ -58,7 +61,9 @@ export default function StatusStrip({ status }) {
     >
       <StatusPill {...schwab} href="/settings#schwab" dataTestid="status-pill-schwab" />
       <StatusPill {...fred} href="/settings#fred" dataTestid="status-pill-fred" />
-      <StatusPill {...cache} href="/settings#cache" dataTestid="status-pill-cache" />
+      {cache && (
+        <StatusPill {...cache} href="/settings#cache" dataTestid="status-pill-cache" />
+      )}
       <StatusPill {...journal} href="/journal" dataTestid="status-pill-journal" />
     </div>
   );

--- a/frontend/e2e/dashboard-readiness-banner.spec.js
+++ b/frontend/e2e/dashboard-readiness-banner.spec.js
@@ -1,0 +1,230 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #147 — Data Readiness Banner.
+ *
+ * Covers AC: severity ranking (worst-wins), hidden when all healthy, FRED
+ * never surfaces on the dashboard, cache pill suppressed when total===0,
+ * `role=alert` for error, `role=status` for warn, session-only dismiss,
+ * reload restores the banner (no persistence).
+ */
+
+const BASE_STATUS = {
+  schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+  fred: { configured: true, valid: true },
+  cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+  journal: { positions_count: 1 },
+};
+
+const BASE_PAYLOAD = {
+  generated_at: '2026-05-12T13:42:00+00:00',
+  status: BASE_STATUS,
+  kpis: {
+    open_positions: 1,
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 1, holding: 0 },
+    notional_value: 1000,
+    notional_change_pct: 0,
+    open_legs: 1,
+    open_legs_breakdown: { puts: 1, calls: 0 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+  },
+  positions: [
+    {
+      id: 'pos-aapl',
+      ticker: 'AAPL',
+      shares: 100,
+      strategy: 'wheel',
+      adjusted_cost_basis: 17240.0,
+      current_price: 175.42,
+      notional: 17542.0,
+      unrealized_pl: 302.0,
+      open_legs_count: 1,
+    },
+  ],
+  open_legs: [],
+  upcoming_expirations: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-05-12T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+};
+
+function withStatus(payload, overrides) {
+  return { ...payload, status: { ...payload.status, ...overrides } };
+}
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('DataReadinessBanner', () => {
+  test('hidden when all sources healthy', async ({ page }) => {
+    await mockDashboard(page, BASE_PAYLOAD);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('data-readiness-banner')).toHaveCount(0);
+  });
+
+  test('renders error banner with role=alert when Schwab disconnected', async ({ page }) => {
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        schwab: { configured: false, valid: false, expires_at: null },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const banner = page.getByTestId('data-readiness-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute('role', 'alert');
+    await expect(banner).toHaveAttribute('data-severity', 'error');
+    // Glyph + text both encode severity (not color alone)
+    await expect(banner).toContainText('⛔');
+    await expect(banner).toContainText('Schwab disconnected');
+  });
+
+  test('renders warn banner with role=status when cache is stale', async ({ page }) => {
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        cache: { fresh: 8, stale: 3, very_stale: 0, total: 11 },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const banner = page.getByTestId('data-readiness-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute('role', 'status');
+    await expect(banner).toHaveAttribute('data-severity', 'warn');
+    await expect(banner).toContainText('⚠');
+    await expect(banner).toContainText('stale');
+  });
+
+  test('error outranks warn when both conditions hold', async ({ page }) => {
+    // Schwab disconnected (error) + cache stale (warn) → error wins.
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        schwab: { configured: false, valid: false, expires_at: null },
+        cache: { fresh: 8, stale: 3, very_stale: 0, total: 11 },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const banner = page.getByTestId('data-readiness-banner');
+    await expect(banner).toHaveAttribute('data-severity', 'error');
+    await expect(banner).toContainText('Schwab disconnected');
+  });
+
+  test('cache very-stale renders as error (red) over schwab expiring (warn)', async ({ page }) => {
+    // Token expiring < 7 days (warn) + cache very_stale (error) → error wins.
+    const tomorrow = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString();
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        schwab: { configured: true, valid: true, expires_at: tomorrow },
+        cache: { fresh: 5, stale: 0, very_stale: 2, total: 7 },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const banner = page.getByTestId('data-readiness-banner');
+    await expect(banner).toHaveAttribute('data-severity', 'error');
+    await expect(banner).toContainText('very stale');
+  });
+
+  test('FRED missing does NOT surface on the dashboard banner', async ({ page }) => {
+    // FRED missing on its own should not raise the banner.
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        fred: { configured: false, valid: false },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('data-readiness-banner')).toHaveCount(0);
+  });
+
+  test('cache pill is hidden when cache total === 0', async ({ page }) => {
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        cache: { fresh: 0, stale: 0, very_stale: 0, total: 0 },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('status-pill-cache')).toHaveCount(0);
+    // Other pills still render
+    await expect(page.getByTestId('status-pill-schwab')).toBeVisible();
+  });
+
+  test('primary CTA navigates to settings when Schwab disconnected', async ({ page }) => {
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        schwab: { configured: false, valid: false, expires_at: null },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('data-readiness-banner-cta-primary').click();
+    await page.waitForURL(/\/settings/);
+    expect(page.url()).toContain('/settings');
+  });
+
+  test('dismiss hides banner for the session; reload restores it', async ({ page }) => {
+    const payload = withStatus(BASE_PAYLOAD, {
+      schwab: { configured: false, valid: false, expires_at: null },
+    });
+    await mockDashboard(page, payload);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const banner = page.getByTestId('data-readiness-banner');
+    await expect(banner).toBeVisible();
+
+    await page.getByTestId('data-readiness-banner-dismiss').click();
+    await expect(page.getByTestId('data-readiness-banner')).toHaveCount(0);
+
+    // Reload — banner reappears because dismiss is session-only (no
+    // localStorage persistence per AC §14.1).
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('data-readiness-banner')).toBeVisible();
+  });
+
+  test('does not persist dismissal to localStorage', async ({ page }) => {
+    const payload = withStatus(BASE_PAYLOAD, {
+      schwab: { configured: false, valid: false, expires_at: null },
+    });
+    await mockDashboard(page, payload);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('data-readiness-banner-dismiss').click();
+
+    const storageKeys = await page.evaluate(() => Object.keys(window.localStorage));
+    // No key should contain 'banner' or 'readiness' (case-insensitive).
+    const matching = storageKeys.filter((k) => /banner|readiness/i.test(k));
+    expect(matching).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- New ``DataReadinessBanner.jsx`` replaces ``StaleBanner`` as the page-top trust signal. Worst-wins severity ranking: Schwab disconnected / cache very stale → red ``role=alert``; Schwab token expiring / cache stale → yellow ``role=status``. Banner is hidden when all sources are healthy.
- FRED deliberately does not surface on the dashboard banner (stays on ``/analysis`` per spec §2.1 / §10 Q5).
- ``StatusStrip.jsx`` now suppresses the cache pill when ``cache.total === 0`` (the "Cache empty" surface moves to Settings).
- Dismissal is session-only React state — no ``localStorage``. Reloading the page restores the banner if the underlying condition still holds (spec §14.1).
- Severity is encoded in text + glyph (``⛔`` / ``⚠`` + prefix word), not color alone.

## Test plan

- [x] ``npx playwright test dashboard-readiness-banner`` — 10/10 pass
- [x] Existing ``npx playwright test dashboard.spec.js`` regression check — 6/6 pass
- [x] Full ``npx playwright test`` — 113 passed, 7 skipped (auth-flow suite that expects auth enabled)
- [x] ``npm run lint`` — no new warnings
- [ ] Manual smoke on a real Schwab-disconnected install (post-merge)

## Test IDs added

- ``data-readiness-banner`` (with ``data-severity={"warn"|"error"}``)
- ``data-readiness-banner-cta-primary``
- ``data-readiness-banner-cta-secondary``
- ``data-readiness-banner-dismiss``
- ``data-readiness-banner-skeleton`` (loading state)

Spec: ``frontend/design-specs/decision-dashboard-v05.md`` §2.1 + §14.1.

Closes #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)