### PR TITLE
V0.5.4: Upgrade KPI row, Expirations card, and Open Legs card (closes #148, #149, #150)

### DIFF
--- a/frontend/components/dashboard/DashboardPage.jsx
+++ b/frontend/components/dashboard/DashboardPage.jsx
@@ -85,6 +85,7 @@ export default function DashboardPage() {
                   <div className="lg:col-span-7">
                     <UpcomingExpirationsCard
                       expirations={data?.upcoming_expirations}
+                      openLegsCount={data?.kpis?.open_legs}
                       loading={loading}
                     />
                   </div>

--- a/frontend/components/dashboard/KpiRow.jsx
+++ b/frontend/components/dashboard/KpiRow.jsx
@@ -10,7 +10,7 @@ import { formatCurrency, formatNumber, formatPercent } from '../../utils/formatt
  *
  * Breakpoints per spec §14.2 (overrides §2.3): `grid-cols-2 md:grid-cols-3
  * lg:grid-cols-7`. The 7th tile spans 2 columns on mobile (`col-span-2`) to
- * avoid an orphan at the bottom of the 4×2 grid.
+ * avoid an orphan at the bottom of the 2-col mobile grid.
  *
  * Empty-state rules (spec §14.3):
  *   - Largest risk: `—` with tooltip (it's a pointer, not an aggregate)

--- a/frontend/components/dashboard/KpiRow.jsx
+++ b/frontend/components/dashboard/KpiRow.jsx
@@ -2,12 +2,24 @@ import StatCard from '../common/StatCard';
 import { formatCurrency, formatNumber, formatPercent } from '../../utils/formatters';
 
 /**
- * KpiRow — four-tile portfolio summary above the decision row.
+ * KpiRow — seven-tile portfolio summary above the decision row.
  *
- * Renders fallback `—` placeholders when values are null (e.g. Schwab
- * disconnected → no notional, no unrealized P/L). Per Q7 we always render
- * the unrealized P/L tile and substitute `—`; consistency over conditional
- * layout.
+ * V0.5 extends the row from 4 to 7 tiles (issue #148):
+ *   - Open positions, Notional value, Open legs, Unrealized P/L (existing)
+ *   - Largest risk, Realized P/L (lifetime), Premium collected (lifetime) (new)
+ *
+ * Breakpoints per spec §14.2 (overrides §2.3): `grid-cols-2 md:grid-cols-3
+ * lg:grid-cols-7`. The 7th tile spans 2 columns on mobile (`col-span-2`) to
+ * avoid an orphan at the bottom of the 4×2 grid.
+ *
+ * Empty-state rules (spec §14.3):
+ *   - Largest risk: `—` with tooltip (it's a pointer, not an aggregate)
+ *   - Realized P/L: `$0` / `0%` (aggregate, mirrors Premium-collected)
+ *   - Premium collected: `$0` / `0 trades`
+ *
+ * Payload-only fields (`kpis.premium_collected_ytd`, `kpis.largest_loser`)
+ * ride in the payload for Next-Actions / analytics but are NOT rendered as
+ * visible tiles in V0.5 — spec §14.4.
  */
 function pctSubtext(pct, label) {
   if (pct == null) return null;
@@ -20,6 +32,11 @@ function plColor(value) {
   if (value > 0) return 'text-green-600 dark:text-green-400';
   if (value < 0) return 'text-red-600 dark:text-red-400';
   return undefined;
+}
+
+function signedCurrency(value) {
+  if (value == null) return '—';
+  return `${value >= 0 ? '+' : ''}${formatCurrency(value)}`;
 }
 
 export default function KpiRow({ kpis }) {
@@ -48,10 +65,35 @@ export default function KpiRow({ kpis }) {
       ? '—'
       : `${pl >= 0 ? '+' : ''}${formatCurrency(pl)}`;
 
+  // Largest risk — pointer to the worst current loser; em-dash when none.
+  const largestRisk = kpis.largest_risk;
+  const largestRiskValue = largestRisk
+    ? `${largestRisk.ticker} ${signedCurrency(largestRisk.unrealized_pl)}`
+    : '—';
+  const largestRiskSubtext = largestRisk
+    ? pctSubtext(largestRisk.unrealized_pl_pct, 'on basis') || undefined
+    : undefined;
+  const largestRiskColor = largestRisk ? plColor(largestRisk.unrealized_pl) : undefined;
+
+  // Realized P/L (lifetime) — aggregate; empty state is $0 / 0%.
+  const realizedPl = kpis.realized_pl ?? 0;
+  const realizedPlValue = signedCurrency(realizedPl);
+  const realizedPlPct = kpis.realized_pl_pct;
+  const realizedPlSubtext =
+    realizedPlPct == null
+      ? '0% lifetime'
+      : `${realizedPlPct > 0 ? '+' : ''}${formatPercent(realizedPlPct)} lifetime`;
+
+  // Premium collected (lifetime) — aggregate; empty state is $0 / 0 trades.
+  const premiumTotal = kpis.premium_collected_total ?? 0;
+  const premiumValue = `${premiumTotal >= 0 ? '+' : ''}${formatCurrency(premiumTotal)}`;
+  const premiumTradesCount = kpis.premium_collected_trades ?? 0;
+  const premiumSubtext = `${premiumTradesCount} trades`;
+
   return (
     <div
       data-testid="dashboard-kpi-row"
-      className="grid grid-cols-2 md:grid-cols-4 gap-4"
+      className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-7 gap-4"
     >
       <StatCard
         label="Open positions"
@@ -78,6 +120,35 @@ export default function KpiRow({ kpis }) {
         colorClass={plColor(pl)}
         dataTestid="kpi-unrealized-pl"
       />
+      <StatCard
+        label="Largest risk"
+        value={largestRiskValue}
+        subtext={largestRiskSubtext}
+        colorClass={largestRiskColor}
+        tooltip="Position with the largest unrealized loss."
+        dataTestid="kpi-largest-risk"
+      />
+      <StatCard
+        label="Realized P/L"
+        value={realizedPlValue}
+        subtext={realizedPlSubtext}
+        colorClass={plColor(realizedPl)}
+        tooltip="Net P/L from closed positions and trades, lifetime."
+        dataTestid="kpi-realized-pl"
+      />
+      {/*
+        7th tile spans 2 columns on mobile (col-span-2) so it fills the
+        bottom of the 2-col grid instead of leaving an orphan slot. At md+
+        (3-col) and lg+ (7-col) it returns to a single column.
+      */}
+      <div className="col-span-2 md:col-span-1">
+        <StatCard
+          label="Premium collected"
+          value={premiumValue}
+          subtext={premiumSubtext}
+          dataTestid="kpi-premium-lifetime"
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -108,8 +108,7 @@ const ACTION_VISUALS = {
 function ActionCell({ action, mobileOnlyUrgent }) {
   const visuals = ACTION_VISUALS[action] || ACTION_VISUALS.hold;
   const isUrgent = action === 'roll' || action === 'manage';
-  // On mobile we hide non-urgent actions per spec §2.5. The `lg:!inline`
-  // override forces the cell back on at the desktop breakpoint.
+  // On mobile we hide non-urgent actions per spec §2.5. `lg:inline` re-shows at desktop.
   const visibilityClass =
     mobileOnlyUrgent && !isUrgent ? 'hidden lg:inline' : 'inline';
   return <span className={`${visibilityClass} ${visuals.className}`}>{visuals.label}</span>;

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -3,6 +3,29 @@ import Card from '../common/Card';
 import EmptyState from '../common/EmptyState';
 import { formatPercent } from '../../utils/formatters';
 
+/**
+ * OpenLegsCard — triage-grade table of every open short option leg.
+ *
+ * V0.5 upgrade (issue #150 / spec §2.5 + §14.5):
+ *   - %CAPTURED column — from `legs[].profit_target_status.captured_pct`.
+ *     Renders `—` whenever `state === "unknown"` (universal V0.5 case
+ *     because live option-chain data is deferred).
+ *   - RISK column — from `legs[].assignment_risk` ("high" / "watch" / "low").
+ *     "High" carries the ⛔ glyph for color-blind safety; all values are
+ *     text-labeled so screen readers and grayscale users get the signal.
+ *   - ACTION column — from `legs[].suggested_action` ("roll" / "hold" /
+ *     "manage"). V0.5 never emits "close" because the underlying signal
+ *     requires live option-chain data (see #146).
+ *   - Earnings glyph (⚠) — rendered next to the expiration when
+ *     `legs[].earnings_in_window === true`. Aria-labeled "Earnings before
+ *     expiration" for screen readers.
+ *
+ * Responsive (spec §2.5):
+ *   - Desktop (lg+): all columns visible.
+ *   - Mobile (< lg): %CAPTURED and RISK hidden; ACTION rendered only when
+ *     the value is "roll" or "manage" (the urgent cases).
+ */
+
 function dteBadgeClass(dte) {
   if (dte <= 7) return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
   if (dte <= 14) return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
@@ -14,7 +37,7 @@ function moneynessText(moneyness) {
   if (moneyness.state === 'ITM') {
     return (
       <span className="text-red-600 dark:text-red-400">
-        ITM by ${moneyness.distance_dollars.toFixed(2)}
+        ITM ${moneyness.distance_dollars.toFixed(2)}
       </span>
     );
   }
@@ -28,6 +51,70 @@ function moneynessText(moneyness) {
   );
 }
 
+function capturedText(status) {
+  // Universal V0.5 rule (spec §14.5): render `—` whenever state is "unknown",
+  // even if captured_pct happens to be non-null. The column ships as a
+  // structural placeholder so the V0.7 live-chain work has somewhere to land.
+  if (!status || status.state === 'unknown' || status.captured_pct == null) {
+    return <span className="text-slate-400">—</span>;
+  }
+  return (
+    <span className="tabular-nums text-slate-700 dark:text-slate-200">
+      {Math.round(status.captured_pct * 100)}%
+    </span>
+  );
+}
+
+const RISK_VISUALS = {
+  high: {
+    label: 'High',
+    glyph: '⛔',
+    className: 'text-red-700 dark:text-red-300 font-medium',
+  },
+  watch: {
+    label: 'Watch',
+    glyph: '',
+    className: 'text-yellow-700 dark:text-yellow-300 font-medium',
+  },
+  low: {
+    label: 'Low',
+    glyph: '',
+    className: 'text-slate-600 dark:text-slate-300',
+  },
+};
+
+function RiskCell({ risk }) {
+  const visuals = RISK_VISUALS[risk] || RISK_VISUALS.low;
+  return (
+    <span className={visuals.className}>
+      {visuals.glyph && (
+        <span aria-hidden="true" className="mr-1">
+          {visuals.glyph}
+        </span>
+      )}
+      {visuals.label}
+    </span>
+  );
+}
+
+const ACTION_VISUALS = {
+  roll: { label: 'Roll', className: 'text-red-700 dark:text-red-300 font-medium' },
+  manage: { label: 'Manage', className: 'text-yellow-700 dark:text-yellow-300 font-medium' },
+  hold: { label: 'Hold', className: 'text-slate-600 dark:text-slate-300' },
+  // V0.5 never emits "close" per spec §14.5, but include for forward-compat.
+  close: { label: 'Close target ✓', className: 'text-green-700 dark:text-green-300 font-medium' },
+};
+
+function ActionCell({ action, mobileOnlyUrgent }) {
+  const visuals = ACTION_VISUALS[action] || ACTION_VISUALS.hold;
+  const isUrgent = action === 'roll' || action === 'manage';
+  // On mobile we hide non-urgent actions per spec §2.5. The `lg:!inline`
+  // override forces the cell back on at the desktop breakpoint.
+  const visibilityClass =
+    mobileOnlyUrgent && !isUrgent ? 'hidden lg:inline' : 'inline';
+  return <span className={`${visibilityClass} ${visuals.className}`}>{visuals.label}</span>;
+}
+
 function LegRow({ leg }) {
   return (
     <Link
@@ -35,24 +122,74 @@ function LegRow({ leg }) {
       data-testid="dashboard-leg-row"
       className="grid grid-cols-12 gap-2 items-center py-2 border-b border-slate-100 dark:border-slate-700 last:border-b-0 hover:bg-slate-50 dark:hover:bg-slate-700/50 px-2 -mx-2 rounded text-sm"
     >
-      <span className="col-span-2 font-semibold text-slate-900 dark:text-white">
+      {/*
+        Mobile (< lg): 12-col grid uses 2/2/3/2/3 for the 5 visible cells
+        (ticker, strike, exp, dte, moneyness); %captured & risk are hidden;
+        action wraps to a full-width row below when urgent.
+        Desktop (lg+): 12-col grid uses 2/1/2/1/2/1/1/2 to fit 8 cells.
+      */}
+      <span className="col-span-2 lg:col-span-2 font-semibold text-slate-900 dark:text-white">
         {leg.ticker}
       </span>
-      <span className="col-span-2 tabular-nums text-slate-700 dark:text-slate-200">
+      <span className="col-span-2 lg:col-span-1 tabular-nums text-slate-700 dark:text-slate-200">
         {leg.strike} {leg.type === 'put' ? 'P' : 'C'}
       </span>
-      <span className="col-span-3 tabular-nums text-slate-600 dark:text-slate-300">
+      <span className="col-span-3 lg:col-span-2 tabular-nums text-slate-600 dark:text-slate-300 flex items-center gap-1">
         {leg.expiration}
+        {leg.earnings_in_window === true && (
+          <span
+            data-testid="dashboard-leg-row-earnings"
+            aria-label="Earnings before expiration"
+            className="text-yellow-600 dark:text-yellow-400"
+          >
+            ⚠
+          </span>
+        )}
       </span>
-      <span className="col-span-2">
+      <span className="col-span-2 lg:col-span-1">
         <span
           className={`inline-block px-2 py-0.5 text-xs rounded-full ${dteBadgeClass(leg.dte)}`}
         >
           {leg.dte}d
         </span>
       </span>
-      <span className="col-span-3 truncate">{moneynessText(leg.moneyness)}</span>
+      <span className="col-span-3 lg:col-span-2 truncate">
+        {moneynessText(leg.moneyness)}
+      </span>
+      <span
+        data-testid="dashboard-leg-row-captured"
+        className="hidden lg:block lg:col-span-1 tabular-nums"
+      >
+        {capturedText(leg.profit_target_status)}
+      </span>
+      <span
+        data-testid="dashboard-leg-row-risk"
+        className="hidden lg:block lg:col-span-1"
+      >
+        <RiskCell risk={leg.assignment_risk} />
+      </span>
+      <span
+        data-testid="dashboard-leg-row-action"
+        className="col-span-12 lg:col-span-2 mt-1 lg:mt-0"
+      >
+        <ActionCell action={leg.suggested_action} mobileOnlyUrgent />
+      </span>
     </Link>
+  );
+}
+
+function HeaderRow() {
+  return (
+    <div className="grid grid-cols-12 gap-2 items-center px-2 -mx-2 pb-2 mb-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+      <span className="col-span-2 lg:col-span-2">Ticker</span>
+      <span className="col-span-2 lg:col-span-1">Strike</span>
+      <span className="col-span-3 lg:col-span-2">Exp</span>
+      <span className="col-span-2 lg:col-span-1">DTE</span>
+      <span className="col-span-3 lg:col-span-2">Moneyness</span>
+      <span className="hidden lg:block lg:col-span-1">% Capt</span>
+      <span className="hidden lg:block lg:col-span-1">Risk</span>
+      <span className="hidden lg:block lg:col-span-2">Action</span>
+    </div>
   );
 }
 
@@ -87,6 +224,7 @@ export default function OpenLegsCard({ legs, loading }) {
     >
       {legs?.length ? (
         <div>
+          <HeaderRow />
           {legs.map((leg) => (
             <LegRow key={leg.id} leg={leg} />
           ))}
@@ -98,7 +236,7 @@ export default function OpenLegsCard({ legs, loading }) {
         <EmptyState
           title="No open option legs"
           description="Sold puts and calls will appear here once you log a trade."
-          primaryAction={{ label: 'Open Options', href: '/options' }}
+          primaryAction={{ label: 'Run scanner →', href: '/options' }}
         />
       )}
     </Card>

--- a/frontend/components/dashboard/UpcomingExpirationsCard.jsx
+++ b/frontend/components/dashboard/UpcomingExpirationsCard.jsx
@@ -1,6 +1,25 @@
 import Link from 'next/link';
 import Card from '../common/Card';
 import EmptyState from '../common/EmptyState';
+import { formatPercent } from '../../utils/formatters';
+
+/**
+ * UpcomingExpirationsCard — densified, three-line decision-oriented rows.
+ *
+ * V0.5 upgrade (issue #149 / spec §2.4 + §14.5):
+ *   - Line 1 (identity + decision tag pill) — existing.
+ *   - Line 2 (moneyness clause · premium remaining clause) — NEW.
+ *     Premium-remaining renders `—` whenever
+ *     `profit_target_status.state === "unknown"`, which is the universal
+ *     V0.5 state because live option-chain integration is deferred.
+ *   - Line 3 (earnings warning OR suggested action window) — NEW, conditional.
+ *     Renders only when `earnings_in_window === true` OR DTE ≤ 7.
+ *
+ * Empty states (spec §2.4):
+ *   - No open legs at all → "No open option legs" + "Run scanner →" CTA.
+ *   - Open legs exist but none ≤ 14 DTE → "Nothing expiring in the next 14
+ *     days" + secondary "View all open legs →" CTA.
+ */
 
 const TAG_PILL = {
   'roll-or-assign': 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
@@ -23,49 +42,140 @@ const TAG_ICON = {
   hold: '',
 };
 
+// Short weekday name for the suggested-window clause ("Roll by Wed close").
+const WEEKDAYS_SHORT = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+function parseISODate(iso) {
+  if (!iso) return null;
+  const d = new Date(`${iso}T00:00:00`);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function formatShortDate(iso) {
+  const d = parseISODate(iso);
+  if (!d) return iso || '';
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${WEEKDAYS_SHORT[d.getDay()]} ${mm}/${dd}`;
+}
+
+function moneynessClause(moneyness) {
+  if (!moneyness) return '—';
+  if (moneyness.state === 'ITM') {
+    return `ITM by $${moneyness.distance_dollars.toFixed(2)}`;
+  }
+  if (moneyness.state === 'ATM') {
+    return 'At the money';
+  }
+  if (moneyness.state === 'OTM' && moneyness.distance_pct != null) {
+    return `OTM ${formatPercent(moneyness.distance_pct, 1)}`;
+  }
+  return '—';
+}
+
+function premiumRemainingClause(status) {
+  // Per spec §14.5 the V0.5 backend universally emits state === "unknown".
+  // Frontend MUST render `—` whenever state is "unknown" regardless of
+  // whether captured_pct happens to be non-null.
+  if (!status || status.state === 'unknown') {
+    return <span className="text-slate-400">Premium remaining —</span>;
+  }
+  const pctText =
+    status.captured_pct == null
+      ? ''
+      : ` (${Math.round(status.captured_pct * 100)}% captured)`;
+  return <span>Premium remaining{pctText}</span>;
+}
+
+function suggestedWindowText(dte) {
+  // Lightweight V0.5 heuristic — the suggested-window clause renders only
+  // when no earnings warning is present and DTE ≤ 7. A full options-chain
+  // integration in V0.7 will replace this with a per-leg recommendation.
+  if (dte <= 0) return 'Expires today';
+  if (dte === 1) return 'Roll by tomorrow close';
+  if (dte <= 3) return 'Roll within the next 1–2 sessions';
+  return 'Roll by mid-week close';
+}
+
 function ExpirationRow({ leg }) {
   const tag = leg.decision_tag;
+  const earningsActive = leg.earnings_in_window === true;
+  const shortDte = leg.dte <= 7;
+  // Line 3 renders only when earnings flag is set OR DTE ≤ 7 (spec §2.4).
+  const showLine3 = earningsActive || shortDte;
+  const showEarningsLine = earningsActive;
+  const showWindowLine = !earningsActive && shortDte;
+
   return (
     <Link
       href={`/journal?position=${encodeURIComponent(leg.position_id)}`}
       data-testid="dashboard-expiration-row"
       className="block py-3 border-b border-slate-100 dark:border-slate-700 last:border-b-0 hover:bg-slate-50 dark:hover:bg-slate-700/50 px-2 -mx-2 rounded"
     >
-      <div className="flex items-baseline gap-2">
-        {TAG_ICON[tag] && (
-          <span
-            className={
-              tag === 'roll-or-assign' || tag === 'manage'
-                ? 'text-red-500'
-                : 'text-yellow-500'
-            }
-            aria-hidden="true"
-          >
-            {TAG_ICON[tag]}
+      {/* Line 1 — identity + decision tag pill (right-aligned). */}
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          {TAG_ICON[tag] && (
+            <span
+              className={
+                tag === 'roll-or-assign' || tag === 'manage'
+                  ? 'text-red-500'
+                  : 'text-yellow-500'
+              }
+              aria-hidden="true"
+            >
+              {TAG_ICON[tag]}
+            </span>
+          )}
+          <span className="font-semibold text-slate-900 dark:text-white">
+            {leg.ticker} {leg.strike} {leg.type === 'put' ? 'P' : 'C'}
           </span>
-        )}
-        <span className="font-semibold text-slate-900 dark:text-white">
-          {leg.ticker} {leg.strike} {leg.type === 'put' ? 'P' : 'C'}
-        </span>
-        <span className="text-sm text-slate-500 dark:text-slate-400">
-          exp {leg.expiration} · {leg.dte} DTE
-        </span>
-      </div>
-      <div className="mt-1 flex items-center gap-2">
-        <span className="text-sm text-slate-600 dark:text-slate-300">
-          {leg.decision_reason}
-        </span>
+          <span className="text-sm text-slate-500 dark:text-slate-400">
+            {leg.expiration} · {leg.dte}d
+          </span>
+        </div>
         <span
           className={`inline-block px-2 py-0.5 text-xs rounded-full ${TAG_PILL[tag] || ''}`}
         >
           {TAG_LABEL[tag] || tag}
         </span>
       </div>
+      {/* Line 2 — moneyness clause · premium remaining clause. */}
+      <div className="mt-1 text-sm text-slate-600 dark:text-slate-300 flex flex-wrap items-baseline gap-x-2">
+        <span>{moneynessClause(leg.moneyness)}</span>
+        <span className="text-slate-300 dark:text-slate-600" aria-hidden="true">
+          ·
+        </span>
+        <span>{premiumRemainingClause(leg.profit_target_status)}</span>
+      </div>
+      {/* Line 3 (conditional) — earnings warning OR suggested-window text. */}
+      {showLine3 && (
+        <div
+          data-testid="dashboard-expiration-row-earnings"
+          className="mt-1 text-sm text-slate-600 dark:text-slate-300"
+        >
+          {showEarningsLine ? (
+            <span className="text-yellow-700 dark:text-yellow-300">
+              <span aria-hidden="true">⚠ </span>
+              Earnings {formatShortDate(leg.expiration)} — roll past or close
+              before
+            </span>
+          ) : (
+            <span className="text-slate-700 dark:text-slate-200">
+              {suggestedWindowText(leg.dte)}
+            </span>
+          )}
+        </div>
+      )}
     </Link>
   );
 }
 
-export default function UpcomingExpirationsCard({ expirations, loading }) {
+export default function UpcomingExpirationsCard({
+  expirations,
+  loading,
+  openLegsCount,
+}) {
   if (loading) {
     return (
       <Card title="Upcoming expirations" description="Next 14 days" dataTestid="dashboard-expirations-card">
@@ -73,13 +183,16 @@ export default function UpcomingExpirationsCard({ expirations, loading }) {
           {[0, 1, 2].map((i) => (
             <div
               key={i}
-              className="h-12 animate-pulse rounded bg-slate-200 dark:bg-slate-700"
+              className="h-16 animate-pulse rounded bg-slate-200 dark:bg-slate-700"
             />
           ))}
         </div>
       </Card>
     );
   }
+
+  const hasOpenLegs = (openLegsCount ?? 0) > 0;
+  const hasExpirations = expirations?.length > 0;
 
   return (
     <Card
@@ -95,16 +208,24 @@ export default function UpcomingExpirationsCard({ expirations, loading }) {
         </Link>
       }
     >
-      {expirations?.length ? (
+      {hasExpirations ? (
         <div>
           {expirations.map((leg) => (
             <ExpirationRow key={leg.id} leg={leg} />
           ))}
         </div>
+      ) : hasOpenLegs ? (
+        <EmptyState
+          title="Nothing expiring in the next 14 days"
+          description="Open legs further out are still listed below."
+          dataTestid="dashboard-expirations-empty-no-near"
+        />
       ) : (
         <EmptyState
-          title="Nothing expiring soon"
-          description="No open option legs expiring in the next 14 days."
+          title="No open option legs"
+          description="Sold puts and calls will appear here once you log a trade."
+          primaryAction={{ label: 'Run scanner →', href: '/options' }}
+          dataTestid="dashboard-expirations-empty-no-legs"
         />
       )}
     </Card>

--- a/frontend/components/dashboard/UpcomingExpirationsCard.jsx
+++ b/frontend/components/dashboard/UpcomingExpirationsCard.jsx
@@ -104,7 +104,6 @@ function ExpirationRow({ leg }) {
   // Line 3 renders only when earnings flag is set OR DTE ≤ 7 (spec §2.4).
   const showLine3 = earningsActive || shortDte;
   const showEarningsLine = earningsActive;
-  const showWindowLine = !earningsActive && shortDte;
 
   return (
     <Link

--- a/frontend/e2e/dashboard-expirations-card.spec.js
+++ b/frontend/e2e/dashboard-expirations-card.spec.js
@@ -1,0 +1,223 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #149 — Upcoming Expirations card upgrade.
+ *
+ * Covers AC:
+ *   - Line 1 identity + decision tag pill (existing — preserved)
+ *   - Line 2 moneyness clause + premium-remaining clause.
+ *     Premium-remaining MUST render `—` when
+ *     `profit_target_status.state === "unknown"` (universal V0.5 state).
+ *   - Line 3 conditional: renders only when `earnings_in_window === true`
+ *     OR DTE ≤ 7. Hidden otherwise.
+ *   - Empty states: no-open-legs vs open-legs-but-none-near.
+ *   - Test IDs: dashboard-expiration-row, dashboard-expiration-row-earnings.
+ */
+
+const BASE_PAYLOAD = {
+  generated_at: '2026-05-12T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 2 },
+  },
+  kpis: {
+    open_positions: 2,
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 2, holding: 0 },
+    notional_value: 10000,
+    notional_change_pct: 0,
+    open_legs: 2,
+    open_legs_breakdown: { puts: 1, calls: 1 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+    largest_risk: null,
+    premium_collected_total: 0,
+    premium_collected_trades: 0,
+    premium_collected_ytd: 0,
+    realized_pl: 0,
+    realized_pl_pct: null,
+    largest_loser: null,
+  },
+  positions: [
+    {
+      id: 'pos-aapl',
+      ticker: 'AAPL',
+      shares: 100,
+      strategy: 'wheel',
+      adjusted_cost_basis: 17240.0,
+      current_price: 175.42,
+      notional: 17542.0,
+      unrealized_pl: 0,
+      open_legs_count: 1,
+    },
+  ],
+  open_legs: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-05-12T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+};
+
+function makeLeg(overrides = {}) {
+  return {
+    id: 'leg-1',
+    ticker: 'AAPL',
+    type: 'put',
+    strike: 175.0,
+    expiration: '2026-05-15',
+    dte: 3,
+    moneyness: { state: 'ITM', distance_pct: 0.0024, distance_dollars: 0.42 },
+    position_id: 'pos-aapl',
+    decision_tag: 'roll-or-assign',
+    decision_reason: 'ITM by $0.42',
+    profit_target_status: { captured_pct: null, state: 'unknown' },
+    assignment_risk: 'high',
+    suggested_action: 'roll',
+    earnings_in_window: false,
+    ...overrides,
+  };
+}
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('UpcomingExpirationsCard (V0.5 — densified rows)', () => {
+  test('renders identity, decision tag, moneyness, and premium-remaining `—`', async ({ page }) => {
+    const leg = makeLeg({ earnings_in_window: false, dte: 3 });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      upcoming_expirations: [leg],
+      open_legs: [leg],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-expiration-row').first();
+    await expect(row).toBeVisible();
+    // Line 1 — identity + DTE + decision tag pill
+    await expect(row).toContainText('AAPL');
+    await expect(row).toContainText('175');
+    await expect(row).toContainText('Roll or assign');
+    // Line 2 — moneyness clause and premium-remaining `—` (state === unknown)
+    await expect(row).toContainText('ITM by $0.42');
+    await expect(row).toContainText('Premium remaining —');
+  });
+
+  test('line 3 earnings warning renders when earnings_in_window === true', async ({ page }) => {
+    const leg = makeLeg({ earnings_in_window: true, dte: 3 });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      upcoming_expirations: [leg],
+      open_legs: [leg],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-expiration-row').first();
+    const earnings = row.getByTestId('dashboard-expiration-row-earnings');
+    await expect(earnings).toBeVisible();
+    // Earnings text prefixed with the word "Earnings" (a11y — not just glyph)
+    await expect(earnings).toContainText('Earnings');
+  });
+
+  test('line 3 renders suggested-window when DTE ≤ 7 and no earnings', async ({ page }) => {
+    const leg = makeLeg({ earnings_in_window: false, dte: 3 });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      upcoming_expirations: [leg],
+      open_legs: [leg],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const earnings = page.getByTestId('dashboard-expiration-row-earnings').first();
+    await expect(earnings).toBeVisible();
+    // No earnings prefix; suggested-window phrase instead.
+    await expect(earnings).not.toContainText('Earnings');
+    await expect(earnings).toContainText(/Roll/i);
+  });
+
+  test('line 3 hidden when no earnings AND DTE > 7', async ({ page }) => {
+    const leg = makeLeg({
+      earnings_in_window: false,
+      dte: 10,
+      decision_tag: 'hold',
+      assignment_risk: 'low',
+      suggested_action: 'hold',
+      moneyness: { state: 'OTM', distance_pct: 0.041, distance_dollars: 1.2 },
+    });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      upcoming_expirations: [leg],
+      open_legs: [leg],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-expiration-row-earnings')).toHaveCount(0);
+  });
+
+  test('premium-remaining shows `—` even when captured_pct is non-null (state must dominate)', async ({ page }) => {
+    // Defensive: backend should never emit captured_pct without state !== "unknown",
+    // but the frontend MUST treat state === "unknown" as authoritative per spec §14.5.
+    const leg = makeLeg({
+      profit_target_status: { captured_pct: 0.6, state: 'unknown' },
+    });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      upcoming_expirations: [leg],
+      open_legs: [leg],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-expiration-row').first()).toContainText('Premium remaining —');
+  });
+
+  test('empty state when no open legs at all', async ({ page }) => {
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      kpis: { ...BASE_PAYLOAD.kpis, open_legs: 0, open_legs_breakdown: { puts: 0, calls: 0 } },
+      upcoming_expirations: [],
+      open_legs: [],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const empty = page.getByTestId('dashboard-expirations-empty-no-legs');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText('No open option legs');
+    await expect(empty.getByRole('link', { name: /Run scanner/i })).toBeVisible();
+  });
+
+  test('empty state when open legs exist but none in 14-day window', async ({ page }) => {
+    const farLeg = makeLeg({
+      id: 'leg-far',
+      dte: 45,
+      earnings_in_window: false,
+      decision_tag: 'hold',
+    });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      kpis: { ...BASE_PAYLOAD.kpis, open_legs: 1, open_legs_breakdown: { puts: 1, calls: 0 } },
+      upcoming_expirations: [],
+      open_legs: [farLeg],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const empty = page.getByTestId('dashboard-expirations-empty-no-near');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText(/Nothing expiring in the next 14 days/);
+  });
+});

--- a/frontend/e2e/dashboard-kpi-row.spec.js
+++ b/frontend/e2e/dashboard-kpi-row.spec.js
@@ -1,0 +1,248 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #148 — KPI row extended to 7 tiles.
+ *
+ * Covers AC:
+ *   - 7 visible tiles (4 existing + Largest risk + Realized P/L + Premium)
+ *   - Each new tile populated with non-null data
+ *   - Each new tile renders the locked empty-state copy (largest_risk `—`;
+ *     realized_pl `$0` / `0%`; premium `$0` / `0 trades`)
+ *   - Tooltip text on Largest risk
+ *   - Payload-only fields (premium_collected_ytd, largest_loser) are NOT
+ *     rendered as visible tiles
+ *   - Breakpoint behavior: 7 columns at lg+, 3 columns at md, 2 columns at sm
+ *   - Test IDs: kpi-largest-risk, kpi-realized-pl, kpi-premium-lifetime
+ */
+
+const BASE_PAYLOAD = {
+  generated_at: '2026-05-12T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 2 },
+  },
+  positions: [
+    {
+      id: 'pos-aapl',
+      ticker: 'AAPL',
+      shares: 100,
+      strategy: 'wheel',
+      adjusted_cost_basis: 17240.0,
+      current_price: 175.42,
+      notional: 17542.0,
+      unrealized_pl: 302.0,
+      open_legs_count: 1,
+    },
+  ],
+  open_legs: [],
+  upcoming_expirations: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-05-12T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+};
+
+const POPULATED_KPIS = {
+  open_positions: 4,
+  open_positions_breakdown: { stock: 0, csp: 1, cc: 0, wheel: 2, holding: 1 },
+  notional_value: 48210.0,
+  notional_change_pct: 0.021,
+  open_legs: 7,
+  open_legs_breakdown: { puts: 4, calls: 3 },
+  unrealized_pl: 612.0,
+  unrealized_pl_pct: 0.013,
+  largest_risk: {
+    ticker: 'TSLA',
+    unrealized_pl: -1420.0,
+    unrealized_pl_pct: -0.072,
+  },
+  premium_collected_total: 2847.0,
+  premium_collected_trades: 38,
+  premium_collected_ytd: 1200.0,
+  realized_pl: 1932.0,
+  realized_pl_pct: 0.041,
+  // Payload-only — must NOT render as a tile
+  largest_loser: { ticker: 'AMD', realized_pl: -420.0, realized_pl_pct: -0.03 },
+};
+
+const EMPTY_KPIS = {
+  open_positions: 0,
+  open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 0, holding: 0 },
+  notional_value: 0,
+  notional_change_pct: null,
+  open_legs: 0,
+  open_legs_breakdown: { puts: 0, calls: 0 },
+  unrealized_pl: null,
+  unrealized_pl_pct: null,
+  // Empty cases per spec §14.3:
+  // - largest_risk: null  → tile renders `—` with tooltip
+  // - realized_pl/pct: 0  → tile renders `$0` / `0%` (NOT em-dash)
+  // - premium: 0 / 0      → tile renders `$0` / `0 trades`
+  largest_risk: null,
+  premium_collected_total: 0,
+  premium_collected_trades: 0,
+  premium_collected_ytd: 0,
+  realized_pl: 0,
+  realized_pl_pct: null,
+  largest_loser: null,
+};
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('KPI row (V0.5 — 7 tiles)', () => {
+  test('renders all seven tiles when populated', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-kpi-row');
+    await expect(row).toBeVisible();
+
+    // Existing four tiles
+    await expect(row.getByTestId('kpi-open-positions')).toBeVisible();
+    await expect(row.getByTestId('kpi-notional')).toBeVisible();
+    await expect(row.getByTestId('kpi-open-legs')).toBeVisible();
+    await expect(row.getByTestId('kpi-unrealized-pl')).toBeVisible();
+
+    // Three new tiles
+    await expect(row.getByTestId('kpi-largest-risk')).toBeVisible();
+    await expect(row.getByTestId('kpi-realized-pl')).toBeVisible();
+    await expect(row.getByTestId('kpi-premium-lifetime')).toBeVisible();
+  });
+
+  test('Largest risk tile shows ticker, signed dollars, percent subtext, and tooltip', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const tile = page.getByTestId('kpi-largest-risk');
+    await expect(tile).toContainText('TSLA');
+    await expect(tile).toContainText('-$1,420');
+    await expect(tile).toContainText('-7.20% on basis');
+    // Tooltip is rendered as a sibling element inside the tile
+    await expect(tile).toContainText('Position with the largest unrealized loss.');
+  });
+
+  test('Realized P/L tile shows signed dollars and lifetime percent', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const tile = page.getByTestId('kpi-realized-pl');
+    await expect(tile).toContainText('+$1,932');
+    await expect(tile).toContainText('+4.10% lifetime');
+    await expect(tile).toContainText('Net P/L from closed positions and trades, lifetime.');
+  });
+
+  test('Premium tile shows signed total and trade count', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const tile = page.getByTestId('kpi-premium-lifetime');
+    await expect(tile).toContainText('+$2,847');
+    await expect(tile).toContainText('38 trades');
+  });
+
+  test('empty Largest risk renders em-dash with tooltip', async ({ page }) => {
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      status: { ...BASE_PAYLOAD.status, journal: { positions_count: 0 } },
+      kpis: EMPTY_KPIS,
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const tile = page.getByTestId('kpi-largest-risk');
+    await expect(tile).toContainText('—');
+    await expect(tile).toContainText('Position with the largest unrealized loss.');
+  });
+
+  test('empty Realized P/L renders $0 / 0% (not em-dash per spec §14.3)', async ({ page }) => {
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      status: { ...BASE_PAYLOAD.status, journal: { positions_count: 0 } },
+      kpis: EMPTY_KPIS,
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const tile = page.getByTestId('kpi-realized-pl');
+    await expect(tile).toContainText('+$0.00');
+    await expect(tile).toContainText('0% lifetime');
+  });
+
+  test('empty Premium renders $0 / 0 trades', async ({ page }) => {
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      status: { ...BASE_PAYLOAD.status, journal: { positions_count: 0 } },
+      kpis: EMPTY_KPIS,
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const tile = page.getByTestId('kpi-premium-lifetime');
+    await expect(tile).toContainText('+$0.00');
+    await expect(tile).toContainText('0 trades');
+  });
+
+  test('payload-only fields (premium_collected_ytd, largest_loser) do NOT render as tiles', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // No tile exposes premium_collected_ytd or largest_loser; only 7 tiles
+    // total render. There is no `kpi-premium-ytd` or `kpi-largest-loser` id.
+    await expect(page.getByTestId('kpi-premium-ytd')).toHaveCount(0);
+    await expect(page.getByTestId('kpi-largest-loser')).toHaveCount(0);
+
+    // largest_loser ticker (AMD) only appears in the payload; not on the row.
+    const row = page.getByTestId('dashboard-kpi-row');
+    await expect(row).not.toContainText('AMD');
+  });
+
+  test('renders 7 columns at desktop breakpoint (no horizontal scroll)', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-kpi-row');
+    // The grid container uses lg:grid-cols-7 at lg+; assert via class presence
+    // since runtime layout differs by browser default font sizes.
+    await expect(row).toHaveClass(/lg:grid-cols-7/);
+
+    // No horizontal scroll on the page body.
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
+  });
+
+  test('mobile (sm) uses 2-column grid; 7th tile spans 2 columns to avoid orphan', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-kpi-row');
+    await expect(row).toHaveClass(/grid-cols-2/);
+
+    // The premium tile wrapper carries the col-span-2 class on mobile.
+    const premiumTile = page.getByTestId('kpi-premium-lifetime');
+    const wrapperHandle = await premiumTile.evaluateHandle((el) => el.parentElement);
+    const wrapperClass = await wrapperHandle.evaluate((el) => el.className);
+    expect(wrapperClass).toContain('col-span-2');
+  });
+});

--- a/frontend/e2e/dashboard-open-legs-card.spec.js
+++ b/frontend/e2e/dashboard-open-legs-card.spec.js
@@ -225,9 +225,31 @@ test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
 
     // The roll action's label is visible (it's the urgent case).
     const actionCells = page.getByTestId('dashboard-leg-row-action');
-    // The action text span inside the roll row is visible
     await expect(actionCells.nth(0).getByText('Roll', { exact: true })).toBeVisible();
     // The hold label is hidden on mobile (it carries `hidden lg:inline`)
     await expect(actionCells.nth(1).getByText('Hold', { exact: true })).not.toBeVisible();
+  });
+
+  test('mobile ACTION column visible for manage (urgent, same as roll)', async ({ page }) => {
+    const manageLeg = makeLeg({ id: 'leg-manage', suggested_action: 'manage', assignment_risk: 'watch' });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [manageLeg] });
+    await page.setViewportSize({ width: 600, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-leg-row-action').getByText('Manage', { exact: true })).toBeVisible();
+  });
+
+  test('close action never renders in V0.5 payload (spec §14.5)', async ({ page }) => {
+    const legs = [
+      makeLeg({ id: 'leg-roll', suggested_action: 'roll' }),
+      makeLeg({ id: 'leg-manage', ticker: 'TSLA', suggested_action: 'manage', assignment_risk: 'watch' }),
+      makeLeg({ id: 'leg-hold', ticker: 'AAPL', suggested_action: 'hold', assignment_risk: 'low', dte: 30 }),
+    ];
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: legs });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('Close target ✓')).toHaveCount(0);
   });
 });

--- a/frontend/e2e/dashboard-open-legs-card.spec.js
+++ b/frontend/e2e/dashboard-open-legs-card.spec.js
@@ -1,0 +1,233 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #150 — Open Option Legs card upgrade.
+ *
+ * Covers AC:
+ *   - %CAPTURED column renders `—` when state === "unknown" (universal V0.5)
+ *   - RISK column reflects `legs[].assignment_risk` (high/watch/low)
+ *   - ACTION column reflects `legs[].suggested_action` (roll/hold/manage —
+ *     never "close" in V0.5 per spec §14.5)
+ *   - Earnings ⚠ glyph in expiration cell when `earnings_in_window === true`,
+ *     with `aria-label="Earnings before expiration"`.
+ *   - Mobile breakpoint hides %CAPTURED and RISK columns.
+ *   - Test IDs preserved: dashboard-leg-row.
+ *   - New test IDs: dashboard-leg-row-captured, -risk, -action.
+ */
+
+const BASE_PAYLOAD = {
+  generated_at: '2026-05-12T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 1 },
+  },
+  kpis: {
+    open_positions: 1,
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 1, holding: 0 },
+    notional_value: 17542,
+    notional_change_pct: 0,
+    open_legs: 3,
+    open_legs_breakdown: { puts: 2, calls: 1 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+    largest_risk: null,
+    premium_collected_total: 0,
+    premium_collected_trades: 0,
+    premium_collected_ytd: 0,
+    realized_pl: 0,
+    realized_pl_pct: null,
+    largest_loser: null,
+  },
+  positions: [
+    {
+      id: 'pos-aapl',
+      ticker: 'AAPL',
+      shares: 100,
+      strategy: 'wheel',
+      adjusted_cost_basis: 17240.0,
+      current_price: 175.42,
+      notional: 17542.0,
+      unrealized_pl: 0,
+      open_legs_count: 1,
+    },
+  ],
+  upcoming_expirations: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-05-12T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+};
+
+function makeLeg(overrides = {}) {
+  return {
+    id: 'leg-1',
+    ticker: 'AAPL',
+    type: 'put',
+    strike: 175.0,
+    expiration: '2026-05-08',
+    dte: 7,
+    moneyness: { state: 'ITM', distance_pct: 0.0024, distance_dollars: 0.42 },
+    position_id: 'pos-aapl',
+    profit_target_status: { captured_pct: null, state: 'unknown' },
+    assignment_risk: 'high',
+    suggested_action: 'roll',
+    earnings_in_window: false,
+    ...overrides,
+  };
+}
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
+  test('%CAPTURED column renders `—` when state is unknown (universal V0.5 case)', async ({ page }) => {
+    const leg = makeLeg();
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const captured = page.getByTestId('dashboard-leg-row-captured').first();
+    await expect(captured).toBeVisible();
+    await expect(captured).toContainText('—');
+  });
+
+  test('RISK column renders "High" with glyph for high-assignment-risk leg', async ({ page }) => {
+    const leg = makeLeg({ assignment_risk: 'high', dte: 7 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const risk = page.getByTestId('dashboard-leg-row-risk').first();
+    await expect(risk).toBeVisible();
+    await expect(risk).toContainText('High');
+  });
+
+  test('assignment-risk thresholds: 14 DTE ITM = Watch, 21 DTE ITM = Low', async ({ page }) => {
+    const watchLeg = makeLeg({
+      id: 'leg-watch',
+      ticker: 'TSLA',
+      dte: 14,
+      assignment_risk: 'watch',
+      suggested_action: 'hold',
+    });
+    const lowLeg = makeLeg({
+      id: 'leg-low',
+      ticker: 'NVDA',
+      dte: 21,
+      assignment_risk: 'low',
+      suggested_action: 'hold',
+      moneyness: { state: 'OTM', distance_pct: 0.02, distance_dollars: 5 },
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [watchLeg, lowLeg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const riskCells = page.getByTestId('dashboard-leg-row-risk');
+    await expect(riskCells.nth(0)).toContainText('Watch');
+    await expect(riskCells.nth(1)).toContainText('Low');
+  });
+
+  test('ACTION column reflects suggested_action — roll / hold / manage', async ({ page }) => {
+    const rollLeg = makeLeg({ id: 'leg-roll', suggested_action: 'roll' });
+    const holdLeg = makeLeg({
+      id: 'leg-hold',
+      ticker: 'TSLA',
+      suggested_action: 'hold',
+      assignment_risk: 'low',
+      dte: 21,
+    });
+    const manageLeg = makeLeg({
+      id: 'leg-manage',
+      ticker: 'NVDA',
+      suggested_action: 'manage',
+      assignment_risk: 'watch',
+      dte: 5,
+      moneyness: { state: 'OTM', distance_pct: 0.02, distance_dollars: 5 },
+    });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      open_legs: [rollLeg, manageLeg, holdLeg],
+    });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const actions = page.getByTestId('dashboard-leg-row-action');
+    await expect(actions.nth(0)).toContainText('Roll');
+    await expect(actions.nth(1)).toContainText('Manage');
+    await expect(actions.nth(2)).toContainText('Hold');
+  });
+
+  test('earnings ⚠ glyph renders in expiration cell when earnings_in_window=true', async ({ page }) => {
+    const leg = makeLeg({ earnings_in_window: true });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const glyph = page.getByTestId('dashboard-leg-row-earnings').first();
+    await expect(glyph).toBeVisible();
+    await expect(glyph).toHaveAttribute('aria-label', 'Earnings before expiration');
+  });
+
+  test('earnings glyph hidden when earnings_in_window=false', async ({ page }) => {
+    const leg = makeLeg({ earnings_in_window: false });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-leg-row-earnings')).toHaveCount(0);
+  });
+
+  test('mobile breakpoint (<lg) hides %CAPTURED and RISK columns', async ({ page }) => {
+    const leg = makeLeg({ assignment_risk: 'high', suggested_action: 'roll' });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 600, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The cells carry the `hidden lg:block` classes; assert they are not
+    // visible at this viewport.
+    await expect(page.getByTestId('dashboard-leg-row-captured').first()).not.toBeVisible();
+    await expect(page.getByTestId('dashboard-leg-row-risk').first()).not.toBeVisible();
+    // The row itself is still visible
+    await expect(page.getByTestId('dashboard-leg-row').first()).toBeVisible();
+  });
+
+  test('mobile ACTION column visible for urgent actions (roll/manage), hidden for hold', async ({ page }) => {
+    const rollLeg = makeLeg({ id: 'leg-roll', suggested_action: 'roll' });
+    const holdLeg = makeLeg({
+      id: 'leg-hold',
+      ticker: 'TSLA',
+      suggested_action: 'hold',
+      assignment_risk: 'low',
+      dte: 21,
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [rollLeg, holdLeg] });
+    await page.setViewportSize({ width: 600, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The roll action's label is visible (it's the urgent case).
+    const actionCells = page.getByTestId('dashboard-leg-row-action');
+    // The action text span inside the roll row is visible
+    await expect(actionCells.nth(0).getByText('Roll', { exact: true })).toBeVisible();
+    // The hold label is hidden on mobile (it carries `hidden lg:inline`)
+    await expect(actionCells.nth(1).getByText('Hold', { exact: true })).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- **#148** — KPI row extended to 7 tiles: Largest Risk, Realized P/L (lifetime), Premium Collected (lifetime). Breakpoints `grid-cols-2 md:grid-cols-3 lg:grid-cols-7` per spec §14.2. Empty states: `$0`/`0%` for P/L and Premium; `—` for Largest Risk.
- **#149** — Upcoming Expirations card: 3-line row density. Line 2 adds moneyness + premium-remaining (renders `—` in V0.5, `profit_target_status.state === "unknown"` universally). Line 3 renders conditionally for earnings or DTE ≤ 7.
- **#150** — Open Option Legs card: %CAPTURED column (always `—` in V0.5), RISK column (`assignment_risk`: high/watch/low), ACTION column (`suggested_action`: roll/manage/hold). Earnings ⚠ glyph when `earnings_in_window=true`.

## Test plan
- [ ] 25 new e2e tests pass: 10 KPI row, 7 expirations, 8 open legs
- [ ] Existing dashboard.spec.js and all Phase 2 specs still pass
- [ ] KPI grid renders 7 columns on lg+, 3 on md, 2 on mobile with orphan col-span-2
- [ ] %CAPTURED always shows `—` (V0.5 universal unknown)
- [ ] Realized P/L empty state shows `$0`/`0%` (not em-dash)
- [ ] Largest Risk empty state shows `—`

🤖 Generated with [Claude Code](https://claude.com/claude-code)