### PR TITLE
V0.5.6: Cost basis accuracy — net assignment premium, preserve gross premium on import (closes #183, closes #184)

### DIFF
--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -42,7 +42,13 @@ class Position(Base):
     id = Column(String, primary_key=True)  # UUID4
     ticker = Column(String, nullable=False)
     shares = Column(Integer, nullable=False, default=100)
-    broker_cost_basis = Column(Float, nullable=False)  # total dollar cost for all shares
+    # Cost basis matching IRS/Schwab convention: ``strike × shares − net
+    # premium of the assigned put`` (net premium = ``gross_premium × 100 ×
+    # contracts − fees_prorated``). Falls back to raw ``strike × shares`` when
+    # no originating short put can be matched to an assignment (orphan
+    # imports); the un-netted case is logged at WARNING. Recomputed on every
+    # ledger replay by ``recompute_position_state`` — never written directly.
+    broker_cost_basis = Column(Float, nullable=False)
     status = Column(String, nullable=False, default="open")  # "open" | "closed"
     strategy = Column(String, nullable=False)  # "csp" | "cc" | "wheel"
     opened_at = Column(String, nullable=False)  # ISO datetime

--- a/backend/app/services/journal.py
+++ b/backend/app/services/journal.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from app.models.database import Position, Trade
 from app.models.schemas import PositionCreate, PositionUpdate, TradeCreate, TradeUpdate
+from app.services.positions import compute_assignment_netting
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +20,16 @@ def compute_total_premiums(trades: list) -> float:
 
 
 def compute_adjusted_basis(broker_cost_basis: float, total_premiums: float) -> float:
-    """Adjusted cost basis = broker_cost_basis - total_premiums."""
+    """Adjusted cost basis = ``broker_cost_basis - total_premiums``.
+
+    After issue #183, ``broker_cost_basis`` already nets the originating
+    short put's premium (minus prorated fees) for every assignment that
+    matched a paired put. To avoid double-counting, callers must pass a
+    ``total_premiums`` value that EXCLUDES the gross premium of those
+    netted puts — :func:`_build_position_response` derives that value via
+    :func:`app.services.positions.compute_assignment_netting`. The
+    subtraction itself is unchanged; the wiring is what shifted.
+    """
     return broker_cost_basis - total_premiums
 
 
@@ -52,10 +62,25 @@ def _build_trade_response(trade: Trade) -> dict:
 
 
 def _build_position_response(position: Position) -> dict:
-    """Build a PositionResponse dict from a Position ORM object."""
+    """Build a PositionResponse dict from a Position ORM object.
+
+    ``total_premiums`` reports the gross premium collected/paid across every
+    trade on the position — that is the "money I have moved on this position
+    via options" headline number the dashboard surfaces. ``adjusted_cost_basis``,
+    however, must exclude any premium that the recomputer already netted into
+    ``broker_cost_basis`` on assignment (issue #183) or it would double-count
+    the put twice. We call :func:`compute_assignment_netting` to learn which
+    sell_put trade_ids were consumed by assignments and subtract their gross
+    premium dollars from the basis-input premium sum.
+    """
     trades = list(position.trades)
     total_premiums = compute_total_premiums(trades)
-    adjusted_cost_basis = compute_adjusted_basis(position.broker_cost_basis, total_premiums)
+    netted_by_trade_id = compute_assignment_netting(trades)
+    netted_premium_total = sum(netted_by_trade_id.values())
+    premiums_for_adjusted_basis = total_premiums - netted_premium_total
+    adjusted_cost_basis = compute_adjusted_basis(
+        position.broker_cost_basis, premiums_for_adjusted_basis
+    )
     min_compliant_cc_strike = compute_min_cc_strike(adjusted_cost_basis, position.shares)
 
     return {

--- a/backend/app/services/positions.py
+++ b/backend/app/services/positions.py
@@ -344,6 +344,137 @@ def _derive_strategy_label(shares: int, open_legs: list[_LegKey]) -> str:
     return "csp"
 
 
+def _match_originating_put(
+    trades_by_id: dict[str, Trade],
+    consumed: "_LegKey | None",
+) -> Trade | None:
+    """Look up the originating short put for an assignment-consumed leg.
+
+    ``_consume_leg`` already returns the originating opening Trade's ``id``
+    via ``_LegKey.trade_id``. This helper centralizes the lookup so both the
+    recomputer (which nets the put's net premium into ``broker_cost_basis``)
+    and the journal read path (which excludes the netted premium from
+    ``total_premiums``) agree on which trade was matched. Returns ``None``
+    when ``consumed`` is ``None`` (the orphan-assignment fallback) or when
+    the originating trade is somehow not the expected ``sell_put`` — the
+    caller falls back to the un-netted raw basis in either case.
+    """
+    if consumed is None:
+        return None
+    trade = trades_by_id.get(consumed.trade_id)
+    if trade is None:
+        return None
+    if trade.trade_type != "sell_put":
+        return None
+    return trade
+
+
+def _pair_leg_for_netting(
+    open_legs: list[_LegKey],
+    option_type: str | None,
+    strike: float,
+    expiration: str,
+) -> _LegKey | None:
+    """Strict-then-FIFO match against open legs, with no logging side effects.
+
+    Mirrors :func:`_consume_leg`'s pairing logic exactly but skips the
+    warning emission used by :func:`recompute_position_state`. The journal
+    read path replays trades on every position fetch, so it must not emit
+    warnings (the recomputer already did, at write time).
+    """
+    candidates: list[str]
+    if option_type is None:
+        candidates = ["put", "call"]
+    else:
+        candidates = [option_type]
+
+    for candidate in candidates:
+        for idx, leg in enumerate(open_legs):
+            if (
+                leg.option_type == candidate
+                and leg.strike == strike
+                and leg.expiration == expiration
+            ):
+                return open_legs.pop(idx)
+
+    for candidate in candidates:
+        side_indices = [
+            i for i, leg in enumerate(open_legs) if leg.option_type == candidate
+        ]
+        if not side_indices:
+            continue
+        fifo_idx = min(side_indices, key=lambda i: open_legs[i].expiration)
+        return open_legs.pop(fifo_idx)
+
+    return None
+
+
+def compute_assignment_netting(trades: list[Trade]) -> dict[str, float]:
+    """Replay a position's ledger and report per-sell_put premium netted into basis.
+
+    Returns a ``{sell_put_trade_id: gross_premium_dollars_netted}`` mapping
+    where ``gross_premium_dollars_netted == premium_per_share * 100 *
+    contracts_consumed_by_assignment``. Used by the journal read path to
+    avoid double-counting netted premium in ``adjusted_cost_basis`` — see
+    :func:`app.services.journal._build_position_response`.
+
+    Pure function — no DB writes, no log emissions. Mirrors the matching
+    logic in :func:`recompute_position_state` so a single source of truth
+    governs which short puts are considered "consumed by assignment" for
+    basis purposes. Sorts trades by ``(opened_at, id)`` to match the
+    recomputer's replay order, then walks the ledger once.
+
+    Fees are not part of the returned value because
+    :func:`app.services.journal.compute_total_premiums` already excludes
+    fees from the gross premium sum — only the gross premium dollars need
+    to be excluded to keep ``adjusted_cost_basis`` correct.
+    """
+    sorted_trades = sorted(trades, key=lambda t: (t.opened_at or "", t.id or ""))
+    by_id: dict[str, Trade] = {t.id: t for t in sorted_trades}
+    open_legs: list[_LegKey] = []
+    netted: dict[str, float] = {}
+
+    for trade in sorted_trades:
+        ttype = trade.trade_type
+        qty = int(trade.quantity or 1)
+
+        opening_side = _option_type_for_open(ttype)
+        if opening_side is not None:
+            for _ in range(qty):
+                open_legs.append(
+                    _LegKey(
+                        option_type=opening_side,
+                        strike=float(trade.strike),
+                        expiration=trade.expiration,
+                        trade_id=trade.id,
+                    )
+                )
+            continue
+
+        if ttype not in _OPTION_CLOSE_TYPES:
+            continue
+
+        close_side = _option_type_for_close(ttype)
+        for _ in range(qty):
+            consumed = _pair_leg_for_netting(
+                open_legs,
+                close_side,
+                float(trade.strike),
+                trade.expiration,
+            )
+            if ttype != "assignment":
+                continue
+            originating = _match_originating_put(by_id, consumed)
+            if originating is None:
+                continue
+            premium_dollars = float(originating.premium or 0.0) * 100.0
+            netted[originating.id] = (
+                netted.get(originating.id, 0.0) + premium_dollars
+            )
+
+    return netted
+
+
 def recompute_position_state(
     db: Session,
     position_id: str,
@@ -462,6 +593,16 @@ def recompute_position_state(
     # the calendar-fallback pass. Applied to ``Trade.closed_at`` in a single
     # pass after the replay so the helpers stay pure (issue #136).
     closes_to_write: list[tuple[str, str]] = []
+    # ``Trade.id`` → ``Trade`` lookup so the assignment branch can resolve the
+    # originating short put for premium-netting into ``broker_cost_basis``
+    # (issue #183).
+    trades_by_id: dict[str, Trade] = {t.id: t for t in trades}
+    # Per-sell_put cumulative count of contracts already consumed by
+    # assignment within this replay. Used to prorate fees: each consumed
+    # contract gets ``fees / total_contracts`` of the originating put's
+    # fee budget netted into basis, summing to the full fee total only when
+    # every contract is consumed.
+    consumed_contracts_by_put: dict[str, int] = {}
 
     for trade in trades:
         ttype = trade.trade_type
@@ -485,6 +626,7 @@ def recompute_position_state(
         # Closing trade types: consume one matching open leg per contract.
         if ttype in _OPTION_CLOSE_TYPES:
             close_side = _option_type_for_close(ttype)
+            consumed_puts_this_trade: list[_LegKey] = []
             for _ in range(qty):
                 consumed = _consume_leg(
                     open_legs,
@@ -500,11 +642,43 @@ def recompute_position_state(
                     # Stamp the resolving trade's opened_at on the consumed
                     # leg's originating Trade row (issue #136).
                     closes_to_write.append((consumed.trade_id, trade.opened_at))
+                if ttype == "assignment" and consumed is not None:
+                    consumed_puts_this_trade.append(consumed)
 
             if ttype == "assignment":
-                # Put assigned: acquire shares at strike.
+                # Put assigned: acquire shares at strike. Then net the
+                # originating short put's premium (minus prorated fees) out
+                # of broker_cost_basis so the stored value matches the IRS
+                # / Schwab convention "strike × shares − net premium" rather
+                # than the raw strike × shares (issue #183).
                 shares += contract_shares
                 basis += float(trade.strike) * contract_shares
+
+                unmatched_contracts = qty - len(consumed_puts_this_trade)
+                for consumed_leg in consumed_puts_this_trade:
+                    originating = _match_originating_put(
+                        trades_by_id, consumed_leg
+                    )
+                    if originating is None:
+                        unmatched_contracts += 1
+                        continue
+                    total_contracts = max(int(originating.quantity or 1), 1)
+                    fee_share = float(originating.fees or 0.0) / total_contracts
+                    premium_dollars = float(originating.premium or 0.0) * 100.0
+                    # Net premium contribution for THIS one consumed contract.
+                    basis -= premium_dollars - fee_share
+                    consumed_contracts_by_put[originating.id] = (
+                        consumed_contracts_by_put.get(originating.id, 0) + 1
+                    )
+                if unmatched_contracts > 0:
+                    logger.warning(
+                        "Un-netted assignment basis for %s assignment "
+                        "trade_id=%s — no matching short put for %d contract(s); "
+                        "falling back to raw strike × shares",
+                        position.ticker,
+                        trade.id,
+                        unmatched_contracts,
+                    )
             elif ttype == "called_away":
                 # Call exercised: shares are removed at the option's strike;
                 # broker basis is reduced proportionally to the shares removed.

--- a/backend/app/services/schwab_csv.py
+++ b/backend/app/services/schwab_csv.py
@@ -190,7 +190,11 @@ def _map_csv_row(raw_row: dict, header_map: dict[str, str]) -> dict | None:
     is_buy = bool(instruction) and instruction.startswith("BUY")
     fee_adjustment = -abs(fees) if is_buy else abs(fees)
 
-    if price is not None and price > 0 and quantity > 0:
+    if direct_trade_type is not None:
+        # Direct-mapped lifecycle rows (assignment / called-away / expired)
+        # are not premium-bearing trades. Keep fees but emit zero premium.
+        premium_per_share = 0.0
+    elif price is not None and price > 0 and quantity > 0:
         premium_per_share = abs(price)
     elif quantity > 0:
         premium_per_share = max(

--- a/backend/app/services/schwab_csv.py
+++ b/backend/app/services/schwab_csv.py
@@ -172,14 +172,24 @@ def _map_csv_row(raw_row: dict, header_map: dict[str, str]) -> dict | None:
 
     amount = _parse_float(raw_row.get(header_map.get("amount", ""), ""))
     fees = _parse_float(raw_row.get(header_map.get("fees & comm", ""), "")) or 0.0
+    price = _parse_float(raw_row.get(header_map.get("price", ""), ""))
 
     if amount is None:
         amount = 0.0
 
-    # Premium per share: abs(Amount) / (quantity * 100). Schwab's "Amount"
-    # column is signed (positive = credit, negative = debit) and already net of
-    # fees, mirroring the API's `netAmount` field.
-    premium_per_share = abs(amount) / (quantity * 100) if quantity > 0 else 0.0
+    # Premium per share: prefer the per-share ``Price`` column when present —
+    # Schwab's CSV exposes the gross premium there directly, which sidesteps
+    # the fee-arithmetic that ``Amount`` is already net of. Fall back to
+    # gross-up math (``abs(Amount) + fees``) when ``Price`` is missing or
+    # unparseable — that path applies to assignment / expired rows that have
+    # no Price column populated, where the fallback produces 0.0 from a 0.0
+    # amount + 0.0 fees anyway. See issue #184.
+    if price is not None and price > 0 and quantity > 0:
+        premium_per_share = abs(price)
+    elif quantity > 0:
+        premium_per_share = (abs(amount) + abs(fees)) / (quantity * 100)
+    else:
+        premium_per_share = 0.0
     if instruction == "BUY_TO_CLOSE":
         premium_per_share = -premium_per_share
 

--- a/backend/app/services/schwab_csv.py
+++ b/backend/app/services/schwab_csv.py
@@ -184,10 +184,18 @@ def _map_csv_row(raw_row: dict, header_map: dict[str, str]) -> dict | None:
     # unparseable — that path applies to assignment / expired rows that have
     # no Price column populated, where the fallback produces 0.0 from a 0.0
     # amount + 0.0 fees anyway. See issue #184.
+    # Buys pay gross + fees; sells receive gross − fees. Fee sign in the
+    # fallback must flip for buy-side rows so gross is recovered correctly.
+    # ``instruction`` is None for direct-mapped types like Expired / Assignment.
+    is_buy = bool(instruction) and instruction.startswith("BUY")
+    fee_adjustment = -abs(fees) if is_buy else abs(fees)
+
     if price is not None and price > 0 and quantity > 0:
         premium_per_share = abs(price)
     elif quantity > 0:
-        premium_per_share = (abs(amount) + abs(fees)) / (quantity * 100)
+        premium_per_share = max(
+            (abs(amount) + fee_adjustment) / (quantity * 100), 0.0
+        )
     else:
         premium_per_share = 0.0
     if instruction == "BUY_TO_CLOSE":

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -66,11 +66,27 @@ def map_schwab_transaction(txn: dict) -> dict | None:
 
     quantity = abs(int(item.get("amount", 1)))
     net_amount = float(txn.get("netAmount", 0))
+    fees = _extract_fees(txn)
 
-    # Premium per share: abs(netAmount) / (quantity * 100)
-    # Positive for sells (credits), negative for buys (debits)
-    if quantity > 0:
-        premium_per_share = abs(net_amount) / (quantity * 100)
+    # Premium per share: prefer the gross per-share price reported on the
+    # transferItem when Schwab provides it; otherwise gross-up the post-fee
+    # ``netAmount`` by adding the fee total back in before dividing. Schwab's
+    # ``netAmount`` field is the *net* dollar movement after commissions and
+    # exchange fees, so using it raw understates the premium by ``fees / (qty
+    # * 100)`` per share (issue #184: a 1-contract sell put at $0.30 with
+    # $0.66 in fees nets to $29.34, which rounds to $0.29 — the visible bug).
+    #
+    # Positive for sells (credits), negative for buys (debits).
+    raw_price = item.get("price")
+    if raw_price is not None:
+        try:
+            premium_per_share = abs(float(raw_price))
+        except (TypeError, ValueError):
+            premium_per_share = (
+                (abs(net_amount) + fees) / (quantity * 100) if quantity > 0 else 0.0
+            )
+    elif quantity > 0:
+        premium_per_share = (abs(net_amount) + fees) / (quantity * 100)
     else:
         premium_per_share = 0.0
 
@@ -78,7 +94,6 @@ def map_schwab_transaction(txn: dict) -> dict | None:
     if instruction in ("BUY_TO_CLOSE",):
         premium_per_share = -premium_per_share
 
-    fees = _extract_fees(txn)
     opened_at = txn.get("transactionDate", "")
 
     return {

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -83,7 +83,11 @@ def map_schwab_transaction(txn: dict) -> dict | None:
     fee_adjustment = -fees if is_buy else fees
 
     raw_price = item.get("price")
-    if raw_price is not None:
+    if instruction == "RECEIVE_DELIVER":
+        # Assignment / called-away are lifecycle events, not premium-bearing
+        # trades. Any fees on these rows stay in ``fees`` only.
+        premium_per_share = 0.0
+    elif raw_price is not None:
         try:
             premium_per_share = abs(float(raw_price))
         except (TypeError, ValueError):

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -77,16 +77,25 @@ def map_schwab_transaction(txn: dict) -> dict | None:
     # $0.66 in fees nets to $29.34, which rounds to $0.29 — the visible bug).
     #
     # Positive for sells (credits), negative for buys (debits).
+    # For sells, |netAmount| = gross − fees → add fees back to recover gross.
+    # For buys, |netAmount| = gross + fees → subtract fees.
+    is_buy = instruction.startswith("BUY")
+    fee_adjustment = -fees if is_buy else fees
+
     raw_price = item.get("price")
     if raw_price is not None:
         try:
             premium_per_share = abs(float(raw_price))
         except (TypeError, ValueError):
             premium_per_share = (
-                (abs(net_amount) + fees) / (quantity * 100) if quantity > 0 else 0.0
+                max((abs(net_amount) + fee_adjustment) / (quantity * 100), 0.0)
+                if quantity > 0
+                else 0.0
             )
     elif quantity > 0:
-        premium_per_share = (abs(net_amount) + fees) / (quantity * 100)
+        premium_per_share = max(
+            (abs(net_amount) + fee_adjustment) / (quantity * 100), 0.0
+        )
     else:
         premium_per_share = 0.0
 

--- a/backend/tests/test_integration_journal.py
+++ b/backend/tests/test_integration_journal.py
@@ -267,6 +267,124 @@ def test_adjusted_basis_no_trades(db_session):
     assert result["adjusted_cost_basis"] == 5000.0
 
 
+def test_adjusted_basis_excludes_assignment_consumed_premium(db_session):
+    """Issue #183: total_premiums must not double-count the put netted into basis.
+
+    Canonical wheel: Sell Put @ $13.50 premium $0.30 fees $0.66 → Assignment.
+    After the recomputer runs, ``broker_cost_basis = 1320.66`` (already nets
+    the $30 gross premium minus $0.66 fees). The journal read path's
+    ``adjusted_cost_basis`` must NOT subtract the same $30 a second time —
+    that would yield $1290.66 instead of the correct $1320.66.
+
+    With no additional premium-earning trades on the position, the canonical
+    AC is ``adjusted_cost_basis == broker_cost_basis == 1320.66``.
+    """
+    # Seed via the service layer so this test exercises the same code path
+    # the API uses. broker_cost_basis is recomputed below.
+    position = _create_sample_position(
+        db_session,
+        ticker="F",
+        broker_cost_basis=0.0,
+        opened_at="2026-03-01T10:00:00Z",
+    )
+    _create_sample_trade(
+        db_session,
+        position["id"],
+        trade_type="sell_put",
+        strike=13.50,
+        expiration="2026-03-27",
+        premium=0.30,
+        fees=0.66,
+        quantity=1,
+        opened_at="2026-03-01T10:00:00Z",
+    )
+    _create_sample_trade(
+        db_session,
+        position["id"],
+        trade_type="assignment",
+        strike=13.50,
+        expiration="2026-03-27",
+        premium=0.0,
+        fees=0.0,
+        quantity=1,
+        opened_at="2026-03-27T16:00:00Z",
+    )
+
+    # Drive the recomputer so broker_cost_basis lands at the netted value.
+    from app.services.positions import recompute_position_state
+
+    recompute_position_state(db_session, position["id"])
+
+    result = get_position(db_session, position["id"])
+
+    assert result["broker_cost_basis"] == pytest.approx(1320.66, abs=1e-4)
+    # total_premiums reports gross premium collected (unchanged semantics).
+    assert result["total_premiums"] == pytest.approx(30.0, abs=1e-4)
+    # adjusted_cost_basis must exclude the netted put — equals basis exactly
+    # when there are no other premium-earning trades.
+    assert result["adjusted_cost_basis"] == pytest.approx(1320.66, abs=1e-4)
+
+
+def test_adjusted_basis_post_assignment_cc_subtracts_only_new_premium(db_session):
+    """Issue #183 follow-on: a CC sold after assignment IS subtracted normally.
+
+    Wheel mid-cycle: Sell Put → Assignment → Sell Call. The assignment-
+    netted put premium stays inside ``broker_cost_basis``; the CC premium
+    is real new income and shows up in ``adjusted_cost_basis``.
+
+    Canonical F-case extended: basis = $1320.66, sell a $15 CC for $0.40
+    → adjusted basis = 1320.66 - 40 = 1280.66.
+    """
+    position = _create_sample_position(
+        db_session,
+        ticker="F",
+        broker_cost_basis=0.0,
+        opened_at="2026-03-01T10:00:00Z",
+    )
+    _create_sample_trade(
+        db_session,
+        position["id"],
+        trade_type="sell_put",
+        strike=13.50,
+        expiration="2026-03-27",
+        premium=0.30,
+        fees=0.66,
+        opened_at="2026-03-01T10:00:00Z",
+    )
+    _create_sample_trade(
+        db_session,
+        position["id"],
+        trade_type="assignment",
+        strike=13.50,
+        expiration="2026-03-27",
+        premium=0.0,
+        fees=0.0,
+        opened_at="2026-03-27T16:00:00Z",
+    )
+    _create_sample_trade(
+        db_session,
+        position["id"],
+        trade_type="sell_call",
+        strike=15.0,
+        expiration="2026-04-17",
+        premium=0.40,
+        fees=0.66,
+        opened_at="2026-04-01T10:00:00Z",
+    )
+
+    from app.services.positions import recompute_position_state
+
+    recompute_position_state(db_session, position["id"])
+
+    result = get_position(db_session, position["id"])
+
+    assert result["broker_cost_basis"] == pytest.approx(1320.66, abs=1e-4)
+    # total_premiums sums every premium gross (30 from put + 40 from call).
+    assert result["total_premiums"] == pytest.approx(70.0, abs=1e-4)
+    # adjusted basis subtracts ONLY the new $40 (the put was already netted).
+    assert result["adjusted_cost_basis"] == pytest.approx(1280.66, abs=1e-4)
+
+
 def test_min_compliant_cc_strike(db_session):
     """Verify 1.10x calculation on adjusted basis."""
     position = _create_sample_position(

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -23,6 +23,7 @@ from app.services.positions import (
     _derive_strategy_label,
     _LegKey,
     _reset_unpaired_warning_cache,
+    compute_assignment_netting,
     recompute_position_state,
 )
 
@@ -2041,3 +2042,340 @@ class TestPersistsTradeClosedAt:
 
         db_session.refresh(sell_put)
         assert sell_put.closed_at == first_close
+
+
+# --- Issue #183: assignment basis netting ------------------------------------
+
+
+class TestAssignmentBasisNetting:
+    """Issue #183: ``broker_cost_basis`` must net the originating put's net
+    premium (gross premium minus prorated fees) when an assignment matches a
+    paired short put.
+
+    Pre-fix: ``broker_cost_basis = strike * shares`` for every assignment,
+    which diverges from Schwab's / IRS's "strike × shares − net premium" by
+    the gross premium minus fees per contract. The fix: at assignment, look
+    up the originating ``sell_put`` via the consumed ``_LegKey.trade_id`` and
+    net its premium dollars (minus prorated fees) out of basis. Fall back to
+    raw ``strike × shares`` and log a WARNING when no matching put is found.
+    """
+
+    def setup_method(self) -> None:
+        # Each test should see the first WARNING for any orphan assignment it
+        # creates rather than a demoted INFO from a prior run.
+        _reset_unpaired_warning_cache()
+
+    def test_basis_nets_assignment_premium(self, db_session):
+        # Canonical wheel cycle: Sell Put @ $13.50, premium $0.30, fees $0.66,
+        # 1 contract → Assignment. Net premium = $30 - $0.66 = $29.34. Basis =
+        # 1350 - 29.34 = $1320.66. This is the user-facing canonical F-case
+        # from issue #183.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                    "premium": 0.30,
+                    "fees": 0.66,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(1320.66, abs=1e-4)
+
+    def test_basis_nets_multi_contract_assignment(self, db_session):
+        # Sell 5 Puts @ $20.00 premium $0.40 fees $3.30; all 5 assigned.
+        # Net premium = 5 * 100 * 0.40 - 3.30 = 200 - 3.30 = 196.70.
+        # Basis = 5 * 100 * 20 - 196.70 = 10000 - 196.70 = 9803.30.
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                    "premium": 0.40,
+                    "fees": 3.30,
+                    "quantity": 5,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                    "quantity": 5,
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        assert result.status == "open"
+        assert result.shares == 500
+        assert result.broker_cost_basis == pytest.approx(9803.30, abs=1e-4)
+
+    def test_basis_prorates_fees_on_partial_assignment(self, db_session):
+        # Sell 5 Puts @ $20.00 premium $0.40 fees $3.30; only 3 assigned.
+        # Each consumed contract gets ``3.30 / 5 = 0.66`` of the fee budget.
+        # Net premium netted = 3 * 100 * 0.40 - 3 * 0.66 = 120 - 1.98 = 118.02.
+        # Basis = 3 * 100 * 20 - 118.02 = 6000 - 118.02 = 5881.98.
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-01",
+                    "premium": 0.40,
+                    "fees": 3.30,
+                    "quantity": 5,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-02-20",
+                    "opened_at": "2026-02-20",
+                    "quantity": 3,
+                },
+            ],
+        )
+
+        # Freeze before the leg's expiration so the 2 unconsumed legs aren't
+        # swept by the calendar fallback.
+        result = recompute_position_state(
+            db_session, pos.id, clock=_frozen_clock(date(2026, 2, 21))
+        )
+
+        assert result.status == "open"
+        assert result.shares == 300
+        assert result.broker_cost_basis == pytest.approx(5881.98, abs=1e-4)
+
+    def test_basis_canonical_f_case_exact_1320_66(self, db_session):
+        # Locks the user-facing AC from issue #183: the canonical F-case
+        # must produce exactly $1320.66 (matches Schwab + IRS records).
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                    "premium": 0.30,
+                    "fees": 0.66,
+                    "quantity": 1,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                    "quantity": 1,
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        # Exact equality — the recomputer rounds basis to 4 decimals and
+        # 1350 - 29.34 = 1320.66 lands cleanly in float.
+        assert result.broker_cost_basis == 1320.66
+
+    def test_basis_multi_cycle_matches_assigned_put_not_expired(
+        self, db_session
+    ):
+        # Wheel re-entry: first sell_put expires worthless, second sell_put
+        # at the same strike is ASSIGNED. The recomputer must net the SECOND
+        # put's premium into basis, not the first (expired) one.
+        pos = _seed_position(
+            db_session,
+            ticker="MARA",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-01-17",
+                    "opened_at": "2026-01-02",
+                    "premium": 0.10,
+                    "fees": 0.66,
+                },
+                {
+                    "trade_type": "expired",
+                    "strike": 20.0,
+                    "expiration": "2026-01-17",
+                    "opened_at": "2026-01-17",
+                },
+                {
+                    "trade_type": "sell_put",
+                    "strike": 20.0,
+                    "expiration": "2026-03-17",
+                    "opened_at": "2026-02-15",
+                    "premium": 0.45,
+                    "fees": 0.66,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 20.0,
+                    "expiration": "2026-03-17",
+                    "opened_at": "2026-03-17",
+                },
+            ],
+        )
+
+        result = recompute_position_state(db_session, pos.id)
+
+        # Second put's net premium = 0.45 * 100 - 0.66 = 44.34.
+        # Basis = 2000 - 44.34 = 1955.66. NOT 2000 - 9.34 = 1990.66 (which
+        # would be the bug of netting the expired first put).
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(1955.66, abs=1e-4)
+
+    def test_basis_falls_back_when_no_matching_put(self, db_session, caplog):
+        # Orphan assignment row — basis falls back to raw strike × shares,
+        # a WARNING is logged, and the recomputer does not crash.
+        pos = _seed_position(
+            db_session,
+            ticker="ZZZ",
+            trades=[
+                {
+                    "trade_type": "assignment",
+                    "strike": 50.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                }
+            ],
+        )
+
+        with caplog.at_level("WARNING", logger="app.services.positions"):
+            result = recompute_position_state(
+                db_session, pos.id, clock=_frozen_clock(date(2026, 5, 8))
+            )
+
+        assert result.shares == 100
+        assert result.broker_cost_basis == pytest.approx(5000.0)
+        assert any(
+            "Un-netted assignment basis" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_basis_zero_premium_no_netting_no_warning(self, db_session, caplog):
+        # Backward-compat: a sell_put with premium=0.0 (legacy imports) still
+        # matches — yielding a net premium of 0.0 — so basis equals raw
+        # strike × shares. The matcher succeeds, so NO un-netted warning
+        # fires.
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        with caplog.at_level("WARNING", logger="app.services.positions"):
+            result = recompute_position_state(db_session, pos.id)
+
+        assert result.broker_cost_basis == pytest.approx(1350.0)
+        assert not any(
+            "Un-netted assignment basis" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+class TestComputeAssignmentNetting:
+    """Pure-function unit tests for the shared netting helper used by the
+    journal read path."""
+
+    def test_no_assignment_returns_empty(self, db_session):
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                    "premium": 0.30,
+                    "fees": 0.66,
+                }
+            ],
+        )
+
+        assert compute_assignment_netting(list(pos.trades)) == {}
+
+    def test_assignment_returns_gross_premium_dollars(self, db_session):
+        # The helper reports gross premium dollars only — fees are NOT
+        # included (compute_total_premiums excludes fees in the same way).
+        pos = _seed_position(
+            db_session,
+            ticker="F",
+            trades=[
+                {
+                    "trade_type": "sell_put",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-01",
+                    "premium": 0.30,
+                    "fees": 0.66,
+                },
+                {
+                    "trade_type": "assignment",
+                    "strike": 13.50,
+                    "expiration": "2026-03-27",
+                    "opened_at": "2026-03-27",
+                },
+            ],
+        )
+
+        result = compute_assignment_netting(list(pos.trades))
+        sell_put = next(t for t in pos.trades if t.trade_type == "sell_put")
+        # 0.30 * 100 = 30.00 gross premium dollars netted for one contract.
+        assert result == {sell_put.id: pytest.approx(30.0, abs=1e-4)}
+
+    def test_orphan_assignment_returns_empty(self, db_session):
+        # No matching sell_put → nothing to net. The journal read path uses
+        # an empty map so it doesn't double-count premiums that aren't there.
+        pos = _seed_position(
+            db_session,
+            ticker="ZZZ",
+            trades=[
+                {
+                    "trade_type": "assignment",
+                    "strike": 50.0,
+                    "expiration": "2026-04-17",
+                    "opened_at": "2026-04-17",
+                }
+            ],
+        )
+
+        assert compute_assignment_netting(list(pos.trades)) == {}

--- a/backend/tests/test_schwab_csv_import.py
+++ b/backend/tests/test_schwab_csv_import.py
@@ -72,8 +72,9 @@ class TestParseSchwabCsv:
         assert row["strike"] == 13.50
         assert row["expiration"] == "2026-03-27"
         assert row["quantity"] == 1
-        # Premium per share = 29.35 / (1 * 100) = 0.2935, positive for sells.
-        assert row["premium"] == pytest.approx(0.2935, abs=1e-4)
+        # Premium per share = gross Price column (0.30), not the post-fee
+        # net (29.35 / 100 = 0.2935) — corrected after #184.
+        assert row["premium"] == pytest.approx(0.30, abs=1e-4)
         assert row["fees"] == 0.65
         assert row["opened_at"] == "2026-03-01"
 
@@ -84,17 +85,18 @@ class TestParseSchwabCsv:
         assert row["ticker"] == "SOFI"
         assert row["trade_type"] == "sell_call"
         assert row["quantity"] == 2
-        # 98.70 / (2 * 100) = 0.4935
-        assert row["premium"] == pytest.approx(0.4935, abs=1e-4)
+        # Gross per-share Price column = 0.50 (was 98.70 / (2*100) = 0.4935
+        # — the post-fee net — corrected after #184).
+        assert row["premium"] == pytest.approx(0.50, abs=1e-4)
 
     def test_buy_to_close_premium_is_negative(self):
         result = parse_schwab_csv(_csv([BUY_TO_CLOSE_ROW]))
         assert len(result) == 1
         row = result[0]
         assert row["trade_type"] == "buy_put_close"
-        # Schwab uses parentheses for negatives; abs(amount) used for premium,
-        # but the buy side flips the sign.
-        assert row["premium"] == pytest.approx(-0.1065, abs=1e-4)
+        # Gross per-share Price column = 0.10 (sign flipped for buy_to_close).
+        # Pre-#184 this used post-fee net (-0.1065).
+        assert row["premium"] == pytest.approx(-0.10, abs=1e-4)
 
     def test_assigned_maps_to_assignment(self):
         result = parse_schwab_csv(_csv([ASSIGNED_PUT_ROW]))
@@ -223,8 +225,9 @@ class TestParseSchwabCsv:
         )
         result = parse_schwab_csv(_csv([row]))
         assert len(result) == 1
-        # 998.70 / (2 * 100) = 4.9935
-        assert result[0]["premium"] == pytest.approx(4.9935, abs=1e-4)
+        # Gross per-share Price column = 5.00 (was 998.70 / (2*100) = 4.9935
+        # — the post-fee net — corrected after #184).
+        assert result[0]["premium"] == pytest.approx(5.00, abs=1e-4)
 
 
 # --- API endpoint integration tests -----------------------------------------

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -127,6 +127,72 @@ class TestMapSchwabTransaction:
         result = map_schwab_transaction(txn)
         assert result["fees"] == 0.0
 
+    def test_premium_grossed_up_when_netamount_excludes_fees(self):
+        """Sell-put net=$29.34 + $0.66 fees + qty=1 → gross premium $0.30, not $0.29.
+
+        Schwab's ``netAmount`` is post-fees, so dividing it by ``qty*100``
+        understates the premium by ``fees / (qty*100)``. Issue #184: that
+        rounding error was the visible "0.29 instead of 0.30" symptom.
+        """
+        fees = {
+            "commission": 0.65,
+            "secFee": 0.01,
+            "optRegFee": 0.0,
+            "rFee": 0.0,
+            "cdscFee": 0.0,
+            "otherCharges": 0.0,
+        }
+        txn = _make_txn(
+            "SELL_TO_OPEN",
+            "PUT",
+            ticker="F",
+            strike=13.50,
+            net_amount=29.34,
+            amount=1,
+            fees=fees,
+        )
+        result = map_schwab_transaction(txn)
+        assert result is not None
+        assert result["premium"] == pytest.approx(0.30, abs=1e-4)
+        assert result["premium"] != pytest.approx(0.2934, abs=1e-4)
+
+    def test_premium_prefers_transferitem_price_when_present(self):
+        """If Schwab exposes ``transferItem.price`` use it directly as gross.
+
+        Some API payloads include the per-share price on the option leg;
+        prefer it over the netAmount gross-up arithmetic. The two approaches
+        should agree but ``price`` is the canonical field.
+        """
+        fees = {"commission": 0.66}
+        txn = _make_txn(
+            "SELL_TO_OPEN",
+            "PUT",
+            net_amount=29.34,
+            amount=1,
+            fees=fees,
+        )
+        # Inject the price field on the transferItem.
+        txn["transferItems"][0]["price"] = 0.30
+        result = map_schwab_transaction(txn)
+        assert result["premium"] == pytest.approx(0.30, abs=1e-4)
+
+    def test_premium_preserves_subpenny_precision(self):
+        """Gross-up math preserves sub-penny precision (e.g. $0.295).
+
+        Sell put @ $0.295 gross × 1 contract = $29.50 gross, minus $0.66 fees
+        = $28.84 net. The import path must recover $0.295 from those inputs.
+        """
+        fees = {"commission": 0.65, "secFee": 0.01}
+        txn = _make_txn(
+            "SELL_TO_OPEN",
+            "PUT",
+            net_amount=28.84,
+            amount=1,
+            fees=fees,
+        )
+        result = map_schwab_transaction(txn)
+        assert result["premium"] == pytest.approx(0.295, abs=1e-4)
+
 
 # --- Duplicate detection ---
 

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -156,6 +156,34 @@ class TestMapSchwabTransaction:
         assert result["premium"] == pytest.approx(0.30, abs=1e-4)
         assert result["premium"] != pytest.approx(0.2934, abs=1e-4)
 
+    def test_buy_to_close_premium_grossed_down_when_netamount_includes_fees(self):
+        """Buy-to-close: |netAmount| = gross + fees, so subtract fees to recover gross.
+
+        Mirrors the sell-side gross-up but in the opposite direction. Without
+        flipping the fee sign on buys, the fallback would over-state the gross
+        premium by ``2 * fees / (qty*100)`` per share.
+        """
+        fees = {
+            "commission": 0.65,
+            "secFee": 0.01,
+            "optRegFee": 0.0,
+            "rFee": 0.0,
+            "cdscFee": 0.0,
+            "otherCharges": 0.0,
+        }
+        txn = _make_txn(
+            "BUY_TO_CLOSE",
+            "PUT",
+            ticker="F",
+            strike=13.50,
+            net_amount=-30.66,
+            amount=1,
+            fees=fees,
+        )
+        result = map_schwab_transaction(txn)
+        assert result is not None
+        assert result["premium"] == pytest.approx(-0.30, abs=1e-4)
+
     def test_premium_prefers_transferitem_price_when_present(self):
         """If Schwab exposes ``transferItem.price`` use it directly as gross.
 

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -184,6 +184,37 @@ class TestMapSchwabTransaction:
         assert result is not None
         assert result["premium"] == pytest.approx(-0.30, abs=1e-4)
 
+    def test_receive_deliver_with_fees_emits_zero_premium(self):
+        """Assignment / called-away rows are not premium-bearing trades.
+
+        If Schwab reports a non-zero fee on a RECEIVE_DELIVER row and omits
+        ``transferItem.price``, the fallback gross-up would otherwise turn the
+        fee into a fabricated premium. Lifecycle rows must keep premium at 0.
+        """
+        fees = {
+            "commission": 0.0,
+            "secFee": 0.10,
+            "optRegFee": 0.0,
+            "rFee": 0.0,
+            "cdscFee": 0.0,
+            "otherCharges": 0.0,
+        }
+        put_txn = _make_txn(
+            "RECEIVE_DELIVER", "PUT", net_amount=0.0, amount=1, fees=fees
+        )
+        result = map_schwab_transaction(put_txn)
+        assert result["trade_type"] == "assignment"
+        assert result["premium"] == 0.0
+        assert result["fees"] == pytest.approx(0.10)
+
+        call_txn = _make_txn(
+            "RECEIVE_DELIVER", "CALL", net_amount=0.0, amount=1, fees=fees
+        )
+        result = map_schwab_transaction(call_txn)
+        assert result["trade_type"] == "called_away"
+        assert result["premium"] == 0.0
+        assert result["fees"] == pytest.approx(0.10)
+
     def test_premium_prefers_transferitem_price_when_present(self):
         """If Schwab exposes ``transferItem.price`` use it directly as gross.
 


### PR DESCRIPTION
## Summary

Closes #183 (P1) and closes #184 (P2). Tonight's V0.5.6 patch.

**The bug (real F position):** our app reported `broker_cost_basis = $1,350.00` for a 100-share F position from a Sell-Put assignment at $13.50; Schwab reported `$1,320.66`. That $29.34 propagates into Covered Call 10%-rule strike selection, Recovery Plan IRR, the Largest-Risk KPI tile, and Realized P/L.

**Two root causes, fixed jointly because #183 depends on #184:**

1. **#184** — Schwab import computed premium as `netAmount / (qty × 100)`. `netAmount` is post-fee, so a $0.30/share gross fill with $0.66 fees stored as $0.2934 (displayed `$0.29`). Now we prefer `transferItem.price` and gross-up the netAmount fallback with the fee sign flipped per buy/sell direction.
2. **#183** — `recompute_position_state` set `broker_cost_basis = strike × shares` on Assignment, ignoring the originating Sell Put's premium. Schwab/IRS basis = `strike × shares − (gross_premium × 100 × contracts − fees_prorated)`. Now the assignment branch looks up the originating put via a shared `_match_originating_put` helper, nets it, and falls back to raw `strike × shares` (logged warning) when no match exists.

A read-side helper (`_pair_leg_for_netting` + `compute_assignment_netting`, both silent) ensures the journal API surface produces the same pairing decisions as the recomputer without spamming logs on every fetch. `adjusted_cost_basis = broker_cost_basis − (total_premiums − netted_gross)` keeps premium that's already baked into basis from being double-counted.

## Canonical F case

After fix: `broker_cost_basis == 1320.66` exactly. Locked in `test_basis_canonical_f_case_exact_1320_66`.

## Files changed

**Backend code**
- `backend/app/services/positions.py` — `_match_originating_put`, `_pair_leg_for_netting`, `compute_assignment_netting`; assignment branch nets premium
- `backend/app/services/journal.py` — `_build_position_response` subtracts netted premium from `total_premiums` before computing adjusted basis
- `backend/app/services/schwab_import.py` — prefer `transferItem.price`; gross-up netAmount fallback with sign-aware fee adjustment
- `backend/app/services/schwab_csv.py` — same precision fix; guard against `instruction is None` for direct-mapped types
- `backend/app/models/database.py` — `Trade.broker_cost_basis` column docstring updated to reflect IRS/Schwab semantics

**Backend tests**
- `backend/tests/test_position_state.py` — canonical $1,320.66 case + 5 variants (multi-contract, partial assignment fee proration, multi-cycle, fallback, zero-premium legacy)
- `backend/tests/test_journal.py` + `test_integration_journal.py` — adjusted-basis double-count guards
- `backend/tests/test_schwab_import.py` — gross-up regression + BUY_TO_CLOSE with non-zero fees
- `backend/tests/test_schwab_csv_import.py` — Price-column happy path + fallback parity

## Test plan

- [x] `cd backend && python -m pytest` — **822 passed, 7 skipped**
- [x] Canonical F-case test asserts `broker_cost_basis == 1320.66` exactly (not approx) through the full recompute code path
- [x] No frontend changes needed — fix is at storage time; `formatCurrency` displays the corrected value automatically
- [ ] CI: backend-tests + frontend-checks + CodeQL green
- [ ] Post-deploy: run Settings → Reconcile journal → Apply on any user with assigned-from-put positions. Expect a `basis_corrections` count surfaced as the retroactive fix.

## Operator note

Realized P/L magnitudes on previously-closed assigned-from-put positions will shift slightly after this lands — that's the bug being corrected, not a new bug. The dashboard Largest-Risk and Realized-P/L tiles may change values. Manually eyeball staging before tonight's ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)