### PR TITLE
V0.5.6.1 hotfix: emit per-share cost_basis in cc_candidate href (closes #186)

### DIFF
--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -397,9 +397,13 @@ def _cc_candidate_actions(
             f"&strategy=covered_call"
             f"&shares={shares_int}"
         )
+        # OptionScanRequest.cost_basis is per-share; broker_cost_basis is total.
+        # Divide before emitting so the scanner's 10% rule and capital math
+        # match (issue #186).
         broker_cost_basis = row.get("broker_cost_basis")
-        if broker_cost_basis is not None:
-            href += f"&cost_basis={quote(str(broker_cost_basis), safe='')}"
+        if broker_cost_basis is not None and shares_int > 0:
+            cost_basis_per_share = broker_cost_basis / shares_int
+            href += f"&cost_basis={quote(str(cost_basis_per_share), safe='')}"
         cards.append(
             {
                 "id": f"position.cc_candidate.{_slugify_ticker(ticker)}",

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from app.services.action_engine import (
     ITM_SHORT_DTE_CAP,
     MAX_ACTIONS,
@@ -381,7 +383,7 @@ class TestCcCandidateTrigger:
         """Regression for #186: F at 100 shares with broker_cost_basis=$1,320.66
         must emit cost_basis=13.2066 per-share, not the raw total.
 
-        Pre-fix the scanner's 10%-rule floor became 1320.66 × 1.01 ≈ $1,333,
+        Pre-fix the scanner's 10%-rule floor became 1320.66 * 1.01 ~= $1,333,
         rejecting every realistic F strike.
         """
         actions = compute_next_actions(
@@ -401,6 +403,16 @@ class TestCcCandidateTrigger:
         href = card["cta"]["href"]
         assert "cost_basis=13.2066" in href
         assert "cost_basis=1320.66" not in href
+
+    @pytest.mark.skip(
+        reason=(
+            "Manual AC from #186: clicking 'Scan F →' on the dashboard yields "
+            "a scanner result with at least one non-rejected strike. Requires "
+            "live option-chain data from Schwab, not automatable in unit tests."
+        )
+    )
+    def test_manual_ac_cc_candidate_yields_non_rejected_strike(self):
+        pass
 
     def test_cc_candidate_href_omits_cost_basis_when_null(self):
         """Null broker_cost_basis must omit the cost_basis param entirely."""

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -371,7 +371,36 @@ class TestCcCandidateTrigger:
         assert "ticker=AAPL" in href
         assert "strategy=covered_call" in href
         assert "shares=100" in href
-        assert "cost_basis=17240.0" in href
+        # cost_basis is emitted PER-SHARE (issue #186) — scanner expects that
+        # unit. 17240.0 total / 100 shares = 172.4 per share.
+        assert "cost_basis=172.4" in href
+        # Must never emit the raw total — that breaks the 10% rule downstream.
+        assert "cost_basis=17240" not in href
+
+    def test_cc_candidate_href_emits_per_share_basis_canonical_f_case(self):
+        """Regression for #186: F at 100 shares with broker_cost_basis=$1,320.66
+        must emit cost_basis=13.2066 per-share, not the raw total.
+
+        Pre-fix the scanner's 10%-rule floor became 1320.66 × 1.01 ≈ $1,333,
+        rejecting every realistic F strike.
+        """
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=0),
+            positions=[
+                _position(
+                    "p-f",
+                    "F",
+                    shares=100,
+                    broker_cost_basis=1320.66,
+                )
+            ],
+            open_legs=[],
+        )
+        card = next(a for a in actions if a["action_id"] == "position.cc_candidate")
+        href = card["cta"]["href"]
+        assert "cost_basis=13.2066" in href
+        assert "cost_basis=1320.66" not in href
 
     def test_cc_candidate_href_omits_cost_basis_when_null(self):
         """Null broker_cost_basis must omit the cost_basis param entirely."""


### PR DESCRIPTION
## Summary

Closes #186 (P1 hotfix for v0.5.6.1).

**Symptom:** Clicking *Scan F →* on a \`position.cc_candidate\` Next Action card pre-filled cost basis with the position's total (\$1,320.66 for 100 F shares), but \`OptionScanRequest.cost_basis\` is — and has always been — **per-share**. The scanner's 10%-rule floor then computed as \`1320.66 × 1.01 ≈ \$1,333.87\` per-share, rejecting every realistic F strike with \`fails_10pct_rule: strike -99.6% above basis\`.

**Fix:** \`action_engine.py::_cc_candidate_actions\` now divides \`broker_cost_basis\` by \`shares\` before emitting the URL param. Existing manual users typing per-share basis into the scanner field are unaffected.

## Why this slipped past CI

The #179 e2e test only asserted the input field rendered \`17240\` (the raw value passed). It never wired through to a scan response, so the unit mismatch wasn't observable in tests. The new regression test (\`test_cc_candidate_href_emits_per_share_basis_canonical_f_case\`) locks the canonical F case at the action-engine level.

## Changes

- \`backend/app/services/action_engine.py\` — divide \`broker_cost_basis\` by \`shares_int\` before emitting; guard against zero-share positions
- \`backend/tests/test_action_engine.py\` — corrected the existing href assertion (was checking 17240 raw, now checks 172.4 per-share) and added the canonical-F regression test

## Test plan

- [x] \`cd backend && python -m pytest\` — **824 passed, 7 skipped**
- [x] New test: F 100 shares × \$1,320.66 broker basis → href contains \`cost_basis=13.2066\`, never \`1320.66\`
- [ ] CI: backend-tests, frontend-checks, CodeQL green
- [ ] Manual: click \"Scan F →\" on dashboard → scanner returns at least one non-rejected strike with default 10% rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)