### PR TITLE
V0.5.6.2 hotfix: round per-share cost_basis to 4 decimals (closes #188)

### DIFF
--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -399,10 +399,13 @@ def _cc_candidate_actions(
         )
         # OptionScanRequest.cost_basis is per-share; broker_cost_basis is total.
         # Divide before emitting so the scanner's 10% rule and capital math
-        # match (issue #186).
+        # match (issue #186). Round to 4 decimals to avoid IEEE 754 float
+        # noise leaking into the URL (issue #188 — e.g., 1320.66/100 →
+        # 13.206600000000002 without round()); 4 decimals matches the
+        # precision convention used by recompute_position_state.
         broker_cost_basis = row.get("broker_cost_basis")
         if broker_cost_basis is not None and shares_int > 0:
-            cost_basis_per_share = broker_cost_basis / shares_int
+            cost_basis_per_share = round(broker_cost_basis / shares_int, 4)
             href += f"&cost_basis={quote(str(cost_basis_per_share), safe='')}"
         cards.append(
             {

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -403,6 +403,9 @@ class TestCcCandidateTrigger:
         href = card["cta"]["href"]
         assert "cost_basis=13.2066" in href
         assert "cost_basis=1320.66" not in href
+        # Regression for #188: no IEEE 754 float-noise tail in the URL.
+        assert "13.206600000000002" not in href
+        assert "13.20660000000001" not in href
 
     @pytest.mark.skip(
         reason=(


### PR DESCRIPTION
## Summary

Closes #188 (P2 hotfix for v0.5.6.2). Quick follow-on to v0.5.6.1.

**Symptom:** the per-share \`cost_basis\` URL param introduced in v0.5.6.1 stringifies the raw division result, which produces IEEE 754 float noise for non-round divisors. F at 100 shares × \$1,320.66 basis → URL emits \`cost_basis=13.206600000000002\`. Functional but ugly in the scanner Cost Basis field.

**Fix:** \`round(broker_cost_basis / shares_int, 4)\` before stringifying. 4 decimals matches the precision convention used by \`recompute_position_state\` (\`positions.py:600\`).

## Test plan

- [x] \`cd backend && python -m pytest tests/test_action_engine.py\` — 36 passed, 1 skipped
- [x] Regression test asserts no float-noise variant slips through (\`13.206600000000002\`, \`13.20660000000001\`)
- [ ] CI green
- [ ] Manual: click Scan F → field shows \`13.2066\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)