### PR TITLE
Design artifacts for #190: Scanner education spec + Storybook mocks

### DIFF
--- a/frontend/components/options/ScannerColumnHeader.jsx
+++ b/frontend/components/options/ScannerColumnHeader.jsx
@@ -1,0 +1,85 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Sortable table header cell with a dedicated info-icon tooltip trigger.
+//
+// Why a dedicated icon (not hover-anywhere on the header): the header cell
+// already owns the click-to-sort affordance. Conflating tooltip and sort
+// would be ambiguous on touch devices. The `ⓘ` button has its own hit target
+// and is keyboard-reachable independently of the sort click.
+//
+// Tooltip content is 3-part: definition / good range / why it matters.
+//
+// Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 2)
+
+import { useState } from 'react';
+
+export default function ScannerColumnHeader({
+  field,
+  label,
+  tooltip, // { definition, range, whyItMatters } | null
+  active = false,
+  sortDir = 'asc',
+  onSort,
+  align = 'right',
+  forceTooltipOpen = false, // story-only convenience prop
+}) {
+  const [open, setOpen] = useState(false);
+  const isOpen = open || forceTooltipOpen;
+
+  return (
+    <th
+      scope="col"
+      className={`px-3 py-2 text-${align} text-xs font-medium text-slate-500 dark:text-slate-400 select-none relative`}
+    >
+      <span className="inline-flex items-center gap-1">
+        <button
+          type="button"
+          onClick={() => onSort?.(field)}
+          data-testid={`scanner-col-sort-${field}`}
+          className="hover:text-slate-700 dark:hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+          aria-label={`Sort by ${label}`}
+        >
+          {label}
+          {active && (
+            <span className="ml-0.5" aria-hidden="true">
+              {sortDir === 'asc' ? '↑' : '↓'}
+            </span>
+          )}
+        </button>
+        {tooltip && (
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            onBlur={() => setOpen(false)}
+            data-testid={`scanner-col-info-${field}`}
+            className="w-4 h-4 inline-flex items-center justify-center rounded-full border border-slate-300 dark:border-slate-600 text-[10px] text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-300 hover:border-blue-400 dark:hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-help"
+            aria-label={`What is ${label}?`}
+            aria-expanded={isOpen}
+          >
+            i
+          </button>
+        )}
+      </span>
+      {isOpen && tooltip && (
+        <div
+          data-testid={`scanner-col-tooltip-${field}`}
+          role="tooltip"
+          className={`absolute z-20 top-full mt-1 ${align === 'right' ? 'right-0' : 'left-0'} w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-3 text-left text-xs text-slate-700 dark:text-slate-200 space-y-2 font-normal normal-case`}
+        >
+          <div>
+            <p className="font-semibold text-slate-900 dark:text-white">What it is</p>
+            <p>{tooltip.definition}</p>
+          </div>
+          <div>
+            <p className="font-semibold text-slate-900 dark:text-white">Good range</p>
+            <p>{tooltip.range}</p>
+          </div>
+          <div>
+            <p className="font-semibold text-slate-900 dark:text-white">Why it matters</p>
+            <p>{tooltip.whyItMatters}</p>
+          </div>
+        </div>
+      )}
+    </th>
+  );
+}

--- a/frontend/components/options/ScannerColumnHeader.stories.jsx
+++ b/frontend/components/options/ScannerColumnHeader.stories.jsx
@@ -1,0 +1,139 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Stories for ScannerColumnHeader (issue #190, Affordance 2).
+// Wraps the header in a real <table> shell so the tooltip positioning and
+// sort affordance are inspectable in the same context they ship in.
+
+import ScannerColumnHeader from './ScannerColumnHeader';
+
+const TOOLTIPS = {
+  delta: {
+    definition:
+      'The option price\'s sensitivity to a $1 move in the underlying. Roughly the market-implied probability the option ends in the money.',
+    range: 'For wheel strategies: 0.20 to 0.35. Lower = safer, less premium.',
+    whyItMatters:
+      'Higher delta means more premium but a higher chance of assignment. Stay in your comfort zone.',
+  },
+  open_interest: {
+    definition:
+      'The number of outstanding contracts at this strike that have not been closed or exercised.',
+    range: 'Look for 500+ contracts. 100+ is acceptable on less liquid names.',
+    whyItMatters:
+      'Higher open interest = tighter bid/ask spreads and easier exits. Thin contracts can cost you 5-10% on slippage.',
+  },
+  annualized_return_pct: {
+    definition:
+      'The return on capital, scaled to a full year. Lets you compare 7-day premiums against 45-day premiums on equal footing.',
+    range: 'Target 20%+ annualized for wheel candidates. Below 15% is rarely worth the assignment risk.',
+    whyItMatters:
+      'A $1 premium on a 7-DTE contract beats a $1.50 premium on 45-DTE every time, once you scale it.',
+  },
+};
+
+function HeaderHarness({ field, label, tooltipKey, active = false, forceTooltipOpen = false }) {
+  // Render inside a real table so absolutely-positioned tooltip looks right.
+  return (
+    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-visible">
+      <table className="w-full text-sm">
+        <thead className="bg-slate-50 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700">
+          <tr>
+            <th className="px-3 py-2 text-left text-xs font-medium text-slate-500 dark:text-slate-400">
+              Strike
+            </th>
+            <ScannerColumnHeader
+              field={field}
+              label={label}
+              tooltip={tooltipKey ? TOOLTIPS[tooltipKey] : null}
+              active={active}
+              sortDir="desc"
+              onSort={() => {}}
+              forceTooltipOpen={forceTooltipOpen}
+            />
+            <th className="px-3 py-2 text-right text-xs font-medium text-slate-500 dark:text-slate-400">
+              Premium
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+          <tr>
+            <td className="px-3 py-2 text-slate-700 dark:text-slate-300">$15.00</td>
+            <td className="px-3 py-2 text-right text-slate-700 dark:text-slate-300">0.28</td>
+            <td className="px-3 py-2 text-right font-medium text-slate-900 dark:text-white">$0.42</td>
+          </tr>
+          <tr>
+            <td className="px-3 py-2 text-slate-700 dark:text-slate-300">$14.50</td>
+            <td className="px-3 py-2 text-right text-slate-700 dark:text-slate-300">0.31</td>
+            <td className="px-3 py-2 text-right font-medium text-slate-900 dark:text-white">$0.55</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Options/ScannerColumnHeader',
+  component: ScannerColumnHeader,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Header cell with a dedicated info icon for tooltip content (definition / ' +
+          'good range / why it matters). The `ⓘ` is separate from the sort click ' +
+          'target — they coexist visually and via keyboard.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+export const DefaultNoTooltipOpen = {
+  name: 'Default — No Tooltip Open',
+  render: () => (
+    <HeaderHarness field="delta" label="Delta" tooltipKey="delta" />
+  ),
+};
+
+export const TooltipOpenDelta = {
+  name: 'Tooltip Open — Delta',
+  render: () => (
+    <HeaderHarness field="delta" label="Delta" tooltipKey="delta" forceTooltipOpen />
+  ),
+};
+
+export const TooltipOpenOI = {
+  name: 'Tooltip Open — OI',
+  render: () => (
+    <HeaderHarness
+      field="open_interest"
+      label="OI"
+      tooltipKey="open_interest"
+      forceTooltipOpen
+    />
+  ),
+};
+
+export const TooltipOpenAnnPct = {
+  name: 'Tooltip Open — Ann.%',
+  render: () => (
+    <HeaderHarness
+      field="annualized_return_pct"
+      label="Ann.%"
+      tooltipKey="annualized_return_pct"
+      forceTooltipOpen
+    />
+  ),
+};
+
+export const WithActiveSortIndicator = {
+  render: () => (
+    <HeaderHarness
+      field="annualized_return_pct"
+      label="Ann.%"
+      tooltipKey="annualized_return_pct"
+      active
+    />
+  ),
+};

--- a/frontend/components/options/ScannerRejectedStrikes.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.jsx
@@ -1,0 +1,115 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Humanized rejected-strikes disclosure. Replaces the inline red `rejection_reasons`
+// join with a bulleted list of plain-English sentences in neutral slate color.
+//
+// The backend adds a `human_reasons` field on `RejectedStrike` (preserving
+// `rejection_reasons` for tests). Mapper lives in
+// `backend/app/services/rejection_messages.py` per the spec. Unknown codes
+// degrade gracefully to the raw string.
+//
+// Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 4)
+
+import { useState } from 'react';
+
+// Stand-in mapper for stories. In production this lives server-side and the
+// payload arrives pre-humanized via `human_reasons`. Kept here for stories
+// that pass raw codes and for the "unknown reason code" fallback variant.
+export const REJECTION_COPY = {
+  fails_10pct_rule:
+    'Strike is below 90% of your cost basis — selling here could force you to part with shares at a loss.',
+  itm_put:
+    'Put is already in the money. CSPs work best below current price; this would be immediate intrinsic loss.',
+  delta_out_of_range:
+    'Delta is outside your target band — too aggressive or too conservative for this scan.',
+  low_open_interest:
+    'Open interest is low. Liquidity may be thin, making it hard to exit at a fair price.',
+  zero_bid:
+    'No buyers are quoting this contract right now. You cannot reliably sell here.',
+  return_below_target:
+    'Premium is below your minimum return-on-capital target.',
+  return_above_cap:
+    'Return is above your sanity-check cap — likely a stale quote or an unusual contract.',
+};
+
+function humanize(code) {
+  return REJECTION_COPY[code] || code; // graceful fallback
+}
+
+function RejectedRow({ rejection }) {
+  const reasons =
+    rejection.human_reasons && rejection.human_reasons.length > 0
+      ? rejection.human_reasons
+      : rejection.rejection_reasons.map(humanize);
+
+  return (
+    <li
+      data-testid="scanner-rejected-strike-row"
+      className="py-2 border-b border-slate-100 dark:border-slate-700 last:border-0"
+    >
+      <div className="flex items-baseline justify-between gap-3 mb-1">
+        <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+          ${rejection.strike.toFixed(2)} {rejection.expiration}
+        </span>
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {reasons.length === 1 ? '1 reason' : `${reasons.length} reasons`}
+        </span>
+      </div>
+      {reasons.length === 1 ? (
+        <p className="text-xs text-slate-600 dark:text-slate-300">{reasons[0]}</p>
+      ) : (
+        <ul className="list-disc list-outside ml-5 space-y-0.5 text-xs text-slate-600 dark:text-slate-300">
+          {reasons.map((r, i) => (
+            <li key={i}>{r}</li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function ScannerRejectedStrikes({
+  rejected = [],
+  defaultOpen = false,
+  visibleCount = 20,
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  if (rejected.length === 0) return null;
+
+  const shown = rejected.slice(0, visibleCount);
+  const hiddenCount = rejected.length - shown.length;
+
+  return (
+    <section
+      data-testid="scanner-rejected-strikes"
+      className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        data-testid="scanner-rejected-strikes-toggle"
+        className="w-full px-4 py-3 flex items-center justify-between text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/50 rounded-xl focus:outline-none focus:ring-2 focus:ring-blue-500"
+        aria-expanded={open}
+      >
+        <span>Rejected Strikes ({rejected.length})</span>
+        <span className="text-xs text-slate-500 dark:text-slate-400">
+          {open ? 'Hide' : 'Show'}
+        </span>
+      </button>
+      {open && (
+        <div className="px-4 pb-4">
+          <ul className="space-y-0">
+            {shown.map((r, i) => (
+              <RejectedRow key={i} rejection={r} />
+            ))}
+          </ul>
+          {hiddenCount > 0 && (
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-2">
+              …and {hiddenCount} more not shown.
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/options/ScannerRejectedStrikes.stories.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.stories.jsx
@@ -1,0 +1,123 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Stories for ScannerRejectedStrikes (issue #190, Affordance 4).
+// Demonstrates: single-rule rejection, multi-rule rejection, many strikes
+// rejected (collapsed disclosure surface), and unknown-code fallback.
+
+import ScannerRejectedStrikes, { REJECTION_COPY } from './ScannerRejectedStrikes';
+
+const meta = {
+  title: 'Options/ScannerRejectedStrikes',
+  component: ScannerRejectedStrikes,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Humanized rejected-strikes disclosure. Bulleted plain-English ' +
+          'sentences in neutral slate color (not red — these are explanations, ' +
+          'not errors). Unknown rejection codes degrade to the raw string so ' +
+          'the user is never blind to a real signal.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+const single = [
+  {
+    strike: 12.50,
+    expiration: '2026-06-18',
+    rejection_reasons: ['fails_10pct_rule'],
+    human_reasons: [REJECTION_COPY.fails_10pct_rule],
+  },
+];
+
+const multi = [
+  {
+    strike: 16.00,
+    expiration: '2026-06-18',
+    rejection_reasons: ['delta_out_of_range', 'low_open_interest', 'zero_bid'],
+    human_reasons: [
+      REJECTION_COPY.delta_out_of_range,
+      REJECTION_COPY.low_open_interest,
+      REJECTION_COPY.zero_bid,
+    ],
+  },
+];
+
+// Mix one strike with reasons expanded out of 50 total.
+const many = (() => {
+  const out = [];
+  const expirations = ['2026-06-18', '2026-07-16', '2026-08-20'];
+  const codes = [
+    ['fails_10pct_rule'],
+    ['delta_out_of_range'],
+    ['low_open_interest'],
+    ['zero_bid'],
+    ['return_below_target'],
+    ['delta_out_of_range', 'low_open_interest'],
+  ];
+  for (let i = 0; i < 50; i++) {
+    const r = codes[i % codes.length];
+    out.push({
+      strike: 10 + i * 0.5,
+      expiration: expirations[i % expirations.length],
+      rejection_reasons: r,
+      human_reasons: r.map((c) => REJECTION_COPY[c]),
+    });
+  }
+  return out;
+})();
+
+const unknown = [
+  {
+    strike: 14.50,
+    expiration: '2026-06-18',
+    rejection_reasons: ['some_future_rule_code_we_have_not_mapped_yet'],
+    // No human_reasons → component falls back to humanize(code) which returns
+    // the raw string when the code is not in REJECTION_COPY.
+  },
+];
+
+export const SingleRuleRejection = {
+  name: 'Single-rule rejection — fails_10pct_rule',
+  args: {
+    rejected: single,
+    defaultOpen: true,
+  },
+};
+
+export const MultiRuleRejection = {
+  name: 'Multi-rule rejection — delta + OI + zero bid',
+  args: {
+    rejected: multi,
+    defaultOpen: true,
+  },
+};
+
+export const ManyStrikesCollapsed = {
+  name: 'Many strikes rejected (50) — disclosure',
+  args: {
+    rejected: many,
+    defaultOpen: false,
+  },
+};
+
+export const ManyStrikesExpanded = {
+  name: 'Many strikes rejected (50) — expanded',
+  args: {
+    rejected: many,
+    defaultOpen: true,
+    visibleCount: 5,
+  },
+};
+
+export const UnknownReasonCode = {
+  name: 'Unknown reason code — fallback rendering',
+  args: {
+    rejected: unknown,
+    defaultOpen: true,
+  },
+};

--- a/frontend/components/options/ScannerStrategyPrimer.jsx
+++ b/frontend/components/options/ScannerStrategyPrimer.jsx
@@ -1,0 +1,107 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Top-of-page educational card that explains the current strategy (Covered Call
+// or Cash-Secured Put) in plain English. Collapsed by default; dismissal is
+// persisted per-strategy in localStorage. Re-shown via a "Show primers" link
+// rendered by ChainFilters footer.
+//
+// Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 1)
+
+import { useState } from 'react';
+
+const COPY = {
+  cc: {
+    title: 'Covered Call — what you are about to do',
+    oneLiner:
+      'You own 100+ shares. You are renting them out to someone who has the right to buy them from you at the strike price.',
+    bullets: [
+      'You collect the premium up front. It is yours to keep no matter what.',
+      'If the stock closes below the strike at expiration, the contract expires and you keep your shares.',
+      'If the stock closes above the strike, your shares get called away at that strike — capping your upside.',
+      'Best when you are neutral-to-mildly-bullish and would be happy to sell at the strike.',
+    ],
+    whenToUse:
+      'Use this on shares you already own and would not mind parting with at the strike price. The 10% rule limits the strike to no less than ~90% of cost basis so you cannot be forced to sell at a loss.',
+  },
+  csp: {
+    title: 'Cash-Secured Put — what you are about to do',
+    oneLiner:
+      'You set aside cash to buy 100 shares at the strike price. Someone pays you for the obligation to do so.',
+    bullets: [
+      'You collect the premium up front. It is yours to keep no matter what.',
+      'If the stock closes above the strike at expiration, the contract expires worthless and you keep your premium and your cash.',
+      'If the stock closes below the strike, you are assigned the shares at the strike price.',
+      'Best when you would be happy to own the shares at the strike — treat the strike as your "buy" price.',
+    ],
+    whenToUse:
+      'Use this when you want to acquire shares at a discount or simply collect income on cash you would otherwise hold. Make sure you have the full strike × 100 in cash before opening the position.',
+  },
+};
+
+export default function ScannerStrategyPrimer({
+  strategy = 'cc',
+  defaultExpanded = false,
+  onDismiss,
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const copy = COPY[strategy] || COPY.cc;
+
+  return (
+    <section
+      data-testid="scanner-strategy-primer"
+      className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-900 rounded-xl"
+    >
+      <header className="px-4 py-3 flex items-center justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          data-testid="scanner-strategy-primer-toggle"
+          className="flex items-center gap-2 text-left flex-1 min-w-0"
+          aria-expanded={expanded}
+        >
+          <span
+            className="text-blue-600 dark:text-blue-300 text-xs font-semibold uppercase tracking-wide"
+            aria-hidden="true"
+          >
+            Primer
+          </span>
+          <span className="text-sm font-semibold text-slate-900 dark:text-white truncate">
+            {copy.title}
+          </span>
+          <span
+            className="ml-auto text-slate-500 dark:text-slate-400 text-xs"
+            aria-hidden="true"
+          >
+            {expanded ? 'Hide' : 'Show'}
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          data-testid="scanner-strategy-primer-dismiss"
+          className="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+          aria-label="Dismiss primer"
+        >
+          Dismiss
+        </button>
+      </header>
+      {expanded && (
+        <div
+          data-testid="scanner-strategy-primer-body"
+          className="px-4 pb-4 pt-1 space-y-3 text-sm text-slate-700 dark:text-slate-200"
+        >
+          <p className="font-medium">{copy.oneLiner}</p>
+          <ul className="list-disc list-outside ml-5 space-y-1.5 text-sm">
+            {copy.bullets.map((b, i) => (
+              <li key={i}>{b}</li>
+            ))}
+          </ul>
+          <p className="text-xs text-slate-600 dark:text-slate-300">
+            <span className="font-semibold">When to use it: </span>
+            {copy.whenToUse}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/components/options/ScannerStrategyPrimer.stories.jsx
+++ b/frontend/components/options/ScannerStrategyPrimer.stories.jsx
@@ -1,0 +1,73 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Stories for ScannerStrategyPrimer (issue #190, Affordance 1).
+// Fixture data only.
+
+import ScannerStrategyPrimer from './ScannerStrategyPrimer';
+
+const meta = {
+  title: 'Options/ScannerStrategyPrimer',
+  component: ScannerStrategyPrimer,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Top-of-page strategy primer for the Options Scanner. Collapsed by ' +
+          'default, persisted dismissal per strategy in localStorage, reacts ' +
+          'to the CC/CSP toggle. See `frontend/design-specs/scanner-education-v0.5.7.md`.',
+      },
+    },
+  },
+  argTypes: {
+    strategy: { control: { type: 'inline-radio' }, options: ['cc', 'csp'] },
+    defaultExpanded: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+export const CoveredCallCollapsed = {
+  name: 'Covered Call — Collapsed',
+  args: {
+    strategy: 'cc',
+    defaultExpanded: false,
+  },
+};
+
+export const CoveredCallExpanded = {
+  name: 'Covered Call — Expanded',
+  args: {
+    strategy: 'cc',
+    defaultExpanded: true,
+  },
+};
+
+export const CashSecuredPutExpanded = {
+  name: 'Cash-Secured Put — Expanded',
+  args: {
+    strategy: 'csp',
+    defaultExpanded: true,
+  },
+};
+
+// Pinned dark-mode story — designer mental-checked color contrast in dark.
+// To verify visually, also toggle the toolbar theme to "dark" on any story.
+export const DarkModeExpanded = {
+  name: 'Dark Mode — Expanded',
+  args: {
+    strategy: 'cc',
+    defaultExpanded: true,
+  },
+  parameters: {
+    themes: { themeOverride: 'dark' },
+    backgrounds: { default: 'dark' },
+  },
+  decorators: [
+    (Story) => (
+      <div className="dark bg-slate-900 p-6 -m-4 min-h-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/frontend/components/options/ScannerStrikeRowExpansion.jsx
+++ b/frontend/components/options/ScannerStrikeRowExpansion.jsx
@@ -1,0 +1,203 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Single-row accordion content for a strike. Appends a "What this trade
+// commits you to" sub-section to the existing Greeks / Metrics / Rule
+// Compliance panel — it does NOT replace the panel.
+//
+// All math derives from fields the scanner already returns:
+//   premium_per_contract, breakeven, fifty_pct_profit_target
+// plus user-input context (cost basis, shares held, capital available).
+//
+// Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 3)
+
+function formatUsd(n, digits = 2) {
+  if (n == null) return '—';
+  const sign = n < 0 ? '-' : '';
+  return `${sign}$${Math.abs(n).toFixed(digits)}`;
+}
+
+// Build the plain-English outcome scenarios for a Covered Call.
+function ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_share, contracts = 1, earnings_in_window }) {
+  const premiumTotal = premium_per_contract * contracts;
+  const sharesAtRisk = 100 * contracts;
+  const calledAwayProceeds = strike * sharesAtRisk;
+  const calledAwayPL = calledAwayProceeds - cost_basis_per_share * sharesAtRisk + premiumTotal;
+  return {
+    obligation: `If assigned, you sell ${sharesAtRisk} share${sharesAtRisk === 100 ? '' : 's'} at $${strike.toFixed(2)}. Total proceeds: ${formatUsd(calledAwayProceeds)}.`,
+    premium: `You collect ${formatUsd(premiumTotal)} in premium right now — yours to keep regardless of outcome.`,
+    breakeven: breakeven != null
+      ? `Your effective break-even if called away: ${formatUsd(breakeven)} per share (cost basis minus premium received).`
+      : null,
+    outcomes: [
+      {
+        label: 'Stock stays below the strike',
+        text: `Contract expires worthless. You keep all ${sharesAtRisk} shares and the ${formatUsd(premiumTotal)} premium. Ready to write another call.`,
+      },
+      {
+        label: 'Stock closes above the strike',
+        text: `Shares are called away at $${strike.toFixed(2)}. Total P/L on this position: ${formatUsd(calledAwayPL)} (proceeds + premium − cost basis). Upside above the strike is forfeit.`,
+      },
+      {
+        label: 'Stock spikes far above the strike',
+        text: 'Same outcome as above — your shares are called at the strike, so the upside is capped. The premium you collected is your max gain beyond the strike.',
+      },
+    ],
+    earnings_in_window: earnings_in_window === true,
+  };
+}
+
+// Build the plain-English outcome scenarios for a Cash-Secured Put.
+function cspScenarios({ strike, premium_per_contract, breakeven, contracts = 1, earnings_in_window }) {
+  const premiumTotal = premium_per_contract * contracts;
+  const sharesAtRisk = 100 * contracts;
+  const cashAtRisk = strike * sharesAtRisk;
+  return {
+    obligation: `You set aside ${formatUsd(cashAtRisk)} as collateral. If assigned, you buy ${sharesAtRisk} share${sharesAtRisk === 100 ? '' : 's'} at $${strike.toFixed(2)}.`,
+    premium: `You collect ${formatUsd(premiumTotal)} in premium right now — yours to keep regardless of outcome.`,
+    breakeven: breakeven != null
+      ? `Your effective entry if assigned: ${formatUsd(breakeven)} per share (strike minus premium received).`
+      : null,
+    outcomes: [
+      {
+        label: 'Stock stays above the strike',
+        text: `Contract expires worthless. You keep your ${formatUsd(cashAtRisk)} and the ${formatUsd(premiumTotal)} premium. Free to sell another put.`,
+      },
+      {
+        label: 'Stock closes below the strike',
+        text: `You are assigned. ${formatUsd(cashAtRisk)} is converted into ${sharesAtRisk} shares at $${strike.toFixed(2)}. Your effective entry is ${formatUsd(breakeven ?? strike - premium_per_contract)} per share.`,
+      },
+      {
+        label: 'Stock drops far below the strike',
+        text: 'Same assignment, but the shares are now worth less than your entry. You are still long the shares; you can write covered calls on them once you own them ("the wheel").',
+      },
+    ],
+    earnings_in_window: earnings_in_window === true,
+  };
+}
+
+export default function ScannerStrikeRowExpansion({
+  strategy = 'cc',
+  strike, // numeric strike $
+  expiration, // 'YYYY-MM-DD'
+  dte,
+  premium_per_contract,
+  breakeven,
+  fifty_pct_profit_target,
+  cost_basis_per_share,
+  contracts = 1,
+  shares_held,
+  earnings_in_window = false,
+  // Mocked Greeks for the existing panel context
+  greeks = { delta: 0.28, gamma: 0.05, theta: -0.012, vega: 0.08, iv: 0.34 },
+}) {
+  const built =
+    strategy === 'csp'
+      ? cspScenarios({ strike, premium_per_contract, breakeven, contracts, earnings_in_window })
+      : ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_share, contracts, earnings_in_window });
+
+  return (
+    <div
+      data-testid="scanner-strike-row-expansion"
+      className="space-y-4"
+    >
+      {/* Existing panel — Greeks / Metrics / Rule Compliance (preserved) */}
+      <div className="grid grid-cols-3 gap-6 text-sm">
+        <div>
+          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Greeks</h4>
+          <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
+            <div>Delta: {greeks.delta.toFixed(3)}</div>
+            <div>Gamma: {greeks.gamma.toFixed(4)}</div>
+            <div>Theta: {greeks.theta.toFixed(4)}</div>
+            <div>Vega: {greeks.vega.toFixed(4)}</div>
+            <div>IV: {(greeks.iv * 100).toFixed(1)}%</div>
+          </div>
+        </div>
+        <div>
+          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Metrics</h4>
+          <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
+            <div>Premium/Contract: {formatUsd(premium_per_contract)}</div>
+            <div>Breakeven: {formatUsd(breakeven)}</div>
+            <div>50% Target: {formatUsd(fifty_pct_profit_target)}</div>
+            <div>DTE: {dte}</div>
+            <div>Exp: {expiration}</div>
+          </div>
+        </div>
+        <div>
+          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Rule Compliance</h4>
+          <div className="space-y-1 text-xs">
+            <div className="text-green-600 dark:text-green-400">✓ 10% Rule</div>
+            <div className="text-green-600 dark:text-green-400">✓ DTE Range</div>
+            <div className="text-green-600 dark:text-green-400">✓ Delta Range</div>
+            <div className="text-green-600 dark:text-green-400">✓ Return Target</div>
+            <div
+              className={
+                earnings_in_window
+                  ? 'text-yellow-600 dark:text-yellow-400'
+                  : 'text-green-600 dark:text-green-400'
+              }
+            >
+              {earnings_in_window ? '! ' : '✓ '}Earnings Check
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* NEW: "What this trade commits you to" sub-section — appended */}
+      <div
+        data-testid="scanner-strike-row-commitment"
+        className="border-t border-slate-200 dark:border-slate-700 pt-4"
+      >
+        <h4 className="font-medium text-slate-900 dark:text-white mb-2 flex items-center gap-2">
+          What this trade commits you to
+          <span className="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+            Plain English
+          </span>
+        </h4>
+        <div className="space-y-3 text-sm text-slate-700 dark:text-slate-200">
+          <div className="grid sm:grid-cols-2 gap-3">
+            <div className="bg-slate-50 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+                Your obligation
+              </p>
+              <p>{built.obligation}</p>
+            </div>
+            <div className="bg-slate-50 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+                Premium collected
+              </p>
+              <p>{built.premium}</p>
+              {built.breakeven && (
+                <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">{built.breakeven}</p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1.5">
+              Outcome scenarios at expiration
+            </p>
+            <ol className="list-decimal list-outside ml-5 space-y-1.5 text-sm">
+              {built.outcomes.map((o, i) => (
+                <li key={i}>
+                  <span className="font-semibold">{o.label}: </span>
+                  <span>{o.text}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          {built.earnings_in_window && (
+            <div
+              data-testid="scanner-strike-row-earnings-flag"
+              className="text-xs bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-md px-3 py-2 text-yellow-800 dark:text-yellow-200"
+            >
+              <span className="font-semibold">Earnings within the contract window. </span>
+              Expect larger price swings between now and expiration — the outcome scenarios above
+              can shift quickly. Consider sizing down or skipping this expiration.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/options/ScannerStrikeRowExpansion.stories.jsx
+++ b/frontend/components/options/ScannerStrikeRowExpansion.stories.jsx
@@ -1,0 +1,122 @@
+// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+//
+// Stories for ScannerStrikeRowExpansion (issue #190, Affordance 3).
+// Mirrors the F-position numbers from the spec: 100 shares, $13.21 basis,
+// $0.18 premium, 36 DTE.
+
+import { useState } from 'react';
+import ScannerStrikeRowExpansion from './ScannerStrikeRowExpansion';
+
+const meta = {
+  title: 'Options/ScannerStrikeRowExpansion',
+  component: ScannerStrikeRowExpansion,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Per-row "What this trade commits you to" sub-section. Appended below ' +
+          'the existing Greeks / Metrics / Rule-Compliance panel — not a replacement. ' +
+          'All math derives from fields the scanner already returns.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+const F_CC_15 = {
+  strategy: 'cc',
+  strike: 15.0,
+  expiration: '2026-06-18',
+  dte: 36,
+  premium_per_contract: 18.0, // $0.18 mid × 100
+  breakeven: 13.03, // 13.21 basis - 0.18 premium
+  fifty_pct_profit_target: 9.0,
+  cost_basis_per_share: 13.21,
+  contracts: 1,
+  shares_held: 100,
+};
+
+const F_CSP_13 = {
+  strategy: 'csp',
+  strike: 13.0,
+  expiration: '2026-06-18',
+  dte: 36,
+  premium_per_contract: 32.0, // $0.32 × 100
+  breakeven: 12.68, // 13.00 - 0.32
+  fifty_pct_profit_target: 16.0,
+  contracts: 1,
+};
+
+// Wraps the expansion in a faux table row so it renders in context.
+function TableShell({ children, collapsed = false }) {
+  const [open, setOpen] = useState(!collapsed);
+  return (
+    <div className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-slate-50 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-700">
+          <tr>
+            <th className="px-3 py-2 text-left text-xs font-medium text-slate-500 dark:text-slate-400">Strike</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-slate-500 dark:text-slate-400">Delta</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-slate-500 dark:text-slate-400">Premium</th>
+            <th className="px-3 py-2 text-right text-xs font-medium text-slate-500 dark:text-slate-400">Ann.%</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 dark:divide-slate-700">
+          <tr
+            className="hover:bg-slate-50 dark:hover:bg-slate-700/50 cursor-pointer"
+            onClick={() => setOpen((v) => !v)}
+          >
+            <td className="px-3 py-2 font-medium text-green-700 dark:text-green-400">$15.00</td>
+            <td className="px-3 py-2 text-right text-slate-700 dark:text-slate-300">0.28</td>
+            <td className="px-3 py-2 text-right font-medium text-slate-900 dark:text-white">$0.18</td>
+            <td className="px-3 py-2 text-right text-blue-600 dark:text-blue-400">14.0%</td>
+          </tr>
+          {open && (
+            <tr>
+              <td colSpan={4} className="px-6 py-4 bg-slate-50 dark:bg-slate-900/50">
+                {children}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export const Collapsed = {
+  render: () => (
+    <TableShell collapsed>
+      <ScannerStrikeRowExpansion {...F_CC_15} />
+    </TableShell>
+  ),
+};
+
+export const ExpandedCoveredCall = {
+  name: 'Expanded — Covered Call $15 strike',
+  render: () => (
+    <TableShell>
+      <ScannerStrikeRowExpansion {...F_CC_15} />
+    </TableShell>
+  ),
+};
+
+export const ExpandedCashSecuredPut = {
+  name: 'Expanded — Cash-Secured Put $13 strike',
+  render: () => (
+    <TableShell>
+      <ScannerStrikeRowExpansion {...F_CSP_13} />
+    </TableShell>
+  ),
+};
+
+export const ExpandedWithEarningsFlag = {
+  name: 'Expanded — earnings-in-window flagged',
+  render: () => (
+    <TableShell>
+      <ScannerStrikeRowExpansion {...F_CC_15} earnings_in_window />
+    </TableShell>
+  ),
+};

--- a/frontend/design-specs/scanner-education-v0.5.7.md
+++ b/frontend/design-specs/scanner-education-v0.5.7.md
@@ -1,0 +1,593 @@
+# Design Spec: Options Scanner — learning surface (Phase A)
+
+- **Issue:** [#190 — Options Scanner: turn results table into a learning surface (Phase A)](https://github.com/ssandy33/regress/issues/190)
+- **Milestone:** V0.5.7
+- **Date:** 2026-05-13
+- **Author:** Designer agent
+- **Status:** Draft — for user review before implementation
+- **Scope:** Frontend visual + structural spec for the four Phase A affordances (primer, header tooltips, per-row expansion, humanized rejected list) plus the backend `human_reasons` field shape. Phase B items (risk panel, earnings context, comparison-layer education, beginner toggle, scenario sparkline) are explicitly **out of scope** — they ship as separate follow-ups after Phase A.
+- **Non-goals:** no AI narration (that is #181 on the Recovery surface), no new pricing math, no new option-chain endpoints.
+
+---
+
+## 0. Why now
+
+The scanner is functionally complete for the primary operator. Phase A adds four deterministic education affordances that widen the audience (less-experienced wheel users, future-self after a break) without lowering the ceiling for the experienced operator — the dense table stays dense, education layers in via hover, click, and a single collapsible block.
+
+The four affordances are deliberately **decorative**: each one can be ignored by an experienced user and the underlying table still does its job. The primer collapses; tooltips are hover-only; the row expansion already exists for Greeks/Metrics today (Phase A enriches it, doesn't introduce it); the rejected list is already collapsed-by-default behind a `<details>` element. None of these are gated dialogs or required reading.
+
+---
+
+## 1. Page anatomy after Phase A (desktop, ≥ lg)
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│ App Header (existing)                                                             │
+├─────────────┬────────────────────────────────────────────────────────────────────┤
+│             │  Schwab API: Connected (existing banner)                            │
+│  ChainFilt. │                                                                     │
+│  (existing  │  ┌─[ NEW: Strategy primer card — collapsed by default ]─────────┐  │
+│   sidebar)  │  │ ▸  What is a Covered Call?            Learn (3 paragraphs)   │  │
+│             │  └─────────────────────────────────────────────────────────────┘  │
+│             │                                                                     │
+│             │  F — Covered Call Scan       Price $13.26          3 opportunities │
+│             │  (existing market context card)                                     │
+│             │                                                                     │
+│             │  Capital Deployment (existing, unchanged)                           │
+│             │                                                                     │
+│             │  ┌─ Strike table (existing) ───────────────────────────────────┐   │
+│             │  │ □  #  Strike  Exp   DTE ⓘ  Bid/Ask  Δ ⓘ  OI ⓘ  Prem ⓘ ... │   │
+│             │  │ ▸  1  $14.00  6/20   38     0.30/.. 0.22 1,240  $0.30 ... │   │
+│             │  │ ▾  2  $15.00  6/20   38     ...                            │   │
+│             │  │      ┌─[ EXPANDED, NEW: Trade explanation block ]──────┐   │   │
+│             │  │      │ Greeks   │ Metrics    │ Rule Compliance         │   │   │
+│             │  │      │  (today) │  (today)   │  (today)                │   │   │
+│             │  │      ├──────────┴────────────┴─────────────────────────┤   │   │
+│             │  │      │ What this trade commits you to                  │   │   │
+│             │  │      │   Obligation:  100 sh × $15.00 = $1,500         │   │   │
+│             │  │      │   Premium:     $0.30 × 100      = $30 up front  │   │   │
+│             │  │      │   Break-even:  $13.26 − $0.30   = $12.96        │   │   │
+│             │  │      │                                                 │   │   │
+│             │  │      │ Three ways this can end                         │   │   │
+│             │  │      │   • Called away at $15 → keep $30 + $174 gain   │   │   │
+│             │  │      │   • Expired worthless → keep $30, still hold sh │   │   │
+│             │  │      │   • Closed early at 50% → keep ~$15, free shares│   │   │
+│             │  │      └─────────────────────────────────────────────────┘   │   │
+│             │  └─────────────────────────────────────────────────────────────┘   │
+│             │                                                                     │
+│             │  RiskRewardPanel (existing, unchanged)                              │
+│             │                                                                     │
+│             │  ▸ Rejected strikes (50) — UPDATED rendering                        │
+│             │      $99.00 6/20 · Strike sits 645% above your $13.26 basis, but   │
+│             │                    the 10% rule only allows up to 1% above.        │
+│             │      $20.00 6/20 · Delta 0.42 is outside your 0.15–0.35 range —    │
+│             │                    too close to the money, higher assignment risk. │
+│             │      $13.50 6/20 · No buyers showing a bid right now (zero_bid).   │
+│             │                                                                     │
+└─────────────┴────────────────────────────────────────────────────────────────────┘
+```
+
+Nothing moves. Three blocks are added (primer, per-row "What this trade commits you to" sub-section, humanized rejection lines) and one is added inline (`ⓘ` icons on numeric headers). The order of the page is unchanged.
+
+---
+
+## 2. Affordance 1 — Strategy primer
+
+### 2.1 Placement and behavior
+
+| Aspect | Decision | Rationale |
+|---|---|---|
+| Position | **Top of main pane**, above the market-context header card | Education before context. Putting it above the header keeps the page's narrative linear (learn → see this scan → see strikes → see rejections). A side-rail would compete with `ChainFilters`. A modal-on-first-visit was rejected — modals interrupt; this is decoration the user can ignore. |
+| Default state | **Collapsed**, with a one-line teaser visible (`What is a Covered Call?  Learn ▸`) | Experienced operator sees a single thin row; less-experienced user has an obvious entry point. |
+| Persistence | `localStorage` key `scanner.primer.<strategy>.dismissed = boolean` | Per-strategy because the CC and CSP primers are different content; dismissing one doesn't dismiss the other. Persists across reloads, scoped to the browser. |
+| Reset path | A "Show primers" link in the footer of `ChainFilters` (next to Reset) clears both keys | Reset of filters and reset of dismissed-state are conceptually adjacent; one place to undo "I learned this, hide it". |
+| Reactivity to strategy toggle | **Yes — re-reads on strategy change** | When the user flips Covered Call → Cash-Secured Put in `ChainFilters`, the primer body swaps. If the user has dismissed CC but not CSP, the CSP primer expands on first view of that strategy and then can be dismissed independently. |
+
+### 2.2 Content shape (collapsed)
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ▸  What is a Covered Call?              Learn ▸          [ × hide ]       │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.3 Content shape (expanded)
+
+Plain prose with a short bulleted "what can go wrong" block. No sub-sections, no images, no diagrams — this is decoration, not a course.
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ▾  What is a Covered Call?                                  [ × hide ]    │
+│                                                                            │
+│   You own 100 shares of a stock and sell someone the right to buy them    │
+│   from you at a higher strike price before a chosen expiration date.      │
+│   You collect a premium up front in exchange for capping your upside.     │
+│                                                                            │
+│   The 10% rule: this scanner only shows strikes at least your             │
+│   "Min Call Distance %" above your cost basis (default 10%). The idea     │
+│   is that if you're called away, you still book a meaningful gain on the  │
+│   stock on top of the premium. Strikes closer than that are filtered      │
+│   into "Rejected Strikes" below the table.                                 │
+│                                                                            │
+│   What can go wrong:                                                       │
+│     • If the stock rips through the strike, you miss the upside above it. │
+│     • If the stock drops, the premium softens but doesn't cancel the loss. │
+│     • If earnings land inside the trade window, IV crush + price gap can  │
+│       move the position faster than usual.                                 │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+The CSP variant differs in body copy (sell-a-put obligation, collateral instead of shares, assignment risk if stock drops below strike). Implementer fills in the exact copy.
+
+### 2.4 Component contract
+
+```
+<StrategyPrimer
+  strategy="covered_call" | "cash_secured_put"
+  dismissed={boolean}             // from localStorage
+  onToggleDismissed={() => void}
+  data-testid="strategy-primer"
+/>
+  └ inner toggle button: data-testid="strategy-primer-toggle"
+  └ hide button:         data-testid="strategy-primer-hide"
+  └ body region:         data-testid="strategy-primer-body" (only when expanded)
+```
+
+Content lives in a small constant inside the component file:
+
+```js
+const PRIMER_CONTENT = {
+  covered_call: { title: "What is a Covered Call?", paragraphs: [...], risks: [...] },
+  cash_secured_put: { title: "What is a Cash-Secured Put?", paragraphs: [...], risks: [...] },
+};
+```
+
+No backend involvement. No props beyond strategy + dismissed.
+
+### 2.5 Visual tokens
+
+| Token | Value |
+|---|---|
+| Card shell | `bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl` |
+| Header padding | `px-4 py-3` |
+| Body padding | `px-4 pb-4` |
+| Title | `text-sm font-medium text-slate-700 dark:text-slate-200` |
+| Body prose | `text-sm text-slate-600 dark:text-slate-400 leading-relaxed` |
+| Risk bullets | same as body, `list-disc pl-5 space-y-1` |
+| Hide-button | `text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300` |
+
+Same shell vocabulary as the existing market-context and capital-utilization cards — slots in without visual novelty.
+
+### 2.6 Mobile (< sm, 640px)
+
+`ChainFilters` is already a drawer on mobile. Primer card spans full width above the market context card, same internal structure. No layout change beyond that.
+
+### 2.7 Empty / edge
+
+- **No strategy selected** is not reachable — `ChainFilters` defaults to `covered_call`. If `strategy` is somehow `null`, render a generic "Pick a strategy in the sidebar to see what it does" one-liner; no expand control.
+- **Pre-scan state** (no `result` yet): primer still renders. It does not depend on scan data. This is a feature: a new user can read the primer before scanning.
+
+---
+
+## 3. Affordance 2 — Column-header tooltips
+
+### 3.1 Trigger pattern
+
+| Surface | Behavior |
+|---|---|
+| Desktop hover | Reveals tooltip after ~150ms hover on the `ⓘ` icon OR anywhere on the header cell. |
+| Keyboard | `ⓘ` is a `<button type="button">` inside the `<th>`, so it is naturally focusable. Tab to the icon → tooltip opens. `Escape` closes it. Tooltip is `role="tooltip"` and `aria-describedby` wires to the icon. |
+| Touch | Tap on `ⓘ` opens; tap outside closes. (No long-press — discoverability is poor.) |
+
+**Decision: small `ⓘ` icon next to the label, not hover-anywhere-on-the-header.** Reason: the header cell is already a sort affordance (`onClick` toggles sort). Conflating "click for sort" and "hover for tooltip" on the same target makes the click target ambiguous on touch (tap → does it sort or explain?). A dedicated icon button isolates the explain affordance and leaves sort untouched.
+
+### 3.2 Visual treatment
+
+```
+  ┌─────────────────────────┐
+  │  Delta  ⓘ    ↑          │      ← icon between label and sort indicator
+  └─────────────────────────┘
+              │
+              ▼  on hover/focus
+  ┌──────────────────────────────────────────────┐
+  │ Delta                                        │
+  │ Roughly the probability the option expires   │
+  │ in the money — and how much the option price │
+  │ moves per $1 of stock move.                  │
+  │                                              │
+  │ Good range for covered calls: 0.15 – 0.30.   │
+  │ Higher = more premium but more assignment    │
+  │ risk; lower = safer but thinner premium.     │
+  └──────────────────────────────────────────────┘
+```
+
+Tokens:
+
+| Token | Value |
+|---|---|
+| Icon | `w-3.5 h-3.5 text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300` |
+| Tooltip surface | `bg-slate-900 dark:bg-slate-700 text-slate-100 text-xs leading-relaxed rounded-lg shadow-lg p-3 max-w-xs` |
+| Tooltip arrow | optional; if hand-rolled, skip; if Radix Tooltip is available, use its arrow primitive |
+| Open delay | 150ms (hover); 0ms (focus) |
+| Close | leave + 100ms; Escape; tap-outside |
+
+### 3.3 Content shape
+
+Every numeric header tooltip is exactly three things:
+
+1. **Definition** — one sentence, plain language.
+2. **Good range** — what value you want for the current strategy.
+3. **Why it matters** — one sentence on the trade-off.
+
+Three reference examples (Delta, Open Interest, Annualized Return). Implementer fills in the rest using this shape.
+
+**Delta**
+> Roughly the probability the option expires in the money — and how much the option price moves per $1 of stock move.
+>
+> **Good range for covered calls:** 0.15 – 0.30. Higher = more premium but more assignment risk; lower = safer but thinner premium.
+
+**OI (Open Interest)**
+> The number of contracts currently open at this strike. A liquidity proxy — higher OI means tighter bid/ask spreads and easier exits.
+>
+> **Good range:** at least 50, ideally 500+. The scanner already filters out anything below 50.
+
+**Ann. % (Annualized Return)**
+> The premium-yield-on-capital extrapolated to a full year. Useful for comparing a 30-day trade against a 60-day trade on equal footing.
+>
+> **Good range:** depends on your target — most wheel traders aim for 15–30% annualized. Higher numbers usually mean more risk somewhere (closer-to-the-money strike, longer DTE, lower-quality underlying).
+
+Columns to cover (verify against `StrikeTable.jsx` header list, current set is): `DTE`, `Bid/Ask`, `Delta`, `OI`, `Premium`, `Return%`, `Ann.%`, `Dist.%`, plus `Contracts` and `Max Income` when the capital-aware columns are showing. Strike, Exp, and # do not get tooltips — they are self-explanatory.
+
+### 3.4 Component contract
+
+```
+<HeaderWithTooltip
+  label="Delta"
+  tooltipKey="delta"
+  sortField="delta"
+  sortField={sortField}
+  sortDir={sortDir}
+  onSort={handleSort}
+  align="right"
+/>
+```
+
+Effectively wraps the existing `SortHeader` and renders an extra `ⓘ` button. Tooltip content lives in a single module:
+
+```js
+// frontend/components/options/columnTooltips.js
+export const COLUMN_TOOLTIPS = {
+  dte: { title: "DTE — Days to Expiration", definition: "…", range: "…", why: "…" },
+  delta: { … },
+  // …
+};
+```
+
+If a tooltip key is missing, render the header without the icon (graceful degradation).
+
+`data-testid`:
+- Icon button: `column-tooltip-trigger-{key}` (e.g. `column-tooltip-trigger-delta`)
+- Tooltip body: `column-tooltip-body-{key}` (only present when open)
+
+### 3.5 Mobile
+
+The strike table already scrolls horizontally on small screens (`overflow-x-auto`). The `ⓘ` icon is small enough not to compete with the header label or sort indicator. Tap → tooltip pops as a popover near the icon (not full-screen). Implementer can lean on Radix Tooltip's mobile-aware behavior if available.
+
+### 3.6 Edge
+
+If the user has filtered out everything and the table is empty, the headers are not rendered (existing empty state replaces the table). Tooltips never appear in an empty-table state — not a concern.
+
+---
+
+## 4. Affordance 3 — Per-row trade explanation
+
+### 4.1 Click affordance
+
+The row is already clickable today — click anywhere on the row toggles the existing expanded panel (Greeks / Metrics / Rule Compliance). Phase A:
+
+| Aspect | Decision |
+|---|---|
+| Trigger | **Keep the existing row click** to toggle expand. Add a visible chevron in the leftmost column (left of the checkbox) so the affordance is discoverable. |
+| Multi-expand | **Single row at a time (accordion-style)**, which matches today's `useState(expandedRow)` behavior. Justification: keeps the table scannable; the user is in "compare three strikes via the table" mode or "drill into one strike" mode, not both. Multi-expand would balloon vertical space and bury the comparison flow further down. |
+| Keyboard | Row is `tabIndex={0}` with `onKeyDown` for `Enter`/`Space`. Chevron rotates `→` to `▾` on expand. Existing `aria-expanded` should be added to the row. |
+
+The existing expanded panel **keeps** its three columns (Greeks / Metrics / Rule Compliance). Phase A **adds a new sub-section below** them.
+
+### 4.2 New sub-section layout
+
+```
+┌─ Expanded row (existing top row stays) ────────────────────────────────────┐
+│  Greeks      │  Metrics            │  Rule Compliance                       │
+│  (existing)  │  (existing)         │  (existing)                            │
+├────────────────────────────────────────────────────────────────────────────┤
+│  NEW: What this trade commits you to                                       │
+│  ────────────────────────────────────────────────────────────────────────  │
+│   Obligation     100 sh × $15.00       =  $1,500   (if called away)         │
+│   Premium        $0.30 × 100           =  $30      collected up front       │
+│   Break-even     $13.26 − $0.30        =  $12.96   stock price floor        │
+│                                                                            │
+│  Three ways this can end                                                   │
+│   ●  Called away at $15.00                                                 │
+│      You sell 100 sh at $15.00 → +$30 premium plus +$174 stock gain         │
+│      = $204 net (assumes your $13.26 cost basis).                          │
+│                                                                            │
+│   ●  Expired worthless (stock stays below $15.00)                          │
+│      Keep the $30 premium, keep the shares. You can sell another call.     │
+│                                                                            │
+│   ●  Closed early at 50% profit target                                     │
+│      Buy back the call for ~$0.15, net ≈ $15 in premium, shares are free   │
+│      to use for a new call sooner.                                         │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.3 Math sourcing (no new backend asks)
+
+All numbers come from data the scanner already returns for the row, plus user inputs already on the page:
+
+| Field | Source |
+|---|---|
+| `obligation_dollars` | `strike × 100` (covered call) or `strike × 100` collateral (CSP) |
+| `premium_dollars` | `premium_per_contract` (already in `StrikeRecommendation`) |
+| `break_even` | `breakeven` field on the row when present; otherwise compute `cost_basis − mid` on the client |
+| Called-away P/L | `(strike − cost_basis) × shares + premium_dollars` |
+| Expired-worthless P/L | `premium_dollars` |
+| Close-early P/L | `premium_dollars × 0.5` (the existing 50% profit target convention; `fifty_pct_profit_target` is already on the row) |
+
+If `cost_basis` is missing (user hasn't entered it), render the section with the formulas visible and a soft hint: *"Enter your cost basis in the sidebar to see dollar outcomes."* The structural block stays — it just shows the formula instead of the number. This matches the spec's empty-state requirement for "per-row expansion when the row would suggest a strike that fails the user's own rules": the row is still shown (per existing `rule_compliance` rendering), the "three ways this can end" math still renders, and the existing yellow flag styling on the strike cell carries the warning. No new error UI.
+
+**No additional backend fields requested for Phase A.** If during implementation a missing field surfaces (e.g., the API doesn't return `premium_per_contract` for CSP rows in the way we need), file a backend-only follow-up; do not block Phase A on it.
+
+### 4.4 Component contract
+
+```
+<TradeExplanation
+  strike={StrikeRecommendation}     // existing row data
+  strategy="covered_call" | "cash_secured_put"
+  costBasis={number | null}          // from ChainFilters state
+  sharesHeld={number | null}         // for CC outcome math
+  capitalAvailable={number | null}   // for CSP outcome math
+/>
+```
+
+`data-testid`:
+- Section root: `trade-explanation-{strike}-{expiration}` (e.g. `trade-explanation-15.00-2026-06-20`)
+- Obligation row: `trade-explanation-obligation`
+- Premium row: `trade-explanation-premium`
+- Break-even row: `trade-explanation-breakeven`
+- Each outcome: `trade-explanation-outcome-{called_away | expired | closed_early}`
+
+### 4.5 Mobile
+
+Existing expanded panel currently renders 3 columns at `grid-cols-3`. On `< sm` it should stack to one column. The new sub-section is naturally vertical and needs no special mobile treatment. **No drawer/modal pattern** — in-place expand is consistent with today's behavior and matches the dense-table feel.
+
+### 4.6 Visual tokens
+
+| Token | Value |
+|---|---|
+| Section divider | `border-t border-slate-200 dark:border-slate-700 mt-4 pt-4` |
+| Sub-section heading | `text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2` |
+| Math rows | `font-mono text-xs text-slate-700 dark:text-slate-200` with three columns: label / formula / annotation |
+| Outcome bullet color | green dot for the favorable path, slate for neutral, no red — this is education, not warning |
+| Outcome body | `text-xs text-slate-600 dark:text-slate-400 leading-relaxed` |
+
+### 4.7 Tone
+
+Plain English, no jargon-first. Avoid "you'll be assigned" → use "you sell the shares at the strike price". Avoid "premium decay" → use "the option's value drops as expiration approaches". Don't add disclaimers — the non-goals already cover "not advice".
+
+---
+
+## 5. Affordance 4 — Humanized rejected strikes
+
+### 5.1 Backend change — new `human_reasons` field
+
+`backend/app/models/schemas.py::RejectedStrike` gains a sibling field:
+
+```python
+class RejectedStrike(BaseModel):
+    strike: float
+    expiration: str
+    rejection_reasons: list[str]      # existing — raw codes for debugging
+    human_reasons: list[str]          # new — one human sentence per code
+```
+
+The raw `rejection_reasons` field **stays** so Playwright tests and any internal debug surface can still assert against the structured codes. The frontend renders `human_reasons` only.
+
+### 5.2 Mapper location
+
+A new module `backend/app/services/rejection_messages.py` exports:
+
+```python
+def humanize_reasons(raw_reasons: list[str], context: dict) -> list[str]:
+    """Map each raw reason string to a one-sentence human explanation.
+
+    context = {
+        "cost_basis": float | None,
+        "current_price": float | None,
+        "min_call_distance_pct": float,
+        "min_delta": float,
+        "max_delta": float,
+        "min_return_pct": float,
+        "max_return_pct": float | None,
+    }
+    """
+```
+
+`OptionsScanner` calls this once per `RejectedStrike` before appending, populating `human_reasons` alongside `rejection_reasons`. Unit tests in `backend/tests/test_rejection_messages.py` cover one input/output pair per reason code (the AC requires "every reason code currently emitted").
+
+### 5.3 Reason-code → sentence templates
+
+Reason codes currently emitted by `options_scanner.py` (verified):
+
+| Code | Raw format | Human sentence template |
+|---|---|---|
+| `fails_10pct_rule` | `fails_10pct_rule: strike {pct:.1f}% above basis, requires {min}%` | `Strike sits {pct:.1f}% above your ${cost_basis:.2f} basis, but the {min}% rule requires at least that much room.` |
+| `itm_put` | `itm_put: strike ${strike:.2f} > price ${current_price:.2f}` | `Strike ${strike:.2f} is above the current price ${current_price:.2f} — that's in-the-money for a put, which the scanner skips.` |
+| `delta_out_of_range` | `delta_out_of_range: |{delta:.2f}| not in [{min}, {max}]` | `Delta {delta:+.2f} is outside your {min}–{max} range — {too_high_or_too_low_explanation}.` See §5.3.1 for the conditional. |
+| `low_open_interest` | `low_open_interest: {oi} < 50` | `Only {oi} contracts open — too thin to trade comfortably (the scanner requires at least 50).` |
+| `zero_bid` | `zero_bid` | `No buyer is showing a bid right now, so there's no real market to sell into.` |
+| `return_below_target` | `return_below_target: {pct:.2f}% < {min_return}%` | `Premium is only {pct:.2f}% of capital — below your {min_return}% target return.` |
+| `return_above_cap` | `return_above_cap: {pct:.2f}% > {max_return}%` | `Premium is {pct:.2f}% of capital — above your {max_return}% cap. Usually means the strike is too close to the money for the risk.` |
+
+#### 5.3.1 Delta sub-cases
+
+`delta_out_of_range` carries two distinct meanings depending on which side it failed on:
+
+- `|delta| > max_delta` → "too close to the money — higher chance of assignment than you've set as acceptable."
+- `|delta| < min_delta` → "too far out of the money — premium is likely too thin to justify the trade."
+
+The mapper picks the appropriate clause by comparing the parsed delta against the context's min/max.
+
+#### 5.3.2 Parser robustness
+
+Raw reason strings are constructed by f-strings in `options_scanner.py`. The mapper parses them with simple regex per code. **Hard rule: if a reason string fails to match any known code, the mapper falls back to the raw string unchanged.** Phase A does not crash on unknown codes; it degrades to today's behavior for that one line.
+
+### 5.4 Frontend rendering
+
+**Decision: bulleted list, one human sentence per rejection. Not flowing prose.** Reason: each strike has its own row already (`$99.00 6/20`); appending a one-sentence reason to that row keeps the existing structure. When a strike has multiple reasons (e.g. both delta and OI fail), the sentences become a small bulleted nested list inside that row.
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│  ▾ Rejected strikes (50)                                                   │
+│  ────────────────────────────────────────────────────────────────────────  │
+│  $99.00  6/20    Strike sits 645.7% above your $13.26 basis, but the 1%   │
+│                  rule requires at least that much room.                    │
+│  ────────────────────────────────────────────────────────────────────────  │
+│  $20.00  6/20    • Delta +0.42 is outside your 0.15–0.35 range — too      │
+│                    close to the money, higher chance of assignment.        │
+│                  • Only 12 contracts open — too thin to trade comfortably. │
+│  ────────────────────────────────────────────────────────────────────────  │
+│  $13.50  6/20    No buyer is showing a bid right now, so there's no real  │
+│                  market to sell into.                                      │
+│  …and 47 more                                                              │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+Existing render in `OptionScanner.jsx` currently joins reasons with `'; '`. Replace with:
+- 1 reason → render as a single sentence (no bullet).
+- 2+ reasons → render as a `<ul>` with `list-disc` and the sentences as items.
+
+### 5.5 Component contract
+
+Inline change to the rejected-strikes block already in `OptionScanner.jsx`. No new component file required — the existing `<details>` element stays. The map happens at render time:
+
+```jsx
+{result.rejected.slice(0, 20).map((r, i) => (
+  <RejectedStrikeRow
+    key={i}
+    strike={r.strike}
+    expiration={r.expiration}
+    reasons={r.human_reasons}    // not r.rejection_reasons
+    data-testid={`rejected-strike-${r.strike}-${r.expiration}`}
+  />
+))}
+```
+
+`RejectedStrikeRow` is a tiny internal component (file-local, no separate file) that handles the 1-vs-many rendering.
+
+### 5.6 Tokens
+
+| Token | Value |
+|---|---|
+| Strike label | `font-medium text-slate-700 dark:text-slate-200 text-xs` |
+| Reason sentence | `text-xs text-slate-600 dark:text-slate-400 leading-relaxed` (NOT red — red was used because it was a debug string; humanized prose is informational, not an error) |
+| Bullet list | `list-disc pl-5 mt-1 space-y-0.5` |
+| Row spacing | `py-2 border-b border-slate-100 dark:border-slate-700` |
+
+**Color change**: today the joined raw reasons render in `text-red-500`. After Phase A, the humanized sentence is the same slate-600/400 as other secondary text. The red was signaling "error string"; once it's a human sentence, no error signal is needed — the fact that it's inside the "Rejected Strikes" disclosure already carries that meaning.
+
+---
+
+## 6. Mobile (< sm, 640px) — composite view
+
+```
+┌──────────────────────────────────────┐
+│  App header                          │
+├──────────────────────────────────────┤
+│  [☰ Filters drawer trigger]          │
+│                                      │
+│  ▸ What is a Covered Call?  Learn ▸ │
+│                                      │
+│  F — Covered Call Scan               │
+│  Price $13.26 · 3 opportunities      │
+│                                      │
+│  Capital Deployment (existing)       │
+│                                      │
+│  ┌──────────────────────────────┐   │
+│  │  Strike table                │   │
+│  │  (horizontal scroll)         │   │
+│  │  Tap row to expand           │   │
+│  └──────────────────────────────┘   │
+│                                      │
+│  ▾ Strike $15.00  6/20  ($30 prem)  │
+│    ┌──────────────────────────────┐ │
+│    │ Greeks                       │ │
+│    │ Metrics                      │ │
+│    │ Rule Compliance              │ │
+│    │ ─────────────────────────── │ │
+│    │ What this trade commits you  │ │
+│    │ to (stacked, full-width)    │ │
+│    │ Three ways this can end      │ │
+│    └──────────────────────────────┘ │
+│                                      │
+│  ▸ Rejected strikes (50)            │
+└──────────────────────────────────────┘
+```
+
+No bottom-sheet, no full-screen drawer for the row expand. The existing in-place expand pattern stays — it's already mobile-friendly because the page is single-column on small screens and the expanded panel becomes a vertical stack.
+
+---
+
+## 7. Test IDs — full inventory
+
+| Element | data-testid |
+|---|---|
+| Primer card root | `strategy-primer` |
+| Primer toggle | `strategy-primer-toggle` |
+| Primer hide | `strategy-primer-hide` |
+| Primer body | `strategy-primer-body` |
+| Column tooltip icon | `column-tooltip-trigger-{key}` |
+| Column tooltip body | `column-tooltip-body-{key}` |
+| Trade explanation section | `trade-explanation-{strike}-{expiration}` |
+| Obligation row | `trade-explanation-obligation` |
+| Premium row | `trade-explanation-premium` |
+| Break-even row | `trade-explanation-breakeven` |
+| Outcome — called away | `trade-explanation-outcome-called_away` |
+| Outcome — expired | `trade-explanation-outcome-expired` |
+| Outcome — closed early | `trade-explanation-outcome-closed_early` |
+| Rejected strike row | `rejected-strike-{strike}-{expiration}` |
+
+Existing test IDs (`strike-table`, `schwab-status-banner`, `capital-utilization-card`, `budget-alert-banner`) are preserved.
+
+---
+
+## 8. Acceptance criteria mapping
+
+The issue's six ACs map to this spec as follows:
+
+1. *Collapsible primer with 10% rule, dismissal persists* → §2.
+2. *Numeric column headers expose keyboard-reachable tooltips* → §3.
+3. *Row expand reveals dollar obligation / premium / break-even / three scenarios* → §4.
+4. *Rejected strikes show human-readable reasons* → §5.
+5. *Backend mapper has unit coverage for every emitted reason code* → §5.3 (table covers all seven current codes; `backend/tests/test_rejection_messages.py` is the test home).
+6. *Frontend e2e: primer present, row expansion shows correct math, Delta tooltip shows on hover* → existing `frontend/e2e/` with a new spec file (`options-scanner-education.spec.ts` or similar — follow the project's existing naming).
+
+---
+
+## 9. Open forks (user sign-off needed before implementer picks up)
+
+The spec defaults each of these; flagging here so they can be overridden:
+
+1. **Primer placement** → **defaulted to top-of-page, collapsed-by-default with localStorage persistence**. Alternative: side-rail in `ChainFilters` (rejected because it competes with filters); modal-on-first-visit (rejected as interruptive).
+2. **Row expansion** → **single-row accordion (matches today)**. Alternative: multi-row expand (rejected; balloons vertical space).
+3. **Rejected list rendering** → **bulleted sentences, one per failed rule, color shifted from red to neutral**. Alternative: flowing prose paragraph per strike (rejected; harder to scan, breaks the per-rule structure).
+4. **Tooltip trigger** → **dedicated `ⓘ` icon, not hover-anywhere on header**. Alternative: hover-anywhere (rejected because it conflicts with the click-to-sort affordance on touch).
+
+---
+
+## 10. Implementation notes (for the planner)
+
+- The primer, the column-tooltip module, and the trade-explanation component are all isolated additions. They can be implemented and tested in any order.
+- The rejected-strikes change spans backend + frontend in one PR (since the frontend depends on the new `human_reasons` field). Suggest sequencing: backend mapper + schema + unit tests first, then frontend swap to consume `human_reasons`.
+- Suggested implementation order: (1) backend `human_reasons` + tests, (2) frontend rejected-list swap, (3) primer, (4) column tooltips, (5) per-row trade explanation, (6) e2e spec covering all four.
+- Don't touch `RiskRewardPanel`, `ChainFilters`, or `useOptionScanner` beyond what is required to thread `costBasis` / `sharesHeld` / `capitalAvailable` into `<TradeExplanation>` (already in scope props for the page).
+- The existing 50% profit target convention (`fifty_pct_profit_target` on each row) is the source for the close-early outcome math. Don't re-derive it.


### PR DESCRIPTION
## Summary

Design-only artifacts for issue #190 (Options Scanner education layer). Adds the canonical design spec plus Storybook mocks covering all four planned affordances:

1. Strategy primer (collapsible explainer panel)
2. Column header tooltips (Delta / OI / Annualized %)
3. Per-row expansion (strike-level detail)
4. Humanized rejected-strikes panel

Refs #190 — this PR does NOT close the issue. Phase A (production implementation) is still to come; the acceptance criteria on #190 stay open.

## What's in this PR

- `frontend/design-specs/scanner-education-v0.5.7.md` — canonical spec doc
- 4 placeholder component files in `frontend/components/options/Scanner*.jsx`, each marked ``// Phase 1.5 mock — Replace during Phase 3.``
- 4 colocated `*.stories.jsx` files with full variant coverage

## Variant inventory

| Component area | Variants |
|---|---|
| `ScannerStrategyPrimer` | 4 (CoveredCallCollapsed, CoveredCallExpanded, CashSecuredPutExpanded, DarkModeExpanded) |
| `ScannerColumnHeader` | 5 (DefaultNoTooltipOpen, TooltipOpenDelta, TooltipOpenOI, TooltipOpenAnnPct, WithActiveSortIndicator) |
| `ScannerStrikeRowExpansion` | 4 (Collapsed, ExpandedCoveredCall, ExpandedCashSecuredPut, ExpandedWithEarningsFlag) |
| `ScannerRejectedStrikes` | 5 (SingleRuleRejection, MultiRuleRejection, ManyStrikesCollapsed, ManyStrikesExpanded, UnknownReasonCode) |
| **Total** | **18** |

## How to view

```
cd frontend && npm run storybook
```

Then navigate to `Options/Scanner*` in the sidebar.

## Validation

- `npm run storybook` — renders all variants cleanly
- `npm run build-storybook` — green
- ESLint clean on the new files

## Design-only — no production code touched

No backend changes, no routing changes, no production component imports. The Storybook mocks are isolated under `frontend/components/options/Scanner*.jsx` and are explicitly marked as Phase 1.5 placeholders to be replaced during Phase 3 implementation. #190's acceptance criteria remain open — Phase A implementation will close them in a follow-up PR.