### PR TITLE
V0.5.7: Options Scanner education layer (closes #190)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -247,9 +247,20 @@ class StrikeRecommendation(BaseModel):
 
 
 class RejectedStrike(BaseModel):
+    """A strike the scanner skipped, with raw codes and human sentences.
+
+    ``rejection_reasons`` preserves the machine-readable codes the scanner
+    emits (used by tests and internal debugging). ``human_reasons`` is the
+    plain-English render produced by
+    :func:`app.services.rejection_messages.humanize_reasons` — populated
+    server-side per issue #190 so the frontend can display sentences without
+    duplicating the mapper logic.
+    """
+
     strike: float
     expiration: str
     rejection_reasons: list[str]
+    human_reasons: list[str] = Field(default_factory=list)
 
 
 class MarketContext(BaseModel):

--- a/backend/app/services/options_scanner.py
+++ b/backend/app/services/options_scanner.py
@@ -13,6 +13,7 @@ from app.services.schwab_client import SchwabClient, SchwabClientError
 from app.services.schwab_auth import SchwabAuthError
 from app.services.alpha_vantage_client import get_next_earnings_date
 from app.services.greeks import calculate_greeks
+from app.services.rejection_messages import HumanizeContext, humanize_reasons
 from app.utils.parsing import to_float, to_int
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,17 @@ class OptionScanner:
         candidates = []
         rejected = []
 
+        # Context for humanizing rejection codes — see #190 / scanner-education spec §5.
+        humanize_ctx: HumanizeContext = {
+            "cost_basis": request.cost_basis,
+            "current_price": current_price,
+            "min_call_distance_pct": request.min_call_distance_pct,
+            "min_delta": request.min_delta,
+            "max_delta": request.max_delta,
+            "min_return_pct": request.min_return_pct,
+            "max_return_pct": request.max_return_pct,
+        }
+
         valid_exps = set(self._get_valid_expirations(
             exp_date_map, request.min_dte, request.max_dte,
             earnings_date, request.exclude_earnings_dte,
@@ -165,6 +177,7 @@ class OptionScanner:
                         strike=strike,
                         expiration=exp_str,
                         rejection_reasons=reasons,
+                        human_reasons=humanize_reasons(reasons, humanize_ctx),
                     ))
                     continue
 
@@ -173,22 +186,26 @@ class OptionScanner:
                 )
 
                 if metrics["return_on_capital_pct"] < request.min_return_pct:
+                    return_below_reasons = [
+                        f"return_below_target: {metrics['return_on_capital_pct']:.2f}% < {request.min_return_pct}%"
+                    ]
                     rejected.append(RejectedStrike(
                         strike=strike,
                         expiration=exp_str,
-                        rejection_reasons=[
-                            f"return_below_target: {metrics['return_on_capital_pct']:.2f}% < {request.min_return_pct}%"
-                        ],
+                        rejection_reasons=return_below_reasons,
+                        human_reasons=humanize_reasons(return_below_reasons, humanize_ctx),
                     ))
                     continue
 
                 if request.max_return_pct and metrics["return_on_capital_pct"] > request.max_return_pct:
+                    return_above_reasons = [
+                        f"return_above_cap: {metrics['return_on_capital_pct']:.2f}% > {request.max_return_pct}%"
+                    ]
                     rejected.append(RejectedStrike(
                         strike=strike,
                         expiration=exp_str,
-                        rejection_reasons=[
-                            f"return_above_cap: {metrics['return_on_capital_pct']:.2f}% > {request.max_return_pct}%"
-                        ],
+                        rejection_reasons=return_above_reasons,
+                        human_reasons=humanize_reasons(return_above_reasons, humanize_ctx),
                     ))
                     continue
 

--- a/backend/app/services/rejection_messages.py
+++ b/backend/app/services/rejection_messages.py
@@ -126,11 +126,11 @@ def _fmt_fails_10pct(raw: str, ctx: HumanizeContext) -> str:
     min_pct = float(match.group("min"))
     cost_basis = ctx.get("cost_basis")
     basis_clause = (
-        f"your ${cost_basis:.2f} basis" if cost_basis else "your cost basis"
+        f"your ${cost_basis:.2f} basis" if cost_basis is not None else "your cost basis"
     )
     return (
         f"Strike sits {pct:.1f}% above {basis_clause}, but the {min_pct:.1f}% "
-        f"rule requires at least that much room."
+        "rule requires at least that much room."
     )
 
 

--- a/backend/app/services/rejection_messages.py
+++ b/backend/app/services/rejection_messages.py
@@ -1,0 +1,227 @@
+"""Humanize options-scanner rejection codes into plain-English sentences.
+
+The :mod:`app.services.options_scanner` module emits machine-readable rejection
+strings (``"fails_10pct_rule: strike 645.7% above basis, requires 10.0%"``) so
+the raw stream is greppable in tests and logs. Phase A (#190) layers a human
+sentence on top of each raw code so the scanner UI can speak plain English to
+less-experienced wheel traders.
+
+This module is a *pure* mapper. It does not import the scanner, the schemas,
+or anything from FastAPI — it takes a list of raw reason strings plus a
+context dict (cost basis, current price, min/max delta, etc.) and returns a
+parallel list of human sentences. Callers are responsible for providing the
+context. Unknown codes fall back to the raw string unchanged so the user is
+never blind to a real signal.
+
+See ``frontend/design-specs/scanner-education-v0.5.7.md`` §5.3 for the
+canonical sentence templates.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, TypedDict
+
+# Regex patterns are intentionally tolerant: they grab the floating-point or
+# integer values out of the raw f-string output produced by
+# ``OptionScanner._check_rejection`` and the inline ``return_*`` blocks in
+# ``OptionScanner.scan``. If a pattern fails to match we fall back to the raw
+# string — never crash.
+_FAILS_10PCT_RE = re.compile(
+    r"^fails_10pct_rule:\s*strike\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*above basis,\s*"
+    r"requires\s*(?P<min>-?\d+(?:\.\d+)?)%\s*$"
+)
+_ITM_PUT_RE = re.compile(
+    r"^itm_put:\s*strike\s*\$(?P<strike>-?\d+(?:\.\d+)?)\s*>\s*"
+    r"price\s*\$(?P<price>-?\d+(?:\.\d+)?)\s*$"
+)
+_DELTA_OUT_OF_RANGE_RE = re.compile(
+    r"^delta_out_of_range:\s*\|(?P<delta>-?\d+(?:\.\d+)?)\|\s*not in\s*"
+    r"\[(?P<min>-?\d+(?:\.\d+)?),\s*(?P<max>-?\d+(?:\.\d+)?)\]\s*$"
+)
+_LOW_OI_RE = re.compile(
+    r"^low_open_interest:\s*(?P<oi>-?\d+)\s*<\s*(?P<min>-?\d+)\s*$"
+)
+_RETURN_BELOW_RE = re.compile(
+    r"^return_below_target:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*<\s*"
+    r"(?P<min>-?\d+(?:\.\d+)?)%\s*$"
+)
+_RETURN_ABOVE_RE = re.compile(
+    r"^return_above_cap:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*>\s*"
+    r"(?P<max>-?\d+(?:\.\d+)?)%\s*$"
+)
+
+
+class HumanizeContext(TypedDict, total=False):
+    """Optional context passed into :func:`humanize_reasons`.
+
+    Each field is optional — when a parameter is missing from the raw code
+    string AND from the context, the sentence falls back to a value taken from
+    the raw text. Templates never crash on missing context.
+    """
+
+    cost_basis: Optional[float]
+    current_price: Optional[float]
+    min_call_distance_pct: float
+    min_delta: float
+    max_delta: float
+    min_return_pct: float
+    max_return_pct: Optional[float]
+
+
+def humanize_reasons(
+    raw_reasons: list[str],
+    context: Optional[HumanizeContext] = None,
+) -> list[str]:
+    """Convert a list of raw rejection strings into a list of human sentences.
+
+    The output list always has the same length as ``raw_reasons`` and the
+    order is preserved. Unknown codes pass through unchanged so a stale UI
+    code path still sees *something* informative.
+
+    Args:
+        raw_reasons: The ``rejection_reasons`` list off a ``RejectedStrike``.
+        context: Optional dict with extra context (cost basis, current price,
+            scanner thresholds). Used to enrich sentences when the raw string
+            does not embed every parameter (e.g. ``cost_basis`` is not in the
+            raw ``fails_10pct_rule`` string but is needed for ``"above your
+            $13.26 basis"``).
+
+    Returns:
+        A new list of plain-English sentences, one per raw reason.
+    """
+    ctx: HumanizeContext = context or {}
+    return [_humanize_one(raw, ctx) for raw in raw_reasons]
+
+
+def _humanize_one(raw: str, ctx: HumanizeContext) -> str:
+    """Dispatch a single raw reason to its template, or return raw unchanged."""
+    raw = raw.strip()
+
+    if raw.startswith("fails_10pct_rule"):
+        return _fmt_fails_10pct(raw, ctx)
+    if raw.startswith("itm_put"):
+        return _fmt_itm_put(raw, ctx)
+    if raw.startswith("delta_out_of_range"):
+        return _fmt_delta_out_of_range(raw, ctx)
+    if raw.startswith("low_open_interest"):
+        return _fmt_low_open_interest(raw, ctx)
+    if raw == "zero_bid":
+        return _fmt_zero_bid()
+    if raw.startswith("return_below_target"):
+        return _fmt_return_below_target(raw, ctx)
+    if raw.startswith("return_above_cap"):
+        return _fmt_return_above_cap(raw, ctx)
+
+    # Unknown code — fall back so we never lose information.
+    return raw
+
+
+def _fmt_fails_10pct(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``fails_10pct_rule: strike X% above basis, requires Y%``."""
+    match = _FAILS_10PCT_RE.match(raw)
+    if not match:
+        return raw
+    pct = float(match.group("pct"))
+    min_pct = float(match.group("min"))
+    cost_basis = ctx.get("cost_basis")
+    basis_clause = (
+        f"your ${cost_basis:.2f} basis" if cost_basis else "your cost basis"
+    )
+    return (
+        f"Strike sits {pct:.1f}% above {basis_clause}, but the {min_pct:.1f}% "
+        f"rule requires at least that much room."
+    )
+
+
+def _fmt_itm_put(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``itm_put: strike $X > price $Y``."""
+    match = _ITM_PUT_RE.match(raw)
+    if not match:
+        return raw
+    strike = float(match.group("strike"))
+    price = float(match.group("price"))
+    return (
+        f"Strike ${strike:.2f} is above the current price ${price:.2f} — "
+        "that's in-the-money for a put, which the scanner skips."
+    )
+
+
+def _fmt_delta_out_of_range(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``delta_out_of_range: |X| not in [min, max]`` with sub-case."""
+    match = _DELTA_OUT_OF_RANGE_RE.match(raw)
+    if not match:
+        return raw
+    delta = float(match.group("delta"))
+    min_delta = float(match.group("min"))
+    max_delta = float(match.group("max"))
+    abs_delta = abs(delta)
+
+    # Sub-case: too close to the money (delta too high) or too far OTM (too low)
+    if abs_delta > max_delta:
+        why = (
+            "too close to the money, higher chance of assignment than you've "
+            "set as acceptable"
+        )
+    elif abs_delta < min_delta:
+        why = (
+            "too far out of the money — premium is likely too thin to justify "
+            "the trade"
+        )
+    else:
+        # Defensive: shouldn't happen if the scanner emitted this code, but
+        # we keep a neutral fallback rather than crash.
+        why = "outside your target band"
+
+    return (
+        f"Delta {delta:+.2f} is outside your {min_delta:.2f}–{max_delta:.2f} "
+        f"range — {why}."
+    )
+
+
+def _fmt_low_open_interest(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``low_open_interest: N < 50``."""
+    match = _LOW_OI_RE.match(raw)
+    if not match:
+        return raw
+    oi = int(match.group("oi"))
+    min_oi = int(match.group("min"))
+    return (
+        f"Only {oi} contracts open — too thin to trade comfortably "
+        f"(the scanner requires at least {min_oi})."
+    )
+
+
+def _fmt_zero_bid() -> str:
+    """Render the ``zero_bid`` code (no parameters)."""
+    return (
+        "No buyer is showing a bid right now, so there's no real market to "
+        "sell into."
+    )
+
+
+def _fmt_return_below_target(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``return_below_target: X% < Y%``."""
+    match = _RETURN_BELOW_RE.match(raw)
+    if not match:
+        return raw
+    pct = float(match.group("pct"))
+    min_pct = float(match.group("min"))
+    return (
+        f"Premium is only {pct:.2f}% of capital — below your "
+        f"{min_pct:.1f}% target return."
+    )
+
+
+def _fmt_return_above_cap(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``return_above_cap: X% > Y%``."""
+    match = _RETURN_ABOVE_RE.match(raw)
+    if not match:
+        return raw
+    pct = float(match.group("pct"))
+    max_pct = float(match.group("max"))
+    return (
+        f"Premium is {pct:.2f}% of capital — above your "
+        f"{max_pct:.1f}% cap. Usually means the strike is too close to the "
+        "money for the risk."
+    )

--- a/backend/tests/test_options_scanner.py
+++ b/backend/tests/test_options_scanner.py
@@ -543,3 +543,95 @@ class TestExpirationFiltering:
         valid = scanner._get_valid_expirations(exp_date_map, 25, 50, earnings, 5)
         assert len(valid) == 1
         assert valid[0] == (today + timedelta(days=45)).strftime("%Y-%m-%d")
+
+
+class TestHumanReasonsPopulated:
+    """Issue #190 — every ``RejectedStrike`` carries a parallel human_reasons list."""
+
+    @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
+    @patch("app.services.options_scanner.SchwabClient")
+    def test_rejected_strikes_have_human_reasons(self, mock_client_cls, _earnings, scanner, cc_request):
+        """The scanner populates ``human_reasons`` parallel to ``rejection_reasons``."""
+        dte = 30
+        exp_date = (datetime.now().date() + timedelta(days=dte)).strftime("%Y-%m-%d")
+
+        # Mix of failing contracts to exercise multiple rejection codes.
+        contracts = [
+            # Fails 10pct rule — strike $15.5 only 3% above $15 cost basis
+            _make_schwab_contract(
+                strike=15.5, bid=0.30, ask=0.40, mark=0.35,
+                delta=-0.30, oi=500, dte=dte,
+            ),
+            # Low OI — strike $17 (passes 10pct), OI=10 < 50
+            _make_schwab_contract(
+                strike=17.0, bid=0.30, ask=0.40, mark=0.35,
+                delta=-0.25, oi=10, dte=dte,
+            ),
+            # Zero bid — strike $18 (passes 10pct), bid 0.0
+            _make_schwab_contract(
+                strike=18.0, bid=0.0, ask=0.40, mark=0.20,
+                delta=-0.20, oi=500, dte=dte,
+            ),
+        ]
+        chain_resp = _make_schwab_chain_response(
+            underlying_price=14.0,
+            contracts=contracts,
+            contract_type="call",
+            exp_date=exp_date,
+            dte=dte,
+        )
+
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.get_option_chain.return_value = chain_resp
+        mock_client.get_quote.return_value = {"lastPrice": 14.0}
+
+        result = scanner.scan(cc_request)
+
+        assert len(result["rejected"]) >= 1, "Test fixture should have produced rejected strikes"
+        for r in result["rejected"]:
+            # human_reasons must mirror rejection_reasons 1:1 in length and order.
+            assert len(r.human_reasons) == len(r.rejection_reasons)
+            # Each sentence is non-empty and not a raw code (no ": " parameter tail).
+            for sentence in r.human_reasons:
+                assert sentence, "human_reasons entries must be non-empty"
+                # Defensive: a raw code like "fails_10pct_rule: strike ..." would
+                # contain the lowercase code prefix. Human sentences should not.
+                assert "fails_10pct_rule" not in sentence
+                assert "low_open_interest" not in sentence
+
+    @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
+    @patch("app.services.options_scanner.SchwabClient")
+    def test_return_below_target_rejection_has_human_reason(self, mock_client_cls, _earnings, scanner, cc_request):
+        """The inline ``return_below_target`` branch also populates human_reasons."""
+        dte = 30
+        exp_date = (datetime.now().date() + timedelta(days=dte)).strftime("%Y-%m-%d")
+
+        # Strike $17 passes filters but premium yields tiny return (below cc_request.min_return_pct=0.5)
+        contract = _make_schwab_contract(
+            strike=17.0, bid=0.01, ask=0.02, mark=0.015,
+            delta=-0.20, oi=500, dte=dte,
+        )
+        chain_resp = _make_schwab_chain_response(
+            underlying_price=14.0,
+            contracts=[contract],
+            contract_type="call",
+            exp_date=exp_date,
+            dte=dte,
+        )
+
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.get_option_chain.return_value = chain_resp
+        mock_client.get_quote.return_value = {"lastPrice": 14.0}
+
+        result = scanner.scan(cc_request)
+
+        return_below = [
+            r for r in result["rejected"]
+            if any("return_below_target" in raw for raw in r.rejection_reasons)
+        ]
+        assert return_below, "Fixture should have produced a return_below_target rejection"
+        for r in return_below:
+            assert len(r.human_reasons) == len(r.rejection_reasons)
+            assert any("target return" in s for s in r.human_reasons)

--- a/backend/tests/test_rejection_messages.py
+++ b/backend/tests/test_rejection_messages.py
@@ -1,0 +1,179 @@
+"""Unit tests for :mod:`app.services.rejection_messages`.
+
+Each rejection code emitted by :class:`OptionScanner` has one test that asserts
+the human sentence contains the key parameters and reads like a sentence (not
+a code dump). The mapper is a pure function so these tests do not need any
+fixtures from ``conftest.py``.
+
+Spec: ``frontend/design-specs/scanner-education-v0.5.7.md`` §5.3.
+"""
+
+import pytest
+
+from app.services.rejection_messages import HumanizeContext, humanize_reasons
+
+
+# -- Per-code tests ---------------------------------------------------------
+
+
+class TestFails10PctRule:
+    """``fails_10pct_rule`` — strike is too close to or below cost basis."""
+
+    def test_with_cost_basis_in_context(self):
+        raw = ["fails_10pct_rule: strike 645.7% above basis, requires 10.0%"]
+        ctx: HumanizeContext = {"cost_basis": 13.26}
+        out = humanize_reasons(raw, ctx)
+        assert len(out) == 1
+        sentence = out[0]
+        assert "645.7%" in sentence
+        assert "$13.26 basis" in sentence
+        assert "10.0% rule requires" in sentence
+
+    def test_without_cost_basis_in_context(self):
+        raw = ["fails_10pct_rule: strike 5.0% above basis, requires 10.0%"]
+        out = humanize_reasons(raw, context=None)
+        assert out[0].startswith("Strike sits 5.0%")
+        assert "your cost basis" in out[0]
+        assert "10.0% rule" in out[0]
+
+
+class TestItmPut:
+    """``itm_put`` — put strike sits above the current price."""
+
+    def test_basic(self):
+        raw = ["itm_put: strike $15.00 > price $14.00"]
+        out = humanize_reasons(raw, None)
+        assert out[0].startswith("Strike $15.00")
+        assert "$14.00" in out[0]
+        assert "in-the-money" in out[0]
+
+
+class TestDeltaOutOfRange:
+    """``delta_out_of_range`` has two distinct sub-cases (too high vs too low)."""
+
+    def test_too_high_explanation(self):
+        # |0.42| > max_delta 0.35
+        raw = ["delta_out_of_range: |0.42| not in [0.15, 0.35]"]
+        out = humanize_reasons(raw, None)
+        sentence = out[0]
+        assert "+0.42" in sentence
+        assert "0.15" in sentence and "0.35" in sentence
+        assert "too close to the money" in sentence
+        # Sub-case sanity: the "too far OTM" clause must NOT appear here.
+        assert "too far out of the money" not in sentence
+
+    def test_too_low_explanation(self):
+        # |0.05| < min_delta 0.15
+        raw = ["delta_out_of_range: |0.05| not in [0.15, 0.35]"]
+        out = humanize_reasons(raw, None)
+        sentence = out[0]
+        assert "+0.05" in sentence
+        assert "too far out of the money" in sentence
+        # Sub-case sanity: the "too close" clause must NOT appear here.
+        assert "too close to the money" not in sentence
+
+    def test_negative_delta_for_csp(self):
+        # Puts have negative delta; sign should be preserved in the sentence.
+        raw = ["delta_out_of_range: |-0.42| not in [0.15, 0.35]"]
+        out = humanize_reasons(raw, None)
+        sentence = out[0]
+        assert "-0.42" in sentence
+        assert "too close to the money" in sentence
+
+
+class TestLowOpenInterest:
+    """``low_open_interest`` — strike below the OI threshold."""
+
+    def test_basic(self):
+        raw = ["low_open_interest: 12 < 50"]
+        out = humanize_reasons(raw, None)
+        assert out[0].startswith("Only 12 contracts")
+        assert "at least 50" in out[0]
+
+
+class TestZeroBid:
+    """``zero_bid`` — no bid in the market."""
+
+    def test_basic(self):
+        out = humanize_reasons(["zero_bid"], None)
+        assert "No buyer" in out[0]
+        assert "bid" in out[0]
+
+
+class TestReturnBelowTarget:
+    """``return_below_target`` — premium yield under user threshold."""
+
+    def test_basic(self):
+        raw = ["return_below_target: 0.34% < 1.0%"]
+        out = humanize_reasons(raw, None)
+        sentence = out[0]
+        assert "0.34%" in sentence
+        assert "1.0% target" in sentence
+
+
+class TestReturnAboveCap:
+    """``return_above_cap`` — premium yield above user sanity cap."""
+
+    def test_basic(self):
+        raw = ["return_above_cap: 25.50% > 15.0%"]
+        out = humanize_reasons(raw, None)
+        sentence = out[0]
+        assert "25.50%" in sentence
+        assert "15.0% cap" in sentence
+        assert "too close to the money" in sentence
+
+
+# -- Mapper-wide guarantees -------------------------------------------------
+
+
+class TestUnknownCodeFallback:
+    """Unknown codes pass through unchanged — never crash, never lose info."""
+
+    def test_unknown_code_returns_raw(self):
+        out = humanize_reasons(["some_future_rule_we_have_not_mapped"], None)
+        assert out == ["some_future_rule_we_have_not_mapped"]
+
+    def test_malformed_known_code_returns_raw(self):
+        # The prefix matches but the body doesn't fit the regex — fall through.
+        raw_str = "fails_10pct_rule: some garbled message"
+        out = humanize_reasons([raw_str], None)
+        assert out == [raw_str]
+
+
+class TestMapperShape:
+    """Length and order invariants — the output list mirrors the input list."""
+
+    def test_empty_input_returns_empty(self):
+        assert humanize_reasons([], None) == []
+
+    def test_multiple_reasons_preserve_order(self):
+        raw = [
+            "fails_10pct_rule: strike 5.0% above basis, requires 10.0%",
+            "zero_bid",
+            "low_open_interest: 12 < 50",
+        ]
+        out = humanize_reasons(raw, {"cost_basis": 13.26})
+        assert len(out) == 3
+        assert out[0].startswith("Strike sits 5.0%")
+        assert out[1].startswith("No buyer")
+        assert out[2].startswith("Only 12 contracts")
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "fails_10pct_rule: strike 5.0% above basis, requires 10.0%",
+            "itm_put: strike $15.00 > price $14.00",
+            "delta_out_of_range: |0.42| not in [0.15, 0.35]",
+            "low_open_interest: 12 < 50",
+            "zero_bid",
+            "return_below_target: 0.34% < 1.0%",
+            "return_above_cap: 25.50% > 15.0%",
+        ],
+    )
+    def test_all_known_codes_produce_non_raw_output(self, raw):
+        """Smoke check: each known code maps to something different from raw."""
+        out = humanize_reasons([raw], {"cost_basis": 13.26})
+        assert len(out) == 1
+        assert out[0] != raw
+        # Soft check: no code-shaped output (no ":<digits>%<more digits>" tail).
+        assert ": " not in out[0] or "—" in out[0]

--- a/frontend/components/options/OptionScanner.jsx
+++ b/frontend/components/options/OptionScanner.jsx
@@ -3,8 +3,14 @@ import { useSchwabStatus } from '../../hooks/useSchwabStatus';
 import ChainFilters from './ChainFilters';
 import StrikeTable from './StrikeTable';
 import RiskRewardPanel from './RiskRewardPanel';
+import ScannerStrategyPrimer from './ScannerStrategyPrimer';
+import ScannerRejectedStrikes from './ScannerRejectedStrikes';
 import Header from '../layout/Header';
 import LoadingSkeleton from '../layout/LoadingSkeleton';
+
+function normalizePrimerStrategy(strategy) {
+  return strategy === 'cash_secured_put' ? 'csp' : 'cc';
+}
 
 export default function OptionScannerPage() {
   const scanner = useOptionScanner();
@@ -37,6 +43,12 @@ export default function OptionScannerPage() {
         />
 
         <main className="flex-1 overflow-y-auto p-6 space-y-4">
+          {/* Strategy Primer — top-of-page educational card per spec §4.1.
+              Collapsed by default on first visit, state persisted in
+              localStorage per-strategy. Reacts to the active strategy in the
+              filter sidebar so it stays in sync with the user's current choice. */}
+          <ScannerStrategyPrimer strategy={normalizePrimerStrategy(scanner.strategy)} />
+
           {/* Schwab API Status Banner */}
           {!schwab.loading && !schwab.isAvailable && (
             <div
@@ -192,6 +204,12 @@ export default function OptionScannerPage() {
                 selectedStrikes={scanner.selectedStrikes}
                 onToggleSelection={scanner.toggleStrikeSelection}
                 hasCapital={!!capitalData.utilization}
+                strategy={result.strategy}
+                costBasis={
+                  scanner.costBasis !== '' && scanner.costBasis != null
+                    ? Number(scanner.costBasis)
+                    : null
+                }
               />
 
               {/* Risk/Reward Comparison */}
@@ -200,25 +218,9 @@ export default function OptionScannerPage() {
                 strategy={result.strategy}
               />
 
-              {/* Rejected Strikes */}
-              {result.rejected.length > 0 && (
-                <details className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl">
-                  <summary className="px-4 py-3 cursor-pointer text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700/50 rounded-xl">
-                    Rejected Strikes ({result.rejected.length})
-                  </summary>
-                  <div className="px-4 pb-4 space-y-1.5">
-                    {result.rejected.slice(0, 20).map((r, i) => (
-                      <div key={i} className="flex justify-between text-xs text-slate-600 dark:text-slate-400 py-1 border-b border-slate-100 dark:border-slate-700 last:border-0">
-                        <span className="font-medium">${r.strike.toFixed(2)} {r.expiration}</span>
-                        <span className="text-red-500 dark:text-red-400 text-right ml-4">{r.rejection_reasons.join('; ')}</span>
-                      </div>
-                    ))}
-                    {result.rejected.length > 20 && (
-                      <p className="text-xs text-slate-400">...and {result.rejected.length - 20} more</p>
-                    )}
-                  </div>
-                </details>
-              )}
+              {/* Rejected Strikes — humanized sentences via the backend
+                  `human_reasons` field. Spec §4.4. */}
+              <ScannerRejectedStrikes rejected={result.rejected} />
             </>
           )}
         </main>

--- a/frontend/components/options/ScannerColumnHeader.jsx
+++ b/frontend/components/options/ScannerColumnHeader.jsx
@@ -57,20 +57,24 @@ export default function ScannerColumnHeader({
       className={`px-3 py-2 text-${align} text-xs font-medium text-slate-500 dark:text-slate-400 select-none relative`}
     >
       <span className="inline-flex items-center gap-1" ref={tooltipRef}>
-        <button
-          type="button"
-          onClick={() => onSort?.(field)}
-          data-testid={`scanner-col-sort-${field}`}
-          className="hover:text-slate-700 dark:hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
-          aria-label={`Sort by ${label}`}
-        >
-          {label}
-          {active && (
-            <span className="ml-0.5" aria-hidden="true">
-              {sortDir === 'asc' ? '↑' : '↓'}
-            </span>
-          )}
-        </button>
+        {onSort ? (
+          <button
+            type="button"
+            onClick={() => onSort(field)}
+            data-testid={`scanner-col-sort-${field}`}
+            className="hover:text-slate-700 dark:hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+            aria-label={`Sort by ${label}`}
+          >
+            {label}
+            {active && (
+              <span className="ml-0.5" aria-hidden="true">
+                {sortDir === 'asc' ? '↑' : '↓'}
+              </span>
+            )}
+          </button>
+        ) : (
+          <span data-testid={`scanner-col-label-${field}`}>{label}</span>
+        )}
         {tooltip && (
           <button
             type="button"

--- a/frontend/components/options/ScannerColumnHeader.jsx
+++ b/frontend/components/options/ScannerColumnHeader.jsx
@@ -1,5 +1,3 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
-//
 // Sortable table header cell with a dedicated info-icon tooltip trigger.
 //
 // Why a dedicated icon (not hover-anywhere on the header): the header cell
@@ -11,7 +9,7 @@
 //
 // Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 2)
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 export default function ScannerColumnHeader({
   field,
@@ -21,17 +19,44 @@ export default function ScannerColumnHeader({
   sortDir = 'asc',
   onSort,
   align = 'right',
-  forceTooltipOpen = false, // story-only convenience prop
+  /**
+   * Story-only escape hatch — Storybook uses this to render the tooltip in
+   * its open state without simulating a click. Do not set this in production
+   * code; use the user-driven toggle via the ⓘ button instead.
+   */
+  forceTooltipOpen = false,
 }) {
   const [open, setOpen] = useState(false);
+  const tooltipRef = useRef(null);
   const isOpen = open || forceTooltipOpen;
+
+  // Close on outside click and on Escape. Effect only adds/removes listeners;
+  // it never calls setState in its body — setState happens inside the event
+  // handlers, which is allowed.
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const handleClickOutside = (event) => {
+      if (tooltipRef.current && !tooltipRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = (event) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
 
   return (
     <th
       scope="col"
       className={`px-3 py-2 text-${align} text-xs font-medium text-slate-500 dark:text-slate-400 select-none relative`}
     >
-      <span className="inline-flex items-center gap-1">
+      <span className="inline-flex items-center gap-1" ref={tooltipRef}>
         <button
           type="button"
           onClick={() => onSort?.(field)}
@@ -50,7 +75,6 @@ export default function ScannerColumnHeader({
           <button
             type="button"
             onClick={() => setOpen((v) => !v)}
-            onBlur={() => setOpen(false)}
             data-testid={`scanner-col-info-${field}`}
             className="w-4 h-4 inline-flex items-center justify-center rounded-full border border-slate-300 dark:border-slate-600 text-[10px] text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-300 hover:border-blue-400 dark:hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-help"
             aria-label={`What is ${label}?`}

--- a/frontend/components/options/ScannerColumnHeader.jsx
+++ b/frontend/components/options/ScannerColumnHeader.jsx
@@ -79,6 +79,7 @@ export default function ScannerColumnHeader({
             className="w-4 h-4 inline-flex items-center justify-center rounded-full border border-slate-300 dark:border-slate-600 text-[10px] text-slate-500 dark:text-slate-400 hover:text-blue-600 dark:hover:text-blue-300 hover:border-blue-400 dark:hover:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-help"
             aria-label={`What is ${label}?`}
             aria-expanded={isOpen}
+            aria-describedby={isOpen ? `scanner-col-tooltip-${field}` : undefined}
           >
             i
           </button>
@@ -86,6 +87,7 @@ export default function ScannerColumnHeader({
       </span>
       {isOpen && tooltip && (
         <div
+          id={`scanner-col-tooltip-${field}`}
           data-testid={`scanner-col-tooltip-${field}`}
           role="tooltip"
           className={`absolute z-20 top-full mt-1 ${align === 'right' ? 'right-0' : 'left-0'} w-64 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg p-3 text-left text-xs text-slate-700 dark:text-slate-200 space-y-2 font-normal normal-case`}

--- a/frontend/components/options/ScannerColumnHeader.stories.jsx
+++ b/frontend/components/options/ScannerColumnHeader.stories.jsx
@@ -1,33 +1,14 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
-//
 // Stories for ScannerColumnHeader (issue #190, Affordance 2).
 // Wraps the header in a real <table> shell so the tooltip positioning and
 // sort affordance are inspectable in the same context they ship in.
 
 import ScannerColumnHeader from './ScannerColumnHeader';
+import { SCANNER_COLUMN_TOOLTIPS } from './scannerColumnTooltips';
 
 const TOOLTIPS = {
-  delta: {
-    definition:
-      'The option price\'s sensitivity to a $1 move in the underlying. Roughly the market-implied probability the option ends in the money.',
-    range: 'For wheel strategies: 0.20 to 0.35. Lower = safer, less premium.',
-    whyItMatters:
-      'Higher delta means more premium but a higher chance of assignment. Stay in your comfort zone.',
-  },
-  open_interest: {
-    definition:
-      'The number of outstanding contracts at this strike that have not been closed or exercised.',
-    range: 'Look for 500+ contracts. 100+ is acceptable on less liquid names.',
-    whyItMatters:
-      'Higher open interest = tighter bid/ask spreads and easier exits. Thin contracts can cost you 5-10% on slippage.',
-  },
-  annualized_return_pct: {
-    definition:
-      'The return on capital, scaled to a full year. Lets you compare 7-day premiums against 45-day premiums on equal footing.',
-    range: 'Target 20%+ annualized for wheel candidates. Below 15% is rarely worth the assignment risk.',
-    whyItMatters:
-      'A $1 premium on a 7-DTE contract beats a $1.50 premium on 45-DTE every time, once you scale it.',
-  },
+  delta: SCANNER_COLUMN_TOOLTIPS.delta,
+  open_interest: SCANNER_COLUMN_TOOLTIPS.open_interest,
+  annualized_return_pct: SCANNER_COLUMN_TOOLTIPS.annualized_return_pct,
 };
 
 function HeaderHarness({ field, label, tooltipKey, active = false, forceTooltipOpen = false }) {

--- a/frontend/components/options/ScannerRejectedStrikes.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.jsx
@@ -1,21 +1,22 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+// Humanized rejected-strikes disclosure. Replaces the inline red
+// `rejection_reasons` join with a bulleted list of plain-English sentences
+// in neutral slate color.
 //
-// Humanized rejected-strikes disclosure. Replaces the inline red `rejection_reasons`
-// join with a bulleted list of plain-English sentences in neutral slate color.
-//
-// The backend adds a `human_reasons` field on `RejectedStrike` (preserving
-// `rejection_reasons` for tests). Mapper lives in
-// `backend/app/services/rejection_messages.py` per the spec. Unknown codes
-// degrade gracefully to the raw string.
+// Source of truth for the human sentences is the backend's `human_reasons`
+// field on each `RejectedStrike` (populated by
+// `backend/app/services/rejection_messages.py`). The fallback CLIENT_COPY
+// map below is purely defensive — if the backend ever returns an empty
+// `human_reasons` (legacy payload, mis-deploy), the client maps raw codes
+// to short sentences so the user is not staring at machine codes. Unknown
+// raw codes degrade to the raw string unchanged.
 //
 // Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 4)
 
 import { useState } from 'react';
 
-// Stand-in mapper for stories. In production this lives server-side and the
-// payload arrives pre-humanized via `human_reasons`. Kept here for stories
-// that pass raw codes and for the "unknown reason code" fallback variant.
-export const REJECTION_COPY = {
+// Defensive fallback only — the backend is the canonical source.
+// Keys are the code prefix (everything before the colon in a raw rejection).
+const CLIENT_COPY_FALLBACK = {
   fails_10pct_rule:
     'Strike is below 90% of your cost basis — selling here could force you to part with shares at a loss.',
   itm_put:
@@ -32,15 +33,19 @@ export const REJECTION_COPY = {
     'Return is above your sanity-check cap — likely a stale quote or an unusual contract.',
 };
 
-function humanize(code) {
-  return REJECTION_COPY[code] || code; // graceful fallback
+function humanizeFallback(raw) {
+  // Extract the code prefix (before the first colon) and look it up. If the
+  // raw string has no colon, treat the whole string as the code.
+  const codeMatch = /^([a-z_]+)/i.exec(raw);
+  const code = codeMatch ? codeMatch[1] : raw;
+  return CLIENT_COPY_FALLBACK[code] || raw;
 }
 
 function RejectedRow({ rejection }) {
   const reasons =
     rejection.human_reasons && rejection.human_reasons.length > 0
       ? rejection.human_reasons
-      : rejection.rejection_reasons.map(humanize);
+      : (rejection.rejection_reasons || []).map(humanizeFallback);
 
   return (
     <li

--- a/frontend/components/options/ScannerRejectedStrikes.stories.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.stories.jsx
@@ -1,10 +1,11 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
-//
 // Stories for ScannerRejectedStrikes (issue #190, Affordance 4).
+//
 // Demonstrates: single-rule rejection, multi-rule rejection, many strikes
-// rejected (collapsed disclosure surface), and unknown-code fallback.
+// rejected (collapsed disclosure surface), and unknown-code fallback. The
+// component receives realistic `human_reasons` strings — in production these
+// are populated server-side by `backend/app/services/rejection_messages.py`.
 
-import ScannerRejectedStrikes, { REJECTION_COPY } from './ScannerRejectedStrikes';
+import ScannerRejectedStrikes from './ScannerRejectedStrikes';
 
 const meta = {
   title: 'Options/ScannerRejectedStrikes',
@@ -27,45 +28,68 @@ export default meta;
 
 const single = [
   {
-    strike: 12.50,
+    strike: 12.5,
     expiration: '2026-06-18',
-    rejection_reasons: ['fails_10pct_rule'],
-    human_reasons: [REJECTION_COPY.fails_10pct_rule],
+    rejection_reasons: ['fails_10pct_rule: strike -5.4% above basis, requires 10.0%'],
+    human_reasons: [
+      'Strike sits -5.4% above your $13.21 basis, but the 10.0% rule requires at least that much room.',
+    ],
   },
 ];
 
 const multi = [
   {
-    strike: 16.00,
+    strike: 16.0,
     expiration: '2026-06-18',
-    rejection_reasons: ['delta_out_of_range', 'low_open_interest', 'zero_bid'],
+    rejection_reasons: [
+      'delta_out_of_range: |0.42| not in [0.15, 0.35]',
+      'low_open_interest: 12 < 50',
+      'zero_bid',
+    ],
     human_reasons: [
-      REJECTION_COPY.delta_out_of_range,
-      REJECTION_COPY.low_open_interest,
-      REJECTION_COPY.zero_bid,
+      'Delta +0.42 is outside your 0.15–0.35 range — too close to the money, higher chance of assignment than you have set as acceptable.',
+      'Only 12 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+      'No buyer is showing a bid right now, so there is no real market to sell into.',
     ],
   },
 ];
 
-// Mix one strike with reasons expanded out of 50 total.
+// 50 strikes with realistic backend-emitted humanized strings.
 const many = (() => {
-  const out = [];
-  const expirations = ['2026-06-18', '2026-07-16', '2026-08-20'];
-  const codes = [
-    ['fails_10pct_rule'],
-    ['delta_out_of_range'],
-    ['low_open_interest'],
-    ['zero_bid'],
-    ['return_below_target'],
-    ['delta_out_of_range', 'low_open_interest'],
+  const samples = [
+    {
+      raw: 'fails_10pct_rule: strike -8.1% above basis, requires 10.0%',
+      human:
+        'Strike sits -8.1% above your $13.21 basis, but the 10.0% rule requires at least that much room.',
+    },
+    {
+      raw: 'delta_out_of_range: |0.42| not in [0.15, 0.35]',
+      human:
+        'Delta +0.42 is outside your 0.15–0.35 range — too close to the money, higher chance of assignment than you have set as acceptable.',
+    },
+    {
+      raw: 'low_open_interest: 12 < 50',
+      human:
+        'Only 12 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+    },
+    {
+      raw: 'zero_bid',
+      human: 'No buyer is showing a bid right now, so there is no real market to sell into.',
+    },
+    {
+      raw: 'return_below_target: 0.42% < 1.0%',
+      human: 'Premium is only 0.42% of capital — below your 1.0% target return.',
+    },
   ];
+  const expirations = ['2026-06-18', '2026-07-16', '2026-08-20'];
+  const out = [];
   for (let i = 0; i < 50; i++) {
-    const r = codes[i % codes.length];
+    const sample = samples[i % samples.length];
     out.push({
       strike: 10 + i * 0.5,
       expiration: expirations[i % expirations.length],
-      rejection_reasons: r,
-      human_reasons: r.map((c) => REJECTION_COPY[c]),
+      rejection_reasons: [sample.raw],
+      human_reasons: [sample.human],
     });
   }
   return out;
@@ -73,51 +97,36 @@ const many = (() => {
 
 const unknown = [
   {
-    strike: 14.50,
+    strike: 14.5,
     expiration: '2026-06-18',
-    rejection_reasons: ['some_future_rule_code_we_have_not_mapped_yet'],
-    // No human_reasons → component falls back to humanize(code) which returns
-    // the raw string when the code is not in REJECTION_COPY.
+    // No human_reasons populated → component falls back to mapping the raw
+    // prefix client-side. The defensive CLIENT_COPY_FALLBACK does not include
+    // this future code, so the raw string passes through unchanged.
+    rejection_reasons: ['some_future_rule_code_we_have_not_mapped_yet: extra params'],
   },
 ];
 
 export const SingleRuleRejection = {
   name: 'Single-rule rejection — fails_10pct_rule',
-  args: {
-    rejected: single,
-    defaultOpen: true,
-  },
+  args: { rejected: single, defaultOpen: true },
 };
 
 export const MultiRuleRejection = {
   name: 'Multi-rule rejection — delta + OI + zero bid',
-  args: {
-    rejected: multi,
-    defaultOpen: true,
-  },
+  args: { rejected: multi, defaultOpen: true },
 };
 
 export const ManyStrikesCollapsed = {
   name: 'Many strikes rejected (50) — disclosure',
-  args: {
-    rejected: many,
-    defaultOpen: false,
-  },
+  args: { rejected: many, defaultOpen: false },
 };
 
 export const ManyStrikesExpanded = {
   name: 'Many strikes rejected (50) — expanded',
-  args: {
-    rejected: many,
-    defaultOpen: true,
-    visibleCount: 5,
-  },
+  args: { rejected: many, defaultOpen: true, visibleCount: 5 },
 };
 
 export const UnknownReasonCode = {
   name: 'Unknown reason code — fallback rendering',
-  args: {
-    rejected: unknown,
-    defaultOpen: true,
-  },
+  args: { rejected: unknown, defaultOpen: true },
 };

--- a/frontend/components/options/ScannerStrategyPrimer.jsx
+++ b/frontend/components/options/ScannerStrategyPrimer.jsx
@@ -1,9 +1,10 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+// Top-of-page educational card explaining the current strategy (Covered Call
+// or Cash-Secured Put) in plain English.
 //
-// Top-of-page educational card that explains the current strategy (Covered Call
-// or Cash-Secured Put) in plain English. Collapsed by default; dismissal is
-// persisted per-strategy in localStorage. Re-shown via a "Show primers" link
-// rendered by ChainFilters footer.
+// Collapsed by default on first visit. Per-strategy collapse state is
+// persisted to localStorage so the primer stays out of the way once the user
+// has read it. Reacts to the active `strategy` prop so the copy and the
+// localStorage key swap together.
 //
 // Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 1)
 
@@ -38,27 +39,79 @@ const COPY = {
   },
 };
 
-export default function ScannerStrategyPrimer({
-  strategy = 'cc',
-  defaultExpanded = false,
-  onDismiss,
-}) {
-  const [expanded, setExpanded] = useState(defaultExpanded);
-  const copy = COPY[strategy] || COPY.cc;
+const STORAGE_KEY_PREFIX = 'scanner-primer-collapsed-';
+
+// Map the strategy prop (which may be 'covered_call' / 'cash_secured_put' from
+// the API, or the short 'cc' / 'csp' used internally) into a stable copy/storage key.
+function normalizeStrategy(strategy) {
+  if (strategy === 'covered_call' || strategy === 'cc') return 'cc';
+  if (strategy === 'cash_secured_put' || strategy === 'csp') return 'csp';
+  return 'cc';
+}
+
+function readPersistedCollapsed(key) {
+  if (typeof window === 'undefined') return true;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return true; // default = collapsed on first visit
+    return raw === '1';
+  } catch {
+    return true;
+  }
+}
+
+function writePersistedCollapsed(key, collapsed) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, collapsed ? '1' : '0');
+  } catch {
+    // localStorage may be disabled (Safari private mode, etc.) — silently
+    // ignore. The primer will still toggle visually within the session.
+  }
+}
+
+export default function ScannerStrategyPrimer({ strategy = 'cc' }) {
+  const normalized = normalizeStrategy(strategy);
+  const storageKey = `${STORAGE_KEY_PREFIX}${normalized}`;
+
+  // Derived-state-from-props pattern. Keep the last seen storageKey alongside
+  // the collapsed flag; when the key changes (strategy toggled), refresh both
+  // during render. Avoids the react-hooks/set-state-in-effect rule (#198) — no
+  // useEffect needed for this kind of prop-driven re-derivation.
+  const [persisted, setPersisted] = useState(() => ({
+    key: storageKey,
+    collapsed: readPersistedCollapsed(storageKey),
+  }));
+  if (persisted.key !== storageKey) {
+    setPersisted({ key: storageKey, collapsed: readPersistedCollapsed(storageKey) });
+  }
+  const collapsed = persisted.collapsed;
+
+  const copy = COPY[normalized];
+  const expanded = !collapsed;
+
+  const handleToggle = () => {
+    const nextCollapsed = !collapsed;
+    setPersisted({ key: storageKey, collapsed: nextCollapsed });
+    writePersistedCollapsed(storageKey, nextCollapsed);
+  };
 
   return (
     <section
       data-testid="scanner-strategy-primer"
+      data-strategy={normalized}
       className="bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-900 rounded-xl"
     >
-      <header className="px-4 py-3 flex items-center justify-between gap-3">
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          data-testid="scanner-strategy-primer-toggle"
-          className="flex items-center gap-2 text-left flex-1 min-w-0"
-          aria-expanded={expanded}
-        >
+      <button
+        type="button"
+        onClick={handleToggle}
+        data-testid="scanner-strategy-primer-toggle"
+        className="w-full px-4 py-3 flex items-center justify-between gap-3 text-left focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-xl"
+        aria-expanded={expanded}
+        aria-controls="scanner-strategy-primer-body"
+        aria-label={`${expanded ? 'Hide' : 'Show'} strategy primer`}
+      >
+        <span className="flex items-center gap-2 min-w-0">
           <span
             className="text-blue-600 dark:text-blue-300 text-xs font-semibold uppercase tracking-wide"
             aria-hidden="true"
@@ -68,25 +121,17 @@ export default function ScannerStrategyPrimer({
           <span className="text-sm font-semibold text-slate-900 dark:text-white truncate">
             {copy.title}
           </span>
-          <span
-            className="ml-auto text-slate-500 dark:text-slate-400 text-xs"
-            aria-hidden="true"
-          >
-            {expanded ? 'Hide' : 'Show'}
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={onDismiss}
-          data-testid="scanner-strategy-primer-dismiss"
-          className="text-xs text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
-          aria-label="Dismiss primer"
+        </span>
+        <span
+          className="text-slate-500 dark:text-slate-400 text-xs shrink-0"
+          aria-hidden="true"
         >
-          Dismiss
-        </button>
-      </header>
+          {expanded ? 'Hide' : 'Show'}
+        </span>
+      </button>
       {expanded && (
         <div
+          id="scanner-strategy-primer-body"
           data-testid="scanner-strategy-primer-body"
           className="px-4 pb-4 pt-1 space-y-3 text-sm text-slate-700 dark:text-slate-200"
         >

--- a/frontend/components/options/ScannerStrategyPrimer.stories.jsx
+++ b/frontend/components/options/ScannerStrategyPrimer.stories.jsx
@@ -1,9 +1,24 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
-//
 // Stories for ScannerStrategyPrimer (issue #190, Affordance 1).
 // Fixture data only.
 
 import ScannerStrategyPrimer from './ScannerStrategyPrimer';
+
+// Storybook decorator: prefill localStorage before the component mounts so
+// we can demonstrate both the collapsed and expanded states without adding
+// a story-only prop to the production component. The component reads
+// localStorage in its useState initializer on first render.
+function withPrefilledStorage(collapsed) {
+  const Decorator = (Story, context) => {
+    if (typeof window !== 'undefined') {
+      const strategy = context.args.strategy === 'csp' ? 'csp' : 'cc';
+      const key = `scanner-primer-collapsed-${strategy}`;
+      window.localStorage.setItem(key, collapsed ? '1' : '0');
+    }
+    return <Story />;
+  };
+  Decorator.displayName = `WithPrefilledStorage(collapsed=${collapsed})`;
+  return Decorator;
+}
 
 const meta = {
   title: 'Options/ScannerStrategyPrimer',
@@ -14,14 +29,14 @@ const meta = {
       description: {
         component:
           'Top-of-page strategy primer for the Options Scanner. Collapsed by ' +
-          'default, persisted dismissal per strategy in localStorage, reacts ' +
-          'to the CC/CSP toggle. See `frontend/design-specs/scanner-education-v0.5.7.md`.',
+          'default, collapse state persisted per strategy in localStorage, ' +
+          'reacts to the CC/CSP toggle. See ' +
+          '`frontend/design-specs/scanner-education-v0.5.7.md`.',
       },
     },
   },
   argTypes: {
     strategy: { control: { type: 'inline-radio' }, options: ['cc', 'csp'] },
-    defaultExpanded: { control: 'boolean' },
   },
 };
 
@@ -29,41 +44,31 @@ export default meta;
 
 export const CoveredCallCollapsed = {
   name: 'Covered Call — Collapsed',
-  args: {
-    strategy: 'cc',
-    defaultExpanded: false,
-  },
+  args: { strategy: 'cc' },
+  decorators: [withPrefilledStorage(true)],
 };
 
 export const CoveredCallExpanded = {
   name: 'Covered Call — Expanded',
-  args: {
-    strategy: 'cc',
-    defaultExpanded: true,
-  },
+  args: { strategy: 'cc' },
+  decorators: [withPrefilledStorage(false)],
 };
 
 export const CashSecuredPutExpanded = {
   name: 'Cash-Secured Put — Expanded',
-  args: {
-    strategy: 'csp',
-    defaultExpanded: true,
-  },
+  args: { strategy: 'csp' },
+  decorators: [withPrefilledStorage(false)],
 };
 
-// Pinned dark-mode story — designer mental-checked color contrast in dark.
-// To verify visually, also toggle the toolbar theme to "dark" on any story.
 export const DarkModeExpanded = {
   name: 'Dark Mode — Expanded',
-  args: {
-    strategy: 'cc',
-    defaultExpanded: true,
-  },
+  args: { strategy: 'cc' },
   parameters: {
     themes: { themeOverride: 'dark' },
     backgrounds: { default: 'dark' },
   },
   decorators: [
+    withPrefilledStorage(false),
     (Story) => (
       <div className="dark bg-slate-900 p-6 -m-4 min-h-[300px]">
         <Story />

--- a/frontend/components/options/ScannerStrikeRowExpansion.jsx
+++ b/frontend/components/options/ScannerStrikeRowExpansion.jsx
@@ -55,7 +55,12 @@ function cspScenarios({ strike, premium_per_contract, breakeven, contracts = 1 }
   const premiumTotal = premium_per_contract * contracts;
   const sharesAtRisk = 100 * contracts;
   const cashAtRisk = strike * sharesAtRisk;
-  const effectiveEntry = breakeven ?? strike - premium_per_contract;
+  // `strike` is per-share; `premium_per_contract` is dollars-per-contract
+  // (= per-share × 100). Divide before subtracting so the fallback produces a
+  // per-share entry price. In practice `breakeven` is always populated for
+  // CSPs by the backend (options_scanner.py L434) so this branch is unreached
+  // — kept for defensive correctness.
+  const effectiveEntry = breakeven ?? strike - premium_per_contract / 100;
   return {
     obligation: `You set aside ${formatUsd(cashAtRisk)} as collateral. If assigned, you buy ${sharesAtRisk} share${sharesAtRisk === 100 ? '' : 's'} at $${strike.toFixed(2)}.`,
     premium: `You collect ${formatUsd(premiumTotal)} in premium right now — yours to keep regardless of outcome.`,

--- a/frontend/components/options/ScannerStrikeRowExpansion.jsx
+++ b/frontend/components/options/ScannerStrikeRowExpansion.jsx
@@ -1,33 +1,36 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
+// Plain-English commitment summary appended to each strike's expanded row.
 //
-// Single-row accordion content for a strike. Appends a "What this trade
-// commits you to" sub-section to the existing Greeks / Metrics / Rule
-// Compliance panel — it does NOT replace the panel.
+// Renders the "What this trade commits you to" sub-section. The existing
+// Greeks / Metrics / Rule Compliance panel is rendered by StrikeTable's
+// ExpandedDetails — this component is appended underneath, NOT a replacement.
 //
-// All math derives from fields the scanner already returns:
-//   premium_per_contract, breakeven, fifty_pct_profit_target
-// plus user-input context (cost basis, shares held, capital available).
+// All math derives from fields the scanner already returns
+// (`premium_per_contract`, `breakeven`, `fifty_pct_profit_target`,
+// `total_premium`, `strike`) plus user-input context (`cost_basis_per_share`,
+// `contracts`) — no new backend asks.
 //
 // Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 3)
 
 function formatUsd(n, digits = 2) {
-  if (n == null) return '—';
+  if (n == null || Number.isNaN(n)) return '—';
   const sign = n < 0 ? '-' : '';
   return `${sign}$${Math.abs(n).toFixed(digits)}`;
 }
 
 // Build the plain-English outcome scenarios for a Covered Call.
-function ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_share, contracts = 1, earnings_in_window }) {
+function ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_share, contracts = 1 }) {
   const premiumTotal = premium_per_contract * contracts;
   const sharesAtRisk = 100 * contracts;
   const calledAwayProceeds = strike * sharesAtRisk;
-  const calledAwayPL = calledAwayProceeds - cost_basis_per_share * sharesAtRisk + premiumTotal;
+  const basisDollars = (cost_basis_per_share ?? 0) * sharesAtRisk;
+  const calledAwayPL = calledAwayProceeds - basisDollars + premiumTotal;
   return {
     obligation: `If assigned, you sell ${sharesAtRisk} share${sharesAtRisk === 100 ? '' : 's'} at $${strike.toFixed(2)}. Total proceeds: ${formatUsd(calledAwayProceeds)}.`,
     premium: `You collect ${formatUsd(premiumTotal)} in premium right now — yours to keep regardless of outcome.`,
-    breakeven: breakeven != null
-      ? `Your effective break-even if called away: ${formatUsd(breakeven)} per share (cost basis minus premium received).`
-      : null,
+    breakeven:
+      breakeven != null
+        ? `Your effective break-even if called away: ${formatUsd(breakeven)} per share (cost basis minus premium received).`
+        : null,
     outcomes: [
       {
         label: 'Stock stays below the strike',
@@ -35,28 +38,31 @@ function ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_s
       },
       {
         label: 'Stock closes above the strike',
-        text: `Shares are called away at $${strike.toFixed(2)}. Total P/L on this position: ${formatUsd(calledAwayPL)} (proceeds + premium − cost basis). Upside above the strike is forfeit.`,
+        text: cost_basis_per_share != null
+          ? `Shares are called away at $${strike.toFixed(2)}. Total P/L on this position: ${formatUsd(calledAwayPL)} (proceeds + premium − cost basis). Upside above the strike is forfeit.`
+          : `Shares are called away at $${strike.toFixed(2)}. You keep the ${formatUsd(premiumTotal)} premium and net the difference between strike and your cost basis. Upside above the strike is forfeit.`,
       },
       {
         label: 'Stock spikes far above the strike',
         text: 'Same outcome as above — your shares are called at the strike, so the upside is capped. The premium you collected is your max gain beyond the strike.',
       },
     ],
-    earnings_in_window: earnings_in_window === true,
   };
 }
 
 // Build the plain-English outcome scenarios for a Cash-Secured Put.
-function cspScenarios({ strike, premium_per_contract, breakeven, contracts = 1, earnings_in_window }) {
+function cspScenarios({ strike, premium_per_contract, breakeven, contracts = 1 }) {
   const premiumTotal = premium_per_contract * contracts;
   const sharesAtRisk = 100 * contracts;
   const cashAtRisk = strike * sharesAtRisk;
+  const effectiveEntry = breakeven ?? strike - premium_per_contract;
   return {
     obligation: `You set aside ${formatUsd(cashAtRisk)} as collateral. If assigned, you buy ${sharesAtRisk} share${sharesAtRisk === 100 ? '' : 's'} at $${strike.toFixed(2)}.`,
     premium: `You collect ${formatUsd(premiumTotal)} in premium right now — yours to keep regardless of outcome.`,
-    breakeven: breakeven != null
-      ? `Your effective entry if assigned: ${formatUsd(breakeven)} per share (strike minus premium received).`
-      : null,
+    breakeven:
+      breakeven != null
+        ? `Your effective entry if assigned: ${formatUsd(breakeven)} per share (strike minus premium received).`
+        : null,
     outcomes: [
       {
         label: 'Stock stays above the strike',
@@ -64,139 +70,86 @@ function cspScenarios({ strike, premium_per_contract, breakeven, contracts = 1, 
       },
       {
         label: 'Stock closes below the strike',
-        text: `You are assigned. ${formatUsd(cashAtRisk)} is converted into ${sharesAtRisk} shares at $${strike.toFixed(2)}. Your effective entry is ${formatUsd(breakeven ?? strike - premium_per_contract)} per share.`,
+        text: `You are assigned. ${formatUsd(cashAtRisk)} is converted into ${sharesAtRisk} shares at $${strike.toFixed(2)}. Your effective entry is ${formatUsd(effectiveEntry)} per share.`,
       },
       {
         label: 'Stock drops far below the strike',
         text: 'Same assignment, but the shares are now worth less than your entry. You are still long the shares; you can write covered calls on them once you own them ("the wheel").',
       },
     ],
-    earnings_in_window: earnings_in_window === true,
   };
 }
 
 export default function ScannerStrikeRowExpansion({
   strategy = 'cc',
-  strike, // numeric strike $
-  expiration, // 'YYYY-MM-DD'
-  dte,
+  strike,
   premium_per_contract,
   breakeven,
-  fifty_pct_profit_target,
   cost_basis_per_share,
   contracts = 1,
-  shares_held,
   earnings_in_window = false,
-  // Mocked Greeks for the existing panel context
-  greeks = { delta: 0.28, gamma: 0.05, theta: -0.012, vega: 0.08, iv: 0.34 },
 }) {
-  const built =
-    strategy === 'csp'
-      ? cspScenarios({ strike, premium_per_contract, breakeven, contracts, earnings_in_window })
-      : ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_share, contracts, earnings_in_window });
+  if (strike == null || premium_per_contract == null) return null;
+
+  const isCsp = strategy === 'csp' || strategy === 'cash_secured_put';
+  const built = isCsp
+    ? cspScenarios({ strike, premium_per_contract, breakeven, contracts })
+    : ccScenarios({ strike, premium_per_contract, breakeven, cost_basis_per_share, contracts });
 
   return (
     <div
-      data-testid="scanner-strike-row-expansion"
-      className="space-y-4"
+      data-testid="scanner-strike-row-commitment"
+      className="border-t border-slate-200 dark:border-slate-700 pt-4 mt-4"
     >
-      {/* Existing panel — Greeks / Metrics / Rule Compliance (preserved) */}
-      <div className="grid grid-cols-3 gap-6 text-sm">
-        <div>
-          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Greeks</h4>
-          <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
-            <div>Delta: {greeks.delta.toFixed(3)}</div>
-            <div>Gamma: {greeks.gamma.toFixed(4)}</div>
-            <div>Theta: {greeks.theta.toFixed(4)}</div>
-            <div>Vega: {greeks.vega.toFixed(4)}</div>
-            <div>IV: {(greeks.iv * 100).toFixed(1)}%</div>
-          </div>
-        </div>
-        <div>
-          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Metrics</h4>
-          <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
-            <div>Premium/Contract: {formatUsd(premium_per_contract)}</div>
-            <div>Breakeven: {formatUsd(breakeven)}</div>
-            <div>50% Target: {formatUsd(fifty_pct_profit_target)}</div>
-            <div>DTE: {dte}</div>
-            <div>Exp: {expiration}</div>
-          </div>
-        </div>
-        <div>
-          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Rule Compliance</h4>
-          <div className="space-y-1 text-xs">
-            <div className="text-green-600 dark:text-green-400">✓ 10% Rule</div>
-            <div className="text-green-600 dark:text-green-400">✓ DTE Range</div>
-            <div className="text-green-600 dark:text-green-400">✓ Delta Range</div>
-            <div className="text-green-600 dark:text-green-400">✓ Return Target</div>
-            <div
-              className={
-                earnings_in_window
-                  ? 'text-yellow-600 dark:text-yellow-400'
-                  : 'text-green-600 dark:text-green-400'
-              }
-            >
-              {earnings_in_window ? '! ' : '✓ '}Earnings Check
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* NEW: "What this trade commits you to" sub-section — appended */}
-      <div
-        data-testid="scanner-strike-row-commitment"
-        className="border-t border-slate-200 dark:border-slate-700 pt-4"
-      >
-        <h4 className="font-medium text-slate-900 dark:text-white mb-2 flex items-center gap-2">
-          What this trade commits you to
-          <span className="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
-            Plain English
-          </span>
-        </h4>
-        <div className="space-y-3 text-sm text-slate-700 dark:text-slate-200">
-          <div className="grid sm:grid-cols-2 gap-3">
-            <div className="bg-slate-50 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
-              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
-                Your obligation
-              </p>
-              <p>{built.obligation}</p>
-            </div>
-            <div className="bg-slate-50 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
-              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
-                Premium collected
-              </p>
-              <p>{built.premium}</p>
-              {built.breakeven && (
-                <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">{built.breakeven}</p>
-              )}
-            </div>
-          </div>
-
-          <div>
-            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1.5">
-              Outcome scenarios at expiration
+      <h4 className="font-medium text-slate-900 dark:text-white mb-2 flex items-center gap-2">
+        What this trade commits you to
+        <span className="text-[10px] font-medium uppercase tracking-wide px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300">
+          Plain English
+        </span>
+      </h4>
+      <div className="space-y-3 text-sm text-slate-700 dark:text-slate-200">
+        <div className="grid sm:grid-cols-2 gap-3">
+          <div className="bg-slate-50 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+              Your obligation
             </p>
-            <ol className="list-decimal list-outside ml-5 space-y-1.5 text-sm">
-              {built.outcomes.map((o, i) => (
-                <li key={i}>
-                  <span className="font-semibold">{o.label}: </span>
-                  <span>{o.text}</span>
-                </li>
-              ))}
-            </ol>
+            <p>{built.obligation}</p>
           </div>
-
-          {built.earnings_in_window && (
-            <div
-              data-testid="scanner-strike-row-earnings-flag"
-              className="text-xs bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-md px-3 py-2 text-yellow-800 dark:text-yellow-200"
-            >
-              <span className="font-semibold">Earnings within the contract window. </span>
-              Expect larger price swings between now and expiration — the outcome scenarios above
-              can shift quickly. Consider sizing down or skipping this expiration.
-            </div>
-          )}
+          <div className="bg-slate-50 dark:bg-slate-900/60 border border-slate-200 dark:border-slate-700 rounded-lg p-3">
+            <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1">
+              Premium collected
+            </p>
+            <p>{built.premium}</p>
+            {built.breakeven && (
+              <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">{built.breakeven}</p>
+            )}
+          </div>
         </div>
+
+        <div>
+          <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wide mb-1.5">
+            Outcome scenarios at expiration
+          </p>
+          <ol className="list-decimal list-outside ml-5 space-y-1.5 text-sm">
+            {built.outcomes.map((o, i) => (
+              <li key={i}>
+                <span className="font-semibold">{o.label}: </span>
+                <span>{o.text}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+
+        {earnings_in_window && (
+          <div
+            data-testid="scanner-strike-row-earnings-flag"
+            className="text-xs bg-yellow-50 dark:bg-yellow-900/30 border border-yellow-200 dark:border-yellow-800 rounded-md px-3 py-2 text-yellow-800 dark:text-yellow-200"
+          >
+            <span className="font-semibold">Earnings within the contract window. </span>
+            Expect larger price swings between now and expiration — the outcome scenarios above
+            can shift quickly. Consider sizing down or skipping this expiration.
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/options/ScannerStrikeRowExpansion.stories.jsx
+++ b/frontend/components/options/ScannerStrikeRowExpansion.stories.jsx
@@ -1,5 +1,3 @@
-// Phase 1.5 mock — placeholder for spec implementation. Replace during Phase 3.
-//
 // Stories for ScannerStrikeRowExpansion (issue #190, Affordance 3).
 // Mirrors the F-position numbers from the spec: 100 shares, $13.21 basis,
 // $0.18 premium, 36 DTE.

--- a/frontend/components/options/StrikeTable.jsx
+++ b/frontend/components/options/StrikeTable.jsx
@@ -1,6 +1,16 @@
 import { useState } from 'react';
+import ScannerColumnHeader from './ScannerColumnHeader';
+import ScannerStrikeRowExpansion from './ScannerStrikeRowExpansion';
+import { SCANNER_COLUMN_TOOLTIPS } from './scannerColumnTooltips';
 
-export default function StrikeTable({ recommendations, selectedStrikes, onToggleSelection, hasCapital = false }) {
+export default function StrikeTable({
+  recommendations,
+  selectedStrikes,
+  onToggleSelection,
+  hasCapital = false,
+  strategy = 'covered_call',
+  costBasis = null,
+}) {
   const [sortField, setSortField] = useState('rank');
   const [sortDir, setSortDir] = useState('asc');
   const [expandedRow, setExpandedRow] = useState(null);
@@ -36,16 +46,16 @@ export default function StrikeTable({ recommendations, selectedStrikes, onToggle
             <tr>
               <th className="px-3 py-2 text-left w-8" />
               <SortHeader field="rank" label="#" sortField={sortField} sortDir={sortDir} onSort={handleSort} align="left" />
-              <SortHeader field="strike" label="Strike" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+              <EduHeader field="strike" label="Strike" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.strike} />
               <SortHeader field="expiration" label="Exp" sortField={sortField} sortDir={sortDir} onSort={handleSort} align="left" />
-              <SortHeader field="dte" label="DTE" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
-              <th className="px-3 py-2 text-right text-xs font-medium text-slate-500 dark:text-slate-400">Bid/Ask</th>
-              <SortHeader field="delta" label="Delta" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
-              <SortHeader field="open_interest" label="OI" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
-              <SortHeader field="total_premium" label="Premium" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
-              <SortHeader field="return_on_capital_pct" label="Return%" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
-              <SortHeader field="annualized_return_pct" label="Ann.%" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
-              <SortHeader field="distance_from_price_pct" label="Dist.%" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
+              <EduHeader field="dte" label="DTE" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.dte} />
+              <BidAskHeader />
+              <EduHeader field="delta" label="Delta" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.delta} />
+              <EduHeader field="open_interest" label="OI" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.open_interest} />
+              <EduHeader field="total_premium" label="Premium" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.total_premium} />
+              <EduHeader field="return_on_capital_pct" label="Return%" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.return_on_capital_pct} />
+              <EduHeader field="annualized_return_pct" label="Ann.%" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.annualized_return_pct} />
+              <EduHeader field="distance_from_price_pct" label="Dist.%" sortField={sortField} sortDir={sortDir} onSort={handleSort} tooltip={SCANNER_COLUMN_TOOLTIPS.distance_from_price_pct} />
               {hasCapital && (
                 <>
                   <SortHeader field="contracts" label="Contracts" sortField={sortField} sortDir={sortDir} onSort={handleSort} />
@@ -111,7 +121,11 @@ export default function StrikeTable({ recommendations, selectedStrikes, onToggle
                   {isExpanded && (
                     <tr>
                       <td colSpan={hasCapital ? 14 : 12} className="px-6 py-4 bg-slate-50 dark:bg-slate-900/50">
-                        <ExpandedDetails strike={s} />
+                        <ExpandedDetails
+                          strike={s}
+                          strategy={strategy}
+                          costBasis={costBasis}
+                        />
                       </td>
                     </tr>
                   )}
@@ -142,52 +156,97 @@ function SortHeader({ field, label, sortField, sortDir, onSort, align = 'right' 
   );
 }
 
-function ExpandedDetails({ strike }) {
+// Sortable column header WITH the educational \u24d8 tooltip. Adapter around the
+// shared ScannerColumnHeader component \u2014 keeps the sort plumbing local to
+// StrikeTable so we don't have to thread sortField/sortDir through every call.
+function EduHeader({ field, label, sortField, sortDir, onSort, tooltip, align = 'right' }) {
   return (
-    <div className="grid grid-cols-3 gap-6 text-sm">
-      <div>
-        <h4 className="font-medium text-slate-900 dark:text-white mb-2">
-          Greeks
-          {strike.greeks_source && strike.greeks_source !== 'market' && (
-            <span className="ml-1.5 text-[10px] font-normal px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400">
-              {strike.greeks_source === 'calculated' ? 'BS calc' : strike.greeks_source}
-            </span>
-          )}
-        </h4>
-        <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
-          <div>Delta: {strike.delta?.toFixed(3) ?? 'N/A'}</div>
-          <div>Gamma: {strike.gamma?.toFixed(4) ?? 'N/A'}</div>
-          <div>Theta: {strike.theta?.toFixed(4) ?? 'N/A'}</div>
-          <div>Vega: {strike.vega?.toFixed(4) ?? 'N/A'}</div>
-          <div>IV: {strike.iv ? (strike.iv * 100).toFixed(1) + '%' : 'N/A'}</div>
-        </div>
-      </div>
-      <div>
-        <h4 className="font-medium text-slate-900 dark:text-white mb-2">Metrics</h4>
-        <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
-          <div>Premium/Contract: ${strike.premium_per_contract.toFixed(2)}</div>
-          <div>Max Profit: ${strike.max_profit.toFixed(2)}</div>
-          {strike.breakeven != null && <div>Breakeven: ${strike.breakeven.toFixed(2)}</div>}
-          {strike.distance_from_basis_pct != null && <div>Dist. from Basis: {strike.distance_from_basis_pct.toFixed(1)}%</div>}
-          <div>50% Target: ${strike.fifty_pct_profit_target.toFixed(2)}</div>
-        </div>
-      </div>
-      <div>
-        <h4 className="font-medium text-slate-900 dark:text-white mb-2">Rule Compliance</h4>
-        <div className="space-y-1 text-xs">
-          <RuleCheck label="10% Rule" passed={strike.rule_compliance.passes_10pct_rule} />
-          <RuleCheck label="DTE Range" passed={strike.rule_compliance.passes_dte_range} />
-          <RuleCheck label="Delta Range" passed={strike.rule_compliance.passes_delta_range} />
-          <RuleCheck label="Earnings Check" passed={strike.rule_compliance.passes_earnings_check} />
-          <RuleCheck label="Return Target" passed={strike.rule_compliance.passes_return_target} />
-        </div>
-        {strike.flags.length > 0 && (
-          <div className="mt-2 text-xs text-yellow-600 dark:text-yellow-400">
-            Flags: {strike.flags.join(', ')}
+    <ScannerColumnHeader
+      field={field}
+      label={label}
+      tooltip={tooltip}
+      active={sortField === field}
+      sortDir={sortDir}
+      onSort={onSort}
+      align={align}
+    />
+  );
+}
+
+// Non-sortable Bid/Ask header with a tooltip. The bid/ask spread isn't a
+// sortable metric (no single numeric column), but it deserves an explainer.
+function BidAskHeader() {
+  return (
+    <ScannerColumnHeader
+      field="bid_ask"
+      label="Bid/Ask"
+      tooltip={SCANNER_COLUMN_TOOLTIPS.bid_ask}
+      align="right"
+    />
+  );
+}
+
+function ExpandedDetails({ strike, strategy = 'covered_call', costBasis = null }) {
+  return (
+    <>
+      <div className="grid grid-cols-3 gap-6 text-sm">
+        <div>
+          <h4 className="font-medium text-slate-900 dark:text-white mb-2">
+            Greeks
+            {strike.greeks_source && strike.greeks_source !== 'market' && (
+              <span className="ml-1.5 text-[10px] font-normal px-1.5 py-0.5 rounded bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400">
+                {strike.greeks_source === 'calculated' ? 'BS calc' : strike.greeks_source}
+              </span>
+            )}
+          </h4>
+          <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
+            <div>Delta: {strike.delta?.toFixed(3) ?? 'N/A'}</div>
+            <div>Gamma: {strike.gamma?.toFixed(4) ?? 'N/A'}</div>
+            <div>Theta: {strike.theta?.toFixed(4) ?? 'N/A'}</div>
+            <div>Vega: {strike.vega?.toFixed(4) ?? 'N/A'}</div>
+            <div>IV: {strike.iv ? (strike.iv * 100).toFixed(1) + '%' : 'N/A'}</div>
           </div>
-        )}
+        </div>
+        <div>
+          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Metrics</h4>
+          <div className="space-y-1 text-xs text-slate-600 dark:text-slate-400">
+            <div>Premium/Contract: ${strike.premium_per_contract.toFixed(2)}</div>
+            <div>Max Profit: ${strike.max_profit.toFixed(2)}</div>
+            {strike.breakeven != null && <div>Breakeven: ${strike.breakeven.toFixed(2)}</div>}
+            {strike.distance_from_basis_pct != null && <div>Dist. from Basis: {strike.distance_from_basis_pct.toFixed(1)}%</div>}
+            <div>50% Target: ${strike.fifty_pct_profit_target.toFixed(2)}</div>
+          </div>
+        </div>
+        <div>
+          <h4 className="font-medium text-slate-900 dark:text-white mb-2">Rule Compliance</h4>
+          <div className="space-y-1 text-xs">
+            <RuleCheck label="10% Rule" passed={strike.rule_compliance.passes_10pct_rule} />
+            <RuleCheck label="DTE Range" passed={strike.rule_compliance.passes_dte_range} />
+            <RuleCheck label="Delta Range" passed={strike.rule_compliance.passes_delta_range} />
+            <RuleCheck label="Earnings Check" passed={strike.rule_compliance.passes_earnings_check} />
+            <RuleCheck label="Return Target" passed={strike.rule_compliance.passes_return_target} />
+          </div>
+          {strike.flags.length > 0 && (
+            <div className="mt-2 text-xs text-yellow-600 dark:text-yellow-400">
+              Flags: {strike.flags.join(', ')}
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+      {/* Plain-English commitment panel — appended below the existing
+          Greeks / Metrics / Rule Compliance grid (spec §4.3). */}
+      <ScannerStrikeRowExpansion
+        strategy={strategy}
+        strike={strike.strike}
+        premium_per_contract={strike.premium_per_contract}
+        breakeven={strike.breakeven}
+        cost_basis_per_share={costBasis}
+        contracts={strike.contracts ?? 1}
+        earnings_in_window={
+          strike.rule_compliance?.passes_earnings_check === false
+        }
+      />
+    </>
   );
 }
 

--- a/frontend/components/options/scannerColumnTooltips.js
+++ b/frontend/components/options/scannerColumnTooltips.js
@@ -1,0 +1,83 @@
+// Canonical column-header tooltip copy for the Options Scanner table.
+//
+// Keyed by the same `field` strings used by StrikeTable's sort handler so
+// the tooltip can be rendered next to the matching column without duplication.
+// Each entry follows the 3-part shape spec'd in
+// `frontend/design-specs/scanner-education-v0.5.7.md` §4.2:
+//   - definition: what the metric measures, in plain English
+//   - range: what's a good number for wheel-style strategies
+//   - whyItMatters: why the trader should care about this column
+//
+// Keep sentences short and clarity-first. No jargon without a translation.
+
+export const SCANNER_COLUMN_TOOLTIPS = {
+  strike: {
+    definition:
+      "The price at which the option contract obligates a transaction at expiration.",
+    range:
+      "For wheel strategies: at or above your cost basis for covered calls (10% rule); at or below current price for cash-secured puts.",
+    whyItMatters:
+      "The strike is the line in the sand — call gets assigned above it, put gets assigned below it.",
+  },
+  dte: {
+    definition: "Days to expiration — calendar days remaining on the contract.",
+    range:
+      "Wheel sweet spot is 25–45 DTE. Shorter = faster theta decay but less premium. Longer = more risk window for assignment.",
+    whyItMatters:
+      "Theta (time decay) accelerates in the last ~30 days. The right DTE balances premium income against tying up capital.",
+  },
+  bid_ask: {
+    definition: "Highest current buy price (bid) and lowest current sell price (ask).",
+    range:
+      "Look for spreads under 5% of the mid-price. Wider spreads cost you on slippage.",
+    whyItMatters:
+      "A wide bid/ask means you give up real money every time you enter or exit. Liquidity matters more than chasing the headline premium.",
+  },
+  delta: {
+    definition:
+      "The option price's sensitivity to a $1 move in the underlying. Roughly the market-implied probability the option ends in the money.",
+    range:
+      "For wheel strategies: 0.20 to 0.35. Lower = safer, less premium. Higher = more income, more assignment risk.",
+    whyItMatters:
+      "Higher delta means more premium but a higher chance of assignment. Stay in your comfort zone.",
+  },
+  open_interest: {
+    definition:
+      "The number of outstanding contracts at this strike that have not been closed or exercised.",
+    range:
+      "Look for 500+ contracts. 100+ is acceptable on less liquid names. Below 50 is usually too thin to trade comfortably.",
+    whyItMatters:
+      "Higher open interest means tighter bid/ask spreads and easier exits. Thin contracts can cost you 5–10% on slippage.",
+  },
+  total_premium: {
+    definition:
+      "The dollar premium per contract — what you receive (for sells) or pay (for buys) for one contract of 100 shares.",
+    range:
+      "Use it alongside Return% and Ann.% — a high-dollar premium can be low-return if the capital tied up is large.",
+    whyItMatters:
+      "This is the actual cash that hits your account. Multiply by contracts to see total income on the trade.",
+  },
+  return_on_capital_pct: {
+    definition: "Premium received divided by the capital required to back the trade.",
+    range:
+      "Target 1% or more per trade. Below 0.5% rarely justifies the assignment risk for short-DTE wheels.",
+    whyItMatters:
+      "Two trades with the same dollar premium can have very different return-on-capital if the strikes are far apart. This normalizes them.",
+  },
+  annualized_return_pct: {
+    definition:
+      "The return on capital scaled to a full year. Lets you compare 7-day premiums against 45-day premiums on equal footing.",
+    range:
+      "Target 20%+ annualized for wheel candidates. Below 15% is rarely worth the assignment risk.",
+    whyItMatters:
+      "A $1 premium on a 7-DTE contract beats a $1.50 premium on 45-DTE every time, once you scale it.",
+  },
+  distance_from_price_pct: {
+    definition:
+      "How far the strike sits above (covered call) or below (cash-secured put) the current underlying price, in percent.",
+    range:
+      "Covered calls: aim for 5–15% above current price. Cash-secured puts: 5–15% below.",
+    whyItMatters:
+      "Distance is your buffer. Bigger buffer = lower assignment risk but also lower premium. This column shows the trade-off directly.",
+  },
+};

--- a/frontend/e2e/scanner-education.spec.js
+++ b/frontend/e2e/scanner-education.spec.js
@@ -1,0 +1,291 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E coverage for #190 — Options Scanner education layer (Phase A).
+ *
+ * Covers the four affordances locked in
+ * `frontend/design-specs/scanner-education-v0.5.7.md`:
+ *   1. Strategy primer (top-of-page, collapsed-by-default, localStorage-persisted)
+ *   2. Column header tooltips (dedicated ⓘ icon, opens on click, closes on Escape)
+ *   3. Per-row expansion ("What this trade commits you to" panel)
+ *   4. Humanized rejected strikes (bulleted human sentences, neutral slate)
+ */
+
+const SCAN_PAYLOAD = {
+  ticker: 'F',
+  current_price: 13.67,
+  strategy: 'covered_call',
+  scan_time: '2026-05-13T12:00:00Z',
+  earnings_date: null,
+  iv_rank: null,
+  recommendations: [
+    {
+      rank: 1,
+      strike: 15.0,
+      expiration: '2026-06-18',
+      dte: 36,
+      bid: 0.3,
+      ask: 0.33,
+      delta: 0.28,
+      gamma: 0.05,
+      theta: -0.012,
+      vega: 0.08,
+      iv: 0.34,
+      open_interest: 23861,
+      total_premium: 32.0,
+      premium_per_contract: 32.0,
+      return_on_capital_pct: 2.42,
+      annualized_return_pct: 24.6,
+      distance_from_price_pct: 9.7,
+      distance_from_basis_pct: 13.5,
+      breakeven: 12.89,
+      fifty_pct_profit_target: 16.0,
+      max_profit: 32.0,
+      contracts: 1,
+      rule_compliance: {
+        passes_10pct_rule: true,
+        passes_dte_range: true,
+        passes_delta_range: true,
+        passes_earnings_check: true,
+        passes_return_target: true,
+      },
+      flags: [],
+    },
+    {
+      rank: 2,
+      strike: 16.0,
+      expiration: '2026-06-18',
+      dte: 36,
+      bid: 0.16,
+      ask: 0.19,
+      delta: 0.17,
+      gamma: 0.04,
+      theta: -0.008,
+      vega: 0.07,
+      iv: 0.32,
+      open_interest: 11692,
+      total_premium: 18.0,
+      premium_per_contract: 18.0,
+      return_on_capital_pct: 1.36,
+      annualized_return_pct: 13.8,
+      distance_from_price_pct: 17.0,
+      distance_from_basis_pct: 21.1,
+      breakeven: 13.03,
+      fifty_pct_profit_target: 9.0,
+      max_profit: 18.0,
+      contracts: 1,
+      rule_compliance: {
+        passes_10pct_rule: true,
+        passes_dte_range: true,
+        passes_delta_range: true,
+        passes_earnings_check: true,
+        passes_return_target: true,
+      },
+      flags: [],
+    },
+  ],
+  rejected: [
+    {
+      strike: 12.5,
+      expiration: '2026-06-18',
+      rejection_reasons: ['fails_10pct_rule: strike -5.4% above basis, requires 10.0%'],
+      human_reasons: [
+        'Strike sits -5.4% above your $13.21 basis, but the 10.0% rule requires at least that much room.',
+      ],
+    },
+    {
+      strike: 16.0,
+      expiration: '2026-07-16',
+      rejection_reasons: [
+        'delta_out_of_range: |0.42| not in [0.15, 0.35]',
+        'low_open_interest: 12 < 50',
+      ],
+      human_reasons: [
+        'Delta +0.42 is outside your 0.15–0.35 range — too close to the money, higher chance of assignment than you have set as acceptable.',
+        'Only 12 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+      ],
+    },
+  ],
+  market_context: {},
+};
+
+function setupMocks(page) {
+  return Promise.all([
+    page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ configured: true, valid: true, error: null, token_expiry: null }),
+      })
+    ),
+    page.route('**/api/options/scan', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SCAN_PAYLOAD),
+      })
+    ),
+  ]);
+}
+
+// Clear localStorage once at the start of each test so primer state is
+// deterministic. NOTE: don't use `context.addInitScript` — that would re-run
+// on every navigation (including `page.reload()`) and wipe state mid-test,
+// which defeats the persistence-across-reload assertion below.
+async function clearScannerStorage(page) {
+  await page.goto('/options');
+  await page.evaluate(() => {
+    try {
+      window.localStorage.removeItem('scanner-primer-collapsed-cc');
+      window.localStorage.removeItem('scanner-primer-collapsed-csp');
+    } catch {
+      // ignore
+    }
+  });
+}
+
+test.describe('Scanner education — strategy primer', () => {
+  test('renders collapsed by default and toggles on click', async ({ page }) => {
+    await setupMocks(page);
+    await clearScannerStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
+    await page.waitForLoadState('networkidle');
+
+    const primer = page.getByTestId('scanner-strategy-primer');
+    await expect(primer).toBeVisible();
+
+    // Body should be hidden initially.
+    await expect(page.getByTestId('scanner-strategy-primer-body')).toHaveCount(0);
+
+    // Click the toggle — body appears with the covered-call copy.
+    await page.getByTestId('scanner-strategy-primer-toggle').click();
+    const body = page.getByTestId('scanner-strategy-primer-body');
+    await expect(body).toBeVisible();
+    await expect(body).toContainText('You own 100+ shares');
+  });
+
+  test('persists expanded state across reload (per strategy)', async ({ page }) => {
+    await setupMocks(page);
+    await clearScannerStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('scanner-strategy-primer-toggle').click();
+    await expect(page.getByTestId('scanner-strategy-primer-body')).toBeVisible();
+
+    // Reload — expanded state persists for CC.
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('scanner-strategy-primer-body')).toBeVisible();
+  });
+
+  test('CC and CSP primers have independent collapse state', async ({ page }) => {
+    await setupMocks(page);
+    await clearScannerStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call');
+    await page.waitForLoadState('networkidle');
+
+    // Expand the CC primer.
+    await page.getByTestId('scanner-strategy-primer-toggle').click();
+    await expect(page.getByTestId('scanner-strategy-primer-body')).toBeVisible();
+
+    // Toggle strategy to CSP via the filter button — CSP primer should be
+    // collapsed (its own localStorage key is untouched).
+    await page.getByRole('button', { name: 'Cash-Secured Put' }).click();
+    await expect(page.getByTestId('scanner-strategy-primer-body')).toHaveCount(0);
+    await expect(page.getByTestId('scanner-strategy-primer')).toHaveAttribute('data-strategy', 'csp');
+  });
+});
+
+test.describe('Scanner education — column tooltips', () => {
+  test('clicking ⓘ opens a 3-part tooltip; Escape closes it', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
+    await page.waitForLoadState('networkidle');
+
+    // Trigger a scan so the table (with column headers) renders.
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await expect(page.getByTestId('strike-table')).toBeVisible();
+
+    const deltaInfo = page.getByTestId('scanner-col-info-delta');
+    await expect(deltaInfo).toBeVisible();
+
+    // Tooltip closed initially.
+    await expect(page.getByTestId('scanner-col-tooltip-delta')).toHaveCount(0);
+
+    // Open by clicking.
+    await deltaInfo.click();
+    const tooltip = page.getByTestId('scanner-col-tooltip-delta');
+    await expect(tooltip).toBeVisible();
+    await expect(tooltip).toContainText('sensitivity to a $1 move');
+    await expect(tooltip).toContainText('0.20 to 0.35');
+    await expect(tooltip).toContainText('Stay in your comfort zone');
+
+    // Escape closes.
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('scanner-col-tooltip-delta')).toHaveCount(0);
+  });
+
+  test('clicking the column label still triggers sort (independent of tooltip)', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await expect(page.getByTestId('strike-table')).toBeVisible();
+
+    // Sort by Delta — clicking the sort button should not open the tooltip.
+    await page.getByTestId('scanner-col-sort-delta').click();
+    await expect(page.getByTestId('scanner-col-tooltip-delta')).toHaveCount(0);
+  });
+});
+
+test.describe('Scanner education — per-row expansion', () => {
+  test('expanding a row reveals the "What this trade commits you to" panel', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+
+    const table = page.getByTestId('strike-table');
+    await expect(table).toBeVisible();
+
+    // Commitment panel not visible while collapsed.
+    await expect(page.getByTestId('scanner-strike-row-commitment')).toHaveCount(0);
+
+    // Click the first row to expand.
+    await table.locator('tbody tr').first().click();
+
+    const commitment = page.getByTestId('scanner-strike-row-commitment');
+    await expect(commitment).toBeVisible();
+    await expect(commitment).toContainText('What this trade commits you to');
+    // Outcome scenarios at expiration:
+    await expect(commitment).toContainText('Stock stays below the strike');
+    await expect(commitment).toContainText('Stock closes above the strike');
+  });
+});
+
+test.describe('Scanner education — humanized rejected strikes', () => {
+  test('renders human sentences from the backend, not raw codes', async ({ page }) => {
+    await setupMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+
+    const disclosure = page.getByTestId('scanner-rejected-strikes');
+    await expect(disclosure).toBeVisible();
+
+    // Open the disclosure.
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Human sentence visible.
+    await expect(disclosure).toContainText(
+      'Strike sits -5.4% above your $13.21 basis'
+    );
+    await expect(disclosure).toContainText('Only 12 contracts open');
+
+    // Raw machine code NOT visible to the user.
+    await expect(disclosure).not.toContainText('fails_10pct_rule:');
+    await expect(disclosure).not.toContainText('delta_out_of_range:');
+    await expect(disclosure).not.toContainText('low_open_interest:');
+  });
+});


### PR DESCRIPTION
## Summary

Phase A of the Options Scanner education layer — turning the scanner results table into a learning surface for users learning covered-calls and cash-secured-puts. Closes #190.

Four production affordances replace the Phase 1.5 mock components:

1. **Strategy primer card** — collapsible introductory card per strategy (CC / CSP) with persisted localStorage state (`scanner-primer-collapsed-cc` / `-csp`).
2. **Column tooltips** — 9 column headers explain what each metric means and why it matters; built on shared `scannerColumnTooltips.js`.
3. **Expandable row commitment panel** — each strike row expands to show the trade obligation, premium, breakeven, and outcome scenarios in plain language.
4. **Humanized rejected strikes** — the rejected-strikes drawer surfaces human-readable reasons sourced from a new backend `rejection_messages.py` mapper (7 reason codes, ARIA-described).

## File-level diff scope

**Backend**
- `backend/app/services/rejection_messages.py` — new mapper covering 7 rejection codes
- `backend/app/services/options_scanner.py` — populate `human_reasons` at 3 construction sites
- `backend/app/models/schemas.py` — add `human_reasons` to `RejectedStrike`

**Frontend (wiring)**
- `frontend/components/options/OptionScanner.jsx`
- `frontend/components/options/StrikeTable.jsx`

**Frontend (production components — replacing Phase 1.5 mocks)**
- `ScannerStrategyPrimer.jsx`
- `ScannerColumnHeader.jsx`
- `ScannerStrikeRowExpansion.jsx`
- `ScannerRejectedStrikes.jsx`
- `scannerColumnTooltips.js` (shared tooltip module)

**Tests**
- `backend/tests/test_rejection_messages.py` — 21 new tests
- `backend/tests/test_options_scanner.py` — updated for `human_reasons` propagation
- `frontend/e2e/scanner-education.spec.js` — 7 Playwright cases

**Storybook** — stories updated to reflect production APIs.

## Test results (at HEAD `1b3e4b6`)

- Backend pytest: **847 passed, 8 skipped**
- Playwright (full suite): **191 passed**
- Frontend lint: green (1 pre-existing `<img>` warning untouched)
- Storybook build: green

## Known minor issues — filed as follow-ups (do NOT block this PR)

These are Nice-to-Have items flagged during code review. Tracked separately for V0.7.x triage:

1. `earnings_in_window` rendering path is currently unreachable in production (backend filters earnings-window expirations entirely before scoring). Either re-add the warning path with a real signal or remove the dead branch.
2. Spec §7 listed per-block test IDs on the row expansion (`trade-explanation-obligation`, `-premium`, `-breakeven`, `-outcome-*`); implementation uses `scanner-strike-row-commitment` instead. E2e tests are aligned with the implementation. Either backfill granular IDs or update the spec.
3. Spec §3.3 said `Contracts` and `Max Income` columns should also get tooltips when capital-aware mode is on. They currently use plain `SortHeader`.
4. Spec §3.3 said the `Strike` column wouldn't get a tooltip; implementation added one. Minor spec drift.

## Operator notes

- No data migration required.
- No breaking changes.
- New localStorage keys (`scanner-primer-collapsed-cc`, `scanner-primer-collapsed-csp`) — harmless if not present.

Closes #190.