### PR TITLE
Add scope=readonly to Schwab OAuth authorize URL (closes #125)

### DIFF
--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -13,6 +13,7 @@ import httpx
 
 from app.services.schwab_auth import (
     SCHWAB_AUTHORIZE_URL,
+    SCHWAB_OAUTH_SCOPE,
     SCHWAB_REDIRECT_URI,
     SCHWAB_TOKEN_URL,
     _upsert_setting,
@@ -38,6 +39,7 @@ def schwab_auth(args):
         f"{SCHWAB_AUTHORIZE_URL}"
         f"?response_type=code"
         f"&client_id={app_key}"
+        f"&scope={SCHWAB_OAUTH_SCOPE}"
         f"&redirect_uri={quote(SCHWAB_REDIRECT_URI, safe='')}"
     )
 
@@ -88,6 +90,8 @@ def schwab_auth(args):
     if "access_token" not in token_data or "refresh_token" not in token_data:
         print("Error: Unexpected token response format. Missing required fields.", file=sys.stderr)
         sys.exit(1)
+
+    print(f"Schwab granted scope: {token_data.get('scope', '(none returned)')}")
 
     now = datetime.now(timezone.utc)
     access_expires = now.replace(microsecond=0) + timedelta(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,8 +11,6 @@ class Settings(BaseSettings):
     slack_webhook_url: str = ""
     schwab_encryption_key: str = ""
     nextauth_secret: Optional[str] = None
-    github_id: str = ""
-    github_secret: str = ""
     allowed_users: str = ""
     database_url: str = "sqlite:///./regression_tool.db"
     cache_ttl_daily_hours: int = 24

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,6 +11,8 @@ class Settings(BaseSettings):
     slack_webhook_url: str = ""
     schwab_encryption_key: str = ""
     nextauth_secret: Optional[str] = None
+    github_id: str = ""
+    github_secret: str = ""
     allowed_users: str = ""
     database_url: str = "sqlite:///./regression_tool.db"
     cache_ttl_daily_hours: int = 24

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, text
 from app.config import settings, get_fred_api_key
 from app.services.schwab_auth import (
     SCHWAB_AUTHORIZE_URL,
+    SCHWAB_OAUTH_SCOPE,
     SCHWAB_REDIRECT_URI,
     SCHWAB_TOKEN_URL,
     SchwabTokenManager,
@@ -175,6 +176,7 @@ def get_schwab_auth_url(req: SchwabAuthUrlRequest):
         f"{SCHWAB_AUTHORIZE_URL}"
         f"?response_type=code"
         f"&client_id={quote(req.app_key.strip(), safe='')}"
+        f"&scope={SCHWAB_OAUTH_SCOPE}"
         f"&redirect_uri={quote(SCHWAB_REDIRECT_URI, safe='')}"
     )
     return {"auth_url": auth_url, "redirect_uri": SCHWAB_REDIRECT_URI}
@@ -227,6 +229,7 @@ def exchange_schwab_callback(req: SchwabCallbackRequest, db: DBSession = Depends
             content={"detail": "Unexpected response from Schwab. Missing token fields."},
         )
 
+    logger.info("Schwab granted scope: %s", token_data.get("scope", "(none returned)"))
     result = store_schwab_tokens(db, app_key, app_secret, token_data)
     return {"status": "ok", **result}
 

--- a/backend/app/services/schwab_auth.py
+++ b/backend/app/services/schwab_auth.py
@@ -21,6 +21,10 @@ logger = logging.getLogger(__name__)
 SCHWAB_TOKEN_URL = "https://api.schwabapi.com/v1/oauth/token"
 SCHWAB_AUTHORIZE_URL = "https://api.schwabapi.com/v1/oauth/authorize"
 SCHWAB_REDIRECT_URI = "https://127.0.0.1:8089/callback"
+# Per Schwab's Swagger UI for /trader/v1/accounts/{hash}/transactions, the OAuth
+# grant must declare scope=readonly. Without it, /transactions silently returns
+# 200 + [] while /accounts continues to work. See issue #125.
+SCHWAB_OAUTH_SCOPE = "readonly"
 
 # Refresh access token when it expires within this many seconds
 ACCESS_TOKEN_REFRESH_BUFFER_SECONDS = 120
@@ -230,7 +234,11 @@ class SchwabTokenManager:
         self._cached_access_token = token_data["access_token"]
         self._cached_access_token_expires = access_expires
 
-        logger.info("Schwab tokens refreshed, access expires %s", access_expires.isoformat())
+        logger.info(
+            "Schwab tokens refreshed, access expires %s, scope=%s",
+            access_expires.isoformat(),
+            token_data.get("scope", "(none returned)"),
+        )
 
 
 def _read_setting(db, key: str) -> str | None:

--- a/backend/tests/test_schwab_settings_auth.py
+++ b/backend/tests/test_schwab_settings_auth.py
@@ -20,6 +20,15 @@ class TestSchwabAuthUrl:
         resp = client.post("/api/settings/schwab/auth-url", json={"app_key": "  "})
         assert resp.status_code == 422
 
+    def test_auth_url_includes_readonly_scope(self, client):
+        # Regression for #125: Schwab's /trader/v1/accounts/{hash}/transactions
+        # endpoint silently returns 200 + [] when the OAuth grant lacks scope.
+        # Schwab's own Swagger UI documents scope=readonly as required for the
+        # transactions endpoint.
+        resp = client.post("/api/settings/schwab/auth-url", json={"app_key": "k"})
+        assert resp.status_code == 200
+        assert "scope=readonly" in resp.json()["auth_url"]
+
 
 def _mock_token_response():
     mock = MagicMock()


### PR DESCRIPTION
## Summary

Closes #125. Schwab's Trader API `/accounts/{hash}/transactions` endpoint silently returns `200 + []` when the OAuth grant lacks the `readonly` scope, while the same token continues to read `/accounts` successfully — explaining the week-long "0 trades found" symptom in #125 that survived every other fix attempt.

Schwab's own Swagger UI for the Transactions endpoint shows `scope=readonly` is the documented authorize-URL parameter required for this endpoint. Our code wasn't sending any `scope` param. The two popular third-party libraries (`schwab-py`, `schwabdev`) also omit scope and "work for some users" — likely because their users' apps default to a permissive scope at the dev-portal level. Schwab's published docs are authoritative.

## What changed

- New constant `SCHWAB_OAUTH_SCOPE = "readonly"` in `backend/app/services/schwab_auth.py`
- Append `&scope=readonly` to both authorize URLs:
  - `backend/app/cli.py` (CLI `python -m app.cli schwab-auth` flow)
  - `backend/app/routers/settings.py` (Settings UI `POST /api/settings/schwab/auth-url`)
- Surface `token_data.get("scope")` at all three token-handling sites (CLI exchange via `print`, Settings callback via `logger.info`, refresh via `logger.info`) so the next re-auth confirms what Schwab actually granted — closing the visibility gap that let this hypothesis sit untested for a week
- Regression test in `backend/tests/test_schwab_settings_auth.py` asserts `scope=readonly` appears in the auth-url response

The token-refresh request body intentionally does **not** resend `scope` — per OAuth 2.0 §6, the server uses the originally granted scope when omitted, which is the desired behavior.

## Post-merge: deployment + validation (owner-driven)

This is the critical part — the local backend can't validate the fix because the user's actual Schwab data lives on the deployed instance at `regression.shawnjsandy.com`.

After merge:

1. SSH to the VPS, run `bash deploy/update.sh` (git pulls main, rebuilds containers, restarts)
2. Open `regression.shawnjsandy.com` → Settings → Schwab → Authorize
3. Walk the browser OAuth flow, paste callback URL back
4. **Check the production backend log** for the new line `Schwab granted scope: readonly`
5. Open Import from Schwab, try a 90-day window

**Three possible outcomes:**

- ✅ **Trades return.** This was the bug. Close #125. The `types`/`scope` items in the original `Code follow-ups` list become done.
- 🟡 **Still 0 trades, but log shows `Schwab granted scope: readonly`.** Scope is honored but it's not the gate. Escalate to Schwab dev-support — but with stronger evidence than the 2026-05-07 diagnostic had.
- ❌ **OAuth flow itself breaks** (Schwab rejects new URL). Unlikely since `scope=readonly` is in Schwab's own docs, but if so the production log will tell us why.

Existing tokens on the deployed instance are tied to the original scope-less grant and won't pick up the new scope on refresh — full re-authorization is required after the deploy.

## Test plan

- [x] Unit test: `pytest tests/test_schwab_settings_auth.py::TestSchwabAuthUrl::test_auth_url_includes_readonly_scope` (added in this PR)
- [ ] **Manual (deployed, owner-driven):** re-authorize on `regression.shawnjsandy.com` and confirm the production log line `Schwab granted scope: readonly`
- [ ] **Manual (deployed, owner-driven):** trigger import from Schwab with a 90-day window and confirm trades return
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)