### PR TITLE
Lower Schwab token-expiring threshold below the token lifetime (closes #204)

### DIFF
--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -31,9 +31,10 @@ from urllib.parse import quote
 MAX_ACTIONS = 8
 
 # How soon a Schwab refresh-token expiry should trigger a P1 warning
-# action. Aligns with the 7-day token lifetime documented in
-# ``schwab_auth.py``.
-TOKEN_EXPIRING_DAYS = 7
+# action. Schwab refresh tokens last 7 days from issuance, so a 7-day
+# threshold would fire immediately after every re-auth and never clear.
+# Mirrors the 48-hour log threshold in ``schwab_auth.py:_refresh_tokens``.
+TOKEN_EXPIRING_DAYS = 2
 
 # Large-loser thresholds (spec §2.2 / Q1). Whichever fires first.
 LARGE_LOSER_PCT_THRESHOLD = -0.05  # -5%
@@ -191,7 +192,7 @@ def _cache_very_stale_action(cache_status: dict) -> dict | None:
 def _schwab_token_expiring_action(
     schwab_status: dict, now: datetime | None = None
 ) -> dict | None:
-    """Build a ``data.schwab_token_expiring`` card when expiry is < 7 days."""
+    """Build a ``data.schwab_token_expiring`` card when expiry is within ``TOKEN_EXPIRING_DAYS``."""
     if schwab_status.get("configured") is not True or schwab_status.get("valid") is False:
         # Disconnected cases are handled by the P0 card above; don't
         # double-emit.
@@ -206,7 +207,7 @@ def _schwab_token_expiring_action(
         # Already expired — `data.schwab_disconnected` handles that case
         # via `valid == False`; this builder is for soon-to-expire only.
         return None
-    if delta.days > TOKEN_EXPIRING_DAYS:
+    if delta.total_seconds() > TOKEN_EXPIRING_DAYS * 86400:
         return None
     days = max(delta.days, 0)
     when = "today" if days == 0 else f"in {days} day{'s' if days != 1 else ''}"

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -164,8 +164,8 @@ class TestCacheVeryStaleTrigger:
 
 
 class TestSchwabTokenExpiringTrigger:
-    def test_emits_within_seven_days(self):
-        soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+    def test_emits_when_within_threshold(self):
+        soon = (datetime.now(timezone.utc) + timedelta(hours=12)).isoformat()
         actions = compute_next_actions(
             status=_status(schwab_expires_at=soon),
             kpis=_kpis(open_legs=1),
@@ -175,7 +175,7 @@ class TestSchwabTokenExpiringTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_token_expiring" in ids
 
-    def test_does_not_emit_when_more_than_seven_days(self):
+    def test_does_not_emit_when_far_from_expiry(self):
         far = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
         actions = compute_next_actions(
             status=_status(schwab_expires_at=far),
@@ -186,10 +186,27 @@ class TestSchwabTokenExpiringTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_token_expiring" not in ids
 
+    def test_does_not_emit_immediately_after_fresh_seven_day_grant(self):
+        # Regression: Schwab refresh tokens last exactly 7 days. A 7-day
+        # threshold here caused the P1 "Renew Schwab token" card to fire
+        # right after every re-auth, displaying "in 6 days" because
+        # ``delta.days`` floor-truncates. The threshold lives in
+        # ``TOKEN_EXPIRING_DAYS`` and must be strictly below the token
+        # lifetime so fresh grants are silent.
+        fresh = (datetime.now(timezone.utc) + timedelta(days=7)).isoformat()
+        actions = compute_next_actions(
+            status=_status(schwab_expires_at=fresh),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "data.schwab_token_expiring" not in ids
+
     def test_does_not_emit_when_disconnected(self):
         # Disconnected case is handled by `data.schwab_disconnected`. No
         # double-emit when both conditions hold.
-        soon = (datetime.now(timezone.utc) + timedelta(days=2)).isoformat()
+        soon = (datetime.now(timezone.utc) + timedelta(hours=12)).isoformat()
         actions = compute_next_actions(
             status=_status(schwab_configured=False, schwab_expires_at=soon),
             kpis=_kpis(open_legs=1),

--- a/frontend/components/dashboard/DataReadinessBanner.jsx
+++ b/frontend/components/dashboard/DataReadinessBanner.jsx
@@ -13,7 +13,7 @@ import { refreshStaleCache } from '../../api/client';
  *
  *   1. error — Schwab not configured / token invalid           (red)
  *   2. error — Cache very-stale > 0                            (red)
- *   3. warn  — Schwab token expiring within 7 days             (yellow)
+ *   3. warn  — Schwab token expiring within 2 days             (yellow)
  *   4. warn  — Cache stale > 0                                 (yellow)
  *   5. ok    — banner hidden
  *
@@ -24,7 +24,10 @@ import { refreshStaleCache } from '../../api/client';
  * banner if the underlying condition still holds (spec §14.1).
  */
 
-const TOKEN_EXPIRING_DAYS = 7;
+// Schwab refresh tokens last 7 days from issuance. A 7-day threshold would
+// fire on every re-auth and never clear; 2 days mirrors the 48-hour log
+// threshold in `backend/app/services/schwab_auth.py:_refresh_tokens`.
+const TOKEN_EXPIRING_DAYS = 2;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
 function tokenExpiresSoon(expiresAt) {
@@ -75,7 +78,7 @@ function resolveBannerCondition(status) {
     };
   }
 
-  // 3) Schwab token expiring within 7 days → warn
+  // 3) Schwab token expiring within 2 days → warn
   if (tokenExpiresSoon(schwab.expires_at)) {
     return {
       severity: 'warn',

--- a/frontend/e2e/dashboard-readiness-banner.spec.js
+++ b/frontend/e2e/dashboard-readiness-banner.spec.js
@@ -130,12 +130,12 @@ test.describe('DataReadinessBanner', () => {
   });
 
   test('cache very-stale renders as error (red) over schwab expiring (warn)', async ({ page }) => {
-    // Token expiring < 7 days (warn) + cache very_stale (error) → error wins.
-    const tomorrow = new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString();
+    // Token expiring < 2 days (warn) + cache very_stale (error) → error wins.
+    const soon = new Date(Date.now() + 12 * 60 * 60 * 1000).toISOString();
     await mockDashboard(
       page,
       withStatus(BASE_PAYLOAD, {
-        schwab: { configured: true, valid: true, expires_at: tomorrow },
+        schwab: { configured: true, valid: true, expires_at: soon },
         cache: { fresh: 5, stale: 0, very_stale: 2, total: 7 },
       })
     );
@@ -145,6 +145,23 @@ test.describe('DataReadinessBanner', () => {
     const banner = page.getByTestId('data-readiness-banner');
     await expect(banner).toHaveAttribute('data-severity', 'error');
     await expect(banner).toContainText('very stale');
+  });
+
+  test('warn banner is hidden for a fresh 7-day Schwab token', async ({ page }) => {
+    // Regression: Schwab refresh tokens last 7 days from issuance, so the
+    // banner must stay silent immediately after re-auth. Previously the
+    // threshold matched the lifetime and fired permanently.
+    const sevenDays = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    await mockDashboard(
+      page,
+      withStatus(BASE_PAYLOAD, {
+        schwab: { configured: true, valid: true, expires_at: sevenDays },
+      })
+    );
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('data-readiness-banner')).toHaveCount(0);
   });
 
   test('FRED missing does NOT surface on the dashboard banner', async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #204. Both `TOKEN_EXPIRING_DAYS` constants were set to **7**, which equals the Schwab refresh-token lifetime (`schwab_auth.py:_refresh_tokens` issues 7-day tokens). The result: the yellow "Schwab token expiring" banner and the P1 "Renew Schwab token" Next Action card fired immediately after every re-auth and never cleared — falsely advertising urgency for the entire session.

Discovered while validating the v0.5.7.1 deploy of #125 — the re-auth path put the dashboard in front of the user with a freshly-minted 7-day token, exposing this latent bug.

## Root cause

Two surfaces, both with `TOKEN_EXPIRING_DAYS = 7`:

- `backend/app/services/action_engine.py:36` — emits the P1 card. `delta.days > 7` returns `None`; for a fresh 7-day token `delta` is ~6d 23h 59m so `delta.days == 6` and the card always emits. Display reads "in 6 days" because `delta.days` floor-truncates.
- `frontend/components/dashboard/DataReadinessBanner.jsx:27` — controls the yellow banner. `diffMs <= 7 * MS_PER_DAY` is always true for a fresh token.

The backend service already used a **48-hour** threshold for its log-warning (`schwab_auth.py:171`), so the surfaces were internally inconsistent with the service layer.

## What changed

- Both `TOKEN_EXPIRING_DAYS` constants lowered from `7` to `2` (matches the 48-hour service-layer threshold).
- Backend threshold check switched from `delta.days > N` to `delta.total_seconds() > N * 86400` — avoids the `timedelta.days` truncation surprise and makes "2 days" actually mean 48 hours.
- **New regression test (backend):** `test_does_not_emit_immediately_after_fresh_seven_day_grant` simulates a fresh 7-day expiry and asserts the card is silent.
- **New regression test (frontend Playwright):** `warn banner is hidden for a fresh 7-day Schwab token` does the same for the banner.
- Renamed existing tests that referenced the old "seven days" framing.
- Existing `cache very-stale outranks schwab expiring` test now uses a 12h delta so it's unambiguously inside the new threshold.

## What didn't change

- `StatusStrip.jsx` "Schwab token expiring" pill is driven by `schwab.valid` (not a threshold) — unaffected.
- The dashboard's local design-spec markdown (`frontend/design-specs/decision-dashboard-v05.md`) is untracked, so the "within 7 days" wording fix in my working copy is not in this PR. Bug #204 captures the spec discrepancy.

## Test plan

- [x] Backend: `pytest tests/test_action_engine.py tests/test_integration_dashboard.py` — 50 passed, 1 skipped locally
- [x] Backend: the new regression test asserts a fresh 7-day token does NOT emit the card
- [ ] Frontend: Playwright `dashboard-readiness-banner.spec.js` (will run in CI)
- [ ] CI green
- [ ] **Manual (deployed):** reload dashboard on `regression.shawnjsandy.com` after merge+deploy — confirm the yellow banner and the "Renew Schwab token" P1 card both disappear (Schwab token was re-authed ~14:58 today, expires 2026-05-21 14:58 — currently well outside the new 2-day window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)