### PR TITLE
V0.5.8: Recovery Plan engine + recommendation layer (closes #182)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.config import settings as app_settings
 from app.logging_config import setup_logging
 from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
-from app.routers import assets, dashboard, data, health, journal, options, regression, sessions, settings
+from app.routers import assets, dashboard, data, health, journal, options, positions, regression, sessions, settings
 from app.services.backup import create_backup
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher, DataFetchError, InvalidTickerError, DataAlignmentError
@@ -164,6 +164,7 @@ app.include_router(settings.router, dependencies=[Depends(get_current_user)])
 app.include_router(options.router, dependencies=[Depends(get_current_user)])
 app.include_router(journal.router, dependencies=[Depends(get_current_user)])
 app.include_router(dashboard.router, dependencies=[Depends(get_current_user)])
+app.include_router(positions.router, dependencies=[Depends(get_current_user)])
 
 
 # --- Exception handlers ---

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -760,3 +760,149 @@ class DashboardResponse(BaseModel):
     # New in V0.5.4 — server-side ranked action engine output. See
     # decision-dashboard-v05.md §2.2 / §14.7.
     next_actions: list[DashboardNextAction] = []
+
+
+# --- Recovery Plan (V0.5.8, issue #182) ---
+
+RECOVERY_PLAN_STATE = Literal["populated", "not-applicable", "not-flagged"]
+RECOVERY_PATH_SLUG = Literal[
+    "sell-redeploy",
+    "wheel-cc",
+    "average-down",
+    "hold-monitor",
+]
+RECOVERY_PATH_ELIGIBILITY = Literal["eligible", "suppressed"]
+RECOVERY_SCORING_CRITERION = Literal[
+    "fastest_breakeven",
+    "lowest_additional_capital",
+    "lowest_opportunity_cost",
+    "strategy_preference_bonus",
+]
+
+
+class RecoveryMonthsRange(BaseModel):
+    """Three-point breakeven uncertainty range emitted per path.
+
+    Every component may be ``None`` (e.g. hold-monitor has no breakeven
+    because it takes no action).
+    """
+
+    best: Optional[float] = None
+    expected: Optional[float] = None
+    worst: Optional[float] = None
+
+
+class RecoveryPath(BaseModel):
+    """One forward path the engine emits for an underwater position.
+
+    Suppressed paths remain in ``paths[]`` but are never selected as the
+    recommended path. Frontend renders them with a de-emphasized treatment.
+    """
+
+    path_id: RECOVERY_PATH_SLUG
+    label: str
+    eligibility: RECOVERY_PATH_ELIGIBILITY
+    suppression_reason: Optional[str] = None
+    capital_tied_up: Optional[float] = None
+    months_to_breakeven: RecoveryMonthsRange
+    opportunity_cost_vs_baseline: Optional[float] = None
+    assumptions: list[str] = Field(default_factory=list)
+    # V0.6 (#181) fills this slot; reserved as None in V0.5.8.
+    narration: Optional[str] = None
+
+
+class RecoveryPositionSummary(BaseModel):
+    """Header summary the page chrome renders above the comparison cards."""
+
+    id: str
+    ticker: str
+    shares: int
+    adjusted_cost_basis: float
+    current_price: Optional[float] = None
+    unrealized_pl: Optional[float] = None
+    pl_pct: Optional[float] = None
+
+
+class RecoveryOkrInputs(BaseModel):
+    """Snapshot of OKR settings consumed by the engine + scoring layer."""
+
+    target_yield: Optional[float] = None
+    sizing_cap_dollars: Optional[float] = None
+    strategy_preference: Optional[str] = None
+
+
+class RecoveryInputs(BaseModel):
+    """Echo of the deterministic inputs that drove the response."""
+
+    current_price: Optional[float] = None
+    cost_basis: Optional[float] = None
+    shares: int
+    okr: RecoveryOkrInputs
+
+
+class RecoveryPathScoreCell(BaseModel):
+    """One cell in the criterion × eligible-path matrix."""
+
+    path_id: RECOVERY_PATH_SLUG
+    raw_value: Optional[float] = None
+    points: int
+    rank: int
+
+
+class RecoveryPathScoreRow(BaseModel):
+    """One criterion row in the scoring matrix (one entry per criterion)."""
+
+    criterion: RECOVERY_SCORING_CRITERION
+    weight: int
+    ranking: list[RecoveryPathScoreCell] = Field(default_factory=list)
+
+
+class RecoveryRankedPath(BaseModel):
+    """One entry in the recommendation's total-ranking list.
+
+    Suppressed paths have ``score`` and ``rank`` of ``None`` and carry the
+    ``suppression_reason`` straight from the engine.
+    """
+
+    path_id: RECOVERY_PATH_SLUG
+    score: Optional[int] = None
+    rank: Optional[int] = None
+    suppression_reason: Optional[str] = None
+
+
+class RecoveryRecommendation(BaseModel):
+    """Deterministic recommendation object layered on top of the path list."""
+
+    recommended_path_id: Optional[RECOVERY_PATH_SLUG] = None
+    recommendation_label: str
+    recommendation_reasons: list[str] = Field(default_factory=list)
+    ranked_paths: list[RecoveryRankedPath] = Field(default_factory=list)
+    path_scores: list[RecoveryPathScoreRow] = Field(default_factory=list)
+    tie_epsilon: float = 1.0
+    disclaimer: str
+
+
+class RecoveryAssumptionRow(BaseModel):
+    """One row in the Assumptions panel (audit surface)."""
+
+    label: str
+    value: str
+    source: str
+
+
+class RecoveryPlanResponse(BaseModel):
+    """Top-level response for ``POST /api/positions/{id}/recovery-plan``.
+
+    ``state == "populated"`` is the only state that carries paths +
+    recommendation. The other two short-circuit before the engine runs.
+    """
+
+    position_id: str
+    as_of: str
+    state: RECOVERY_PLAN_STATE
+    position: Optional[RecoveryPositionSummary] = None
+    inputs: Optional[RecoveryInputs] = None
+    paths: list[RecoveryPath] = Field(default_factory=list)
+    recommendation: Optional[RecoveryRecommendation] = None
+    assumptions: list[RecoveryAssumptionRow] = Field(default_factory=list)
+    disclaimer: Optional[str] = None

--- a/backend/app/routers/positions.py
+++ b/backend/app/routers/positions.py
@@ -103,14 +103,32 @@ def _read_okr_settings(db: DBSession) -> dict[str, Any]:
     }
 
 
-def _build_position_summary(position: dict, current_price: float | None) -> dict:
-    """Compute the header summary the frontend renders above the cards."""
+def _build_position_summary(
+    position: dict,
+    current_price: float | None,
+    *,
+    cost_basis: float | None = None,
+) -> dict:
+    """Compute the header summary the frontend renders above the cards.
+
+    ``cost_basis`` is the effective basis the caller resolved (adjusted
+    basis with a ``broker_cost_basis`` fallback). When omitted, the same
+    fallback is applied here so the P/L math never silently drops to
+    ``None`` for a position that has only a broker basis.
+    """
     shares = int(position.get("shares") or 0)
-    adjusted_basis = float(position.get("adjusted_cost_basis") or 0.0)
+    if cost_basis is not None:
+        effective_basis = float(cost_basis)
+    else:
+        effective_basis = float(
+            position.get("adjusted_cost_basis")
+            or position.get("broker_cost_basis")
+            or 0.0
+        )
     notional = (current_price or 0.0) * shares
-    if shares > 0 and adjusted_basis > 0:
-        unrealized_pl = notional - adjusted_basis
-        pl_pct = unrealized_pl / adjusted_basis
+    if shares > 0 and effective_basis > 0:
+        unrealized_pl = notional - effective_basis
+        pl_pct = unrealized_pl / effective_basis
     else:
         unrealized_pl = None
         pl_pct = None
@@ -118,7 +136,7 @@ def _build_position_summary(position: dict, current_price: float | None) -> dict
         "id": position["id"],
         "ticker": position["ticker"],
         "shares": shares,
-        "adjusted_cost_basis": adjusted_basis,
+        "adjusted_cost_basis": effective_basis,
         "current_price": current_price,
         "unrealized_pl": unrealized_pl,
         "pl_pct": pl_pct,
@@ -250,7 +268,7 @@ def build_recovery_plan(
             content={"detail": GENERIC_RECOVERY_500_DETAIL},
         )
 
-    summary = _build_position_summary(position, current_price)
+    summary = _build_position_summary(position, current_price, cost_basis=cost_basis)
     if not _is_flagged(summary["unrealized_pl"], summary["pl_pct"]):
         return RecoveryPlanResponse(
             position_id=position_id,

--- a/backend/app/routers/positions.py
+++ b/backend/app/routers/positions.py
@@ -1,0 +1,293 @@
+"""Positions router — Recovery Plan endpoint (issue #182).
+
+Single route: ``POST /api/positions/{position_id}/recovery-plan``. Composes
+the position fetch + live quote + OKR settings + path engine + scoring
+layer into the unified ``RecoveryPlanResponse`` shape.
+
+Branch shape:
+
+- 404 — ``Position not found``
+- ``state == "not-applicable"`` — option-only positions (``shares == 0``)
+  or closed positions; engine never runs.
+- ``state == "not-flagged"`` — position above the review threshold (-5% or
+  -$1,000); engine never runs. Returned with the position summary so the
+  frontend can render the EmptyState.
+- ``state == "populated"`` — full payload with paths + recommendation.
+- 500 — Schwab quote failure. Generic detail message per CLAUDE.md; no
+  ``str(e)`` leaks.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import AppSetting, get_db
+from app.models.schemas import RecoveryPlanResponse
+from app.services import journal
+from app.services.recovery_engine import (
+    DEFAULT_SIZING_CAP_DOLLARS,
+    WHEEL_MONTHLY_PREMIUM_PCT,
+    compute_recovery_paths,
+)
+from app.services.recovery_scoring import DISCLAIMER_TEXT, score_recovery_paths
+from app.services.schwab_client import SchwabClient
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/positions", tags=["positions"])
+
+# Largest-loser flag thresholds — must mirror
+# :mod:`app.services.action_engine` so the dashboard CTA and the recovery
+# page agree on what "flagged" means.
+LARGE_LOSER_PCT_THRESHOLD: float = -0.05
+LARGE_LOSER_DOLLAR_THRESHOLD: float = -1000.0
+
+# Cost-basis-zero positions can't be meaningfully underwater (recovery
+# math divides by basis-derived inputs); short-circuit to not-applicable.
+MIN_COST_BASIS_FOR_RECOVERY: float = 0.01
+
+# Generic 500 detail per CLAUDE.md — never leak ``str(e)``.
+GENERIC_RECOVERY_500_DETAIL = (
+    "Failed to build recovery plan. Please try again."
+)
+
+
+def _get_app_setting(db: DBSession, key: str) -> str | None:
+    """Read a single ``app_settings`` row by key. ``None`` when missing."""
+    entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+    return entry.value if entry else None
+
+
+def _read_okr_settings(db: DBSession) -> dict[str, Any]:
+    """Read OKR scoring inputs from ``app_settings`` with defaults.
+
+    Keys live alongside the existing ``cache_ttl_*`` keys and are
+    populated by #156/#157 when that work lands. Defaults documented in the
+    plan §5:
+
+    - ``okr_target_yield`` → ``None`` (suppresses sell-redeploy)
+    - ``okr_sizing_cap_dollars`` → :data:`DEFAULT_SIZING_CAP_DOLLARS`
+    - ``okr_strategy_preference`` → ``None`` (dormant bonus row in V0.5.8)
+    """
+    target_raw = _get_app_setting(db, "okr_target_yield")
+    cap_raw = _get_app_setting(db, "okr_sizing_cap_dollars")
+    pref_raw = _get_app_setting(db, "okr_strategy_preference")
+
+    target_yield: float | None
+    sizing_cap: float
+
+    try:
+        target_yield = float(target_raw) if target_raw not in (None, "") else None
+    except (TypeError, ValueError):
+        target_yield = None
+
+    try:
+        sizing_cap = (
+            float(cap_raw) if cap_raw not in (None, "") else DEFAULT_SIZING_CAP_DOLLARS
+        )
+    except (TypeError, ValueError):
+        sizing_cap = DEFAULT_SIZING_CAP_DOLLARS
+
+    strategy_preference = pref_raw if pref_raw not in (None, "") else None
+
+    return {
+        "target_yield": target_yield,
+        "sizing_cap_dollars": sizing_cap,
+        "strategy_preference": strategy_preference,
+    }
+
+
+def _build_position_summary(position: dict, current_price: float | None) -> dict:
+    """Compute the header summary the frontend renders above the cards."""
+    shares = int(position.get("shares") or 0)
+    adjusted_basis = float(position.get("adjusted_cost_basis") or 0.0)
+    notional = (current_price or 0.0) * shares
+    if shares > 0 and adjusted_basis > 0:
+        unrealized_pl = notional - adjusted_basis
+        pl_pct = unrealized_pl / adjusted_basis
+    else:
+        unrealized_pl = None
+        pl_pct = None
+    return {
+        "id": position["id"],
+        "ticker": position["ticker"],
+        "shares": shares,
+        "adjusted_cost_basis": adjusted_basis,
+        "current_price": current_price,
+        "unrealized_pl": unrealized_pl,
+        "pl_pct": pl_pct,
+    }
+
+
+def _is_flagged(unrealized_pl: float | None, pl_pct: float | None) -> bool:
+    """Mirror the action-engine flag rule: either threshold trips it."""
+    if unrealized_pl is None:
+        return False
+    if unrealized_pl <= LARGE_LOSER_DOLLAR_THRESHOLD:
+        return True
+    if pl_pct is not None and pl_pct <= LARGE_LOSER_PCT_THRESHOLD:
+        return True
+    return False
+
+
+def _format_pct(value: float | None) -> str:
+    if value is None:
+        return "Not set"
+    return f"{value * 100:.0f}%"
+
+
+def _format_dollar(value: float | None) -> str:
+    if value is None:
+        return "Not set"
+    return f"${value:,.0f}"
+
+
+def _build_assumptions_panel(
+    okr: dict[str, Any],
+    current_price: float | None,
+) -> list[dict]:
+    """Build the 6-row Assumptions audit panel from the response inputs."""
+    price_str = (
+        f"${current_price:,.2f}" if isinstance(current_price, (int, float)) else "Unknown"
+    )
+    return [
+        {
+            "label": "Premium rate (Wheel)",
+            "value": f"{WHEEL_MONTHLY_PREMIUM_PCT * 100:.1f}% / month",
+            "source": "V0.5.8 heuristic (#183 V0.7)",
+        },
+        {
+            "label": "Target yield (Sell & redeploy)",
+            "value": _format_pct(okr.get("target_yield")),
+            "source": "Settings → OKRs",
+        },
+        {
+            "label": "Sizing cap (Average down)",
+            "value": _format_dollar(okr.get("sizing_cap_dollars")),
+            "source": "Settings → OKRs",
+        },
+        {
+            "label": "Strategy preference",
+            "value": okr.get("strategy_preference") or "Not set",
+            "source": "Settings → OKRs (V0.6)",
+        },
+        {
+            "label": "Current price",
+            "value": price_str,
+            "source": "Schwab quote",
+        },
+        {
+            "label": "Tax / wash sale",
+            "value": "Not modeled",
+            "source": "User responsibility",
+        },
+    ]
+
+
+@router.post("/{position_id}/recovery-plan", response_model=RecoveryPlanResponse)
+def build_recovery_plan(
+    position_id: str,
+    db: DBSession = Depends(get_db),
+):
+    """Compose the Recovery Plan response for a single position.
+
+    Wires the deterministic engine + scoring pieces together. No LLM,
+    single Schwab quote, generic error message on failure.
+    """
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return JSONResponse(
+            status_code=404, content={"detail": "Position not found"}
+        )
+
+    as_of = datetime.now(timezone.utc).isoformat()
+
+    # Branch: option-only / closed / zero-cost-basis → not-applicable.
+    shares = int(position.get("shares") or 0)
+    cost_basis = float(position.get("adjusted_cost_basis") or 0.0)
+    if cost_basis <= MIN_COST_BASIS_FOR_RECOVERY:
+        cost_basis = float(position.get("broker_cost_basis") or 0.0)
+    if (
+        shares <= 0
+        or position.get("status") == "closed"
+        or cost_basis <= MIN_COST_BASIS_FOR_RECOVERY
+    ):
+        return RecoveryPlanResponse(
+            position_id=position_id,
+            as_of=as_of,
+            state="not-applicable",
+            position=None,
+            inputs=None,
+            paths=[],
+            recommendation=None,
+            assumptions=[],
+            disclaimer=DISCLAIMER_TEXT,
+        )
+
+    # Live quote — broad-exception guard so we never propagate ``str(e)``
+    # to the client per CLAUDE.md.
+    try:
+        quote = SchwabClient().get_quote(position["ticker"])
+        current_price_raw = quote.get("lastPrice")
+        if current_price_raw is None or float(current_price_raw) <= 0:
+            raise ValueError("Schwab quote missing usable lastPrice")
+        current_price = float(current_price_raw)
+    except Exception as exc:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.error(
+            "Recovery plan quote fetch failed for %s (%s): %s",
+            position_id,
+            position.get("ticker"),
+            exc,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": GENERIC_RECOVERY_500_DETAIL},
+        )
+
+    summary = _build_position_summary(position, current_price)
+    if not _is_flagged(summary["unrealized_pl"], summary["pl_pct"]):
+        return RecoveryPlanResponse(
+            position_id=position_id,
+            as_of=as_of,
+            state="not-flagged",
+            position=summary,
+            inputs=None,
+            paths=[],
+            recommendation=None,
+            assumptions=[],
+            disclaimer=DISCLAIMER_TEXT,
+        )
+
+    okr = _read_okr_settings(db)
+
+    paths = compute_recovery_paths(
+        position=position,
+        current_price=current_price,
+        target_yield=okr["target_yield"],
+        sizing_cap_dollars=okr["sizing_cap_dollars"],
+    )
+    recommendation = score_recovery_paths(paths, okr)
+    assumptions = _build_assumptions_panel(okr, current_price)
+
+    return RecoveryPlanResponse(
+        position_id=position_id,
+        as_of=as_of,
+        state="populated",
+        position=summary,
+        inputs={
+            "current_price": current_price,
+            "cost_basis": cost_basis,
+            "shares": shares,
+            "okr": okr,
+        },
+        paths=paths,
+        recommendation=recommendation,
+        assumptions=assumptions,
+        disclaimer=DISCLAIMER_TEXT,
+    )

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -269,9 +269,12 @@ def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
         "title": f"Review {ticker}",
         "subject": {"ticker": ticker, "amount": amount},
         "reason": "Position is below your review threshold (-5% or -$1,000).",
+        # V0.5.8 (#182): the CTA destination moved from the Journal filter
+        # page to the new Recovery Plan route. Same PR ships the
+        # destination so the link never 404s mid-deploy.
         "cta": {
             "label": f"Review {ticker}",
-            "href": f"/journal?position={quote(str(worst['id']), safe='')}",
+            "href": f"/positions/{quote(str(worst['id']), safe='')}/recovery",
             "kind": "link",
         },
     }

--- a/backend/app/services/recovery_engine.py
+++ b/backend/app/services/recovery_engine.py
@@ -1,0 +1,450 @@
+"""Recovery Plan path engine — deterministic forward-path enumeration.
+
+Given an underwater position, the engine enumerates four candidate forward
+paths and emits a deterministic scenario per path:
+
+- ``sell-redeploy`` — accept realized loss, redeploy freed capital in a
+  fresh CSP at the configured target yield.
+- ``wheel-cc`` — grind monthly premium against the unrealized loss using
+  the V0.5.8 1.5%/month wheel-premium heuristic.
+- ``average-down`` — buy more shares at the current price; suppressed when
+  the resulting capital tied up exceeds the per-position sizing cap.
+- ``hold-monitor`` — no action; track the position with no new capital
+  committed.
+
+The engine is a **pure function**: every input is plain in-memory data and
+every output dict is byte-identical for the same input. No DB, no network,
+no LLM. The scoring layer (``recovery_scoring.py``) consumes only the
+fields emitted here plus OKR settings.
+
+V0.5.8 design decisions locked in the issue body + spec:
+
+- ``months_to_breakeven`` is a ``{best, expected, worst}`` range, never a
+  single point estimate, because the engine surfaces the uncertainty
+  explicitly. Each component may be ``None`` (hold-monitor in particular).
+- ``opportunity_cost_vs_baseline`` is a signed dollar value; sell-redeploy
+  is the baseline and emits ``0``.
+- Suppressed paths stay in ``paths[]`` so the frontend can render them with
+  a de-emphasized treatment plus the ``suppression_reason``.
+- ``narration`` is reserved for V0.6 (#181) and stays ``None`` here.
+
+No ``irr`` field anywhere — the older v0.5.6 plan emitted one; the
+recommendation-layer rewrite dropped it.
+"""
+
+from __future__ import annotations
+
+import math
+
+# --- Constants --------------------------------------------------------------
+
+# Wheel-path monthly premium heuristic (% of strike, per issue AC). The
+# scanner integration in V0.7 (#183) replaces this with live option-chain
+# premium; until then the assumption is rendered verbatim in the UI.
+WHEEL_MONTHLY_PREMIUM_PCT: float = 0.015
+
+# Best/expected/worst multipliers applied to the deterministic
+# expected-months estimate to materialize the range the engine emits.
+# Best case: premium runs 25% higher than the heuristic (faster grind);
+# worst case: 30% lower (slower grind).
+WHEEL_BE_MULTIPLIERS: tuple[float, float, float] = (0.8, 1.0, 1.3)
+
+# Hard-coded sizing cap used when ``okr_sizing_cap_dollars`` is unset. Per
+# the plan §5: defaults are documented in the Assumptions panel.
+DEFAULT_SIZING_CAP_DOLLARS: float = 5000.0
+
+# Canonical display labels. Stable per slug; rendered verbatim by the
+# frontend.
+_PATH_LABELS: dict[str, str] = {
+    "sell-redeploy": "Sell & redeploy",
+    "wheel-cc": "Wheel covered calls",
+    "average-down": "Average down",
+    "hold-monitor": "Hold & monitor",
+}
+
+# Canonical emission order. The engine always returns paths in this order
+# so consumers (scoring, frontend) can index without sorting.
+_PATH_ORDER: tuple[str, ...] = (
+    "sell-redeploy",
+    "wheel-cc",
+    "average-down",
+    "hold-monitor",
+)
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _empty_range() -> dict:
+    """Helper returning the ``{best, expected, worst}`` null-range dict."""
+    return {"best": None, "expected": None, "worst": None}
+
+
+def _format_dollar(amount: float) -> str:
+    """Render a positive dollar amount with comma grouping (no sign)."""
+    return f"${amount:,.0f}"
+
+
+def _format_pct(pct: float) -> str:
+    """Render a yield as ``N%`` with no decimal (e.g. ``18%``)."""
+    return f"{pct * 100:.0f}%"
+
+
+# --- Path builders ----------------------------------------------------------
+
+
+def _sell_redeploy_path(
+    *,
+    realized_loss: float,
+    freed_capital: float,
+    target_yield: float | None,
+) -> dict:
+    """Build the ``sell-redeploy`` path scenario.
+
+    Sell-redeploy is the **baseline** against which other paths' opportunity
+    cost is computed, so its own ``opportunity_cost_vs_baseline`` is ``0``.
+    Suppressed when ``target_yield`` is ``None`` because the breakeven
+    estimate has no anchor without a target yield.
+    """
+    if target_yield is None:
+        return {
+            "path_id": "sell-redeploy",
+            "label": _PATH_LABELS["sell-redeploy"],
+            "eligibility": "suppressed",
+            "suppression_reason": "Target yield not configured",
+            "capital_tied_up": None,
+            "months_to_breakeven": _empty_range(),
+            "opportunity_cost_vs_baseline": None,
+            "assumptions": [
+                "Sell & redeploy requires a target yield from Settings → OKRs.",
+            ],
+            "narration": None,
+        }
+
+    # Annual expected return on freed capital, in dollars.
+    annual_return = max(freed_capital, 0.0) * target_yield
+    if annual_return <= 0 or realized_loss <= 0:
+        # Without a positive annual return there's no breakeven horizon.
+        months_range = _empty_range()
+    else:
+        # Months to earn back the realized loss at the configured yield.
+        expected_months = (realized_loss / annual_return) * 12.0
+        months_range = {
+            "best": round(expected_months * 0.8, 1),
+            "expected": round(expected_months, 1),
+            "worst": round(expected_months * 1.3, 1),
+        }
+
+    assumptions = [
+        f"Assumes redeployed capital earns {_format_pct(target_yield)} target yield.",
+        f"Freed capital after sale: {_format_dollar(max(freed_capital, 0.0))}.",
+    ]
+
+    return {
+        "path_id": "sell-redeploy",
+        "label": _PATH_LABELS["sell-redeploy"],
+        "eligibility": "eligible",
+        "suppression_reason": None,
+        "capital_tied_up": round(max(freed_capital, 0.0), 2),
+        "months_to_breakeven": months_range,
+        # Baseline: the engine pins this to exactly 0 so the rest of the
+        # paths' deltas are well-defined.
+        "opportunity_cost_vs_baseline": 0.0,
+        "assumptions": assumptions,
+        "narration": None,
+    }
+
+
+def _wheel_cc_path(
+    *,
+    realized_loss: float,
+    current_price: float,
+    shares: int,
+    target_yield: float | None,
+) -> dict:
+    """Build the ``wheel-cc`` path scenario.
+
+    Premium math: ``monthly_premium_dollars = WHEEL_MONTHLY_PREMIUM_PCT *
+    strike_proxy * shares`` where ``strike_proxy = current_price`` (ATM
+    short-call assumption — honest in absence of option-chain data).
+    """
+    strike_proxy = max(current_price, 0.0)
+    monthly_premium = WHEEL_MONTHLY_PREMIUM_PCT * strike_proxy * max(shares, 0)
+    capital_tied_up = round(strike_proxy * max(shares, 0), 2)
+
+    if monthly_premium <= 0 or realized_loss <= 0:
+        months_range = _empty_range()
+    else:
+        # ceil(loss / premium * multiplier). Best case: premium runs higher
+        # (faster grind, fewer months). Worst case: premium runs lower
+        # (slower grind, more months).
+        best = math.ceil((realized_loss / monthly_premium) * WHEEL_BE_MULTIPLIERS[0])
+        expected = math.ceil((realized_loss / monthly_premium) * WHEEL_BE_MULTIPLIERS[1])
+        worst = math.ceil((realized_loss / monthly_premium) * WHEEL_BE_MULTIPLIERS[2])
+        months_range = {"best": best, "expected": expected, "worst": worst}
+
+    # Opportunity cost: capital tied up in shares could have earned the
+    # target yield in a fresh CSP minus the premium income the wheel
+    # generates. We surface gross annual premium foregone as the rough
+    # baseline-comparison signal until the V0.7 chain integration.
+    annual_premium = monthly_premium * 12.0
+    if target_yield is None:
+        opp_cost = None
+    else:
+        baseline_annual = capital_tied_up * target_yield
+        opp_cost = round(baseline_annual - annual_premium, 2)
+
+    assumptions = [
+        (
+            f"Assumes {WHEEL_MONTHLY_PREMIUM_PCT * 100:.1f}%/month premium on "
+            f"${strike_proxy:,.2f} strike (V0.5.8 heuristic, see #183)."
+        ),
+    ]
+    if target_yield is not None:
+        assumptions.append(
+            f"Opportunity cost compares to {_format_pct(target_yield)} target yield baseline."
+        )
+
+    return {
+        "path_id": "wheel-cc",
+        "label": _PATH_LABELS["wheel-cc"],
+        "eligibility": "eligible",
+        "suppression_reason": None,
+        "capital_tied_up": capital_tied_up,
+        "months_to_breakeven": months_range,
+        "opportunity_cost_vs_baseline": opp_cost,
+        "assumptions": assumptions,
+        "narration": None,
+    }
+
+
+def _average_down_path(
+    *,
+    shares: int,
+    current_price: float,
+    adjusted_cost_basis: float,
+    target_yield: float | None,
+    sizing_cap_dollars: float,
+) -> dict:
+    """Build the ``average-down`` path scenario.
+
+    Suppressed when ``capital_tied_up > sizing_cap_dollars``. The path
+    stays in the response (frontend renders the de-emphasized treatment)
+    so the user can see *why* it isn't recommended.
+    """
+    additional_capital = max(current_price, 0.0) * max(shares, 0)
+    new_basis_total = max(adjusted_cost_basis, 0.0) + additional_capital
+    capital_tied_up = round(new_basis_total, 2)
+
+    # Sizing cap gate. Per design spec §3.3 the reason text contains the
+    # word "sizing cap" so the frontend CTA mapper routes the user to
+    # /settings#okrs.
+    if capital_tied_up > sizing_cap_dollars:
+        return {
+            "path_id": "average-down",
+            "label": _PATH_LABELS["average-down"],
+            "eligibility": "suppressed",
+            "suppression_reason": (
+                f"Exceeds your {_format_dollar(sizing_cap_dollars)} per-position "
+                "sizing cap"
+            ),
+            "capital_tied_up": None,
+            "months_to_breakeven": _empty_range(),
+            "opportunity_cost_vs_baseline": None,
+            "assumptions": [
+                f"Sizing cap from Settings → OKRs: {_format_dollar(sizing_cap_dollars)}.",
+                (
+                    f"Adding {_format_dollar(additional_capital)} would tie up "
+                    f"{_format_dollar(capital_tied_up)} total."
+                ),
+            ],
+            "narration": None,
+        }
+
+    # New cost basis per share after doubling the position.
+    total_shares = max(shares, 0) * 2
+    if total_shares > 0:
+        new_basis_per_share = new_basis_total / total_shares
+        # Months to breakeven: when does the average-of-old + new exceed the
+        # new per-share cost? Without a price-recovery model we cannot
+        # answer that deterministically — surface the range as null and let
+        # the assumption note explain why.
+        months_range = _empty_range()
+    else:
+        new_basis_per_share = 0.0
+        months_range = _empty_range()
+
+    if target_yield is None:
+        opp_cost = None
+    else:
+        # Capital that could have earned the target yield in a fresh CSP.
+        opp_cost = round(additional_capital * target_yield, 2)
+
+    assumptions = [
+        (
+            f"Adds {_format_dollar(additional_capital)} at "
+            f"${current_price:,.2f}/share — new basis {_format_dollar(new_basis_per_share)} "
+            "per share."
+        ),
+        f"Within {_format_dollar(sizing_cap_dollars)} sizing cap.",
+        "Breakeven horizon depends on price-recovery assumptions not modeled.",
+    ]
+
+    return {
+        "path_id": "average-down",
+        "label": _PATH_LABELS["average-down"],
+        "eligibility": "eligible",
+        "suppression_reason": None,
+        "capital_tied_up": capital_tied_up,
+        "months_to_breakeven": months_range,
+        "opportunity_cost_vs_baseline": opp_cost,
+        "assumptions": assumptions,
+        "narration": None,
+    }
+
+
+def _hold_monitor_path(
+    *,
+    shares: int,
+    current_price: float,
+    adjusted_cost_basis: float,
+    target_yield: float | None,
+) -> dict:
+    """Build the ``hold-monitor`` path scenario.
+
+    Hold takes no action, so:
+    - ``capital_tied_up`` is the current notional (no new money committed),
+    - ``months_to_breakeven`` is all ``None`` (no action → no breakeven),
+    - ``opportunity_cost_vs_baseline`` is the full annual yield foregone on
+      freed capital, when target yield is known.
+    """
+    freed_capital = max(current_price, 0.0) * max(shares, 0)
+    capital_tied_up = round(max(adjusted_cost_basis, 0.0), 2)
+
+    if target_yield is None:
+        opp_cost = None
+    else:
+        opp_cost = round(freed_capital * target_yield, 2)
+
+    assumptions = [
+        "Tracks the position at current price; no new capital committed.",
+    ]
+    if target_yield is not None:
+        assumptions.append(
+            f"Annual opportunity cost = {_format_dollar(freed_capital)} × "
+            f"{_format_pct(target_yield)} target yield."
+        )
+
+    return {
+        "path_id": "hold-monitor",
+        "label": _PATH_LABELS["hold-monitor"],
+        "eligibility": "eligible",
+        "suppression_reason": None,
+        "capital_tied_up": capital_tied_up,
+        "months_to_breakeven": _empty_range(),
+        "opportunity_cost_vs_baseline": opp_cost,
+        "assumptions": assumptions,
+        "narration": None,
+    }
+
+
+# --- Public surface ---------------------------------------------------------
+
+
+def compute_recovery_paths(
+    *,
+    position: dict,
+    current_price: float,
+    target_yield: float | None,
+    sizing_cap_dollars: float | None,
+) -> list[dict]:
+    """Compute the four candidate recovery paths for a flagged position.
+
+    Pure function: same inputs → byte-identical output. No DB, no network,
+    no LLM calls.
+
+    Args:
+        position: Plain dict with at least ``shares`` and either
+            ``adjusted_cost_basis`` or ``broker_cost_basis``.
+        current_price: Live (or last-known) price per share.
+        target_yield: OKR target yield as a fraction (e.g. ``0.18``).
+            ``None`` suppresses the sell-redeploy path and zeroes out
+            opportunity-cost columns that depend on it.
+        sizing_cap_dollars: OKR per-position sizing cap in dollars. ``None``
+            falls back to :data:`DEFAULT_SIZING_CAP_DOLLARS`.
+
+    Returns:
+        Four-element list in canonical order (sell-redeploy, wheel-cc,
+        average-down, hold-monitor).
+    """
+    shares = int(position.get("shares") or 0)
+    adjusted_cost_basis = float(position.get("adjusted_cost_basis") or 0.0)
+    # Adjusted cost basis is the authoritative input — broker_cost_basis is
+    # only used when adjusted is missing (e.g. zero-trade positions).
+    if adjusted_cost_basis <= 0:
+        adjusted_cost_basis = float(position.get("broker_cost_basis") or 0.0)
+
+    current_price = max(float(current_price or 0.0), 0.0)
+    cap = (
+        float(sizing_cap_dollars)
+        if sizing_cap_dollars is not None
+        else DEFAULT_SIZING_CAP_DOLLARS
+    )
+
+    # Realized loss for the sell-redeploy / wheel projections. If the
+    # position is above water we still emit paths (the user can audit) but
+    # the breakeven range collapses to ``None``.
+    current_notional = current_price * max(shares, 0)
+    realized_loss = max(adjusted_cost_basis - current_notional, 0.0)
+    freed_capital = current_notional
+
+    paths = [
+        _sell_redeploy_path(
+            realized_loss=realized_loss,
+            freed_capital=freed_capital,
+            target_yield=target_yield,
+        ),
+        _wheel_cc_path(
+            realized_loss=realized_loss,
+            current_price=current_price,
+            shares=shares,
+            target_yield=target_yield,
+        ),
+        _average_down_path(
+            shares=shares,
+            current_price=current_price,
+            adjusted_cost_basis=adjusted_cost_basis,
+            target_yield=target_yield,
+            sizing_cap_dollars=cap,
+        ),
+        _hold_monitor_path(
+            shares=shares,
+            current_price=current_price,
+            adjusted_cost_basis=adjusted_cost_basis,
+            target_yield=target_yield,
+        ),
+    ]
+    # Defensive: enforce canonical order so the scoring layer can index by
+    # position rather than slug-search.
+    by_slug = {p["path_id"]: p for p in paths}
+    return [by_slug[slug] for slug in _PATH_ORDER]
+
+
+def canonical_path_labels() -> dict[str, str]:
+    """Return a copy of the slug→label mapping for callers that need it."""
+    return dict(_PATH_LABELS)
+
+
+def canonical_path_order() -> tuple[str, ...]:
+    """Return the canonical emission order as a tuple of slugs."""
+    return _PATH_ORDER
+
+
+__all__ = [
+    "WHEEL_MONTHLY_PREMIUM_PCT",
+    "WHEEL_BE_MULTIPLIERS",
+    "DEFAULT_SIZING_CAP_DOLLARS",
+    "compute_recovery_paths",
+    "canonical_path_labels",
+    "canonical_path_order",
+]

--- a/backend/app/services/recovery_scoring.py
+++ b/backend/app/services/recovery_scoring.py
@@ -1,0 +1,605 @@
+"""Recovery Plan scoring engine — deterministic recommendation layer.
+
+Consumes the path list emitted by :mod:`app.services.recovery_engine` plus
+the user's OKR settings and emits a deterministic ``Recommendation`` dict:
+
+- ``recommended_path_id`` — slug of the single best-fit eligible path, or
+  ``None`` in the two degradation states (no-clear-best-fit / no-eligible).
+- ``recommendation_label`` — template-rendered, never free-form prose.
+- ``recommendation_reasons`` — 2–4 template-rendered explanation strings.
+- ``ranked_paths`` — every path (eligible + suppressed) with score + rank.
+- ``path_scores`` — one row per criterion × every eligible path; the
+  Inspect-Scoring matrix's source of truth.
+- ``tie_epsilon`` — the constant the matrix renders in its footnote.
+- ``disclaimer`` — the canonical legal-style statement per issue AC.
+
+Algorithm:
+1. Filter the engine's paths into eligible vs suppressed.
+2. For each criterion, rank the eligible paths by the relevant raw value,
+   award the criterion's weight in points to the leader (with ties at
+   exact equality splitting — all tied leaders get the full weight).
+3. Sum points per path → ``totals``. Rank by total; surface as
+   ``ranked_paths``.
+4. If the top two total scores are within :data:`TIE_EPSILON`, no path is
+   recommended (``recommended_path_id = None``).
+5. Otherwise render ``recommendation_label`` and 2–4
+   ``recommendation_reasons`` from the frozen template dicts.
+
+Pure function: no DB, no HTTP, no LLM. Same input → byte-identical output
+(enforced by ``test_recovery_scoring.py::test_reproducibility_*``).
+
+**Strategy-preference bonus** (issue AC, dormant in V0.5.8):
+
+The bonus reads ``okr_settings.strategy_preference``; when the field is
+unset (V0.5.8 default — OKR persistence in #156/#157 ships later), every
+cell in the bonus row scores ``0`` so the matrix renders the unset-row
+form. When the field lands later (income-first → wheel-cc, etc.), no code
+change is required.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# --- Constants --------------------------------------------------------------
+
+# Top-two total tie threshold. When the gap between rank 1 and rank 2
+# eligible totals is ≤ this value, the engine emits
+# ``recommended_path_id = None`` and ``recommendation_label = "No clear
+# best fit"`` (issue AC §Recommendation engine).
+TIE_EPSILON: float = 1.0
+
+# Per-criterion weights. Awarded to the leader (or split among ties at
+# exact equality). Defaults from the issue body's scoring table.
+WEIGHT_FASTEST_BREAKEVEN: int = 3
+WEIGHT_LOWEST_CAPITAL: int = 3
+WEIGHT_LOWEST_OPPORTUNITY_COST: int = 2
+WEIGHT_STRATEGY_PREFERENCE: int = 2
+
+# Canonical disclaimer rendered by the panel footer. Frozen by snapshot
+# tests (`test_recovery_scoring_snapshots.py`).
+DISCLAIMER_TEXT: str = (
+    "This is a fit recommendation based on your configured preferences "
+    "and stated assumptions. It is not investment advice, a price "
+    "prediction, or a trade execution suggestion."
+)
+
+# Strategy-preference → path-slug mapping. Dormant in V0.5.8; activates
+# automatically when #156/#157 persists the field. ``"passive"`` and
+# unknown values fall through to no bonus.
+STRATEGY_PREFERENCE_TO_PATH: dict[str, str] = {
+    "income-first": "wheel-cc",
+    "capital-efficient": "sell-redeploy",
+    "conviction-add": "average-down",
+}
+
+# Label templates — frozen by snapshot tests. Keyed on the recommendation
+# state (and optional preference flag where applicable).
+LABEL_TEMPLATES: dict[str, str] = {
+    # Happy path with no strategy preference (V0.5.8 default).
+    "recommended_neutral": "Best fit on capital efficiency and breakeven: {path_label}",
+    # Happy path with strategy preference set (activates when #156/#157 lands).
+    "recommended_with_strategy_preference": (
+        "Best fit for {preference} strategy: {path_label}"
+    ),
+    # Top-two within tie_epsilon.
+    "no_clear_best_fit": "No clear best fit",
+    # Every path suppressed.
+    "no_eligible_path": "No eligible path under current sizing rules",
+}
+
+# Reason templates — keyed on the criterion the path won. The frontend
+# never renders these directly; the scoring engine fills in the kwargs and
+# returns the resolved strings.
+REASON_TEMPLATES: dict[str, str] = {
+    "fastest_breakeven_solo": (
+        "Fastest expected breakeven ({months} months vs {next_months} for the next option)"
+    ),
+    "fastest_breakeven_unique": "Fastest expected breakeven ({months} months)",
+    "lowest_additional_capital_zero": "Lowest additional capital required ($0)",
+    "lowest_additional_capital_amount": (
+        "Lowest additional capital required (${capital:,.0f} vs ${next_capital:,.0f} for the next option)"
+    ),
+    "lowest_opportunity_cost_zero": "Lowest opportunity cost vs baseline (${opp_cost:,.0f})",
+    "lowest_opportunity_cost_amount": (
+        "Lowest opportunity cost vs baseline (${opp_cost:,.0f})"
+    ),
+    "strategy_preference_match": "Matches your configured {preference} strategy preference",
+    "within_sizing_cap": "Within your per-position sizing cap",
+}
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+def _criterion_raw_value(path: dict, criterion: str) -> float | None:
+    """Return the raw numeric value a path contributes to a given criterion.
+
+    Returns ``None`` when the path has no value for the criterion (e.g.
+    hold-monitor on ``fastest_breakeven``). Callers treat ``None`` as
+    "worst tier" — never a leader.
+    """
+    if criterion == "fastest_breakeven":
+        rng = path.get("months_to_breakeven") or {}
+        return rng.get("expected")
+    if criterion == "lowest_additional_capital":
+        return path.get("capital_tied_up")
+    if criterion == "lowest_opportunity_cost":
+        cost = path.get("opportunity_cost_vs_baseline")
+        # Absolute distance from baseline so signed wins on either side
+        # don't artificially win this column.
+        if cost is None:
+            return None
+        return abs(cost)
+    return None
+
+
+def _rank_paths_for_criterion(
+    eligible: list[dict],
+    criterion: str,
+    weight: int,
+) -> list[dict]:
+    """Build the ranking cells for one criterion.
+
+    Lower raw value is better (fastest breakeven, least capital, least
+    opportunity cost). ``None`` raw values sort to the bottom and earn
+    zero points.
+
+    Returns a list of cell dicts ordered to match the engine's canonical
+    path order — the ``rank`` field carries the actual ranking.
+    """
+    # Build (path_id, raw, original_index) tuples for deterministic sort.
+    indexed = []
+    for idx, p in enumerate(eligible):
+        raw = _criterion_raw_value(p, criterion)
+        indexed.append((p["path_id"], raw, idx))
+
+    # Sort: non-None raw values first (ascending), then None values last.
+    # The original-index tiebreaker keeps determinism when two paths share
+    # the same raw value AND the same path_id (cannot happen in practice,
+    # but the guarantee is cheap).
+    def _sort_key(entry):
+        path_id, raw, idx = entry
+        if raw is None:
+            return (1, 0.0, idx, path_id)
+        return (0, raw, idx, path_id)
+
+    sorted_entries = sorted(indexed, key=_sort_key)
+
+    # Assign ranks: tied non-None values at exact equality share rank 1.
+    rank_by_path: dict[str, int] = {}
+    points_by_path: dict[str, int] = {}
+    leader_raw: float | None = None
+    leader_set = False
+    for entry in sorted_entries:
+        path_id, raw, _ = entry
+        if raw is None:
+            rank_by_path[path_id] = len(eligible)  # worst rank
+            points_by_path[path_id] = 0
+            continue
+        if not leader_set:
+            leader_raw = raw
+            leader_set = True
+            rank_by_path[path_id] = 1
+            points_by_path[path_id] = weight
+        elif raw == leader_raw:
+            # Exact tie → both leaders get the full weight per the AC
+            # ("tied leaders get the full weight"; the example in the
+            # issue body awards +3 to every $0-capital path).
+            rank_by_path[path_id] = 1
+            points_by_path[path_id] = weight
+        else:
+            # Strict rank-2 and beyond — no points on this criterion.
+            # Assign deterministic ranks (2, 3, …) by encounter order.
+            rank_by_path[path_id] = max(rank_by_path.values()) + 1
+            points_by_path[path_id] = 0
+
+    # Build cell list in canonical (engine emission) order.
+    cells: list[dict] = []
+    for idx, p in enumerate(eligible):
+        path_id = p["path_id"]
+        raw = _criterion_raw_value(p, criterion)
+        cells.append(
+            {
+                "path_id": path_id,
+                "raw_value": raw,
+                "points": points_by_path[path_id],
+                "rank": rank_by_path[path_id],
+            }
+        )
+    return cells
+
+
+def _strategy_preference_row(
+    eligible: list[dict],
+    weight: int,
+    preference: str | None,
+) -> dict:
+    """Build the strategy-preference bonus row.
+
+    When ``preference`` is unset or maps to no path (V0.5.8 default,
+    "passive", or an unknown value), every cell scores ``0``. When the
+    preference maps to one of the eligible paths, that path's cell gets
+    the full ``weight`` in points.
+
+    The row is always emitted so the frontend can render the unset
+    callout (design spec §4.5 row 1).
+    """
+    target_slug = (
+        STRATEGY_PREFERENCE_TO_PATH.get(preference) if preference else None
+    )
+    cells: list[dict] = []
+    for p in eligible:
+        slug = p["path_id"]
+        if target_slug is not None and slug == target_slug:
+            cells.append(
+                {
+                    "path_id": slug,
+                    "raw_value": None,
+                    "points": weight,
+                    "rank": 1,
+                }
+            )
+        else:
+            cells.append(
+                {
+                    "path_id": slug,
+                    "raw_value": None,
+                    "points": 0,
+                    # Per design spec §4.5: cells in the unset row render as
+                    # em-dashes; rank is meaningless. Emit a deterministic
+                    # value (worst rank among eligible) for shape stability.
+                    "rank": len(eligible),
+                }
+            )
+    return {
+        "criterion": "strategy_preference_bonus",
+        "weight": weight,
+        "ranking": cells,
+    }
+
+
+def _build_reasons(
+    *,
+    eligible: list[dict],
+    recommended: dict,
+    path_scores: list[dict],
+    okr_settings: dict[str, Any],
+) -> list[str]:
+    """Build the 2–4 ``recommendation_reasons`` for the recommended path.
+
+    Walks the ``path_scores`` rows in deterministic order, emits one reason
+    per criterion where the recommended path was a (sole or tied) leader.
+    Always appends "Within your per-position sizing cap" for completeness
+    so the reason list is never below 2 entries.
+    """
+    reasons: list[str] = []
+    slug = recommended["path_id"]
+    # Index path_scores by criterion for easy lookup.
+    by_criterion = {row["criterion"]: row for row in path_scores}
+
+    # 1. fastest_breakeven
+    row = by_criterion.get("fastest_breakeven")
+    if row:
+        cells = {c["path_id"]: c for c in row["ranking"]}
+        rec_cell = cells.get(slug)
+        if rec_cell and rec_cell["rank"] == 1 and rec_cell["raw_value"] is not None:
+            # Look for next-rank (rank > 1) cell with a raw_value to fill the
+            # comparison parenthetical.
+            next_cells = sorted(
+                [c for c in row["ranking"] if c["rank"] > 1 and c["raw_value"] is not None],
+                key=lambda c: (c["raw_value"], c["path_id"]),
+            )
+            if next_cells:
+                reasons.append(
+                    REASON_TEMPLATES["fastest_breakeven_solo"].format(
+                        months=_fmt_months(rec_cell["raw_value"]),
+                        next_months=_fmt_months(next_cells[0]["raw_value"]),
+                    )
+                )
+            else:
+                reasons.append(
+                    REASON_TEMPLATES["fastest_breakeven_unique"].format(
+                        months=_fmt_months(rec_cell["raw_value"]),
+                    )
+                )
+
+    # 2. lowest_additional_capital
+    row = by_criterion.get("lowest_additional_capital")
+    if row:
+        cells = {c["path_id"]: c for c in row["ranking"]}
+        rec_cell = cells.get(slug)
+        if rec_cell and rec_cell["rank"] == 1:
+            raw = rec_cell["raw_value"] or 0
+            if raw == 0:
+                reasons.append(REASON_TEMPLATES["lowest_additional_capital_zero"])
+            else:
+                next_cells = sorted(
+                    [
+                        c
+                        for c in row["ranking"]
+                        if c["rank"] > 1 and c["raw_value"] is not None
+                    ],
+                    key=lambda c: (c["raw_value"], c["path_id"]),
+                )
+                next_capital = next_cells[0]["raw_value"] if next_cells else raw
+                reasons.append(
+                    REASON_TEMPLATES["lowest_additional_capital_amount"].format(
+                        capital=raw,
+                        next_capital=next_capital,
+                    )
+                )
+
+    # 3. lowest_opportunity_cost
+    row = by_criterion.get("lowest_opportunity_cost")
+    if row:
+        cells = {c["path_id"]: c for c in row["ranking"]}
+        rec_cell = cells.get(slug)
+        if rec_cell and rec_cell["rank"] == 1 and rec_cell["raw_value"] is not None:
+            # Use the recommended path's actual signed opportunity cost
+            # (the criterion raw_value is the absolute distance).
+            signed = next(
+                (
+                    p.get("opportunity_cost_vs_baseline")
+                    for p in eligible
+                    if p["path_id"] == slug
+                ),
+                rec_cell["raw_value"],
+            )
+            if signed is None:
+                signed = rec_cell["raw_value"]
+            if signed == 0:
+                reasons.append(
+                    REASON_TEMPLATES["lowest_opportunity_cost_zero"].format(opp_cost=signed)
+                )
+            else:
+                reasons.append(
+                    REASON_TEMPLATES["lowest_opportunity_cost_amount"].format(
+                        opp_cost=signed
+                    )
+                )
+
+    # 4. strategy_preference_bonus
+    row = by_criterion.get("strategy_preference_bonus")
+    preference = okr_settings.get("strategy_preference") if okr_settings else None
+    if (
+        row
+        and preference
+        and STRATEGY_PREFERENCE_TO_PATH.get(preference) == slug
+    ):
+        reasons.append(
+            REASON_TEMPLATES["strategy_preference_match"].format(preference=preference)
+        )
+
+    # Always-present anchor when nothing else fits (keeps list ≥ 2 entries).
+    if len(reasons) < 2:
+        reasons.append(REASON_TEMPLATES["within_sizing_cap"])
+
+    # Per AC: 2–4 entries. Cap deterministically.
+    return reasons[:4]
+
+
+def _fmt_months(value: float) -> str:
+    """Format a months value for reason templates (drop trailing zeros)."""
+    if value == int(value):
+        return f"{int(value)}"
+    return f"{value:g}"
+
+
+def _build_label(
+    *,
+    recommended: dict | None,
+    state: str,
+    preference: str | None,
+) -> str:
+    """Render the recommendation label from the frozen template dict."""
+    if state == "no_clear_best_fit":
+        return LABEL_TEMPLATES["no_clear_best_fit"]
+    if state == "no_eligible_path":
+        return LABEL_TEMPLATES["no_eligible_path"]
+    # Happy path.
+    if (
+        preference
+        and recommended
+        and STRATEGY_PREFERENCE_TO_PATH.get(preference) == recommended["path_id"]
+    ):
+        return LABEL_TEMPLATES["recommended_with_strategy_preference"].format(
+            preference=preference,
+            path_label=recommended["label"],
+        )
+    return LABEL_TEMPLATES["recommended_neutral"].format(
+        path_label=recommended["label"] if recommended else "",
+    )
+
+
+# --- Public surface ---------------------------------------------------------
+
+
+def score_recovery_paths(
+    paths: list[dict],
+    okr_settings: dict[str, Any] | None = None,
+) -> dict:
+    """Score the engine's paths and emit the deterministic recommendation.
+
+    Args:
+        paths: Output of :func:`recovery_engine.compute_recovery_paths`.
+            Suppressed paths must still be present; this function filters
+            them.
+        okr_settings: Optional dict carrying ``target_yield``,
+            ``sizing_cap_dollars``, and ``strategy_preference``. Missing
+            keys are treated as unset.
+
+    Returns:
+        Recommendation dict ready to attach to the ``RecoveryPlanResponse``.
+    """
+    okr_settings = okr_settings or {}
+    preference = okr_settings.get("strategy_preference") or None
+
+    eligible = [p for p in paths if p.get("eligibility") == "eligible"]
+    suppressed = [p for p in paths if p.get("eligibility") == "suppressed"]
+
+    # All paths suppressed → "No eligible path".
+    if not eligible:
+        ranked = [
+            {
+                "path_id": p["path_id"],
+                "score": None,
+                "rank": None,
+                "suppression_reason": p.get("suppression_reason") or "",
+            }
+            for p in paths
+        ]
+        return {
+            "recommended_path_id": None,
+            "recommendation_label": _build_label(
+                recommended=None, state="no_eligible_path", preference=preference
+            ),
+            "recommendation_reasons": [
+                "Every path violates your configured constraints.",
+                "Adjust your caps in Settings → OKRs to enable more paths.",
+            ],
+            "ranked_paths": ranked,
+            "path_scores": [],
+            "tie_epsilon": TIE_EPSILON,
+            "disclaimer": DISCLAIMER_TEXT,
+        }
+
+    # Per-criterion ranking.
+    path_scores: list[dict] = [
+        {
+            "criterion": "fastest_breakeven",
+            "weight": WEIGHT_FASTEST_BREAKEVEN,
+            "ranking": _rank_paths_for_criterion(
+                eligible, "fastest_breakeven", WEIGHT_FASTEST_BREAKEVEN
+            ),
+        },
+        {
+            "criterion": "lowest_additional_capital",
+            "weight": WEIGHT_LOWEST_CAPITAL,
+            "ranking": _rank_paths_for_criterion(
+                eligible, "lowest_additional_capital", WEIGHT_LOWEST_CAPITAL
+            ),
+        },
+        {
+            "criterion": "lowest_opportunity_cost",
+            "weight": WEIGHT_LOWEST_OPPORTUNITY_COST,
+            "ranking": _rank_paths_for_criterion(
+                eligible, "lowest_opportunity_cost", WEIGHT_LOWEST_OPPORTUNITY_COST
+            ),
+        },
+        _strategy_preference_row(eligible, WEIGHT_STRATEGY_PREFERENCE, preference),
+    ]
+
+    # Aggregate totals.
+    totals: dict[str, int] = {p["path_id"]: 0 for p in eligible}
+    for row in path_scores:
+        for cell in row["ranking"]:
+            totals[cell["path_id"]] += cell["points"]
+
+    # Rank eligible paths by total (desc); tie-break on canonical engine
+    # order so the output is fully deterministic.
+    order_by_slug = {p["path_id"]: idx for idx, p in enumerate(eligible)}
+    sorted_eligible = sorted(
+        eligible,
+        key=lambda p: (-totals[p["path_id"]], order_by_slug[p["path_id"]]),
+    )
+
+    # Assign integer ranks; equal totals share the same rank (dense ranking
+    # is overkill here — the matrix Total/Rank rows just need a number).
+    ranked_paths: list[dict] = []
+    last_total: int | None = None
+    last_rank = 0
+    for idx, p in enumerate(sorted_eligible):
+        total = totals[p["path_id"]]
+        if total != last_total:
+            last_rank = idx + 1
+            last_total = total
+        ranked_paths.append(
+            {
+                "path_id": p["path_id"],
+                "score": total,
+                "rank": last_rank,
+                "suppression_reason": None,
+            }
+        )
+
+    # Append suppressed paths so the full deck is in ``ranked_paths``.
+    for p in suppressed:
+        ranked_paths.append(
+            {
+                "path_id": p["path_id"],
+                "score": None,
+                "rank": None,
+                "suppression_reason": p.get("suppression_reason") or "",
+            }
+        )
+
+    # Tie-epsilon check on top two eligible totals.
+    top_total = ranked_paths[0]["score"] if ranked_paths else None
+    second_total: int | None = None
+    if len(sorted_eligible) >= 2:
+        second_total = totals[sorted_eligible[1]["path_id"]]
+
+    no_clear_best = (
+        second_total is not None
+        and top_total is not None
+        and (top_total - second_total) <= TIE_EPSILON
+    )
+
+    if no_clear_best:
+        # Build a degradation-state reason list referencing the top two.
+        top_two = sorted_eligible[:2]
+        reasons = [
+            (
+                "The top two paths score within "
+                f"{int(TIE_EPSILON)} point of each other — both are within "
+                "your configured preferences."
+            ),
+            f"Close on: {top_two[0]['label']} and {top_two[1]['label']}.",
+        ]
+        return {
+            "recommended_path_id": None,
+            "recommendation_label": _build_label(
+                recommended=None, state="no_clear_best_fit", preference=preference
+            ),
+            "recommendation_reasons": reasons,
+            "ranked_paths": ranked_paths,
+            "path_scores": path_scores,
+            "tie_epsilon": TIE_EPSILON,
+            "disclaimer": DISCLAIMER_TEXT,
+        }
+
+    # Happy path — single winner.
+    recommended = sorted_eligible[0]
+    label = _build_label(
+        recommended=recommended, state="recommended", preference=preference
+    )
+    reasons = _build_reasons(
+        eligible=eligible,
+        recommended=recommended,
+        path_scores=path_scores,
+        okr_settings=okr_settings,
+    )
+    return {
+        "recommended_path_id": recommended["path_id"],
+        "recommendation_label": label,
+        "recommendation_reasons": reasons,
+        "ranked_paths": ranked_paths,
+        "path_scores": path_scores,
+        "tie_epsilon": TIE_EPSILON,
+        "disclaimer": DISCLAIMER_TEXT,
+    }
+
+
+__all__ = [
+    "TIE_EPSILON",
+    "WEIGHT_FASTEST_BREAKEVEN",
+    "WEIGHT_LOWEST_CAPITAL",
+    "WEIGHT_LOWEST_OPPORTUNITY_COST",
+    "WEIGHT_STRATEGY_PREFERENCE",
+    "DISCLAIMER_TEXT",
+    "STRATEGY_PREFERENCE_TO_PATH",
+    "LABEL_TEMPLATES",
+    "REASON_TEMPLATES",
+    "score_recovery_paths",
+]

--- a/backend/app/services/recovery_scoring.py
+++ b/backend/app/services/recovery_scoring.py
@@ -100,10 +100,7 @@ REASON_TEMPLATES: dict[str, str] = {
     "lowest_additional_capital_amount": (
         "Lowest additional capital required (${capital:,.0f} vs ${next_capital:,.0f} for the next option)"
     ),
-    "lowest_opportunity_cost_zero": "Lowest opportunity cost vs baseline (${opp_cost:,.0f})",
-    "lowest_opportunity_cost_amount": (
-        "Lowest opportunity cost vs baseline (${opp_cost:,.0f})"
-    ),
+    "lowest_opportunity_cost": "Lowest opportunity cost vs baseline (${opp_cost:,.0f})",
     "strategy_preference_match": "Matches your configured {preference} strategy preference",
     "within_sizing_cap": "Within your per-position sizing cap",
 }
@@ -348,16 +345,9 @@ def _build_reasons(
             )
             if signed is None:
                 signed = rec_cell["raw_value"]
-            if signed == 0:
-                reasons.append(
-                    REASON_TEMPLATES["lowest_opportunity_cost_zero"].format(opp_cost=signed)
-                )
-            else:
-                reasons.append(
-                    REASON_TEMPLATES["lowest_opportunity_cost_amount"].format(
-                        opp_cost=signed
-                    )
-                )
+            reasons.append(
+                REASON_TEMPLATES["lowest_opportunity_cost"].format(opp_cost=signed)
+            )
 
     # 4. strategy_preference_bonus
     row = by_criterion.get("strategy_preference_bonus")

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -273,6 +273,22 @@ class TestLargeLoserTrigger:
         assert len(loser_cards) == 1
         assert loser_cards[0]["subject"]["ticker"] == "BBB"
 
+    def test_cta_href_points_at_recovery_plan_route(self):
+        # V0.5.8 (#182): the loser CTA destination flipped from the journal
+        # filter page to the Recovery Plan route. Both shipped in the same
+        # PR so the link does not 404 between deploys.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-loser", "TSLA", unrealized_pl=-2000.0, pl_pct=-0.20),
+            ],
+            open_legs=[],
+        )
+        loser_card = next(a for a in actions if a["action_id"] == "position.large_loser")
+        assert loser_card["cta"]["href"] == "/positions/p-loser/recovery"
+        assert "/journal?position=" not in loser_card["cta"]["href"]
+
 
 class TestItmShortDteTrigger:
     def test_emits_when_itm_and_short_dte(self):

--- a/backend/tests/test_recovery_engine.py
+++ b/backend/tests/test_recovery_engine.py
@@ -1,0 +1,402 @@
+"""Unit tests for the Recovery Plan path engine.
+
+The engine is a pure function. These tests exercise the math per path
+against fixed inputs (no DB, no HTTP), the suppression branches
+(target-yield missing, sizing-cap exceeded), and the determinism /
+external-call guarantees from the AC.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.recovery_engine import (
+    DEFAULT_SIZING_CAP_DOLLARS,
+    WHEEL_BE_MULTIPLIERS,
+    WHEEL_MONTHLY_PREMIUM_PCT,
+    canonical_path_order,
+    compute_recovery_paths,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — the canonical SOFI position used across most tests.
+# ---------------------------------------------------------------------------
+
+
+def _sofi_position(**overrides) -> dict:
+    """Canonical SOFI fixture from the design spec (100 sh, basis $38)."""
+    base = {
+        "id": "pos-sofi",
+        "ticker": "SOFI",
+        "shares": 100,
+        "adjusted_cost_basis": 3800.0,
+        "broker_cost_basis": 3800.0,
+        "status": "open",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Canonical shape + ordering
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalShape:
+    def test_returns_four_paths_in_canonical_order(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        assert [p["path_id"] for p in paths] == list(canonical_path_order())
+        assert len(paths) == 4
+
+    def test_every_path_has_required_fields(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        for p in paths:
+            assert set(p.keys()) >= {
+                "path_id",
+                "label",
+                "eligibility",
+                "suppression_reason",
+                "capital_tied_up",
+                "months_to_breakeven",
+                "opportunity_cost_vs_baseline",
+                "assumptions",
+                "narration",
+            }
+            assert p["eligibility"] in {"eligible", "suppressed"}
+            assert set(p["months_to_breakeven"].keys()) == {
+                "best",
+                "expected",
+                "worst",
+            }
+            # narration is reserved for V0.6; engine emits None.
+            assert p["narration"] is None
+            # assumptions must always be a non-empty list of strings so the
+            # frontend has at least one row to render per path.
+            assert isinstance(p["assumptions"], list)
+            assert all(isinstance(s, str) for s in p["assumptions"])
+
+    def test_no_irr_field_anywhere(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        for p in paths:
+            assert "irr" not in p, f"path {p['path_id']} leaked stale 'irr' field"
+
+
+# ---------------------------------------------------------------------------
+# sell-redeploy
+# ---------------------------------------------------------------------------
+
+
+class TestSellRedeployPath:
+    def test_suppressed_when_target_yield_missing(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=None,
+            sizing_cap_dollars=5000.0,
+        )
+        sell = next(p for p in paths if p["path_id"] == "sell-redeploy")
+        assert sell["eligibility"] == "suppressed"
+        assert sell["suppression_reason"] == "Target yield not configured"
+        assert sell["capital_tied_up"] is None
+        assert sell["opportunity_cost_vs_baseline"] is None
+
+    def test_eligible_when_target_yield_set(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        sell = next(p for p in paths if p["path_id"] == "sell-redeploy")
+        assert sell["eligibility"] == "eligible"
+        assert sell["suppression_reason"] is None
+        # freed_capital = 100 sh * $8 = $800
+        assert sell["capital_tied_up"] == pytest.approx(800.0)
+        # baseline path → opportunity cost is exactly zero
+        assert sell["opportunity_cost_vs_baseline"] == 0.0
+        # realized_loss = $3800 - $800 = $3000; annual_return = $800 * 0.18 = $144
+        # months_expected = (3000 / 144) * 12 = 250
+        assert sell["months_to_breakeven"]["expected"] == pytest.approx(250.0)
+        assert sell["months_to_breakeven"]["best"] == pytest.approx(200.0)
+        assert sell["months_to_breakeven"]["worst"] == pytest.approx(325.0)
+
+
+# ---------------------------------------------------------------------------
+# wheel-cc
+# ---------------------------------------------------------------------------
+
+
+class TestWheelCcPath:
+    def test_premium_pct_in_assumptions(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        wheel = next(p for p in paths if p["path_id"] == "wheel-cc")
+        # The exact "1.5%/month" copy must be in the assumption list — the
+        # frontend pattern-matches on this string.
+        assumption_blob = " ".join(wheel["assumptions"])
+        pct_str = f"{WHEEL_MONTHLY_PREMIUM_PCT * 100:.1f}%/month"
+        assert pct_str in assumption_blob
+        assert "heuristic" in assumption_blob.lower()
+
+    def test_breakeven_range_uses_multipliers(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        wheel = next(p for p in paths if p["path_id"] == "wheel-cc")
+        # monthly_premium = 0.015 * $8 * 100 = $12
+        # realized_loss = $3000; base months = 250
+        # best = ceil(250 * 0.8) = 200; expected = 250; worst = ceil(250 * 1.3) = 325
+        assert wheel["months_to_breakeven"]["best"] == 200
+        assert wheel["months_to_breakeven"]["expected"] == 250
+        assert wheel["months_to_breakeven"]["worst"] == 325
+        # Multipliers stay in sync with the published constant.
+        assert WHEEL_BE_MULTIPLIERS == (0.8, 1.0, 1.3)
+
+    def test_capital_tied_up_is_strike_proxy_x_shares(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        wheel = next(p for p in paths if p["path_id"] == "wheel-cc")
+        # strike_proxy = $8, shares = 100 → $800
+        assert wheel["capital_tied_up"] == pytest.approx(800.0)
+
+    def test_opportunity_cost_vs_baseline_when_yield_set(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        wheel = next(p for p in paths if p["path_id"] == "wheel-cc")
+        # baseline_annual = $800 * 0.18 = $144
+        # annual_premium = $12/mo * 12 = $144
+        # opp_cost = $144 - $144 = $0
+        assert wheel["opportunity_cost_vs_baseline"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# average-down
+# ---------------------------------------------------------------------------
+
+
+class TestAverageDownPath:
+    def test_suppressed_when_sizing_cap_breached(self):
+        # SOFI: shares=100, basis=$3800, current=$8 → adding 100 shares at
+        # $8 = $800 in fresh capital; total tied up = $4600 → within $5000
+        # cap. To force suppression, bump the cap below the new total.
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=2000.0,
+        )
+        avg = next(p for p in paths if p["path_id"] == "average-down")
+        assert avg["eligibility"] == "suppressed"
+        assert avg["suppression_reason"] is not None
+        assert "sizing cap" in avg["suppression_reason"].lower()
+        # Capital fields must be None per the suppressed contract.
+        assert avg["capital_tied_up"] is None
+        assert avg["opportunity_cost_vs_baseline"] is None
+
+    def test_eligible_within_cap(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        avg = next(p for p in paths if p["path_id"] == "average-down")
+        assert avg["eligibility"] == "eligible"
+        # capital_tied_up = $3800 + $800 = $4600
+        assert avg["capital_tied_up"] == pytest.approx(4600.0)
+        # opp_cost = additional_capital * target_yield = $800 * 0.18 = $144
+        assert avg["opportunity_cost_vs_baseline"] == pytest.approx(144.0)
+
+    def test_uses_default_sizing_cap_when_unset(self):
+        # When the OKR cap is None the engine falls back to the documented
+        # default. With the SOFI fixture, $4600 < $5000 default → eligible.
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=None,
+        )
+        avg = next(p for p in paths if p["path_id"] == "average-down")
+        assert avg["eligibility"] == "eligible"
+        assert DEFAULT_SIZING_CAP_DOLLARS == 5000.0
+
+
+# ---------------------------------------------------------------------------
+# hold-monitor
+# ---------------------------------------------------------------------------
+
+
+class TestHoldMonitorPath:
+    def test_breakeven_range_is_all_null(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        hold = next(p for p in paths if p["path_id"] == "hold-monitor")
+        assert hold["months_to_breakeven"] == {
+            "best": None,
+            "expected": None,
+            "worst": None,
+        }
+
+    def test_opportunity_cost_is_freed_capital_x_yield(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        hold = next(p for p in paths if p["path_id"] == "hold-monitor")
+        # freed_capital = $800; opp_cost = $800 * 0.18 = $144
+        assert hold["opportunity_cost_vs_baseline"] == pytest.approx(144.0)
+
+    def test_capital_tied_up_is_current_basis(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        hold = next(p for p in paths if p["path_id"] == "hold-monitor")
+        # adjusted_cost_basis = $3800
+        assert hold["capital_tied_up"] == pytest.approx(3800.0)
+
+    def test_eligible_even_when_yield_unset(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=8.0,
+            target_yield=None,
+            sizing_cap_dollars=5000.0,
+        )
+        hold = next(p for p in paths if p["path_id"] == "hold-monitor")
+        # Hold needs no target yield to be eligible — it's the "do nothing"
+        # baseline.
+        assert hold["eligibility"] == "eligible"
+        assert hold["opportunity_cost_vs_baseline"] is None
+
+
+# ---------------------------------------------------------------------------
+# Determinism + external-call guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminism:
+    def test_byte_identical_output_for_same_input(self):
+        kwargs = {
+            "position": _sofi_position(),
+            "current_price": 8.0,
+            "target_yield": 0.18,
+            "sizing_cap_dollars": 5000.0,
+        }
+        out_a = compute_recovery_paths(**kwargs)
+        out_b = compute_recovery_paths(**kwargs)
+        assert json.dumps(out_a, sort_keys=True) == json.dumps(out_b, sort_keys=True)
+
+
+class TestNoExternalCalls:
+    """Static check: engine must not import HTTP / LLM clients."""
+
+    FORBIDDEN_TOP_LEVEL_MODULES = {
+        "httpx",
+        "requests",
+        "openai",
+        "anthropic",
+        "urllib",
+        "socket",
+    }
+
+    def test_engine_module_has_no_forbidden_imports(self):
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "app"
+            / "services"
+            / "recovery_engine.py"
+        )
+        tree = ast.parse(path.read_text())
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imported.add(node.module.split(".")[0])
+        leaks = self.FORBIDDEN_TOP_LEVEL_MODULES & imported
+        assert not leaks, f"recovery_engine.py imports forbidden modules: {leaks}"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_position_above_water_returns_eligible_paths_with_null_breakeven(self):
+        # current_price * shares > adjusted_cost_basis → no realized loss.
+        paths = compute_recovery_paths(
+            position=_sofi_position(adjusted_cost_basis=500.0),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        # sell-redeploy: realized_loss=0 → breakeven range collapses
+        sell = next(p for p in paths if p["path_id"] == "sell-redeploy")
+        assert sell["months_to_breakeven"]["expected"] is None
+
+    def test_zero_current_price_treated_as_zero_dollars(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(),
+            current_price=0.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        wheel = next(p for p in paths if p["path_id"] == "wheel-cc")
+        # Premium math collapses to zero — no breakeven horizon.
+        assert wheel["months_to_breakeven"]["expected"] is None
+
+    def test_zero_shares_collapses_paths_to_zero_dollars(self):
+        paths = compute_recovery_paths(
+            position=_sofi_position(shares=0),
+            current_price=8.0,
+            target_yield=0.18,
+            sizing_cap_dollars=5000.0,
+        )
+        wheel = next(p for p in paths if p["path_id"] == "wheel-cc")
+        assert wheel["capital_tied_up"] == pytest.approx(0.0)

--- a/backend/tests/test_recovery_router.py
+++ b/backend/tests/test_recovery_router.py
@@ -1,0 +1,267 @@
+"""Integration tests for the Recovery Plan router.
+
+Uses the in-memory SQLite ``client`` fixture from ``conftest.py``.
+Monkeypatches ``SchwabClient.get_quote`` so no real Schwab calls are made.
+
+Covers:
+
+- Happy path: flagged position → ``state == "populated"`` with paths +
+  recommendation.
+- 404 for unknown position.
+- ``state == "not-applicable"`` for shares=0 / closed / zero-basis.
+- ``state == "not-flagged"`` for position above the threshold.
+- 500 with the **generic** detail message when the quote fails — and the
+  500 body does NOT leak ``str(e)`` (CLAUDE.md compliance).
+- ``okr_target_yield`` / ``okr_sizing_cap_dollars`` read from
+  ``app_settings``; defaults when unset.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.models.database import AppSetting, Position
+from app.services.schwab_client import SchwabClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers — seed positions directly via SQLAlchemy
+# ---------------------------------------------------------------------------
+
+
+def _seed_position(
+    client,
+    *,
+    pos_id: str = "pos-sofi",
+    ticker: str = "SOFI",
+    shares: int = 100,
+    broker_cost_basis: float = 3800.0,
+    status: str = "open",
+) -> str:
+    """Insert a position row into the in-memory test DB.
+
+    The ``client`` fixture wires the test session against the in-memory
+    DB so we just grab one and add. Returns the position id.
+    """
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        pos = Position(
+            id=pos_id,
+            ticker=ticker,
+            shares=shares,
+            broker_cost_basis=broker_cost_basis,
+            status=status,
+            strategy="csp",
+            opened_at="2024-01-01",
+        )
+        db.add(pos)
+        db.commit()
+    finally:
+        db.close()
+    return pos_id
+
+
+def _seed_setting(client, key: str, value: str) -> None:
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        db.add(AppSetting(key=key, value=value))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _quote(last_price: float) -> dict:
+    """Return a Schwab-quote-shaped dict for the monkeypatch."""
+    return {"lastPrice": last_price}
+
+
+# ---------------------------------------------------------------------------
+# 404
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_plan_returns_404_when_position_missing(client):
+    resp = client.post("/api/positions/nope-id/recovery-plan")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Position not found"}
+
+
+# ---------------------------------------------------------------------------
+# Not-applicable / not-flagged
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_plan_not_applicable_for_zero_shares(client):
+    _seed_position(client, shares=0)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["state"] == "not-applicable"
+    assert payload["paths"] == []
+    assert payload["recommendation"] is None
+
+
+def test_recovery_plan_not_applicable_for_closed_position(client):
+    _seed_position(client, status="closed", shares=100)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "not-applicable"
+
+
+def test_recovery_plan_not_applicable_for_zero_basis(client):
+    _seed_position(client, broker_cost_basis=0.0)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "not-applicable"
+
+
+def test_recovery_plan_not_flagged_above_threshold(client):
+    # Position with $3800 basis at $40 current price → $4000 notional, +$200
+    # gain → does not breach either threshold.
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(40.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["state"] == "not-flagged"
+    # Header summary IS rendered (per spec — frontend EmptyState wants the
+    # ticker / shares / basis context).
+    assert payload["position"]["ticker"] == "SOFI"
+
+
+# ---------------------------------------------------------------------------
+# Happy path — populated
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_plan_populated_for_flagged_position(client):
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    _seed_setting(client, "okr_target_yield", "0.18")
+    _seed_setting(client, "okr_sizing_cap_dollars", "5000.0")
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["state"] == "populated"
+    # 4 paths in canonical order.
+    assert [p["path_id"] for p in payload["paths"]] == [
+        "sell-redeploy",
+        "wheel-cc",
+        "average-down",
+        "hold-monitor",
+    ]
+    # Recommendation present + tie_epsilon surfaced.
+    assert payload["recommendation"] is not None
+    assert payload["recommendation"]["tie_epsilon"] == 1.0
+    # Assumptions panel has all 6 documented rows.
+    labels = [a["label"] for a in payload["assumptions"]]
+    assert labels == [
+        "Premium rate (Wheel)",
+        "Target yield (Sell & redeploy)",
+        "Sizing cap (Average down)",
+        "Strategy preference",
+        "Current price",
+        "Tax / wash sale",
+    ]
+    # Disclaimer always present at the top level.
+    assert "fit recommendation" in payload["disclaimer"]
+
+
+def test_recovery_plan_uses_okr_target_yield_from_settings(client):
+    _seed_position(client, broker_cost_basis=3800.0)
+    _seed_setting(client, "okr_target_yield", "0.20")
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    payload = resp.json()
+    assert payload["inputs"]["okr"]["target_yield"] == pytest.approx(0.20)
+    # Sell-redeploy is eligible (target yield set).
+    sell = next(p for p in payload["paths"] if p["path_id"] == "sell-redeploy")
+    assert sell["eligibility"] == "eligible"
+
+
+def test_recovery_plan_suppresses_sell_redeploy_when_target_yield_unset(client):
+    _seed_position(client, broker_cost_basis=3800.0)
+    # No target_yield seeded → defaults to None.
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    payload = resp.json()
+    sell = next(p for p in payload["paths"] if p["path_id"] == "sell-redeploy")
+    assert sell["eligibility"] == "suppressed"
+    assert sell["suppression_reason"] == "Target yield not configured"
+
+
+def test_recovery_plan_uses_default_sizing_cap_when_unset(client):
+    _seed_position(client, broker_cost_basis=3800.0)
+    _seed_setting(client, "okr_target_yield", "0.18")
+    # No sizing-cap seeded → default $5,000.
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    payload = resp.json()
+    assert payload["inputs"]["okr"]["sizing_cap_dollars"] == pytest.approx(5000.0)
+
+
+# ---------------------------------------------------------------------------
+# Quote failure → generic 500 + no str(e) leak
+# ---------------------------------------------------------------------------
+
+
+_UNIQUE_LEAK_NEEDLE = "ZZZ-do-not-leak-this-needle-ZZZ"
+
+
+def test_recovery_plan_quote_failure_returns_generic_500(client):
+    _seed_position(client, broker_cost_basis=3800.0)
+
+    def _raise(_self, *_args, **_kwargs):
+        raise RuntimeError(_UNIQUE_LEAK_NEEDLE)
+
+    with patch.object(SchwabClient, "get_quote", _raise):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body == {"detail": "Failed to build recovery plan. Please try again."}
+    # CLAUDE.md compliance: no part of the underlying exception leaks into
+    # the response body.
+    assert _UNIQUE_LEAK_NEEDLE not in resp.text
+
+
+def test_recovery_plan_treats_missing_last_price_as_quote_failure(client):
+    _seed_position(client, broker_cost_basis=3800.0)
+    with patch.object(SchwabClient, "get_quote", return_value={}):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 500
+    assert resp.json() == {
+        "detail": "Failed to build recovery plan. Please try again."
+    }
+
+
+# ---------------------------------------------------------------------------
+# Response schema validation
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_plan_response_matches_schema(client):
+    _seed_position(client, broker_cost_basis=3800.0)
+    _seed_setting(client, "okr_target_yield", "0.18")
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    payload = resp.json()
+    # Round-trip the response through the Pydantic schema to confirm it
+    # validates without errors. If a field is missing or shaped wrong,
+    # this raises ValidationError.
+    from app.models.schemas import RecoveryPlanResponse
+
+    RecoveryPlanResponse.model_validate(payload)

--- a/backend/tests/test_recovery_scoring.py
+++ b/backend/tests/test_recovery_scoring.py
@@ -1,0 +1,592 @@
+"""Unit tests for the Recovery Plan scoring engine.
+
+Covers the recommendation-engine ACs from issue #182:
+
+- leader-per-criterion picks up the points
+- ties at exact equality split points
+- tie within ``TIE_EPSILON = 1.0`` → ``recommended_path_id = None`` +
+  ``"No clear best fit"`` label
+- suppressed path with winning metrics is never recommended
+- OKR strategy-preference bonus applied when set, dormant when unset
+- bonus criterion row is always present (so the unset callout renders)
+- all paths suppressed → ``"No eligible path under current sizing rules"``
+- reproducibility: same input → byte-identical recommendation
+- ``path_scores[]`` shape — one entry per criterion × all eligible paths
+- ``recommendation_reasons`` length 2–4, drawn from frozen templates
+- no LLM / HTTP imports in the module
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+from app.services.recovery_engine import compute_recovery_paths
+from app.services.recovery_scoring import (
+    DISCLAIMER_TEXT,
+    LABEL_TEMPLATES,
+    REASON_TEMPLATES,
+    STRATEGY_PREFERENCE_TO_PATH,
+    TIE_EPSILON,
+    WEIGHT_FASTEST_BREAKEVEN,
+    WEIGHT_LOWEST_CAPITAL,
+    WEIGHT_LOWEST_OPPORTUNITY_COST,
+    WEIGHT_STRATEGY_PREFERENCE,
+    score_recovery_paths,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sofi_position(**overrides) -> dict:
+    base = {
+        "id": "pos-sofi",
+        "ticker": "SOFI",
+        "shares": 100,
+        "adjusted_cost_basis": 3800.0,
+        "broker_cost_basis": 3800.0,
+        "status": "open",
+    }
+    base.update(overrides)
+    return base
+
+
+def _sofi_paths(target_yield: float | None = 0.18, sizing_cap: float = 5000.0):
+    return compute_recovery_paths(
+        position=_sofi_position(),
+        current_price=8.0,
+        target_yield=target_yield,
+        sizing_cap_dollars=sizing_cap,
+    )
+
+
+def _make_path(
+    *,
+    path_id: str,
+    label: str = "X",
+    eligibility: str = "eligible",
+    suppression_reason: str | None = None,
+    capital_tied_up: float | None = 0.0,
+    expected_months: float | None = None,
+    opportunity_cost: float | None = 0.0,
+) -> dict:
+    """Lightweight path-dict builder for scoring-only tests."""
+    return {
+        "path_id": path_id,
+        "label": label,
+        "eligibility": eligibility,
+        "suppression_reason": suppression_reason,
+        "capital_tied_up": capital_tied_up,
+        "months_to_breakeven": {
+            "best": None,
+            "expected": expected_months,
+            "worst": None,
+        },
+        "opportunity_cost_vs_baseline": opportunity_cost,
+        "assumptions": [],
+        "narration": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sanity / canonical shape
+# ---------------------------------------------------------------------------
+
+
+class TestCanonicalShape:
+    def test_response_has_required_top_level_keys(self):
+        paths = _sofi_paths()
+        rec = score_recovery_paths(paths, {})
+        assert set(rec.keys()) == {
+            "recommended_path_id",
+            "recommendation_label",
+            "recommendation_reasons",
+            "ranked_paths",
+            "path_scores",
+            "tie_epsilon",
+            "disclaimer",
+        }
+
+    def test_disclaimer_is_canonical_text(self):
+        rec = score_recovery_paths(_sofi_paths(), {})
+        assert rec["disclaimer"] == DISCLAIMER_TEXT
+        # Per advice-framing audit: no prescriptive verbs in the disclaimer.
+        for verb in ("you should", "buy ", "sell ", "hold "):
+            assert verb not in DISCLAIMER_TEXT.lower(), (
+                f"disclaimer leaks prescriptive verb '{verb}'"
+            )
+
+    def test_tie_epsilon_matches_module_constant(self):
+        rec = score_recovery_paths(_sofi_paths(), {})
+        assert rec["tie_epsilon"] == TIE_EPSILON == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Leader-per-criterion + tie handling
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderPerCriterion:
+    def test_unique_leader_collects_full_weight(self):
+        # Path A is the unique leader on fastest_breakeven.
+        paths = [
+            _make_path(
+                path_id="wheel-cc", label="Wheel", capital_tied_up=100,
+                expected_months=4, opportunity_cost=0,
+            ),
+            _make_path(
+                path_id="sell-redeploy", label="Sell", capital_tied_up=200,
+                expected_months=10, opportunity_cost=50,
+            ),
+            _make_path(
+                path_id="hold-monitor", label="Hold", capital_tied_up=300,
+                expected_months=20, opportunity_cost=200,
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "fastest_breakeven"
+        )
+        cells = {c["path_id"]: c for c in row["ranking"]}
+        assert cells["wheel-cc"]["points"] == WEIGHT_FASTEST_BREAKEVEN
+        assert cells["sell-redeploy"]["points"] == 0
+        assert cells["hold-monitor"]["points"] == 0
+
+    def test_exact_tie_splits_points_among_leaders(self):
+        # All three paths have $0 capital — the AC example: all three get +3.
+        paths = [
+            _make_path(
+                path_id="wheel-cc", label="Wheel", capital_tied_up=0,
+                expected_months=4, opportunity_cost=100,
+            ),
+            _make_path(
+                path_id="sell-redeploy", label="Sell", capital_tied_up=0,
+                expected_months=10, opportunity_cost=0,
+            ),
+            _make_path(
+                path_id="hold-monitor", label="Hold", capital_tied_up=0,
+                expected_months=20, opportunity_cost=200,
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "lowest_additional_capital"
+        )
+        for cell in row["ranking"]:
+            assert cell["points"] == WEIGHT_LOWEST_CAPITAL
+            assert cell["rank"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tie within epsilon → no clear best fit
+# ---------------------------------------------------------------------------
+
+
+class TestTieWithinEpsilon:
+    def test_top_two_within_epsilon_yields_no_clear_best_fit(self):
+        # Construct two paths that score 5 and 5 on totals → tied.
+        paths = [
+            # wheel-cc wins fastest_breakeven (+3) and ties capital (+3).
+            _make_path(
+                path_id="wheel-cc", label="Wheel", capital_tied_up=0,
+                expected_months=4, opportunity_cost=200,
+            ),
+            # sell-redeploy ties capital (+3) and wins opp-cost (+2).
+            _make_path(
+                path_id="sell-redeploy", label="Sell", capital_tied_up=0,
+                expected_months=10, opportunity_cost=0,
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        # Totals: wheel=3+3=6; sell=3+2=5. Gap=1 → within epsilon → no clear.
+        assert rec["recommended_path_id"] is None
+        assert rec["recommendation_label"] == "No clear best fit"
+        assert rec["recommendation_label"] == LABEL_TEMPLATES["no_clear_best_fit"]
+        # Ranked paths still rendered.
+        assert len(rec["ranked_paths"]) >= 2
+        assert rec["ranked_paths"][0]["score"] == 6
+        assert rec["ranked_paths"][1]["score"] == 5
+
+    def test_gap_larger_than_epsilon_recommends_single_path(self):
+        # wheel-cc dominates: +3 (fastest) +3 (capital) +2 (opp_cost) = 8.
+        # hold-monitor: capital ties (+3 if tied) but otherwise 0.
+        paths = [
+            _make_path(
+                path_id="wheel-cc", label="Wheel", capital_tied_up=0,
+                expected_months=4, opportunity_cost=0,
+            ),
+            _make_path(
+                path_id="sell-redeploy", label="Sell", capital_tied_up=500,
+                expected_months=20, opportunity_cost=100,
+            ),
+            _make_path(
+                path_id="hold-monitor", label="Hold", capital_tied_up=800,
+                expected_months=None, opportunity_cost=300,
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        assert rec["recommended_path_id"] == "wheel-cc"
+
+
+# ---------------------------------------------------------------------------
+# Suppressed paths
+# ---------------------------------------------------------------------------
+
+
+class TestSuppressedHandling:
+    def test_suppressed_path_with_winning_metrics_is_not_recommended(self):
+        # Force a suppressed path that *would* dominate the metrics.
+        paths = [
+            _make_path(
+                path_id="wheel-cc", label="Wheel", capital_tied_up=100,
+                expected_months=10, opportunity_cost=50,
+            ),
+            _make_path(
+                path_id="average-down",
+                label="Average down",
+                eligibility="suppressed",
+                suppression_reason="Exceeds your $5,000 per-position sizing cap",
+                capital_tied_up=None,
+                expected_months=None,
+                opportunity_cost=None,
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        # Only wheel-cc is eligible → must be recommended.
+        assert rec["recommended_path_id"] == "wheel-cc"
+        # Suppressed path is in ranked_paths with null score+rank.
+        suppressed_entry = next(
+            r for r in rec["ranked_paths"] if r["path_id"] == "average-down"
+        )
+        assert suppressed_entry["score"] is None
+        assert suppressed_entry["rank"] is None
+        assert "sizing cap" in (suppressed_entry["suppression_reason"] or "")
+
+    def test_all_paths_suppressed_yields_no_eligible_path(self):
+        paths = [
+            _make_path(
+                path_id="sell-redeploy",
+                label="Sell",
+                eligibility="suppressed",
+                suppression_reason="Target yield not configured",
+            ),
+            _make_path(
+                path_id="average-down",
+                label="Average down",
+                eligibility="suppressed",
+                suppression_reason="Exceeds your $5,000 per-position sizing cap",
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        assert rec["recommended_path_id"] is None
+        assert (
+            rec["recommendation_label"]
+            == LABEL_TEMPLATES["no_eligible_path"]
+            == "No eligible path under current sizing rules"
+        )
+        # Reasons list still 2–4 entries.
+        assert 2 <= len(rec["recommendation_reasons"]) <= 4
+        # path_scores collapses to empty when nothing is eligible.
+        assert rec["path_scores"] == []
+
+
+# ---------------------------------------------------------------------------
+# Strategy-preference bonus (dormant in V0.5.8)
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyPreferenceBonus:
+    def test_unset_preference_keeps_bonus_row_with_all_zero_cells(self):
+        # V0.5.8 default — strategy_preference unset.
+        rec = score_recovery_paths(_sofi_paths(), {})
+        bonus_row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "strategy_preference_bonus"
+        )
+        assert bonus_row["weight"] == WEIGHT_STRATEGY_PREFERENCE
+        for cell in bonus_row["ranking"]:
+            assert cell["points"] == 0, (
+                "unset preference must not contribute points"
+            )
+
+    def test_set_preference_awards_bonus_to_matching_path(self):
+        rec = score_recovery_paths(
+            _sofi_paths(), {"strategy_preference": "income-first"}
+        )
+        bonus_row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "strategy_preference_bonus"
+        )
+        # income-first → wheel-cc per the mapping.
+        wheel_cell = next(
+            c for c in bonus_row["ranking"] if c["path_id"] == "wheel-cc"
+        )
+        assert wheel_cell["points"] == WEIGHT_STRATEGY_PREFERENCE
+
+    def test_unknown_preference_defaults_to_no_bonus(self):
+        rec = score_recovery_paths(
+            _sofi_paths(), {"strategy_preference": "definitely-not-real"}
+        )
+        bonus_row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "strategy_preference_bonus"
+        )
+        assert all(c["points"] == 0 for c in bonus_row["ranking"])
+
+    def test_passive_preference_yields_no_bonus(self):
+        rec = score_recovery_paths(
+            _sofi_paths(), {"strategy_preference": "passive"}
+        )
+        bonus_row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "strategy_preference_bonus"
+        )
+        assert all(c["points"] == 0 for c in bonus_row["ranking"])
+
+    def test_label_uses_neutral_template_when_preference_unset(self):
+        rec = score_recovery_paths(_sofi_paths(), {})
+        if rec["recommended_path_id"] is not None:
+            # Label must come from the neutral template, not the
+            # with-strategy-preference one.
+            assert rec["recommendation_label"].startswith(
+                "Best fit on capital efficiency and breakeven"
+            )
+
+    def test_strategy_mapping_locked(self):
+        # If this assertion ever fails, dependent #156/#157 work and the
+        # design spec §4.5 need updating together.
+        assert STRATEGY_PREFERENCE_TO_PATH == {
+            "income-first": "wheel-cc",
+            "capital-efficient": "sell-redeploy",
+            "conviction-add": "average-down",
+        }
+
+
+# ---------------------------------------------------------------------------
+# path_scores shape + reasons
+# ---------------------------------------------------------------------------
+
+
+class TestPathScoresMatrix:
+    def test_one_row_per_criterion_in_canonical_order(self):
+        rec = score_recovery_paths(_sofi_paths(), {})
+        criteria = [r["criterion"] for r in rec["path_scores"]]
+        assert criteria == [
+            "fastest_breakeven",
+            "lowest_additional_capital",
+            "lowest_opportunity_cost",
+            "strategy_preference_bonus",
+        ]
+
+    def test_each_row_has_one_cell_per_eligible_path(self):
+        paths = _sofi_paths()
+        eligible = [p for p in paths if p["eligibility"] == "eligible"]
+        rec = score_recovery_paths(paths, {})
+        for row in rec["path_scores"]:
+            assert len(row["ranking"]) == len(eligible)
+            assert {c["path_id"] for c in row["ranking"]} == {
+                p["path_id"] for p in eligible
+            }
+
+    def test_each_cell_has_raw_value_points_rank(self):
+        rec = score_recovery_paths(_sofi_paths(), {})
+        for row in rec["path_scores"]:
+            for cell in row["ranking"]:
+                assert set(cell.keys()) == {"path_id", "raw_value", "points", "rank"}
+
+
+class TestRecommendationReasons:
+    def _happy_path_recommendation(self):
+        """Drive the engine to a single-winner happy-path recommendation.
+
+        The default SOFI fixture ties on enough criteria that the scoring
+        engine emits ``no-clear-best-fit`` — that's a separate scoring path
+        with its own degradation copy. Use a synthetic path list here so
+        the happy-path reason templates are the only thing under test.
+        """
+        paths = [
+            _make_path(
+                path_id="wheel-cc", label="Wheel covered calls",
+                capital_tied_up=100, expected_months=4, opportunity_cost=50,
+            ),
+            _make_path(
+                path_id="sell-redeploy", label="Sell & redeploy",
+                capital_tied_up=500, expected_months=10, opportunity_cost=0,
+            ),
+            _make_path(
+                path_id="hold-monitor", label="Hold & monitor",
+                capital_tied_up=800, expected_months=None, opportunity_cost=300,
+            ),
+        ]
+        return score_recovery_paths(paths, {})
+
+    def test_reasons_length_2_to_4_on_happy_path(self):
+        rec = self._happy_path_recommendation()
+        assert rec["recommended_path_id"] == "wheel-cc"
+        assert 2 <= len(rec["recommendation_reasons"]) <= 4
+
+    def test_all_reasons_come_from_templates_on_happy_path(self):
+        rec = self._happy_path_recommendation()
+        # Every reason must look like one of the frozen templates with the
+        # placeholders filled in. We assert by recognizing template prefixes.
+        template_prefixes = {
+            "Fastest expected breakeven",
+            "Lowest additional capital required",
+            "Lowest opportunity cost vs baseline",
+            "Matches your configured",
+            "Within your per-position sizing cap",
+        }
+        for reason in rec["recommendation_reasons"]:
+            assert any(reason.startswith(p) for p in template_prefixes), (
+                f"reason '{reason}' did not match any template prefix"
+            )
+
+    def test_reasons_avoid_prescriptive_advice_wording(self):
+        # Cover both code paths — happy + degraded — so the advice-framing
+        # audit runs against every emitted reason.
+        for rec in (
+            self._happy_path_recommendation(),
+            score_recovery_paths(_sofi_paths(), {}),
+        ):
+            for reason in rec["recommendation_reasons"]:
+                low = reason.lower()
+                assert "you should" not in low
+                assert "buy more" not in low
+                assert "sell now" not in low
+
+
+# ---------------------------------------------------------------------------
+# Reproducibility (AC: same input → byte-identical recommendation)
+# ---------------------------------------------------------------------------
+
+
+class TestReproducibility:
+    def test_byte_identical_recommendation_object(self):
+        paths = _sofi_paths()
+        a = score_recovery_paths(paths, {})
+        b = score_recovery_paths(paths, {})
+        assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+    def test_byte_identical_with_strategy_preference(self):
+        paths = _sofi_paths()
+        a = score_recovery_paths(paths, {"strategy_preference": "income-first"})
+        b = score_recovery_paths(paths, {"strategy_preference": "income-first"})
+        assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Static guard: no LLM / HTTP imports in scoring module
+# ---------------------------------------------------------------------------
+
+
+class TestNoExternalCalls:
+    FORBIDDEN = {"httpx", "requests", "openai", "anthropic", "urllib", "socket"}
+
+    def test_scoring_module_imports_are_pure(self):
+        path = (
+            Path(__file__).resolve().parents[1]
+            / "app"
+            / "services"
+            / "recovery_scoring.py"
+        )
+        tree = ast.parse(path.read_text())
+        names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    names.add(alias.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    names.add(node.module.split(".")[0])
+        leaks = self.FORBIDDEN & names
+        assert not leaks, f"scoring module imports forbidden modules: {leaks}"
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — template strings frozen after merge (AC)
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateSnapshots:
+    """Inline snapshot of the LABEL + REASON template dicts.
+
+    Failing this test means a template string changed — that's an
+    intentional product decision and the snapshot needs to be updated in
+    the same commit (the AC explicitly says "Template strings for
+    `recommendation_label` and `recommendation_reasons` are frozen by
+    snapshot tests after merge").
+    """
+
+    EXPECTED_LABEL_TEMPLATES: dict[str, str] = {
+        "recommended_neutral": "Best fit on capital efficiency and breakeven: {path_label}",
+        "recommended_with_strategy_preference": (
+            "Best fit for {preference} strategy: {path_label}"
+        ),
+        "no_clear_best_fit": "No clear best fit",
+        "no_eligible_path": "No eligible path under current sizing rules",
+    }
+
+    EXPECTED_REASON_TEMPLATES: dict[str, str] = {
+        "fastest_breakeven_solo": (
+            "Fastest expected breakeven ({months} months vs {next_months} for the next option)"
+        ),
+        "fastest_breakeven_unique": "Fastest expected breakeven ({months} months)",
+        "lowest_additional_capital_zero": "Lowest additional capital required ($0)",
+        "lowest_additional_capital_amount": (
+            "Lowest additional capital required (${capital:,.0f} vs ${next_capital:,.0f} for the next option)"
+        ),
+        "lowest_opportunity_cost_zero": "Lowest opportunity cost vs baseline (${opp_cost:,.0f})",
+        "lowest_opportunity_cost_amount": (
+            "Lowest opportunity cost vs baseline (${opp_cost:,.0f})"
+        ),
+        "strategy_preference_match": "Matches your configured {preference} strategy preference",
+        "within_sizing_cap": "Within your per-position sizing cap",
+    }
+
+    def test_label_templates_frozen(self):
+        assert LABEL_TEMPLATES == self.EXPECTED_LABEL_TEMPLATES
+
+    def test_reason_templates_frozen(self):
+        assert REASON_TEMPLATES == self.EXPECTED_REASON_TEMPLATES
+
+    def test_disclaimer_text_frozen(self):
+        assert DISCLAIMER_TEXT == (
+            "This is a fit recommendation based on your configured "
+            "preferences and stated assumptions. It is not investment "
+            "advice, a price prediction, or a trade execution suggestion."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_single_eligible_path_is_always_recommended(self):
+        paths = [
+            _make_path(
+                path_id="hold-monitor", label="Hold", capital_tied_up=100,
+                expected_months=None, opportunity_cost=0,
+            ),
+        ]
+        rec = score_recovery_paths(paths, {})
+        # Only one eligible → trivially the recommended path. Tie-epsilon
+        # has nothing to compare to.
+        assert rec["recommended_path_id"] == "hold-monitor"
+
+    def test_empty_okr_settings_treated_as_unset(self):
+        rec_a = score_recovery_paths(_sofi_paths(), None)
+        rec_b = score_recovery_paths(_sofi_paths(), {})
+        # Different empty containers, identical output.
+        assert json.dumps(rec_a, sort_keys=True) == json.dumps(rec_b, sort_keys=True)
+
+    def test_hold_monitor_null_breakeven_treated_as_worst_tier(self):
+        rec = score_recovery_paths(_sofi_paths(), {})
+        row = next(
+            r for r in rec["path_scores"] if r["criterion"] == "fastest_breakeven"
+        )
+        hold_cell = next(c for c in row["ranking"] if c["path_id"] == "hold-monitor")
+        assert hold_cell["points"] == 0

--- a/backend/tests/test_recovery_scoring.py
+++ b/backend/tests/test_recovery_scoring.py
@@ -537,10 +537,7 @@ class TestTemplateSnapshots:
         "lowest_additional_capital_amount": (
             "Lowest additional capital required (${capital:,.0f} vs ${next_capital:,.0f} for the next option)"
         ),
-        "lowest_opportunity_cost_zero": "Lowest opportunity cost vs baseline (${opp_cost:,.0f})",
-        "lowest_opportunity_cost_amount": (
-            "Lowest opportunity cost vs baseline (${opp_cost:,.0f})"
-        ),
+        "lowest_opportunity_cost": "Lowest opportunity cost vs baseline (${opp_cost:,.0f})",
         "strategy_preference_match": "Matches your configured {preference} strategy preference",
         "within_sizing_cap": "Within your per-position sizing cap",
     }

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -318,4 +318,13 @@ export async function getDashboard() {
   return data;
 }
 
+// --- Recovery Plan (V0.5.8, issue #182) ---
+
+export async function getRecoveryPlan(id) {
+  const { data } = await api.post(
+    `/api/positions/${encodeURIComponent(id)}/recovery-plan`,
+  );
+  return data;
+}
+
 export default api;

--- a/frontend/app/positions/[id]/recovery/page.jsx
+++ b/frontend/app/positions/[id]/recovery/page.jsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { use } from 'react';
+import dynamic from 'next/dynamic';
+import LoadingSkeleton from '@/components/layout/LoadingSkeleton';
+
+// Route shell for /positions/[id]/recovery — the Recovery Plan panel
+// (issue #182). The largest-loser dashboard CTA navigates here.
+const RecoveryPlanPage = dynamic(
+  () => import('@/components/recovery/RecoveryPlanPage'),
+  {
+    loading: () => (
+      <div className="h-screen flex items-center justify-center bg-slate-100 dark:bg-slate-900">
+        <LoadingSkeleton />
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+export default function PositionRecovery({ params }) {
+  // Next 16: route params are delivered as a Promise; `use()` unwraps it.
+  const { id } = use(params);
+  return <RecoveryPlanPage positionId={id} />;
+}

--- a/frontend/components/recovery/RecoveryAssumptionsPanel.jsx
+++ b/frontend/components/recovery/RecoveryAssumptionsPanel.jsx
@@ -1,0 +1,63 @@
+// Assumptions audit panel — six rows in fixed order.
+//
+// Spec: frontend/design-specs/issue-182-recovery-recommendation.md §5.
+// The backend emits the full list with labels + values + sources; the
+// component just renders the table inside a <details> wrapper.
+
+export default function RecoveryAssumptionsPanel({ assumptions, defaultOpen = false }) {
+  if (!assumptions || assumptions.length === 0) return null;
+  return (
+    <details
+      data-testid="recovery-assumptions-panel"
+      open={defaultOpen}
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+    >
+      <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-200">
+        Assumptions
+      </summary>
+      <div className="px-4 pb-4">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              <th className="text-left py-2 pr-3">Label</th>
+              <th className="text-left py-2 pr-3">Value</th>
+              <th className="text-left py-2">Source</th>
+            </tr>
+          </thead>
+          <tbody>
+            {assumptions.map((row) => (
+              <tr
+                key={row.label}
+                data-testid={`recovery-assumption-${slugify(row.label)}`}
+                className="border-t border-slate-100 dark:border-slate-700/40"
+              >
+                <td className="py-2 pr-3 text-slate-700 dark:text-slate-200">
+                  {row.label}
+                </td>
+                <td
+                  className={
+                    row.value === 'Not set'
+                      ? 'py-2 pr-3 text-slate-500 dark:text-slate-400 tabular-nums'
+                      : 'py-2 pr-3 text-slate-900 dark:text-white tabular-nums'
+                  }
+                >
+                  {row.value}
+                </td>
+                <td className="py-2 text-xs text-slate-500 dark:text-slate-400">
+                  {row.source}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </details>
+  );
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}

--- a/frontend/components/recovery/RecoveryPathCard.jsx
+++ b/frontend/components/recovery/RecoveryPathCard.jsx
@@ -1,0 +1,223 @@
+// Per-path comparison card for the Recovery Plan grid.
+//
+// Three treatments:
+//   - default              — neutral border, full opacity
+//   - recommended          — blue ring + ✦ Recommended pill
+//   - suppressed           — dashed border, 70% opacity, amber inline reason
+//
+// Spec: frontend/design-specs/issue-182-recovery-recommendation.md §3.
+
+import Link from 'next/link';
+import { suppressionReasonToCta } from './suppressionReasonCta';
+
+function formatDollar(value) {
+  if (value === null || value === undefined || Number.isNaN(value)) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  return `${sign}$${abs.toLocaleString(undefined, {
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function formatMonths(value) {
+  if (value === null || value === undefined) return '—';
+  if (Number.isInteger(value)) return `${value} mo`;
+  return `${value} mo`;
+}
+
+function opportunityCostColor(slug, value) {
+  if (slug === 'sell-redeploy') return 'text-slate-500';
+  if (value === null || value === undefined) return 'text-slate-500';
+  if (value > 0) return 'text-rose-600 dark:text-rose-400';
+  if (value < 0) return 'text-emerald-600 dark:text-emerald-400';
+  return 'text-slate-500';
+}
+
+function opportunityCostSuffix(slug) {
+  return slug === 'sell-redeploy' ? '(baseline)' : '/ yr vs baseline';
+}
+
+function keyAssumption(path) {
+  if (!path.assumptions || path.assumptions.length === 0) return null;
+  // Surface the first assumption (engine emits the most-load-bearing one first).
+  return path.assumptions[0];
+}
+
+export default function RecoveryPathCard({ path, isRecommended }) {
+  const slug = path.path_id;
+  const suppressed = path.eligibility === 'suppressed';
+  const months = path.months_to_breakeven || {};
+  const cta = suppressed ? suppressionReasonToCta(path.suppression_reason) : null;
+
+  const shell = [
+    'relative rounded-xl p-4 transition',
+    suppressed
+      ? 'bg-slate-50 dark:bg-slate-800/60 border border-dashed border-slate-300 dark:border-slate-600 opacity-70'
+      : 'bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700',
+    isRecommended && !suppressed ? 'ring-2 ring-blue-500/40' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const ariaLabel = suppressed
+    ? `${path.label} — suppressed: ${path.suppression_reason || 'not eligible'}`
+    : isRecommended
+    ? `${path.label} — recommended path`
+    : path.label;
+
+  return (
+    <article
+      data-testid={`recovery-path-card-${slug}`}
+      data-eligibility={path.eligibility}
+      data-recommended={isRecommended ? 'true' : 'false'}
+      aria-label={ariaLabel}
+      className={shell}
+    >
+      {isRecommended && !suppressed && (
+        <span
+          data-testid={`recovery-path-card-${slug}-recommended-badge`}
+          className="absolute top-3 right-3 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
+        >
+          <span aria-hidden="true">✦</span> Recommended
+        </span>
+      )}
+
+      <h3 className="text-base font-semibold text-slate-900 dark:text-white pr-24">
+        {path.label}
+      </h3>
+
+      <div className="mt-3">
+        <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Capital tied up
+        </div>
+        <div
+          data-testid={`recovery-path-card-${slug}-capital`}
+          className={
+            suppressed
+              ? 'text-2xl font-semibold tabular-nums text-slate-400 dark:text-slate-500'
+              : 'text-3xl font-semibold tabular-nums text-slate-900 dark:text-white'
+          }
+        >
+          {suppressed ? '—' : formatDollar(path.capital_tied_up)}
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          {slug === 'hold-monitor' ? 'Breakeven' : 'Months to breakeven'}
+        </div>
+        {suppressed ? (
+          <div className="text-2xl font-semibold text-slate-400 dark:text-slate-500">—</div>
+        ) : slug === 'hold-monitor' ? (
+          <div
+            data-testid={`recovery-path-card-${slug}-breakeven-expected`}
+            className="text-sm text-slate-500 dark:text-slate-400 italic mt-1"
+          >
+            — Hold does not breakeven without action.
+          </div>
+        ) : (
+          <div className="space-y-1 mt-1">
+            <RangeRow
+              label="best"
+              value={formatMonths(months.best)}
+              testId={`recovery-path-card-${slug}-breakeven-best`}
+            />
+            <RangeRow
+              label="expected"
+              value={formatMonths(months.expected)}
+              testId={`recovery-path-card-${slug}-breakeven-expected`}
+            />
+            <RangeRow
+              label="worst"
+              value={formatMonths(months.worst)}
+              testId={`recovery-path-card-${slug}-breakeven-worst`}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3">
+        <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+          Opportunity cost
+        </div>
+        <div
+          data-testid={`recovery-path-card-${slug}-opp-cost`}
+          className={
+            suppressed
+              ? 'text-2xl font-semibold text-slate-400 dark:text-slate-500'
+              : `text-base font-medium tabular-nums ${opportunityCostColor(
+                  slug,
+                  path.opportunity_cost_vs_baseline,
+                )}`
+          }
+        >
+          {suppressed ? (
+            '—'
+          ) : (
+            <>
+              {formatDollar(path.opportunity_cost_vs_baseline)}{' '}
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {opportunityCostSuffix(slug)}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      {suppressed && (
+        <div
+          data-testid={`recovery-path-card-${slug}-suppression`}
+          className="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 text-sm text-amber-700 dark:text-amber-300"
+        >
+          <span aria-hidden="true" className="text-amber-600 mr-1">
+            ⚠
+          </span>
+          {path.suppression_reason}
+          {cta && (
+            <div className="mt-2">
+              <Link
+                href={cta.href}
+                data-testid={`recovery-path-card-${slug}-suppression-cta`}
+                className="text-amber-800 dark:text-amber-200 font-medium hover:underline"
+              >
+                {cta.label}
+              </Link>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!suppressed && keyAssumption(path) && (
+        <p
+          data-testid={`recovery-path-card-${slug}-assumption`}
+          className="text-xs italic text-slate-500 dark:text-slate-400 mt-3"
+        >
+          {keyAssumption(path)}
+        </p>
+      )}
+
+      <div
+        data-testid={`recovery-narration-${slug}`}
+        className="min-h-[3rem] mt-3"
+        aria-hidden="true"
+      />
+    </article>
+  );
+}
+
+function RangeRow({ label, value, testId }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span aria-hidden="true" className="text-slate-300 dark:text-slate-600">
+        ▎
+      </span>
+      <span className="text-sm text-slate-500 dark:text-slate-400 w-24">{label}</span>
+      <span
+        data-testid={testId}
+        className="text-base font-medium tabular-nums text-slate-700 dark:text-slate-200"
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/frontend/components/recovery/RecoveryPlanPage.jsx
+++ b/frontend/components/recovery/RecoveryPlanPage.jsx
@@ -1,0 +1,152 @@
+// Top-level page for /positions/[id]/recovery.
+//
+// State machine:
+//   - loading             → skeleton
+//   - error               → empty state with retry
+//   - not-applicable      → EmptyState (option-only or closed)
+//   - not-flagged         → EmptyState (position recovered above threshold)
+//   - populated           → RecoveryPlanView
+//
+// Spec: frontend/design-specs/issue-182-recovery-recommendation.md §1.
+
+import Link from 'next/link';
+import Header from '../layout/Header';
+import { useRecoveryPlan } from '../../hooks/useRecoveryPlan';
+import RecoveryPlanView from './RecoveryPlanView';
+
+function formatPct(value) {
+  if (value === null || value === undefined) return null;
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatDollar(value) {
+  if (value === null || value === undefined) return null;
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  return `${sign}$${abs.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+}
+
+function PositionHeader({ position, state }) {
+  if (!position) return null;
+  const pct = formatPct(position.pl_pct);
+  const pl = formatDollar(position.unrealized_pl);
+  return (
+    <div data-testid="recovery-position-header">
+      <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
+        Recovery plan: {position.ticker}
+      </h1>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+        {position.shares} sh · basis {formatDollar(position.adjusted_cost_basis)}
+        {position.current_price !== null && position.current_price !== undefined
+          ? ` · current $${position.current_price.toFixed(2)}`
+          : ''}
+        {pl !== null && pct !== null
+          ? ` · unrealized ${pl} (${pct})`
+          : ''}
+      </p>
+      {state === 'populated' && (
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+          Flagged because P/L breached your review threshold (-5% or -$1,000).
+        </p>
+      )}
+    </div>
+  );
+}
+
+function EmptyState({ testId, title, body }) {
+  return (
+    <div
+      data-testid={testId}
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 text-center"
+    >
+      <h2 className="text-base font-semibold text-slate-900 dark:text-white">
+        {title}
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-2 max-w-prose mx-auto">
+        {body}
+      </p>
+      <Link
+        href="/dashboard"
+        className="inline-block mt-4 text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+      >
+        ← Back to dashboard
+      </Link>
+    </div>
+  );
+}
+
+export default function RecoveryPlanPage({ positionId }) {
+  const { data, loading, error, refetch } = useRecoveryPlan(positionId);
+
+  return (
+    <div
+      data-testid="recovery-plan-page"
+      className="h-screen flex flex-col bg-slate-100 dark:bg-slate-900"
+    >
+      <Header sessions={[]} onLoadSession={() => {}} />
+      <main className="flex-1 overflow-y-auto p-6 space-y-4">
+        <Link
+          href="/dashboard"
+          className="inline-block text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+          data-testid="recovery-back-to-dashboard"
+        >
+          ← Back to dashboard
+        </Link>
+
+        {loading && !data && (
+          <div data-testid="recovery-plan-loading" className="space-y-4">
+            <div className="h-24 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              {[0, 1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="h-64 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse"
+                />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div
+            data-testid="recovery-plan-error"
+            className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 text-sm text-red-700 dark:text-red-300 flex items-center justify-between"
+          >
+            <span>{error}</span>
+            <button
+              type="button"
+              onClick={refetch}
+              className="px-3 py-1.5 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!error && data && (
+          <>
+            <PositionHeader position={data.position} state={data.state} />
+
+            {data.state === 'not-applicable' && (
+              <EmptyState
+                testId="recovery-plan-not-applicable"
+                title="Recovery plan not applicable"
+                body="This position is closed or holds no shares. The Recovery Plan engine only runs against open share positions that are flagged as underwater."
+              />
+            )}
+
+            {data.state === 'not-flagged' && (
+              <EmptyState
+                testId="recovery-plan-not-flagged"
+                title="Position is above your review threshold"
+                body="The Recovery Plan engine only runs against positions that breach the -5% or -$1,000 review threshold. This position no longer qualifies."
+              />
+            )}
+
+            {data.state === 'populated' && <RecoveryPlanView data={data} />}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/recovery/RecoveryPlanPage.jsx
+++ b/frontend/components/recovery/RecoveryPlanPage.jsx
@@ -46,7 +46,8 @@ function PositionHeader({ position, state }) {
       </p>
       {state === 'populated' && (
         <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
-          Flagged because P/L breached your review threshold (-5% or -$1,000).
+          Flagged because unrealized P/L breached your configured review
+          threshold.
         </p>
       )}
     </div>
@@ -139,7 +140,7 @@ export default function RecoveryPlanPage({ positionId }) {
               <EmptyState
                 testId="recovery-plan-not-flagged"
                 title="Position is above your review threshold"
-                body="The Recovery Plan engine only runs against positions that breach the -5% or -$1,000 review threshold. This position no longer qualifies."
+                body="The Recovery Plan engine only runs against positions that breach your configured review threshold. This position no longer qualifies."
               />
             )}
 

--- a/frontend/components/recovery/RecoveryPlanView.jsx
+++ b/frontend/components/recovery/RecoveryPlanView.jsx
@@ -1,0 +1,67 @@
+// Composition surface for the populated Recovery Plan state.
+//
+// Renders: banner (top) → 4-up card grid (middle) → scoring matrix
+// (collapsed) → assumptions (collapsed) → persistent disclaimer (footer).
+//
+// Spec: frontend/design-specs/issue-182-recovery-recommendation.md §1.
+
+import RecoveryRecommendationBanner from './RecoveryRecommendationBanner';
+import RecoveryPathCard from './RecoveryPathCard';
+import RecoveryScoringMatrix from './RecoveryScoringMatrix';
+import RecoveryAssumptionsPanel from './RecoveryAssumptionsPanel';
+
+export default function RecoveryPlanView({ data }) {
+  if (!data) return null;
+  const { paths = [], recommendation, assumptions = [], disclaimer } = data;
+  const recommendedId = recommendation?.recommended_path_id || null;
+
+  return (
+    <div className="space-y-6">
+      <RecoveryRecommendationBanner
+        recommendation={recommendation}
+        rankedPaths={recommendation?.ranked_paths || []}
+      />
+
+      <div>
+        <h3 className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+          Compare paths
+        </h3>
+        <div
+          data-testid="recovery-path-grid"
+          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4"
+        >
+          {paths.map((path) => (
+            <RecoveryPathCard
+              key={path.path_id}
+              path={path}
+              isRecommended={path.path_id === recommendedId}
+            />
+          ))}
+        </div>
+      </div>
+
+      <RecoveryScoringMatrix
+        pathScores={recommendation?.path_scores || []}
+        rankedPaths={recommendation?.ranked_paths || []}
+        paths={paths}
+        recommendedPathId={recommendedId}
+        tieEpsilon={recommendation?.tie_epsilon}
+      />
+
+      <RecoveryAssumptionsPanel assumptions={assumptions} />
+
+      <footer
+        data-testid="recovery-disclaimer"
+        className="mt-8 p-4 rounded-lg bg-slate-100 dark:bg-slate-800/40 border border-slate-200 dark:border-slate-700"
+        aria-label="Recovery plan disclaimer"
+      >
+        <p
+          data-testid="recovery-disclaimer-text"
+          className="text-xs text-slate-500 dark:text-slate-400 max-w-prose mx-auto"
+        >
+          {disclaimer}
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/components/recovery/RecoveryRecommendationBanner.jsx
+++ b/frontend/components/recovery/RecoveryRecommendationBanner.jsx
@@ -1,0 +1,209 @@
+// Three-variant Recovery Plan recommendation banner.
+//
+// Variants:
+//   - 'recommended'        — blue tint, ✦ glyph, label + bullets, mini-disclaimer
+//   - 'no-clear-best-fit'  — slate neutral, = glyph, top-2 list, no card emphasis
+//   - 'no-eligible-path'   — amber, ⓘ glyph, suppressed list, Adjust caps → CTA
+//
+// Spec: frontend/design-specs/issue-182-recovery-recommendation.md §2.
+// All copy variants come from the backend's `recommendation.recommendation_label`
+// + `recommendation_reasons`; the banner just shapes the chrome.
+
+import Link from 'next/link';
+
+const MINI_DISCLAIMER =
+  'This is a fit recommendation against your configured preferences and stated assumptions — not investment advice or a price prediction.';
+
+function deriveState(recommendation) {
+  if (!recommendation) return 'recommended';
+  if (recommendation.recommended_path_id) return 'recommended';
+  if (
+    recommendation.recommendation_label === 'No eligible path under current sizing rules'
+  ) {
+    return 'no-eligible-path';
+  }
+  return 'no-clear-best-fit';
+}
+
+function variantClasses(state) {
+  switch (state) {
+    case 'no-clear-best-fit':
+      return 'rounded-xl border p-5 border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800';
+    case 'no-eligible-path':
+      return 'rounded-xl border p-5 border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20';
+    case 'recommended':
+    default:
+      return 'rounded-xl border p-5 border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/20';
+  }
+}
+
+function variantGlyph(state) {
+  switch (state) {
+    case 'no-clear-best-fit':
+      return { char: '=', cls: 'text-xl text-slate-500' };
+    case 'no-eligible-path':
+      return { char: 'ⓘ', cls: 'text-xl text-amber-600 dark:text-amber-300' };
+    case 'recommended':
+    default:
+      return { char: '✦', cls: 'text-xl text-blue-600 dark:text-blue-300' };
+  }
+}
+
+function inspectScoringLink() {
+  // Opens (if collapsed) and scrolls to the matrix. Honor reduced motion.
+  return () => {
+    const matrix = document.querySelector('[data-testid="recovery-scoring-matrix"]');
+    if (!matrix) return;
+    if (typeof matrix.open !== 'undefined') {
+      matrix.open = true;
+    }
+    const prefersReducedMotion = window.matchMedia?.(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    matrix.scrollIntoView({
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
+      block: 'start',
+    });
+  };
+}
+
+export default function RecoveryRecommendationBanner({
+  recommendation,
+  rankedPaths,
+  dataTestid = 'recovery-recommendation-banner',
+}) {
+  if (!recommendation) return null;
+  const state = deriveState(recommendation);
+  const glyph = variantGlyph(state);
+
+  return (
+    <section
+      data-testid={dataTestid}
+      data-state={state}
+      className={variantClasses(state)}
+      aria-label="Recovery plan recommendation"
+    >
+      <div className="flex items-start gap-3">
+        <span aria-hidden="true" className={glyph.cls}>
+          {glyph.char}
+        </span>
+        <div className="flex-1 min-w-0">
+          <h2
+            data-testid="recovery-recommendation-label"
+            className="text-base font-semibold text-slate-900 dark:text-white"
+          >
+            {recommendation.recommendation_label}
+          </h2>
+
+          {state === 'recommended' && recommendation.recommendation_reasons?.length > 0 && (
+            <>
+              <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 mt-3 mb-2">
+                Why this fits
+              </div>
+              <ul
+                data-testid="recovery-recommendation-reasons"
+                className="list-disc pl-5 space-y-1"
+              >
+                {recommendation.recommendation_reasons.map((reason, idx) => (
+                  <li
+                    key={reason}
+                    data-testid={`recovery-recommendation-reason-${idx}`}
+                    className="text-sm text-slate-700 dark:text-slate-200"
+                  >
+                    {reason}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+
+          {state === 'no-clear-best-fit' && (
+            <>
+              <p className="text-sm text-slate-700 dark:text-slate-200 mt-2">
+                The top two paths score within {recommendation.tie_epsilon} point of each
+                other — both are within your configured preferences. The numbers are
+                below; the call is yours.
+              </p>
+              <ul
+                data-testid="recovery-recommendation-reasons"
+                className="list-disc pl-5 space-y-1 mt-3"
+              >
+                {(rankedPaths || [])
+                  .filter((rp) => rp.rank !== null)
+                  .slice(0, 2)
+                  .map((rp, idx) => (
+                    <li
+                      key={rp.path_id}
+                      data-testid={`recovery-recommendation-reason-${idx}`}
+                      className="text-sm text-slate-700 dark:text-slate-200"
+                    >
+                      {labelForPath(rp.path_id)} — {rp.score} pts (rank {rp.rank})
+                    </li>
+                  ))}
+              </ul>
+            </>
+          )}
+
+          {state === 'no-eligible-path' && (
+            <>
+              <p className="text-sm text-amber-700 dark:text-amber-300 mt-2">
+                Every path violates your per-position sizing cap or another
+                configured constraint. Adjust your caps in Settings → OKRs, or
+                evaluate paths manually using the matrix below.
+              </p>
+              <ul
+                data-testid="recovery-recommendation-reasons"
+                className="list-disc pl-5 space-y-1 mt-3"
+              >
+                {(rankedPaths || []).map((rp, idx) => (
+                  <li
+                    key={rp.path_id}
+                    data-testid={`recovery-recommendation-reason-${idx}`}
+                    className="text-sm text-amber-700 dark:text-amber-300"
+                  >
+                    {labelForPath(rp.path_id)} —{' '}
+                    {rp.suppression_reason || '(no specific reason)'}
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-3">
+                <Link
+                  href="/settings#okrs"
+                  data-testid="recovery-recommendation-adjust-caps"
+                  className="text-sm font-medium text-amber-800 dark:text-amber-200 hover:underline"
+                >
+                  Adjust caps →
+                </Link>
+              </div>
+            </>
+          )}
+
+          <p
+            data-testid="recovery-recommendation-disclaimer-inline"
+            className="text-xs text-slate-500 dark:text-slate-400 mt-3"
+          >
+            {MINI_DISCLAIMER}{' '}
+            <button
+              type="button"
+              onClick={inspectScoringLink()}
+              className="font-medium text-blue-700 dark:text-blue-300 hover:underline"
+            >
+              Inspect scoring ▾
+            </button>
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+const PATH_LABELS = {
+  'sell-redeploy': 'Sell & redeploy',
+  'wheel-cc': 'Wheel covered calls',
+  'average-down': 'Average down',
+  'hold-monitor': 'Hold & monitor',
+};
+
+function labelForPath(slug) {
+  return PATH_LABELS[slug] || slug;
+}

--- a/frontend/components/recovery/RecoveryScoringMatrix.jsx
+++ b/frontend/components/recovery/RecoveryScoringMatrix.jsx
@@ -1,0 +1,279 @@
+// Full criterion × eligible-path scoring matrix, inside a <details> element
+// (collapsed by default per design Q1). Suppressed paths render as a stacked
+// footer (not as columns), one entry per path.
+//
+// Spec: frontend/design-specs/issue-182-recovery-recommendation.md §4.
+
+import Link from 'next/link';
+
+const PATH_LABELS = {
+  'sell-redeploy': 'Sell & redeploy',
+  'wheel-cc': 'Wheel covered calls',
+  'average-down': 'Average down',
+  'hold-monitor': 'Hold & monitor',
+};
+
+const CRITERION_LABELS = {
+  fastest_breakeven: 'Fastest breakeven',
+  lowest_additional_capital: 'Lowest add’l capital',
+  lowest_opportunity_cost: 'Lowest opp. cost',
+  strategy_preference_bonus: 'Strategy preference',
+};
+
+const CRITERION_SLUGS = {
+  fastest_breakeven: 'fastest-breakeven',
+  lowest_additional_capital: 'lowest-additional-capital',
+  lowest_opportunity_cost: 'lowest-opportunity-cost',
+  strategy_preference_bonus: 'strategy-preference-bonus',
+};
+
+function formatRaw(criterion, value) {
+  if (value === null || value === undefined) return '—';
+  if (criterion === 'fastest_breakeven') {
+    return `${value} mo`;
+  }
+  if (
+    criterion === 'lowest_additional_capital'
+    || criterion === 'lowest_opportunity_cost'
+  ) {
+    return `$${value.toLocaleString(undefined, { maximumFractionDigits: 0 })}`;
+  }
+  return '—';
+}
+
+function isStrategyPreferenceUnset(row) {
+  if (!row || row.criterion !== 'strategy_preference_bonus') return false;
+  return (row.ranking || []).every((c) => (c.points || 0) === 0);
+}
+
+export default function RecoveryScoringMatrix({
+  pathScores,
+  rankedPaths,
+  paths,
+  recommendedPathId,
+  tieEpsilon,
+  defaultOpen = false,
+}) {
+  if (!pathScores || pathScores.length === 0) return null;
+
+  // Compute the column order (eligible paths only, in canonical engine order).
+  const eligiblePathIds = (paths || [])
+    .filter((p) => p.eligibility === 'eligible')
+    .map((p) => p.path_id);
+  const eligibleLookup = Object.fromEntries(
+    (paths || []).map((p) => [p.path_id, p]),
+  );
+
+  const totalsByPath = Object.fromEntries(
+    (rankedPaths || [])
+      .filter((rp) => rp.score !== null && rp.score !== undefined)
+      .map((rp) => [rp.path_id, { score: rp.score, rank: rp.rank }]),
+  );
+
+  const suppressedRanked = (rankedPaths || []).filter(
+    (rp) => rp.score === null,
+  );
+
+  return (
+    <details
+      data-testid="recovery-scoring-matrix"
+      open={defaultOpen}
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+    >
+      <summary
+        data-testid="recovery-scoring-matrix-summary"
+        className="cursor-pointer select-none px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-200"
+      >
+        Inspect scoring ({pathScores.length} criteria, {eligiblePathIds.length}{' '}
+        eligible paths
+        {suppressedRanked.length > 0 ? `, ${suppressedRanked.length} suppressed` : ''}
+        )
+      </summary>
+
+      <div className="px-4 pb-4">
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 mb-3">
+          How each path scored against each criterion. Weights are V0.5.8 defaults
+          — these are inputs to a fit calculation, not financial scoring.
+        </p>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border-collapse">
+            <thead>
+              <tr className="border-b border-slate-200 dark:border-slate-700">
+                <th
+                  scope="col"
+                  className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 py-2 pr-3 sticky left-0 bg-white dark:bg-slate-800"
+                >
+                  Criterion (weight)
+                </th>
+                {eligiblePathIds.map((pid) => (
+                  <th
+                    key={pid}
+                    scope="col"
+                    className="text-left text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 py-2 px-3"
+                  >
+                    {PATH_LABELS[pid] || eligibleLookup[pid]?.label || pid}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {pathScores.map((row) => {
+                const unsetPref = isStrategyPreferenceUnset(row);
+                return (
+                  <tr
+                    key={row.criterion}
+                    data-testid={`recovery-scoring-row-${CRITERION_SLUGS[row.criterion] || row.criterion}`}
+                    className="border-b border-slate-100 dark:border-slate-700/40"
+                  >
+                    <th
+                      scope="row"
+                      className="text-left py-2 pr-3 text-slate-700 dark:text-slate-200 sticky left-0 bg-white dark:bg-slate-800"
+                    >
+                      {CRITERION_LABELS[row.criterion] || row.criterion}
+                      <span className="ml-2 text-xs text-slate-400">×{row.weight}</span>
+                      {unsetPref && (
+                        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                          Strategy preference is unset —{' '}
+                          <Link
+                            href="/settings#okrs"
+                            data-testid="recovery-scoring-strategy-preference-link"
+                            className="text-blue-700 dark:text-blue-300 hover:underline"
+                          >
+                            Settings → OKRs
+                          </Link>{' '}
+                          to activate.
+                        </div>
+                      )}
+                    </th>
+                    {eligiblePathIds.map((pid) => {
+                      const cell = (row.ranking || []).find(
+                        (c) => c.path_id === pid,
+                      );
+                      const isLeader = cell?.rank === 1 && cell?.points > 0;
+                      return (
+                        <td
+                          key={pid}
+                          data-testid={`recovery-scoring-cell-${CRITERION_SLUGS[row.criterion] || row.criterion}-${pid}`}
+                          className={
+                            'py-2 px-3 text-slate-700 dark:text-slate-200 '
+                            + (isLeader
+                              ? 'bg-blue-50 dark:bg-blue-900/10'
+                              : '')
+                          }
+                        >
+                          {cell ? (
+                            <>
+                              <span className="tabular-nums">
+                                {formatRaw(row.criterion, cell.raw_value)}
+                              </span>
+                              <span className="text-slate-400 mx-1">·</span>
+                              <span className="font-medium">{cell.points} pts</span>
+                              {isLeader && (
+                                <span
+                                  aria-hidden="true"
+                                  className="ml-1 text-blue-600 dark:text-blue-300"
+                                >
+                                  ✦
+                                </span>
+                              )}
+                            </>
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+
+              <tr className="border-t-2 border-slate-200 dark:border-slate-700">
+                <th
+                  scope="row"
+                  className="text-left py-2 pr-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 sticky left-0 bg-white dark:bg-slate-800"
+                >
+                  Total
+                </th>
+                {eligiblePathIds.map((pid) => {
+                  const total = totalsByPath[pid];
+                  const recommended = pid === recommendedPathId;
+                  return (
+                    <td
+                      key={pid}
+                      data-testid={`recovery-scoring-total-${pid}`}
+                      className={
+                        'py-2 px-3 font-medium '
+                        + (recommended
+                          ? 'text-blue-700 dark:text-blue-300'
+                          : 'text-slate-700 dark:text-slate-200')
+                      }
+                    >
+                      {total ? `${total.score} pts` : '—'}
+                      {recommended && (
+                        <span aria-hidden="true" className="ml-1">
+                          ✦
+                        </span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+              <tr>
+                <th
+                  scope="row"
+                  className="text-left py-2 pr-3 text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 sticky left-0 bg-white dark:bg-slate-800"
+                >
+                  Rank
+                </th>
+                {eligiblePathIds.map((pid) => {
+                  const total = totalsByPath[pid];
+                  const recommended = pid === recommendedPathId;
+                  return (
+                    <td
+                      key={pid}
+                      data-testid={`recovery-scoring-rank-${pid}`}
+                      className="py-2 px-3 text-slate-700 dark:text-slate-200"
+                    >
+                      {total ? total.rank : '—'}
+                      {recommended && (
+                        <span className="ml-1 text-xs text-blue-700 dark:text-blue-300">
+                          (recommended)
+                        </span>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {suppressedRanked.length > 0 && (
+          <div className="mt-3 p-3 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700">
+            <div className="text-xs uppercase tracking-wide text-amber-700 dark:text-amber-300 mb-1">
+              Suppressed
+            </div>
+            <ul className="space-y-1">
+              {suppressedRanked.map((rp) => (
+                <li
+                  key={rp.path_id}
+                  data-testid={`recovery-scoring-suppressed-${rp.path_id}`}
+                  className="text-sm text-amber-700 dark:text-amber-300"
+                >
+                  {PATH_LABELS[rp.path_id] || rp.path_id} —{' '}
+                  {rp.suppression_reason || '(no reason provided)'}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-3">
+          Weights are V0.5.8 defaults. Points are awarded per criterion based on
+          rank; ties within {tieEpsilon} total points are flagged as “no clear best fit.”
+        </p>
+      </div>
+    </details>
+  );
+}

--- a/frontend/components/recovery/suppressionReasonCta.js
+++ b/frontend/components/recovery/suppressionReasonCta.js
@@ -1,0 +1,18 @@
+// Maps a path's `suppression_reason` string to an inline CTA.
+//
+// Design spec §3.3 — string-match rules. The backend does not emit a
+// structured suppression code in V0.5.8, so the mapping lives entirely on
+// the frontend. Pure function so it can be exercised in isolation via the
+// Playwright spec or a future node test.
+
+export function suppressionReasonToCta(reason) {
+  if (!reason || typeof reason !== 'string') return null;
+  const low = reason.toLowerCase();
+  if (low.includes('sizing cap') || low.includes('sizing rule')) {
+    return { label: 'Adjust cap →', href: '/settings#okrs' };
+  }
+  if (low.includes('target yield')) {
+    return { label: 'Set target yield →', href: '/settings#okrs' };
+  }
+  return null;
+}

--- a/frontend/e2e/recovery-plan.spec.js
+++ b/frontend/e2e/recovery-plan.spec.js
@@ -406,9 +406,14 @@ test.describe('Recovery Plan panel', () => {
       'No clear best fit',
     );
 
-    // Ranked paths are still listed even with no recommended path.
+    // In the degradation state the banner intentionally has no templated
+    // `recommendation_reasons` (fixture leaves it `[]`). Instead it renders
+    // the top-two `ranked_paths` in the same `recovery-recommendation-reasons`
+    // list so the user still sees the close call. Assert those two entries.
     const reasons = page.getByTestId('recovery-recommendation-reasons').locator('li');
-    expect(await reasons.count()).toBeGreaterThanOrEqual(2);
+    expect(await reasons.count()).toBe(2);
+    await expect(reasons.first()).toContainText('Sell & redeploy');
+    await expect(reasons.nth(1)).toContainText('Wheel covered calls');
 
     // The path cards still render; none carries the recommended badge.
     await expect(page.getByTestId('recovery-path-grid')).toBeVisible();
@@ -442,5 +447,14 @@ test.describe('Recovery Plan panel', () => {
     await expect(page.getByTestId('recovery-plan-error')).toContainText(
       'Failed to build recovery plan',
     );
+  });
+
+  // Manual AC (CLAUDE.md — document non-automatable steps as a skipped test).
+  // The issue's PR test plan includes a manual visual review of the populated
+  // panel. Layout/visual fidelity is not asserted here; the structural,
+  // copy, and state-machine ACs above are the automated contract.
+  test.skip('manual: visual review of the populated panel layout', () => {
+    // Intentionally skipped — visual fidelity is verified by hand against the
+    // design intent before merge. Not automatable in Playwright assertions.
   });
 });

--- a/frontend/e2e/recovery-plan.spec.js
+++ b/frontend/e2e/recovery-plan.spec.js
@@ -1,0 +1,446 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #182 — Recovery Plan engine + recommendation layer.
+ *
+ * Covers the issue's Tests section:
+ *   - flagged position → open Recovery Plan → 3-4 path cards render with values
+ *   - "Suggested fit" banner renders with the label + ≥2 "Why this fits" bullets
+ *   - expand "Inspect scoring" → full criterion × path matrix visible
+ *   - suppressed-card rendering (de-emphasized, suppression reason inline)
+ *   - disclaimer visible on the panel
+ *   - "No clear best fit" degradation state (driven by a route-intercept fixture)
+ *
+ * The Recovery Plan endpoint is `POST /api/positions/{id}/recovery-plan`. Every
+ * test mocks it at the route level — no live backend or Schwab quote required.
+ */
+
+const DISCLAIMER =
+  'This is a fit recommendation based on your configured preferences and stated assumptions. It is not investment advice, a price prediction, or a trade execution suggestion.';
+
+const POSITION_ID = 'pos-sofi';
+
+// --- Fixture builders -------------------------------------------------------
+
+function positionSummary() {
+  return {
+    id: POSITION_ID,
+    ticker: 'SOFI',
+    shares: 200,
+    adjusted_cost_basis: 7800.0,
+    current_price: 23.76,
+    unrealized_pl: -3048.0,
+    pl_pct: -0.39,
+  };
+}
+
+function assumptions() {
+  return [
+    {
+      label: 'Premium rate (Wheel)',
+      value: '1.5% / month',
+      source: 'V0.5.8 heuristic (#183 V0.7)',
+    },
+    {
+      label: 'Target yield (Sell & redeploy)',
+      value: '12%',
+      source: 'Settings → OKRs',
+    },
+    {
+      label: 'Sizing cap (Average down)',
+      value: '$5,000',
+      source: 'Settings → OKRs',
+    },
+    {
+      label: 'Strategy preference',
+      value: 'Not set',
+      source: 'Settings → OKRs (V0.6)',
+    },
+    { label: 'Current price', value: '$23.76', source: 'Schwab quote' },
+    {
+      label: 'Tax / wash sale',
+      value: 'Not modeled',
+      source: 'User responsibility',
+    },
+  ];
+}
+
+function eligiblePaths() {
+  return [
+    {
+      path_id: 'sell-redeploy',
+      label: 'Sell & redeploy',
+      eligibility: 'eligible',
+      suppression_reason: null,
+      capital_tied_up: 0,
+      months_to_breakeven: { best: 5, expected: 6, worst: 9 },
+      opportunity_cost_vs_baseline: 0,
+      assumptions: ['Redeploy freed capital into a fresh CSP at 12% target yield.'],
+      narration: null,
+    },
+    {
+      path_id: 'wheel-cc',
+      label: 'Wheel covered calls',
+      eligibility: 'eligible',
+      suppression_reason: null,
+      capital_tied_up: 0,
+      months_to_breakeven: { best: 8, expected: 11, worst: 16 },
+      opportunity_cost_vs_baseline: 200,
+      assumptions: ['Assumes 1.5%/month premium on the share count (V0.5.8 heuristic).'],
+      narration: null,
+    },
+    {
+      path_id: 'hold-monitor',
+      label: 'Hold & monitor',
+      eligibility: 'eligible',
+      suppression_reason: null,
+      capital_tied_up: 0,
+      months_to_breakeven: { best: null, expected: null, worst: null },
+      opportunity_cost_vs_baseline: 800,
+      assumptions: ['No action taken — set price alerts at your chosen thresholds.'],
+      narration: null,
+    },
+  ];
+}
+
+function suppressedAverageDown() {
+  return {
+    path_id: 'average-down',
+    label: 'Average down',
+    eligibility: 'suppressed',
+    suppression_reason: 'Exceeds per-position sizing cap ($4,752 vs $5,000 — would breach)',
+    capital_tied_up: null,
+    months_to_breakeven: { best: null, expected: null, worst: null },
+    opportunity_cost_vs_baseline: null,
+    assumptions: [],
+    narration: null,
+  };
+}
+
+function pathScores() {
+  return [
+    {
+      criterion: 'fastest_breakeven',
+      weight: 3,
+      ranking: [
+        { path_id: 'sell-redeploy', raw_value: 6, points: 3, rank: 1 },
+        { path_id: 'wheel-cc', raw_value: 11, points: 0, rank: 2 },
+        { path_id: 'hold-monitor', raw_value: null, points: 0, rank: 3 },
+      ],
+    },
+    {
+      criterion: 'lowest_additional_capital',
+      weight: 3,
+      ranking: [
+        { path_id: 'sell-redeploy', raw_value: 0, points: 3, rank: 1 },
+        { path_id: 'wheel-cc', raw_value: 0, points: 3, rank: 1 },
+        { path_id: 'hold-monitor', raw_value: 0, points: 3, rank: 1 },
+      ],
+    },
+    {
+      criterion: 'lowest_opportunity_cost',
+      weight: 2,
+      ranking: [
+        { path_id: 'sell-redeploy', raw_value: 0, points: 2, rank: 1 },
+        { path_id: 'wheel-cc', raw_value: 200, points: 0, rank: 2 },
+        { path_id: 'hold-monitor', raw_value: 800, points: 0, rank: 3 },
+      ],
+    },
+  ];
+}
+
+// Populated payload with a clear recommendation (sell-redeploy wins).
+function populatedPayload() {
+  return {
+    position_id: POSITION_ID,
+    as_of: '2026-05-15T14:32:00+00:00',
+    state: 'populated',
+    position: positionSummary(),
+    inputs: {
+      current_price: 23.76,
+      cost_basis: 7800.0,
+      shares: 200,
+      okr: {
+        target_yield: 0.12,
+        sizing_cap_dollars: 5000.0,
+        strategy_preference: null,
+      },
+    },
+    paths: [...eligiblePaths(), suppressedAverageDown()],
+    recommendation: {
+      recommended_path_id: 'sell-redeploy',
+      recommendation_label: 'Best fit on capital efficiency and breakeven: Sell & redeploy',
+      recommendation_reasons: [
+        'Fastest expected breakeven (6 months vs 11 for the next option)',
+        'Lowest additional capital required ($0)',
+        'Lowest opportunity cost vs baseline ($0)',
+      ],
+      ranked_paths: [
+        { path_id: 'sell-redeploy', score: 8, rank: 1, suppression_reason: null },
+        { path_id: 'wheel-cc', score: 3, rank: 2, suppression_reason: null },
+        { path_id: 'hold-monitor', score: 3, rank: 3, suppression_reason: null },
+        {
+          path_id: 'average-down',
+          score: null,
+          rank: null,
+          suppression_reason:
+            'Exceeds per-position sizing cap ($4,752 vs $5,000 — would breach)',
+        },
+      ],
+      path_scores: pathScores(),
+      tie_epsilon: 1.0,
+      disclaimer: DISCLAIMER,
+    },
+    assumptions: assumptions(),
+    disclaimer: DISCLAIMER,
+  };
+}
+
+// Degradation payload: top two eligible paths tie within tie_epsilon.
+function noClearBestFitPayload() {
+  const base = populatedPayload();
+  base.recommendation = {
+    recommended_path_id: null,
+    recommendation_label: 'No clear best fit',
+    recommendation_reasons: [],
+    ranked_paths: [
+      { path_id: 'sell-redeploy', score: 6, rank: 1, suppression_reason: null },
+      { path_id: 'wheel-cc', score: 6, rank: 2, suppression_reason: null },
+      { path_id: 'hold-monitor', score: 3, rank: 3, suppression_reason: null },
+      {
+        path_id: 'average-down',
+        score: null,
+        rank: null,
+        suppression_reason:
+          'Exceeds per-position sizing cap ($4,752 vs $5,000 — would breach)',
+      },
+    ],
+    path_scores: pathScores(),
+    tie_epsilon: 1.0,
+    disclaimer: DISCLAIMER,
+  };
+  return base;
+}
+
+// not-flagged: position recovered above the review threshold.
+function notFlaggedPayload() {
+  return {
+    position_id: POSITION_ID,
+    as_of: '2026-05-15T14:32:00+00:00',
+    state: 'not-flagged',
+    position: {
+      ...positionSummary(),
+      unrealized_pl: 120.0,
+      pl_pct: 0.015,
+    },
+    inputs: null,
+    paths: [],
+    recommendation: null,
+    assumptions: [],
+    disclaimer: DISCLAIMER,
+  };
+}
+
+function mockRecoveryPlan(page, payload, status = 200) {
+  return page.route(`**/api/positions/${POSITION_ID}/recovery-plan`, (route) =>
+    route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+async function openRecoveryPlan(page) {
+  await page.goto(`/positions/${POSITION_ID}/recovery`);
+  await page.waitForLoadState('networkidle');
+}
+
+// --- Tests ------------------------------------------------------------------
+
+test.describe('Recovery Plan panel', () => {
+  test('flagged position renders 3-4 path cards with values', async ({ page }) => {
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    await expect(page.getByTestId('recovery-plan-page')).toBeVisible();
+
+    const grid = page.getByTestId('recovery-path-grid');
+    await expect(grid).toBeVisible();
+
+    // All four paths render (3 eligible + 1 suppressed).
+    await expect(page.getByTestId('recovery-path-card-sell-redeploy')).toBeVisible();
+    await expect(page.getByTestId('recovery-path-card-wheel-cc')).toBeVisible();
+    await expect(page.getByTestId('recovery-path-card-hold-monitor')).toBeVisible();
+    await expect(page.getByTestId('recovery-path-card-average-down')).toBeVisible();
+
+    // 3-4 path cards in total. The per-card data-testid is `recovery-path-card-{slug}`;
+    // nested testids (e.g. `-capital`) extend it, so match `<article>` cards
+    // by their `data-eligibility` attribute to avoid double-counting.
+    const cardCount = await page
+      .locator('article[data-testid^="recovery-path-card-"]')
+      .count();
+    expect(cardCount).toBeGreaterThanOrEqual(3);
+    expect(cardCount).toBeLessThanOrEqual(4);
+
+    // Eligible cards show their computed values, not placeholders.
+    await expect(
+      page.getByTestId('recovery-path-card-wheel-cc-capital'),
+    ).toContainText('$0');
+    await expect(
+      page.getByTestId('recovery-path-card-wheel-cc-breakeven-expected'),
+    ).toContainText('11 mo');
+    await expect(
+      page.getByTestId('recovery-path-card-wheel-cc-opp-cost'),
+    ).toContainText('$200');
+
+    // The reserved V0.6 narration placeholder is present (not omitted).
+    await expect(page.getByTestId('recovery-narration-wheel-cc')).toBeAttached();
+  });
+
+  test('"Suggested fit" banner renders the label + ≥2 "Why this fits" bullets', async ({
+    page,
+  }) => {
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const banner = page.getByTestId('recovery-recommendation-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute('data-state', 'recommended');
+
+    await expect(page.getByTestId('recovery-recommendation-label')).toContainText(
+      'Best fit on capital efficiency and breakeven: Sell & redeploy',
+    );
+
+    const reasons = page.getByTestId('recovery-recommendation-reasons').locator('li');
+    expect(await reasons.count()).toBeGreaterThanOrEqual(2);
+    await expect(reasons.first()).toContainText('Fastest expected breakeven');
+  });
+
+  test('recommended card is emphasized; suppressed card is de-emphasized with reason inline', async ({
+    page,
+  }) => {
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const recommended = page.getByTestId('recovery-path-card-sell-redeploy');
+    await expect(recommended).toHaveAttribute('data-recommended', 'true');
+    await expect(
+      page.getByTestId('recovery-path-card-sell-redeploy-recommended-badge'),
+    ).toBeVisible();
+
+    const suppressed = page.getByTestId('recovery-path-card-average-down');
+    await expect(suppressed).toHaveAttribute('data-eligibility', 'suppressed');
+    await expect(
+      page.getByTestId('recovery-path-card-average-down-suppression'),
+    ).toContainText('Exceeds per-position sizing cap');
+  });
+
+  test('"Inspect scoring" expands the full criterion × path matrix', async ({ page }) => {
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const matrix = page.getByTestId('recovery-scoring-matrix');
+    await expect(matrix).toBeVisible();
+    // Collapsed by default (locked decision Q1).
+    await expect(matrix).not.toHaveJSProperty('open', true);
+
+    await page.getByTestId('recovery-scoring-matrix-summary').click();
+    await expect(matrix).toHaveJSProperty('open', true);
+
+    // One row per criterion.
+    await expect(
+      page.getByTestId('recovery-scoring-row-fastest-breakeven'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('recovery-scoring-row-lowest-additional-capital'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('recovery-scoring-row-lowest-opportunity-cost'),
+    ).toBeVisible();
+
+    // A cell per eligible path carries raw value + points.
+    await expect(
+      page.getByTestId('recovery-scoring-cell-fastest-breakeven-sell-redeploy'),
+    ).toContainText('3 pts');
+
+    // Suppressed paths appear in the footer, not as a column.
+    await expect(
+      page.getByTestId('recovery-scoring-suppressed-average-down'),
+    ).toContainText('Exceeds per-position sizing cap');
+  });
+
+  test('disclaimer is rendered persistently on the panel', async ({ page }) => {
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const disclaimer = page.getByTestId('recovery-disclaimer-text');
+    await expect(disclaimer).toBeVisible();
+    await expect(disclaimer).toHaveText(DISCLAIMER);
+  });
+
+  test('every assumption is visible in the assumptions panel', async ({ page }) => {
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const panel = page.getByTestId('recovery-assumptions-panel');
+    await expect(panel).toBeVisible();
+
+    // The premium-rate, target-yield, sizing-cap and strategy-preference
+    // assumptions are all surfaced (not buried).
+    await expect(panel).toContainText('1.5% / month');
+    await expect(panel).toContainText('12%');
+    await expect(panel).toContainText('$5,000');
+    await expect(panel).toContainText('Strategy preference');
+  });
+
+  test('"No clear best fit" degradation state still renders the ranked paths', async ({
+    page,
+  }) => {
+    await mockRecoveryPlan(page, noClearBestFitPayload());
+    await openRecoveryPlan(page);
+
+    const banner = page.getByTestId('recovery-recommendation-banner');
+    await expect(banner).toHaveAttribute('data-state', 'no-clear-best-fit');
+    await expect(page.getByTestId('recovery-recommendation-label')).toContainText(
+      'No clear best fit',
+    );
+
+    // Ranked paths are still listed even with no recommended path.
+    const reasons = page.getByTestId('recovery-recommendation-reasons').locator('li');
+    expect(await reasons.count()).toBeGreaterThanOrEqual(2);
+
+    // The path cards still render; none carries the recommended badge.
+    await expect(page.getByTestId('recovery-path-grid')).toBeVisible();
+    await expect(
+      page.locator('[data-testid$="-recommended-badge"]'),
+    ).toHaveCount(0);
+
+    // The scoring matrix is still available for manual audit.
+    await expect(page.getByTestId('recovery-scoring-matrix')).toBeVisible();
+  });
+
+  test('not-flagged position renders the empty state instead of the panel', async ({
+    page,
+  }) => {
+    await mockRecoveryPlan(page, notFlaggedPayload());
+    await openRecoveryPlan(page);
+
+    await expect(page.getByTestId('recovery-plan-not-flagged')).toBeVisible();
+    await expect(page.getByTestId('recovery-recommendation-banner')).toHaveCount(0);
+  });
+
+  test('backend error surfaces a retry affordance', async ({ page }) => {
+    await mockRecoveryPlan(
+      page,
+      { detail: 'Failed to build recovery plan. Please try again.' },
+      500,
+    );
+    await openRecoveryPlan(page);
+
+    await expect(page.getByTestId('recovery-plan-error')).toBeVisible();
+    await expect(page.getByTestId('recovery-plan-error')).toContainText(
+      'Failed to build recovery plan',
+    );
+  });
+});

--- a/frontend/hooks/useRecoveryPlan.js
+++ b/frontend/hooks/useRecoveryPlan.js
@@ -17,9 +17,13 @@ export function useRecoveryPlan(positionId) {
 
   const refetch = useCallback(async () => {
     if (!positionId) {
+      // Clear any previously-loaded plan so a stale position never lingers.
+      setData(null);
       setLoading(false);
       return;
     }
+    // Drop the prior position's plan before the new fetch resolves.
+    setData(null);
     setLoading(true);
     setError(null);
     try {

--- a/frontend/hooks/useRecoveryPlan.js
+++ b/frontend/hooks/useRecoveryPlan.js
@@ -1,0 +1,40 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getRecoveryPlan } from '../api/client';
+
+/**
+ * useRecoveryPlan — fetch the Recovery Plan payload for a single position.
+ *
+ * Mirrors `useDashboard`: returns `{ data, loading, error, refetch }`. The
+ * backend handles all branching (not-applicable, not-flagged, populated),
+ * so the hook is dumb and just exposes the payload.
+ *
+ * Pattern: V0.5.8 / issue #182.
+ */
+export function useRecoveryPlan(positionId) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refetch = useCallback(async () => {
+    if (!positionId) {
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await getRecoveryPlan(positionId);
+      setData(payload);
+    } catch (e) {
+      setError(e?.response?.data?.detail || 'Failed to load recovery plan');
+    } finally {
+      setLoading(false);
+    }
+  }, [positionId]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, loading, error, refetch };
+}


### PR DESCRIPTION
## Summary

- Deterministic 4-path recovery engine (sell & redeploy, wheel covered calls, average down, hold & monitor) — every number is a unit-tested computation, no LLM anywhere in the request path.
- Rules-based scoring / recommendation layer that ranks paths against configured OKR preferences, emits a "best fit" recommendation with templated "Why this fits" reasons, and gracefully degrades to "No clear best fit" on ties and "No eligible path" when everything is suppressed.
- Recovery Plan UI panel at `/positions/[id]/recovery`: suggested-fit banner, 4-up comparison grid (recommended emphasized, suppressed de-emphasized with reason inline), collapsible full scoring matrix, assumptions audit panel, and a persistent disclaimer.
- Largest-loser dashboard CTA flips to the new Recovery Plan route.
- Test coverage: backend pytest for the path engine + scoring engine + router + snapshot-frozen templates; Playwright e2e for the panel, banner, matrix expansion, suppressed cards, disclaimer, and the no-clear-best-fit degradation state.

## Test plan

- [x] Backend pytest green (913 passed, 8 skipped)
- [x] Frontend lint clean (no new warnings) + production build green
- [x] `recovery-plan` Playwright e2e green (9 tests)
- [x] Full frontend e2e suite green (200 passed; 1 pre-existing flaky toast-timing test unrelated to this change, passes in isolation)
- [ ] Manual visual check of the populated panel vs the design intent

🤖 Generated with [Claude Code](https://claude.com/claude-code)