### PR TITLE
Add PRD and ADR discussion category templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/adr.yml
+++ b/.github/DISCUSSION_TEMPLATE/adr.yml
@@ -1,0 +1,272 @@
+title: "ADR: [Short decision title]"
+labels: ["adr"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Architecture Decision Record
+
+        An ADR records one architectural decision: the codebase reality it
+        must fit, the chosen approach, and the boundaries an implementation
+        agent works within.
+
+        **Write an ADR before building** when the work adds a service or
+        module, changes a data model or a public contract, introduces a
+        cross-cutting pattern, or chooses between approaches that are
+        expensive to reverse. Skip it for small, local changes.
+
+        **How to use this discussion:**
+        - The authoring (CTO) agent fills every section from a real review of
+          the current code.
+        - The implementation agent treats **Decision**, **Implementation
+          guidance**, and **Agent boundaries** as binding.
+        - Keep this post the single source of truth — edit it as the decision
+          evolves; use the thread for review and sign-off.
+        - Link the issues and PRs created from this ADR back to this discussion.
+
+        > ⚠️ This ADR must describe the codebase **as it is today**, not an
+        > idealized architecture. If a section can't be grounded in the actual
+        > code, say so explicitly instead of guessing.
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: Status
+      description: Lifecycle stage of this decision.
+      options:
+        - Proposed
+        - Accepted
+        - Superseded
+        - Deprecated
+      default: 0
+    validations:
+      required: true
+
+  - type: input
+    id: feature
+    attributes:
+      label: Feature or initiative
+      description: The work this decision enables. Link the PRD, issue, epic, project, or discussion.
+      placeholder: "PRD #209 / epic #156 / discussions/210"
+    validations:
+      required: true
+
+  - type: textarea
+    id: codebase-review
+    attributes:
+      label: Codebase review summary
+      description: The primary input — what was actually read in the current codebase before deciding.
+      value: |
+        **Code reviewed:** <files, modules, services, jobs inspected>
+
+        **Current architecture:** <how the relevant slice works today>
+
+        **Existing patterns:** <conventions this decision must stay consistent with>
+
+        **Relevant surfaces:**
+        - Files / modules:
+        - APIs / contracts:
+        - Services / jobs:
+        - Database tables:
+        - Frontend surfaces:
+
+        **Current tests & validation:** <suites, fixtures, CI checks covering this area>
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: Why a decision is needed now.
+      value: |
+        - **Problem:** <what we are solving>
+        - **Why decide now:** <what forces the decision>
+        - **Cost of doing nothing:** <what happens if we don't>
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: Goals
+      description: What this decision should enable. Specific and checkable.
+      value: |
+        -
+        -
+    validations:
+      required: false
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals
+      description: What this decision deliberately does NOT attempt to solve.
+      value: |
+        -
+    validations:
+      required: false
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: Constraints
+      description: Hard limits the decision must respect.
+      value: |
+        - **Product:**
+        - **Technical:**
+        - **Backward compatibility:**
+        - **Security / privacy:**
+        - **Performance:**
+        - **Operational:**
+    validations:
+      required: false
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Options considered
+      description: The realistic approaches, each with honest pros and cons.
+      value: |
+        ### Option A — <name>
+        - Pros:
+        - Cons:
+
+        ### Option B — <name>
+        - Pros:
+        - Cons:
+
+        ### Option C — <name>
+        - Pros:
+        - Cons:
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision
+      description: The choice. Binding for the implementation agent.
+      value: |
+        **Chosen:** <Option X>
+
+        **We will:** <what gets built>
+
+        **We will NOT:** <what is explicitly out of scope for this decision>
+    validations:
+      required: true
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale
+      description: Why this option, why not the others, what tradeoffs are accepted.
+      value: |
+        - **Why this option:**
+        - **Why the alternatives were rejected:**
+        - **Tradeoffs accepted:**
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Implementation guidance for AI agent
+      description: Concrete direction for the implementation agent.
+      value: |
+        - **Files / modules to modify:**
+        - **Integration points:**
+        - **Data model / schema changes:**
+        - **API / contract changes:**
+        - **Feature flags:**
+        - **Error handling expectations:**
+        - **Observability:** <logs, metrics, traces to add>
+        - **Security / privacy requirements:**
+        - **Performance considerations:**
+    validations:
+      required: true
+
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: Agent boundaries
+      description: Guardrails for the implementation agent.
+      value: |
+        - **Allowed to change:**
+        - **Do NOT change:**
+        - **Patterns to follow:**
+        - **Patterns to avoid:**
+        - **Stop and ask when:** <conditions that require human or CTO clarification before proceeding>
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete and testable. Per CLAUDE.md, every criterion must become automated test coverage on the implementing PR.
+      value: |
+        - [ ] Functional: <expected behavior>
+        - [ ] Edge cases: <boundary and failure behavior>
+        - [ ] Tests: <coverage added>
+        - [ ] Documentation: <what gets updated>
+        - [ ] Rollout: <flag, migration, or deploy requirement met>
+    validations:
+      required: true
+
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing and validation plan
+      description: How the change is proven correct.
+      value: |
+        - **Unit tests:**
+        - **Integration tests:**
+        - **E2E / manual QA:**
+        - **Required validation commands:** <exact commands the agent and CI must run, e.g. `cd backend && python -m pytest`>
+    validations:
+      required: false
+
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Rollout and rollback plan
+      value: |
+        - **Feature flag strategy:**
+        - **Migration plan:**
+        - **Rollout steps:**
+        - **Rollback steps:**
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and mitigations
+      value: |
+        - **Risk:** <...> — **Mitigation:** <...>
+    validations:
+      required: false
+
+  - type: textarea
+    id: open-questions
+    attributes:
+      label: Open questions
+      value: |
+        -
+    validations:
+      required: false
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      value: |
+        - PRD:
+        - Issues:
+        - Pull requests:
+        - Related ADRs:
+        - Design docs:
+        - Relevant code paths:
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/prd.yml
+++ b/.github/DISCUSSION_TEMPLATE/prd.yml
@@ -1,0 +1,150 @@
+title: "[PRD]: <feature name>"
+labels: ["prd"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Product Requirements Document
+
+        Use this discussion to draft, review, and ratify a PRD before any issues
+        or implementation work begin. Keep it the single source of truth — edit
+        this post as the spec evolves, and use the thread below for review
+        comments and decisions.
+
+        > Once approved, link the issues created from this PRD back to this
+        > discussion so the trail stays connected.
+
+  - type: input
+    id: summary
+    attributes:
+      label: One-line summary
+      description: A single sentence describing what this delivers and for whom.
+      placeholder: "Give traders an earnings-calendar view so they can plan regressions around earnings dates."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: Status
+      description: Current lifecycle stage of this PRD.
+      options:
+        - Draft
+        - In review
+        - Approved
+        - Shipped
+        - Shelved
+      default: 0
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: Relative urgency. Used to align with issue priority labels (P0–P4).
+      options:
+        - Critical
+        - High
+        - Medium
+        - Low
+      default: 2
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem & background
+      description: What problem are we solving? Who has it, and what is the cost of not solving it? Include context, current behavior, and any prior art.
+      placeholder: Describe the user pain, the current workaround, and why now.
+    validations:
+      required: true
+
+  - type: textarea
+    id: goals
+    attributes:
+      label: Goals
+      description: The specific, measurable outcomes this work must achieve.
+      value: |
+        -
+        -
+    validations:
+      required: true
+
+  - type: textarea
+    id: non-goals
+    attributes:
+      label: Non-goals / out of scope
+      description: Explicitly list what this work will NOT do, to prevent scope creep.
+      value: |
+        -
+    validations:
+      required: false
+
+  - type: textarea
+    id: users
+    attributes:
+      label: Target users & use cases
+      description: Who is this for? Describe the personas and the scenarios in which they use it.
+    validations:
+      required: false
+
+  - type: textarea
+    id: requirements
+    attributes:
+      label: Proposed solution & requirements
+      description: Describe the proposed approach and the functional requirements. Use numbered requirements (R1, R2, …) so they can be referenced in review.
+      placeholder: |
+        R1. ...
+        R2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: User stories & acceptance criteria
+      description: Concrete, testable criteria. Per CLAUDE.md, every criterion here must become automated test coverage on the implementing PR.
+      value: |
+        - [ ] As a <user>, I can <do something> so that <benefit>
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: metrics
+    attributes:
+      label: Success metrics
+      description: How will we know this succeeded? Quantify where possible.
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Dependencies, risks & open questions
+      description: External dependencies, technical risks, and unresolved questions blocking approval.
+    validations:
+      required: false
+
+  - type: input
+    id: milestone
+    attributes:
+      label: Target milestone / release
+      description: The release or milestone this is planned for, if known.
+      placeholder: "v0.6.0"
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submit checklist
+      options:
+        - label: I searched existing PRDs and issues to avoid duplicating an effort
+          required: true
+        - label: Goals and acceptance criteria are specific and testable
+          required: true
+        - label: Out-of-scope items are listed to bound the work
+          required: false


### PR DESCRIPTION
## Summary

Adds two GitHub Discussions form templates under `.github/DISCUSSION_TEMPLATE/`:

- **`prd.yml`** — Product Requirements Document template (committed earlier on this branch, not previously PR'd).
- **`adr.yml`** — Architecture Decision Record template (new).

Both are YAML discussion category forms. They take effect only once merged to `main` — GitHub loads discussion templates from the default branch.

## ADR template

Structured for the project's agent workflow: a CTO-style agent authors the ADR from a review of the current codebase, and an implementation agent uses it as a build spec. Sections:

- Codebase review summary (the primary input — current architecture, patterns, relevant files/APIs/tables/tests)
- Problem statement, goals, non-goals, constraints
- Options considered, decision, rationale
- Implementation guidance + explicit agent boundaries and stop conditions
- Acceptance criteria, testing/validation plan, rollout & rollback, risks, open questions, references

The `adr` label referenced by the template has been created.

## Notes

- Templates only — no code or runtime behavior changes.
- `prd.yml` is already in active use (e.g. discussions #209, #213); this PR brings it onto `main` alongside the new ADR template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)