### PR TITLE
Add tests for config credential retrieval and main.py security checks (closes #85)

### DIFF
--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,0 +1,232 @@
+"""Direct tests for credential retrieval in ``app.config``.
+
+Covers the two-tier lookup pattern of ``get_fred_api_key()`` and
+``get_schwab_credentials()``: environment variable first, then the
+encrypted ``AppSetting`` DB fallback. See issue #85.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.config import get_fred_api_key, get_schwab_credentials
+from app.models.database import AppSetting, Base
+from app.services.encryption import encrypt_value
+
+TEST_KEY = Fernet.generate_key().decode()
+
+
+@pytest.fixture()
+def db_session_factory():
+    """In-memory SQLite sessionmaker for patching ``SessionLocal``.
+
+    Returns the ``sessionmaker`` so tests can both seed data and pass it
+    in as the ``SessionLocal`` the config functions import.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield sessionmaker(bind=engine)
+    engine.dispose()
+
+
+def _seed(factory, **kv):
+    """Insert ``AppSetting`` rows from key/value pairs."""
+    db = factory()
+    try:
+        for key, value in kv.items():
+            db.add(AppSetting(key=key, value=value))
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestGetFredApiKey:
+    def test_get_fred_api_key_from_env(self):
+        """Env var set — returns the env value without touching the DB."""
+        with patch("app.config.settings") as mock_settings:
+            mock_settings.fred_api_key = "env_fred_key"
+            assert get_fred_api_key() == "env_fred_key"
+
+    def test_get_fred_api_key_from_db_fallback(self, db_session_factory):
+        """No env var — returns the value stored in the DB."""
+        _seed(db_session_factory, fred_api_key="db_fred_key")
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ):
+            mock_settings.fred_api_key = ""
+            assert get_fred_api_key() == "db_fred_key"
+
+    def test_get_fred_api_key_env_precedence_over_db(self, db_session_factory):
+        """Env var wins even when a DB row also exists."""
+        _seed(db_session_factory, fred_api_key="db_fred_key")
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ):
+            mock_settings.fred_api_key = "env_fred_key"
+            assert get_fred_api_key() == "env_fred_key"
+
+    def test_get_fred_api_key_missing_both(self, db_session_factory):
+        """No env var and no DB row — returns empty string, never raises."""
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ):
+            mock_settings.fred_api_key = ""
+            assert get_fred_api_key() == ""
+
+    def test_get_fred_api_key_db_error_returns_empty(self):
+        """A DB failure is swallowed — returns empty string, never raises."""
+        def _boom():
+            raise RuntimeError("db unavailable")
+
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", _boom
+        ):
+            mock_settings.fred_api_key = ""
+            assert get_fred_api_key() == ""
+
+
+class TestGetSchwabCredentials:
+    def test_get_schwab_credentials_from_env(self):
+        """Both env vars set — returns them without touching the DB."""
+        with patch("app.config.settings") as mock_settings:
+            mock_settings.schwab_app_key = "env_key"
+            mock_settings.schwab_app_secret = "env_secret"
+            assert get_schwab_credentials() == ("env_key", "env_secret")
+
+    def test_get_schwab_credentials_partial_env(self, db_session_factory):
+        """Only one env var set — falls through to the DB fallback path.
+
+        ``get_schwab_credentials`` only short-circuits when *both* env vars
+        are set. With one missing, it enters the DB branch, and any DB row
+        found overwrites the corresponding value — including the half that
+        was supplied via env. This documents the actual two-tier behavior.
+        """
+        _seed(
+            db_session_factory,
+            schwab_app_key=encrypt_value("db_key", key=TEST_KEY),
+            schwab_app_secret=encrypt_value("db_secret", key=TEST_KEY),
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = "env_key"
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = TEST_KEY
+            app_key, app_secret = get_schwab_credentials()
+        # Both DB rows present — both halves are taken from the DB.
+        assert app_key == "db_key"
+        assert app_secret == "db_secret"
+
+    def test_get_schwab_credentials_partial_env_no_db_keeps_env(
+        self, db_session_factory
+    ):
+        """One env var set, no DB rows — the env half is preserved.
+
+        With no DB rows to overwrite it, the env-supplied value survives
+        and the missing half stays empty.
+        """
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = "env_key"
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = TEST_KEY
+            app_key, app_secret = get_schwab_credentials()
+        assert app_key == "env_key"
+        assert app_secret == ""
+
+    def test_get_schwab_credentials_db_fallback(self, db_session_factory):
+        """No env vars — credentials are decrypted from the DB."""
+        _seed(
+            db_session_factory,
+            schwab_app_key=encrypt_value("real_key", key=TEST_KEY),
+            schwab_app_secret=encrypt_value("real_secret", key=TEST_KEY),
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = ""
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = TEST_KEY
+            assert get_schwab_credentials() == ("real_key", "real_secret")
+
+    def test_get_schwab_credentials_db_fallback_no_key(self, db_session_factory):
+        """No encryption key configured — DB values are returned as stored."""
+        _seed(
+            db_session_factory,
+            schwab_app_key="plain_key",
+            schwab_app_secret="plain_secret",
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = ""
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = ""
+            assert get_schwab_credentials() == ("plain_key", "plain_secret")
+
+    def test_get_schwab_credentials_env_precedence_over_db(self, db_session_factory):
+        """Env vars win even when DB rows also exist."""
+        _seed(
+            db_session_factory,
+            schwab_app_key=encrypt_value("db_key", key=TEST_KEY),
+            schwab_app_secret=encrypt_value("db_secret", key=TEST_KEY),
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = "env_key"
+            mock_settings.schwab_app_secret = "env_secret"
+            enc_settings.schwab_encryption_key = TEST_KEY
+            assert get_schwab_credentials() == ("env_key", "env_secret")
+
+    def test_get_schwab_credentials_missing_both(self, db_session_factory):
+        """No env vars and no DB rows — returns ('', ''), never raises."""
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = ""
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = TEST_KEY
+            assert get_schwab_credentials() == ("", "")
+
+    def test_credential_decryption_failure(self, db_session_factory):
+        """A corrupted DB value is handled gracefully — never raises.
+
+        ``decrypt_value`` raises ``InvalidToken`` on garbage ciphertext;
+        ``get_schwab_credentials`` swallows it and returns the env-level
+        defaults (empty strings here) instead of propagating.
+        """
+        _seed(
+            db_session_factory,
+            schwab_app_key="ENC:not-a-valid-fernet-token",
+            schwab_app_secret="ENC:also-garbage",
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = ""
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = TEST_KEY
+            # Must not raise; corrupted ciphertext degrades to the defaults.
+            assert get_schwab_credentials() == ("", "")
+
+    def test_get_schwab_credentials_db_error_returns_defaults(self):
+        """A DB failure is swallowed — returns ('', ''), never raises."""
+        def _boom():
+            raise RuntimeError("db unavailable")
+
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", _boom
+        ):
+            mock_settings.schwab_app_key = ""
+            mock_settings.schwab_app_secret = ""
+            assert get_schwab_credentials() == ("", "")

--- a/backend/tests/test_main_security.py
+++ b/backend/tests/test_main_security.py
@@ -1,0 +1,256 @@
+"""Tests for the startup security gate and exception handlers in ``app.main``.
+
+``_run_security_checks()`` is a fail-closed encryption gate: if Schwab
+tokens exist in the DB but no encryption key is configured, the app must
+refuse to start. The registered exception handlers must never leak raw
+exception text into responses. See issue #85.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import _run_security_checks
+from app.models.database import AppSetting, Base
+from app.services.encryption import EncryptionKeyMissing, encrypt_value
+
+TEST_KEY = Fernet.generate_key().decode()
+
+
+@pytest.fixture()
+def db_session_factory():
+    """In-memory SQLite sessionmaker for patching ``app.main.SessionLocal``."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    yield sessionmaker(bind=engine)
+    engine.dispose()
+
+
+def _seed(factory, **kv):
+    """Insert ``AppSetting`` rows from key/value pairs."""
+    db = factory()
+    try:
+        for key, value in kv.items():
+            db.add(AppSetting(key=key, value=value))
+        db.commit()
+    finally:
+        db.close()
+
+
+class TestSecurityChecks:
+    def test_security_checks_pass_with_valid_key(self, db_session_factory):
+        """Valid encryption key — the check completes without raising."""
+        with patch("app.main.SessionLocal", db_session_factory), patch(
+            "app.services.encryption.settings"
+        ) as enc_settings, patch("app.main.app_settings") as app_settings:
+            enc_settings.schwab_encryption_key = TEST_KEY
+            app_settings.database_url = "sqlite:///:memory:"
+            # Must not raise — valid key satisfies the gate.
+            _run_security_checks()
+
+    def test_security_checks_pass_without_key_when_no_tokens(
+        self, db_session_factory
+    ):
+        """No key and no stored tokens — the check warns but does not raise."""
+        with patch("app.main.SessionLocal", db_session_factory), patch(
+            "app.services.encryption.settings"
+        ) as enc_settings, patch("app.main.app_settings") as app_settings, patch(
+            "app.main.logger"
+        ) as mock_logger:
+            enc_settings.schwab_encryption_key = ""
+            app_settings.database_url = "sqlite:///:memory:"
+            # No tokens in DB: must not raise, but must log a warning.
+            _run_security_checks()
+            assert mock_logger.warning.called
+
+    def test_security_checks_fail_without_key(self, db_session_factory):
+        """Fail-closed: stored Schwab tokens + no key — raises EncryptionKeyMissing.
+
+        This is the critical security gate. If it passed silently, the app
+        could start and overwrite encrypted tokens with plaintext.
+        """
+        _seed(db_session_factory, schwab_access_token="some_stored_token")
+        with patch("app.main.SessionLocal", db_session_factory), patch(
+            "app.services.encryption.settings"
+        ) as enc_settings, patch("app.main.app_settings") as app_settings:
+            enc_settings.schwab_encryption_key = ""
+            app_settings.database_url = "sqlite:///:memory:"
+            with pytest.raises(EncryptionKeyMissing):
+                _run_security_checks()
+
+    def test_security_checks_migrates_plaintext_tokens_with_key(
+        self, db_session_factory
+    ):
+        """With a key set, plaintext tokens in the DB are encrypted in place."""
+        _seed(db_session_factory, schwab_access_token="plaintext_token")
+        with patch("app.main.SessionLocal", db_session_factory), patch(
+            "app.services.encryption.settings"
+        ) as enc_settings, patch("app.main.app_settings") as app_settings:
+            enc_settings.schwab_encryption_key = TEST_KEY
+            app_settings.database_url = "sqlite:///:memory:"
+            _run_security_checks()
+
+        db = db_session_factory()
+        try:
+            entry = (
+                db.query(AppSetting)
+                .filter(AppSetting.key == "schwab_access_token")
+                .first()
+            )
+            # The plaintext value must no longer be stored as-is.
+            assert entry.value != "plaintext_token"
+            assert entry.value.startswith("ENC:")
+        finally:
+            db.close()
+
+    def test_security_checks_db_error_propagates_when_no_key(self):
+        """A DB error during the no-key token check propagates — fail-closed.
+
+        The source comments are explicit: better to fail than to silently
+        run with unencrypted tokens.
+        """
+        def _boom():
+            raise RuntimeError("db unavailable")
+
+        with patch("app.main.SessionLocal", _boom), patch(
+            "app.services.encryption.settings"
+        ) as enc_settings, patch("app.main.app_settings") as app_settings:
+            enc_settings.schwab_encryption_key = ""
+            app_settings.database_url = "sqlite:///:memory:"
+            with pytest.raises(RuntimeError):
+                _run_security_checks()
+
+
+class TestExceptionHandlers:
+    """The registered handlers must return safe, generic response bodies.
+
+    Exercised through the ``client`` fixture and dedicated error-raising
+    routes so the full FastAPI handler path is covered.
+    """
+
+    def test_schwab_auth_handler_returns_generic_message(self, client):
+        """SchwabAuthError handler returns a generic message, not raw text."""
+        from app.main import app
+        from app.services.schwab_auth import SchwabAuthError
+
+        secret = "leaky-internal-detail-XYZ"
+
+        @app.get("/api/_test/schwab-error")
+        def _raise_schwab_error():
+            raise SchwabAuthError(secret)
+
+        try:
+            resp = client.get("/api/_test/schwab-error")
+            assert resp.status_code == 401
+            body = resp.text
+            # The raw exception text must not appear in the response.
+            assert secret not in body
+            assert "not configured" in resp.json()["detail"]
+        finally:
+            app.router.routes = [
+                r
+                for r in app.router.routes
+                if getattr(r, "path", None) != "/api/_test/schwab-error"
+            ]
+
+    def test_unhandled_exception_does_not_leak_raw_text(self):
+        """A generic unhandled exception does not echo its message to the client.
+
+        FastAPI's default 500 handler returns a generic ``Internal Server
+        Error`` body; the raw exception text must not reach the response.
+        A dedicated ``TestClient`` with ``raise_server_exceptions=False`` is
+        used so the server-side 500 response is observable (the shared
+        ``client`` fixture re-raises unhandled exceptions instead).
+        """
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        secret = "unhandled-secret-detail-ABC"
+
+        @app.get("/api/_test/boom")
+        def _raise_unhandled():
+            raise RuntimeError(secret)
+
+        try:
+            with patch("app.main.init_db"), patch(
+                "app.main.setup_logging"
+            ), patch("app.main.create_backup", return_value=""), patch(
+                "app.main._run_security_checks"
+            ):
+                with TestClient(
+                    app, raise_server_exceptions=False
+                ) as boom_client:
+                    resp = boom_client.get("/api/_test/boom")
+            assert resp.status_code == 500
+            assert secret not in resp.text
+        finally:
+            app.router.routes = [
+                r
+                for r in app.router.routes
+                if getattr(r, "path", None) != "/api/_test/boom"
+            ]
+
+    def test_data_fetch_error_handler_status_code(self, client):
+        """DataFetchError handler maps to HTTP 502."""
+        from app.main import app
+        from app.services.data_fetcher import DataFetchError
+
+        @app.get("/api/_test/data-fetch-error")
+        def _raise_data_fetch_error():
+            raise DataFetchError("upstream provider unavailable")
+
+        try:
+            resp = client.get("/api/_test/data-fetch-error")
+            assert resp.status_code == 502
+        finally:
+            app.router.routes = [
+                r
+                for r in app.router.routes
+                if getattr(r, "path", None) != "/api/_test/data-fetch-error"
+            ]
+
+    def test_invalid_ticker_error_handler_status_code(self, client):
+        """InvalidTickerError handler maps to HTTP 404."""
+        from app.main import app
+        from app.services.data_fetcher import InvalidTickerError
+
+        @app.get("/api/_test/invalid-ticker")
+        def _raise_invalid_ticker():
+            raise InvalidTickerError("ZZZZ")
+
+        try:
+            resp = client.get("/api/_test/invalid-ticker")
+            assert resp.status_code == 404
+        finally:
+            app.router.routes = [
+                r
+                for r in app.router.routes
+                if getattr(r, "path", None) != "/api/_test/invalid-ticker"
+            ]
+
+    def test_value_error_handler_status_code(self, client):
+        """ValueError handler maps to HTTP 400."""
+        from app.main import app
+
+        @app.get("/api/_test/value-error")
+        def _raise_value_error():
+            raise ValueError("bad input")
+
+        try:
+            resp = client.get("/api/_test/value-error")
+            assert resp.status_code == 400
+        finally:
+            app.router.routes = [
+                r
+                for r in app.router.routes
+                if getattr(r, "path", None) != "/api/_test/value-error"
+            ]


### PR DESCRIPTION
Closes #85

Adds direct, dedicated test coverage for two foundational pieces of infrastructure that were previously only exercised indirectly through higher-level integration tests. Pure test-coverage work — no implementation code was changed.

## Files added

- `backend/tests/test_config.py` — 14 tests for the `get_fred_api_key()` / `get_schwab_credentials()` two-tier lookup
- `backend/tests/test_main_security.py` — 10 tests for `_run_security_checks()` and the registered exception handlers

## AC coverage

### Config (`backend/app/config.py`)

| Acceptance criterion | Test(s) |
|---|---|
| `test_get_fred_api_key_from_env` — env var set, returns env value | `TestGetFredApiKey::test_get_fred_api_key_from_env` |
| `test_get_fred_api_key_from_db_fallback` — no env var, returns decrypted DB value | `TestGetFredApiKey::test_get_fred_api_key_from_db_fallback` |
| `test_get_fred_api_key_missing_both` — no env var, no DB entry, returns `None` | `TestGetFredApiKey::test_get_fred_api_key_missing_both` (see note below) |
| `test_get_schwab_credentials_from_env` — all env vars set | `TestGetSchwabCredentials::test_get_schwab_credentials_from_env` |
| `test_get_schwab_credentials_partial_env` — some env vars missing, behavior is correct | `TestGetSchwabCredentials::test_get_schwab_credentials_partial_env` + `..._partial_env_no_db_keeps_env` |
| `test_get_schwab_credentials_db_fallback` — credentials loaded from DB with decryption | `TestGetSchwabCredentials::test_get_schwab_credentials_db_fallback` + `..._db_fallback_no_key` |
| `test_credential_decryption_failure` — corrupted DB value handled gracefully, not raised | `TestGetSchwabCredentials::test_credential_decryption_failure` |

Extra coverage from the issue's stated gaps: env-var precedence over DB (`test_get_fred_api_key_env_precedence_over_db`, `test_get_schwab_credentials_env_precedence_over_db`), DB-error resilience (`test_get_fred_api_key_db_error_returns_empty`, `test_get_schwab_credentials_db_error_returns_defaults`), and missing-both for Schwab (`test_get_schwab_credentials_missing_both`).

### Security checks (`backend/app/main.py`)

| Acceptance criterion | Test(s) |
|---|---|
| `test_security_checks_pass_with_valid_key` — valid key, app proceeds | `TestSecurityChecks::test_security_checks_pass_with_valid_key` |
| `test_security_checks_fail_without_key` — missing key, app refuses to start | `TestSecurityChecks::test_security_checks_fail_without_key` |
| `test_exception_handler_returns_generic_message` — unhandled exception, no raw text leaked | `TestExceptionHandlers::test_schwab_auth_handler_returns_generic_message` + `test_unhandled_exception_does_not_leak_raw_text` |

Extra coverage: the no-key/no-tokens warning path (`test_security_checks_pass_without_key_when_no_tokens`), plaintext-token migration on startup (`test_security_checks_migrates_plaintext_tokens_with_key`), the deliberately-propagating DB-error path during the fail-closed check (`test_security_checks_db_error_propagates_when_no_key`), and exception-handler status-code mapping for `DataFetchError` (502), `InvalidTickerError` (404), and `ValueError` (400).

## Notes

- **`get_fred_api_key()` returns `""`, not `None`.** The issue's AC text says "returns `None`"; the implementation returns an empty string `""` (a falsy sentinel). The test asserts the actual behavior (`== ""`). No code was changed.
- **`get_schwab_credentials()` partial-env behavior:** the function only short-circuits when *both* env vars are set. With one missing it enters the DB branch, and any DB row found overwrites that value — including the env-supplied half. `test_get_schwab_credentials_partial_env` documents this real behavior; `..._partial_env_no_db_keeps_env` covers the case where no DB row exists and the env half survives.
- The `_run_security_checks()` DB-error path intentionally propagates (fail-closed by design, per the source comments) — covered as a documented expectation, not a bug.

## Test result

Full backend suite: **937 passed, 8 skipped** (the 8 skips are pre-existing in other files; the two new files contribute 24 passing tests, 0 skips).

```
cd backend && python -m pytest
937 passed, 8 skipped in 117.26s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)