### PR TITLE
Implement nonce-based CSP for script-src (#33)

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -3,6 +3,14 @@
 	encode gzip
 
 	# Security headers
+	#
+	# Content-Security-Policy is deliberately NOT set here (issue #33). CSP is
+	# now nonce-based and owned by the Next.js app: frontend/middleware.js mints
+	# a fresh per-request nonce and emits the `Content-Security-Policy` header
+	# with `script-src 'nonce-...'` instead of `'unsafe-inline'`. Caddy's
+	# `header` directive *replaces* a header, so setting CSP here would clobber
+	# the per-request nonce and the policy would never take effect. The
+	# `/grafana/*` handler below still clears CSP for Grafana, which owns its own.
 	header {
 		X-Frame-Options "DENY"
 		X-Content-Type-Options "nosniff"
@@ -10,7 +18,6 @@
 		Referrer-Policy "strict-origin-when-cross-origin"
 		Permissions-Policy "camera=(), microphone=(), geolocation=()"
 		Strict-Transport-Security "max-age=31536000; includeSubDomains"
-		Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'"
 		-Server
 	}
 

--- a/frontend/e2e/csp-nonce.spec.js
+++ b/frontend/e2e/csp-nonce.spec.js
@@ -1,0 +1,205 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #33 — nonce-based Content-Security-Policy for `script-src`.
+ *
+ * PR #32 had added `'unsafe-inline'` to `script-src` to unblock Next.js
+ * hydration, which weakens XSS protection. This change moves CSP generation
+ * into `frontend/middleware.js`, which mints a fresh per-request nonce and
+ * emits `script-src 'nonce-<value>' 'wasm-unsafe-eval'` (no `'unsafe-inline'`).
+ *
+ * These tests run against the Playwright `webServer` (`npm run dev`) — Caddy is
+ * NOT in the loop. That is intentional: the nonce must originate from the
+ * Next.js middleware (the only layer rendering the HTML), so `next dev`
+ * exercises the real production code path and is the source of truth.
+ *
+ * Auth-aware: like `auth-flow.spec.js`, behavior depends on whether
+ * `NEXTAUTH_SECRET` is set when the dev server starts.
+ *   - Auth NOT configured (CI default — routes public): `/dashboard` renders,
+ *     so the full suite runs, including the hydration / inline-script checks.
+ *   - Auth configured (e.g. a local `.env.local`): protected routes 307 to
+ *     `/auth/signin`, which is excluded from the middleware matcher. The CSP
+ *     header is still asserted on the middleware-issued redirect response
+ *     (the middleware stamps CSP on redirects too), and the hydration checks
+ *     are skipped with a documented reason — the redirect chain leaves the
+ *     dev server and the rendered page is not under this middleware's control.
+ *
+ * Non-automatable AC — the `deploy/Caddyfile` edit (removing the static CSP
+ * line so it no longer shadows the middleware header) cannot be exercised here
+ * because e2e runs against `next dev`, not Caddy. It is verified manually on
+ * deploy. These tests cover the Next.js side, which is what produces the nonce.
+ *
+ * Scope note — `style-src 'unsafe-inline'` is intentionally retained: Next.js
+ * + Tailwind v4 inject inline styles and Next.js does not nonce inline styles.
+ * Issue #33 scopes the hardening to `script-src` only; this is not an oversight.
+ */
+
+/**
+ * Extract the `script-src` directive substring from a CSP header value.
+ * @param {string | undefined} csp - The raw Content-Security-Policy header.
+ * @returns {string} The `script-src` directive, or '' if absent.
+ */
+function scriptSrcDirective(csp) {
+  if (!csp) return '';
+  const directive = csp
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith('script-src'));
+  return directive ?? '';
+}
+
+/**
+ * Parse the nonce value out of a `script-src` directive.
+ * @param {string} csp - The raw Content-Security-Policy header.
+ * @returns {string | null} The nonce, or null if no nonce token is present.
+ */
+function parseNonce(csp) {
+  const match = scriptSrcDirective(csp).match(/'nonce-([A-Za-z0-9+/=]+)'/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Assert a CSP header value satisfies issue #33: a nonce token is present,
+ * `'unsafe-inline'` is gone from `script-src`, and `'wasm-unsafe-eval'` stays.
+ * @param {string | undefined} csp - The raw Content-Security-Policy header.
+ */
+function assertNonceCsp(csp) {
+  expect(csp, 'a Content-Security-Policy header is present').toBeTruthy();
+  const scriptSrc = scriptSrcDirective(csp);
+  expect(scriptSrc, 'script-src directive is present').not.toBe('');
+  // A per-request nonce token must be present.
+  expect(scriptSrc).toMatch(/'nonce-[A-Za-z0-9+/=]+'/);
+  // 'unsafe-inline' must no longer be granted to scripts — the core AC of #33.
+  expect(scriptSrc).not.toContain("'unsafe-inline'");
+  // 'wasm-unsafe-eval' must be retained — plotly.js-finance-dist uses WASM.
+  expect(scriptSrc).toContain("'wasm-unsafe-eval'");
+}
+
+/**
+ * Fetch `/dashboard` without following redirects so the response captured is
+ * the one the Next.js middleware produced for this request.
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @returns {Promise<import('@playwright/test').APIResponse>}
+ */
+function fetchDashboard(request, suffix = '') {
+  return request.get(`/dashboard${suffix}`, { maxRedirects: 0 });
+}
+
+test.describe('Nonce-based CSP (#33)', () => {
+  test('script-src uses a nonce, drops unsafe-inline, keeps wasm-unsafe-eval', async ({
+    request,
+  }) => {
+    // maxRedirects: 0 — capture the exact response the middleware emitted,
+    // whether that is the rendered page (auth off) or a redirect (auth on).
+    // The middleware stamps the nonce CSP on both.
+    const response = await fetchDashboard(request);
+    assertNonceCsp(response.headers()['content-security-policy']);
+  });
+
+  test('nonce is fresh per request (not reused or cached)', async ({
+    request,
+  }) => {
+    const first = await fetchDashboard(request);
+    const second = await fetchDashboard(request, '?cb=1');
+
+    const firstNonce = parseNonce(
+      first.headers()['content-security-policy'],
+    );
+    const secondNonce = parseNonce(
+      second.headers()['content-security-policy'],
+    );
+
+    expect(firstNonce, 'first response carries a nonce').toBeTruthy();
+    expect(secondNonce, 'second response carries a nonce').toBeTruthy();
+    expect(
+      firstNonce,
+      'each request gets a distinct nonce',
+    ).not.toBe(secondNonce);
+  });
+
+  test('app hydrates under the nonce CSP with no script-src violations', async ({
+    page,
+    request,
+  }) => {
+    // Hydration can only be exercised when the dashboard renders directly.
+    // With auth configured the route 307s to /auth/signin (matcher-excluded),
+    // so the rendered page is not produced by this middleware — skip cleanly.
+    const probe = await fetchDashboard(request);
+    test.skip(
+      probe.status() >= 300 && probe.status() < 400,
+      'Auth enforced — /dashboard redirects; hydration covered when auth is off',
+    );
+
+    const cspViolations = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (/content security policy/i.test(text) && /script/i.test(text)) {
+        cspViolations.push(text);
+      }
+    });
+
+    const response = await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+    assertNonceCsp(response.headers()['content-security-policy']);
+
+    // The dark-mode toggle is a client component — a working toggle proves
+    // React hydrated, i.e. the framework inline scripts executed under the
+    // nonce. If the nonce were missing/mismatched, hydration would be blocked.
+    const toggle = page.getByTestId('dark-mode-toggle');
+    await expect(toggle).toBeVisible();
+
+    const html = page.locator('html');
+    const hadDark = await html.evaluate((el) => el.classList.contains('dark'));
+    await toggle.click();
+    if (hadDark) {
+      await expect(html).not.toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    } else {
+      await expect(html).toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    }
+
+    expect(
+      cspViolations,
+      `no script-src CSP violations: ${cspViolations.join(' | ')}`,
+    ).toHaveLength(0);
+  });
+
+  test('inline framework scripts carry the matching nonce in the HTML', async ({
+    request,
+  }) => {
+    // Inline framework scripts only exist on a rendered page — see the skip
+    // rationale in the hydration test above.
+    const response = await fetchDashboard(request);
+    test.skip(
+      response.status() >= 300 && response.status() < 400,
+      'Auth enforced — /dashboard redirects; inline-script check needs a rendered page',
+    );
+
+    const headerNonce = parseNonce(
+      response.headers()['content-security-policy'],
+    );
+    expect(headerNonce, 'response CSP carries a nonce').toBeTruthy();
+
+    // Verify against the *raw HTML body* the server emitted, not the live DOM.
+    // Modern browsers blank out the `nonce` DOM attribute AND property after
+    // parsing (an anti-exfiltration measure), so `getAttribute('nonce')`
+    // returns '' in page context — the nonce is still honoured during parse,
+    // which is why scripts execute and the page hydrates. The server-rendered
+    // HTML is where Next.js stamps the nonce, so assert it there.
+    const html = await response.text();
+    const nonceAttrs = [
+      ...html.matchAll(/<script[^>]*\snonce="([A-Za-z0-9+/=]+)"/gi),
+    ].map((m) => m[1]);
+
+    expect(
+      nonceAttrs.length,
+      'at least one inline <script> in the HTML carries a nonce attribute',
+    ).toBeGreaterThan(0);
+    // Every nonce Next.js stamped must equal the one in the response header.
+    for (const attr of nonceAttrs) {
+      expect(
+        attr,
+        'each framework script nonce matches the response CSP nonce',
+      ).toBe(headerNonce);
+    }
+  });
+});

--- a/frontend/middleware.js
+++ b/frontend/middleware.js
@@ -11,34 +11,140 @@ import { NextResponse } from "next/server";
  * (the new default landing route). When auth is *not* configured, the
  * `app/page.jsx` server-side redirect handles the same case so unauthenticated
  * deployments still land on the dashboard. Belt and suspenders.
+ *
+ * Issue #33: nonce-based Content-Security-Policy. A fresh per-request nonce is
+ * generated here (the only layer that renders the HTML) and:
+ *   - set on the *request* headers (`x-nonce` + `Content-Security-Policy`) so
+ *     Next.js 16 stamps the same nonce onto every framework/runtime inline
+ *     `<script>` at render time;
+ *   - set on the *response* headers so the browser enforces the policy.
+ * Both are required: the request header drives render-time propagation, the
+ * response header drives browser enforcement. Caddy no longer sets CSP for app
+ * routes (see deploy/Caddyfile) so this middleware is the single source of
+ * truth for the `script-src` policy. Gated by `CSP_NONCE_ENABLED` (default on)
+ * as a no-redeploy kill-switch — when off, no CSP header is emitted and a
+ * Caddy-restored static header can take over.
  */
 
 const authSecret = process.env.NEXTAUTH_SECRET;
 
 const authFullyConfigured = Boolean(authSecret);
 
+// Kill-switch: any value other than an explicit "false" leaves nonce CSP on.
+const cspNonceEnabled = process.env.CSP_NONCE_ENABLED !== "false";
+
+/**
+ * Build the Content-Security-Policy header value for a given nonce.
+ *
+ * `script-src` carries `'nonce-<value>'` (replacing the old `'unsafe-inline'`)
+ * plus `'wasm-unsafe-eval'` — the latter is required by `plotly.js-finance-dist`
+ * (WebAssembly) and must not be dropped or charts break. `style-src` keeps
+ * `'unsafe-inline'` intentionally: Next.js + Tailwind v4 inject inline styles
+ * and Next.js does not nonce inline styles; issue #33 scopes the hardening to
+ * `script-src` only.
+ *
+ * @param {string} nonce - The per-request base64 nonce.
+ * @returns {string} The CSP header value.
+ */
+function buildContentSecurityPolicy(nonce) {
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'wasm-unsafe-eval'`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+  ].join("; ");
+}
+
+/**
+ * Generate a fresh per-request CSP nonce.
+ *
+ * Uses the Edge-runtime Web Crypto global (`crypto.getRandomValues`) — Node's
+ * `crypto` module must not be imported here, it fails the edge build. 16 random
+ * bytes give 128 bits of entropy, matching the CSP-spec recommendation.
+ *
+ * @returns {string} A base64-encoded nonce.
+ */
+function generateNonce() {
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  return btoa(String.fromCharCode(...bytes));
+}
+
 async function middleware(request) {
+  // When the kill-switch is off, bypass all nonce/CSP plumbing entirely.
+  if (!cspNonceEnabled) {
+    if (!authFullyConfigured) {
+      return NextResponse.next();
+    }
+    const { auth } = await import("@/auth");
+    const wrapped = auth((req) => {
+      if (!req.auth?.user) {
+        const signInUrl = new URL("/auth/signin", req.url);
+        signInUrl.searchParams.set("callbackUrl", req.url);
+        return NextResponse.redirect(signInUrl);
+      }
+      if (
+        req.nextUrl.pathname === "/" &&
+        !req.nextUrl.searchParams.get("session")
+      ) {
+        return NextResponse.redirect(new URL("/dashboard", req.url));
+      }
+      return NextResponse.next();
+    });
+    return wrapped(request);
+  }
+
+  const nonce = generateNonce();
+  const csp = buildContentSecurityPolicy(nonce);
+
+  // Clone the incoming request headers and stamp the nonce + CSP onto them.
+  // Passing these through `NextResponse.next({ request })` is what makes
+  // Next.js see the policy at render time and propagate the nonce to its
+  // framework inline scripts.
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  /**
+   * Attach the CSP response header to any NextResponse before returning it.
+   * @param {import("next/server").NextResponse} response
+   * @returns {import("next/server").NextResponse}
+   */
+  const withCsp = (response) => {
+    response.headers.set("Content-Security-Policy", csp);
+    return response;
+  };
+
   if (!authFullyConfigured) {
     // No auth configured: let the static `app/page.jsx` redirect handle `/`.
-    return NextResponse.next();
+    return withCsp(NextResponse.next({ request: { headers: requestHeaders } }));
   }
 
   // Use the Auth.js middleware wrapper pattern — await auth() without a
-  // request argument cannot read cookies in middleware context.
+  // request argument cannot read cookies in middleware context. Every
+  // NextResponse the callback builds threads `requestHeaders` so the nonce
+  // reaches render regardless of how the auth() wrapper forwards the request,
+  // and `withCsp` stamps the enforced response header on the final value.
   const { auth } = await import("@/auth");
   const wrapped = auth((req) => {
     if (!req.auth?.user) {
       const signInUrl = new URL("/auth/signin", req.url);
       signInUrl.searchParams.set("callbackUrl", req.url);
-      return NextResponse.redirect(signInUrl);
+      return withCsp(NextResponse.redirect(signInUrl));
     }
     // Authenticated: redirect bare `/` to `/dashboard`. Preserve any
     // `?session=` param by deferring to the static page.jsx fallback when it's
     // present (the session-recovery URL form pre-#114).
-    if (req.nextUrl.pathname === "/" && !req.nextUrl.searchParams.get("session")) {
-      return NextResponse.redirect(new URL("/dashboard", req.url));
+    if (
+      req.nextUrl.pathname === "/" &&
+      !req.nextUrl.searchParams.get("session")
+    ) {
+      return withCsp(NextResponse.redirect(new URL("/dashboard", req.url)));
     }
-    return NextResponse.next();
+    return withCsp(
+      NextResponse.next({ request: { headers: requestHeaders } }),
+    );
   });
 
   return wrapped(request);


### PR DESCRIPTION
Closes #33

## Summary

PR #32 added `'unsafe-inline'` to the `script-src` CSP directive to unblock Next.js hydration, which weakens XSS protection by allowing any inline script to execute. This PR replaces `'unsafe-inline'` with a **fresh per-request nonce**, restoring `script-src` hardening.

CSP generation moves from a static Caddy header into Next.js middleware — the only layer that renders the HTML, so the nonce in the response header and the nonce on the framework inline `<script>` tags are guaranteed identical for the same request. Next.js 16 supports this natively: when the *incoming request* carries a CSP header with `script-src 'nonce-<value>'`, Next.js stamps that same nonce onto every runtime inline script it emits. The middleware sets the nonce + CSP on both the **request** headers (drives render-time propagation) and the **response** headers (drives browser enforcement).

## Acceptance criteria

- [x] `script-src` uses a per-request `'nonce-<value>'` instead of `'unsafe-inline'`
- [x] The nonce is generated fresh per request (not cached/reused)
- [x] Next.js framework inline scripts carry the matching nonce (app hydrates, no `script-src` CSP violations)
- [x] `'wasm-unsafe-eval'` retained in `script-src` (plotly.js-finance-dist uses WASM)
- [x] Static CSP removed from `deploy/Caddyfile` so it no longer shadows the middleware nonce
- [x] Automated test coverage (`frontend/e2e/csp-nonce.spec.js`)

## Files changed

- `frontend/middleware.js` — per-request nonce via the Edge-runtime Web Crypto global (`crypto.getRandomValues`, 128 bits); CSP applied on both auth branches and on redirect responses; request headers threaded through every `NextResponse` so the nonce reaches render regardless of how the Auth.js `auth()` wrapper forwards the request.
- `deploy/Caddyfile` — removed the static `Content-Security-Policy` line from the top-level `header` block. All other security headers and the `/grafana/*` CSP-clearing block unchanged.
- `frontend/e2e/csp-nonce.spec.js` *(new)* — Playwright spec.

No new dependencies. No backend, schema, or migration changes.

## Caddy / middleware coupling

The `frontend/middleware.js` and `deploy/Caddyfile` changes are **coupled and must ship together**. Caddy's `header` directive *replaces* a header — if Caddy keeps setting a static CSP it clobbers the per-request nonce header from Next.js and the nonce never takes effect; removing the Caddy CSP without the middleware CSP in place would ship a release with *no* `script-src` policy. Hence one PR.

## Kill-switch

The middleware CSP is gated behind a `CSP_NONCE_ENABLED` env var (default **on** — any value other than the literal `false` keeps it on). If set to `false`, the middleware emits no CSP header, so a Caddy-restored static header can take over without a frontend rebuild — a no-redeploy rollback path for this first production-intended release. Production hot-fix: re-add the static CSP line to the bind-mounted `Caddyfile` and `caddy reload`.

## Testing notes

`cd frontend && npx playwright test e2e/csp-nonce.spec.js`

The spec is auth-aware (mirrors `auth-flow.spec.js`):
- **Auth not configured** (CI default — routes public): `/dashboard` renders; all 4 tests run including hydration / inline-script checks. Verified: 4 passed.
- **Auth configured** (a local `.env.local`): protected routes 307 to `/auth/signin` (matcher-excluded). The 2 header-level tests run against the middleware-issued redirect (CSP is stamped on redirects too); the 2 hydration tests skip with a documented reason. Verified: 2 passed, 2 skipped.

Manual verification (curl against `next dev`): `/dashboard` returns `script-src 'self' 'nonce-<base64>' 'wasm-unsafe-eval'`, and the raw HTML body contains `<script nonce="<base64>">` matching the response header.

`npm run lint` (0 errors — 1 pre-existing unrelated warning in `UserMenu.jsx`) and `npm run build` both green.

## Deviations from the plan

- **Auth() wrapper header threading (Risk #2):** the plan flagged uncertainty over whether Auth.js v5's `auth()` forwards the modified request headers. Resolved by applying the plan's "simpler robust approach" up front — every `NextResponse` the `auth()` callback builds explicitly threads `{ request: { headers: requestHeaders } }`, and a `withCsp` helper stamps the enforced response header on the wrapper's return value. The nonce reaches render correctly (verified: raw HTML scripts carry the matching nonce).
- **Inline-script test (plan Test 4):** the plan assumed the live-DOM `nonce` *attribute* is readable via `getAttribute`. In practice modern browsers blank out the `nonce` attribute *and* property after parsing (an anti-exfiltration measure) — `page.evaluate` returns empty strings. The test was changed to assert the nonce on the **raw server-rendered HTML body** (`response.text()`), which is where Next.js stamps it and is the correct source of truth.

## Unresolved risk

- **Manual deploy verification required** — e2e runs against `next dev`, not Caddy. The `deploy/Caddyfile` edit must be verified on the actual deploy (the static CSP is gone, the Next.js nonce header passes through untouched). Documented as a non-automatable AC in the spec's file header. The `caddy reload` rollback path keeps this low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)