### PR TITLE
V1.0: rules_config persistence + shared reader — Trading Rules Layer keystone (closes #156)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -272,19 +272,41 @@ class MarketContext(BaseModel):
 
 
 class OptionScanRequest(BaseModel):
+    """Request body for ``POST /api/options/scan``.
+
+    Rule fields default to ``None`` and are backfilled by the scan router
+    from the persisted ``rules_config`` (see
+    :func:`app.services.rules_config.load_rules_config`). An explicit
+    non-``None`` value on the request still wins — per-request override is
+    preserved. Omitting a rule field is the common case; the resolved value
+    comes from the trader's configured Trading Rules.
+    """
+
     ticker: str
     strategy: str  # "cash_secured_put" | "covered_call"
     cost_basis: Optional[float] = None
     capital_available: Optional[float] = None
     shares_held: Optional[int] = 100
-    min_dte: int = 25
-    max_dte: int = 50
-    min_return_pct: float = 1.0
+    # Entry-rule fields — None means "resolve from rules_config" (issue #156).
+    min_dte: Optional[int] = None
+    max_dte: Optional[int] = None
+    min_return_pct: Optional[float] = None
     max_return_pct: Optional[float] = None
-    min_call_distance_pct: float = 10.0
-    max_delta: float = 0.35
-    min_delta: float = 0.15
-    exclude_earnings_dte: int = 5
+    min_call_distance_pct: Optional[float] = None
+    max_delta: Optional[float] = None
+    min_delta: Optional[float] = None
+    exclude_earnings_dte: Optional[int] = None
+    # Universe-rule fields — also resolved from rules_config when None.
+    min_open_interest: Optional[int] = None
+    max_bid_ask_spread_pct: Optional[float] = None
+    min_iv_rank: Optional[float] = None
+    # Covered-call cost-basis floor toggle. When True (default), a CC strike
+    # below the cost-basis floor is flagged with a ``below_cost_basis``
+    # rejection reason; the candidate is never dropped.
+    cost_basis_floor_enabled: bool = True
+    # Covered-call at-or-above-cost-basis floor margin, whole-percent — None
+    # means resolve from rules_config (entry.min_call_distance_from_cost_basis_pct).
+    min_call_distance_from_cost_basis_pct: Optional[float] = None
 
 
 class OptionScanResponse(BaseModel):

--- a/backend/app/routers/options.py
+++ b/backend/app/routers/options.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session as DBSession
 from app.models.database import get_db
 from app.models.schemas import OptionScanRequest, OptionScanResponse
 from app.services.options_scanner import OptionScanner, OptionScannerError
+from app.services.rules_config import RulesConfig, load_rules_config
 from app.services.schwab_client import SchwabClient, SchwabClientError
 from app.services.schwab_auth import SchwabAuthError
 from app.utils.parsing import to_float, to_int
@@ -15,16 +16,71 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/options", tags=["options"])
 
 
-def _get_scanner(db: DBSession = Depends(get_db)) -> OptionScanner:
+def _get_scanner() -> OptionScanner:
     return OptionScanner()
+
+
+def _resolve_scan_rules(req: OptionScanRequest, rules: RulesConfig) -> None:
+    """Backfill any unset rule field on ``req`` from the resolved config.
+
+    Mutates ``req`` in place: every rule field left ``None`` is filled from
+    ``rules``; an explicit caller-supplied value is left untouched, so a
+    per-request override always wins (issue #156).
+
+    The delta band is strategy-specific — a covered-call scan with no explicit
+    delta override is backfilled from the CC band, everything else from the CSP
+    band — matching the catalog's two distinct delta ranges.
+    """
+    entry = rules.entry
+    universe = rules.universe
+
+    if req.min_dte is None:
+        req.min_dte = int(entry.dte_range.min)
+    if req.max_dte is None:
+        req.max_dte = int(entry.dte_range.max)
+    if req.min_return_pct is None:
+        req.min_return_pct = entry.min_monthly_return_pct
+    if req.exclude_earnings_dte is None:
+        req.exclude_earnings_dte = entry.earnings_buffer_days
+    if req.min_call_distance_pct is None:
+        req.min_call_distance_pct = entry.min_call_distance_pct
+    if req.min_call_distance_from_cost_basis_pct is None:
+        req.min_call_distance_from_cost_basis_pct = (
+            entry.min_call_distance_from_cost_basis_pct
+        )
+
+    # Strategy-specific delta band. Backfill the pair together so a partial
+    # override (only min_delta set) does not silently mix bands.
+    delta_band = (
+        entry.delta_range_cc
+        if req.strategy == "covered_call"
+        else entry.delta_range_csp
+    )
+    if req.min_delta is None:
+        req.min_delta = delta_band.min
+    if req.max_delta is None:
+        req.max_delta = delta_band.max
+
+    if req.min_open_interest is None:
+        req.min_open_interest = universe.min_open_interest
+    if req.max_bid_ask_spread_pct is None:
+        req.max_bid_ask_spread_pct = universe.max_bid_ask_spread_pct
+    if req.min_iv_rank is None:
+        req.min_iv_rank = universe.min_iv_rank
 
 
 @router.post("/scan", response_model=OptionScanResponse)
 def scan_options(
     req: OptionScanRequest,
     scanner: OptionScanner = Depends(_get_scanner),
+    db: DBSession = Depends(get_db),
 ):
-    """Scan option chain for wheel strategy opportunities."""
+    """Scan option chain for wheel strategy opportunities.
+
+    Unset rule fields on the request are resolved from the persisted
+    ``rules_config`` (issue #156) before the scan runs.
+    """
+    _resolve_scan_rules(req, load_rules_config(db))
     return scanner.scan(req)
 
 

--- a/backend/app/routers/positions.py
+++ b/backend/app/routers/positions.py
@@ -31,10 +31,10 @@ from app.models.database import AppSetting, get_db
 from app.models.schemas import RecoveryPlanResponse
 from app.services import journal
 from app.services.recovery_engine import (
-    DEFAULT_SIZING_CAP_DOLLARS,
     WHEEL_MONTHLY_PREMIUM_PCT,
     compute_recovery_paths,
 )
+from app.services.rules_config import load_rules_config
 from app.services.recovery_scoring import DISCLAIMER_TEXT, score_recovery_paths
 from app.services.schwab_client import SchwabClient
 
@@ -65,34 +65,31 @@ def _get_app_setting(db: DBSession, key: str) -> str | None:
 
 
 def _read_okr_settings(db: DBSession) -> dict[str, Any]:
-    """Read OKR scoring inputs from ``app_settings`` with defaults.
+    """Read the recovery-engine scoring inputs from settings.
 
-    Keys live alongside the existing ``cache_ttl_*`` keys and are
-    populated by #156/#157 when that work lands. Defaults documented in the
-    plan §5:
+    Two of these are OKR reads on flat ``app_settings`` keys (ADR-001: target
+    yield and strategy preference are OKRs):
 
     - ``okr_target_yield`` → ``None`` (suppresses sell-redeploy)
-    - ``okr_sizing_cap_dollars`` → :data:`DEFAULT_SIZING_CAP_DOLLARS`
     - ``okr_strategy_preference`` → ``None`` (dormant bonus row in V0.5.8)
+
+    The per-position sizing cap is **no longer** an ``okr_*`` flat key. Per
+    ADR-001 it is a Trading Rule, so it is resolved from
+    ``rules_config.position.sizing_cap_dollars`` via
+    :func:`app.services.rules_config.load_rules_config` (issue #156). With no
+    stored ``rules_config`` row that resolves to the catalog default ($5,000).
     """
     target_raw = _get_app_setting(db, "okr_target_yield")
-    cap_raw = _get_app_setting(db, "okr_sizing_cap_dollars")
     pref_raw = _get_app_setting(db, "okr_strategy_preference")
 
     target_yield: float | None
-    sizing_cap: float
-
     try:
         target_yield = float(target_raw) if target_raw not in (None, "") else None
     except (TypeError, ValueError):
         target_yield = None
 
-    try:
-        sizing_cap = (
-            float(cap_raw) if cap_raw not in (None, "") else DEFAULT_SIZING_CAP_DOLLARS
-        )
-    except (TypeError, ValueError):
-        sizing_cap = DEFAULT_SIZING_CAP_DOLLARS
+    # Sizing cap comes from rules_config (issue #156), not an okr_* flat key.
+    sizing_cap = load_rules_config(db).position.sizing_cap_dollars
 
     strategy_preference = pref_raw if pref_raw not in (None, "") else None
 

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -26,6 +26,8 @@ from datetime import datetime, timezone
 from typing import Iterable
 from urllib.parse import quote
 
+from app.services.rules_config import DEFAULT_RULES_CONFIG, RulesConfig
+
 # Cap from spec §2.2: anything beyond 8 cards is noise; the user should
 # triage in the destination tool.
 MAX_ACTIONS = 8
@@ -43,7 +45,11 @@ LARGE_LOSER_DOLLAR_THRESHOLD = -1000.0  # -$1,000
 # Cap on per-leg ITM short-DTE cards. Spec §2.2: "one card per leg, capped
 # at 3 most-urgent".
 ITM_SHORT_DTE_CAP = 3
-ITM_SHORT_DTE_MAX_DTE = 7
+
+# The DTE threshold for the ITM/short-DTE cards is a trading rule — it is
+# resolved from ``rules_config.management.expiration_warning_days`` (issue
+# #156) and passed in by the dashboard. The catalog default is 7, so the
+# behavior is unchanged when no ``rules_config`` row is stored.
 
 # Sort priority bases per spec §14.7. Lower number = ranked first inside
 # the priority bucket. Two sub-bucket keys live alongside these to break
@@ -280,13 +286,19 @@ def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
     }
 
 
-def _itm_short_dte_actions(open_legs: Iterable[dict]) -> list[dict]:
-    """Build up to ``ITM_SHORT_DTE_CAP`` per-leg ``expiration.itm_short_dte`` cards."""
+def _itm_short_dte_actions(
+    open_legs: Iterable[dict], short_dte_max: int
+) -> list[dict]:
+    """Build up to ``ITM_SHORT_DTE_CAP`` per-leg ``expiration.itm_short_dte`` cards.
+
+    ``short_dte_max`` is the DTE threshold resolved from
+    ``rules_config.management.expiration_warning_days`` (issue #156).
+    """
     cards: list[dict] = []
     for leg in open_legs:
         dte = leg.get("dte")
         moneyness = leg.get("moneyness") or {}
-        if dte is None or dte > ITM_SHORT_DTE_MAX_DTE:
+        if dte is None or dte > short_dte_max:
             continue
         if moneyness.get("state") != "ITM":
             continue
@@ -320,17 +332,21 @@ def _itm_short_dte_actions(open_legs: Iterable[dict]) -> list[dict]:
     return cards[:ITM_SHORT_DTE_CAP]
 
 
-def _short_dte_aggregate_actions(open_legs: Iterable[dict]) -> list[dict]:
+def _short_dte_aggregate_actions(
+    open_legs: Iterable[dict], short_dte_max: int
+) -> list[dict]:
     """Build aggregated ``expiration.short_dte`` cards — one per ticker.
 
-    Aggregated because a 7-DTE OTM book often contains the same ticker
+    Aggregated because a short-DTE OTM book often contains the same ticker
     repeatedly, and per-leg cards would crowd out higher-priority signals.
+    ``short_dte_max`` is the DTE threshold resolved from
+    ``rules_config.management.expiration_warning_days`` (issue #156).
     """
     by_ticker: dict[str, dict] = {}
     for leg in open_legs:
         dte = leg.get("dte")
         moneyness = leg.get("moneyness") or {}
-        if dte is None or dte > ITM_SHORT_DTE_MAX_DTE:
+        if dte is None or dte > short_dte_max:
             continue
         if moneyness.get("state") == "ITM":
             # ITM legs are handled by the per-leg card.
@@ -358,11 +374,11 @@ def _short_dte_aggregate_actions(open_legs: Iterable[dict]) -> list[dict]:
                 "title": f"Review {ticker} legs",
                 "subject": {
                     "ticker": ticker,
-                    "amount": f"{count} {leg_word} ≤ {ITM_SHORT_DTE_MAX_DTE} DTE",
+                    "amount": f"{count} {leg_word} ≤ {short_dte_max} DTE",
                 },
                 "reason": (
                     f"{count} open {leg_word} on {ticker} expire within "
-                    f"{ITM_SHORT_DTE_MAX_DTE} days."
+                    f"{short_dte_max} days."
                 ),
                 "cta": {
                     "label": f"Manage {ticker}",
@@ -470,6 +486,7 @@ def compute_next_actions(
     kpis: dict,
     positions: list[dict],
     open_legs: list[dict],
+    rules: RulesConfig = DEFAULT_RULES_CONFIG,
     now: datetime | None = None,
 ) -> list[dict]:
     """Compute the ranked Next Actions list for the dashboard payload.
@@ -479,9 +496,18 @@ def compute_next_actions(
     deterministic for any given input — same input, same order, byte for
     byte.
 
+    ``rules`` is the resolved :class:`~app.services.rules_config.RulesConfig`
+    (issue #156); the caller — ``routers/dashboard.py`` via
+    ``build_dashboard_payload`` — resolves it so the engine keeps no DB
+    dependency. It defaults to the catalog defaults so a caller that omits it
+    behaves exactly as before.
+
     Returns at most :data:`MAX_ACTIONS` entries.
     """
     candidates: list[dict] = []
+
+    # DTE threshold for the ITM/short-DTE expiration cards — a trading rule.
+    short_dte_max = rules.management.expiration_warning_days
 
     schwab = status.get("schwab", {}) or {}
     cache = status.get("cache", {}) or {}
@@ -504,8 +530,8 @@ def compute_next_actions(
     if loser_card is not None:
         candidates.append(loser_card)
 
-    candidates.extend(_itm_short_dte_actions(open_legs))
-    candidates.extend(_short_dte_aggregate_actions(open_legs))
+    candidates.extend(_itm_short_dte_actions(open_legs, short_dte_max))
+    candidates.extend(_short_dte_aggregate_actions(open_legs, short_dte_max))
     candidates.extend(_cc_candidate_actions(positions, open_legs))
 
     no_legs_card = _no_open_legs_action(kpis)

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -27,6 +27,7 @@ from app.services.dashboard_legs import (
     filter_upcoming,
     parse_iso_to_utc,
 )
+from app.services.rules_config import load_rules_config
 from app.services.schwab_auth import SchwabAuthError, SchwabTokenManager
 from app.services.schwab_client import SchwabClient, SchwabClientError
 
@@ -610,6 +611,8 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
     )
 
     # Action engine — pure, deterministic, recomputed every call (spec §2.2).
+    # Trading rules are resolved here (the router/service layer) and passed
+    # in so the engine stays a pure function with no DB dependency (#156).
     next_actions = compute_next_actions(
         status={
             "schwab": schwab_status,
@@ -620,6 +623,7 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         kpis=kpis,
         positions=position_rows,
         open_legs=open_legs,
+        rules=load_rules_config(db),
     )
     _attach_next_suggested_actions(position_rows, next_actions, open_legs)
 

--- a/backend/app/services/options_scanner.py
+++ b/backend/app/services/options_scanner.py
@@ -14,6 +14,7 @@ from app.services.schwab_auth import SchwabAuthError
 from app.services.alpha_vantage_client import get_next_earnings_date
 from app.services.greeks import calculate_greeks
 from app.services.rejection_messages import HumanizeContext, humanize_reasons
+from app.services.rules_config import DEFAULT_RULES_CONFIG
 from app.utils.parsing import to_float, to_int
 
 logger = logging.getLogger(__name__)
@@ -27,8 +28,16 @@ class OptionScanner:
     """Scans option chains for wheel strategy opportunities (CC and CSP)."""
 
     def scan(self, request: OptionScanRequest) -> dict:
-        """Main entry point: fetch Schwab chain, filter strikes, rank, return."""
+        """Main entry point: fetch Schwab chain, filter strikes, rank, return.
+
+        Rule fields on ``request`` are normally resolved from the persisted
+        ``rules_config`` by the scan router (issue #156). Any field still
+        ``None`` here — a direct caller that skipped the router — is filled
+        defensively from the catalog defaults so ``scan`` never crashes on an
+        unresolved rule.
+        """
         self._validate_request(request)
+        self._resolve_rule_defaults(request)
 
         today = datetime.now().date()
         from_date = (today + timedelta(days=request.min_dte)).strftime("%Y-%m-%d")
@@ -101,6 +110,12 @@ class OptionScanner:
         candidates = []
         rejected = []
 
+        # IV rank gate (issue #156 / ADR-002): there is no IV-rank data source
+        # wired today, so ``iv_rank`` is always None and the gate is inert. The
+        # ``min_iv_rank`` rule and the ``iv_rank_below_floor`` rejection are
+        # plumbed so a future IV-rank feed (ADR-002 OQ4) needs no scanner change.
+        scan_iv_rank: Optional[float] = None
+
         # Context for humanizing rejection codes — see #190 / scanner-education spec §5.
         humanize_ctx: HumanizeContext = {
             "cost_basis": request.cost_basis,
@@ -111,6 +126,8 @@ class OptionScanner:
             "min_return_pct": request.min_return_pct,
             "max_return_pct": request.max_return_pct,
         }
+
+        iv_rank_reasons = self._check_iv_rank(request, scan_iv_rank)
 
         valid_exps = set(self._get_valid_expirations(
             exp_date_map, request.min_dte, request.max_dte,
@@ -169,8 +186,11 @@ class OptionScanner:
                     flags.append("calculated_greeks")
 
                 reasons = self._check_rejection(
-                    request, strike, current_price, delta, oi, bid, mid, dte,
+                    request, strike, current_price, delta, oi, bid, ask, mid, dte,
                 )
+                # IV rank is a per-scan gate; it applies uniformly to every
+                # strike. Inert today (no IV-rank data source — see above).
+                reasons = reasons + iv_rank_reasons
 
                 if reasons:
                     rejected.append(RejectedStrike(
@@ -256,11 +276,58 @@ class OptionScanner:
             "strategy": request.strategy,
             "scan_time": datetime.now(timezone.utc).isoformat(),
             "earnings_date": earnings_date,
-            "iv_rank": None,
+            "iv_rank": scan_iv_rank,
             "recommendations": ranked[:20],
             "rejected": rejected[:50],
             "market_context": market_context,
         }
+
+    # ---- Rule resolution ----
+
+    def _resolve_rule_defaults(self, req: OptionScanRequest) -> None:
+        """Backfill any unset rule field from the catalog defaults.
+
+        The scan router resolves rules from the stored ``rules_config`` before
+        calling :meth:`scan`; by the time this runs every field is usually
+        already set. This is a defensive fallback for a direct caller (tests,
+        the action engine's CC scan links) that bypasses the router — it fills
+        only the fields still ``None`` with :data:`DEFAULT_RULES_CONFIG`
+        values, never overriding an explicit value.
+        """
+        entry = DEFAULT_RULES_CONFIG.entry
+        universe = DEFAULT_RULES_CONFIG.universe
+
+        if req.min_dte is None:
+            req.min_dte = int(entry.dte_range.min)
+        if req.max_dte is None:
+            req.max_dte = int(entry.dte_range.max)
+        if req.min_return_pct is None:
+            req.min_return_pct = entry.min_monthly_return_pct
+        if req.exclude_earnings_dte is None:
+            req.exclude_earnings_dte = entry.earnings_buffer_days
+        if req.min_call_distance_pct is None:
+            req.min_call_distance_pct = entry.min_call_distance_pct
+        if req.min_call_distance_from_cost_basis_pct is None:
+            req.min_call_distance_from_cost_basis_pct = (
+                entry.min_call_distance_from_cost_basis_pct
+            )
+
+        delta_band = (
+            entry.delta_range_cc
+            if req.strategy == "covered_call"
+            else entry.delta_range_csp
+        )
+        if req.min_delta is None:
+            req.min_delta = delta_band.min
+        if req.max_delta is None:
+            req.max_delta = delta_band.max
+
+        if req.min_open_interest is None:
+            req.min_open_interest = universe.min_open_interest
+        if req.max_bid_ask_spread_pct is None:
+            req.max_bid_ask_spread_pct = universe.max_bid_ask_spread_pct
+        if req.min_iv_rank is None:
+            req.min_iv_rank = universe.min_iv_rank
 
     # ---- Validation ----
 
@@ -337,10 +404,17 @@ class OptionScanner:
         delta: Optional[float],
         oi: int,
         bid: float,
+        ask: float,
         mid: float,
         dte: int,
     ) -> list[str]:
-        """Return list of rejection reasons, or empty list if strike passes."""
+        """Return list of rejection reasons, or empty list if strike passes.
+
+        Rule thresholds (open-interest floor, spread cap, distance rules) are
+        resolved on ``req`` before the scan runs — they come from the
+        persisted ``rules_config`` via the scan router (issue #156). A rejected
+        strike is never dropped; reasons are surfaced on the response.
+        """
         reasons = []
 
         # Strategy-specific strike filter
@@ -352,6 +426,17 @@ class OptionScanner:
                     f"fails_10pct_rule: strike {distance:.1f}% above basis, "
                     f"requires {req.min_call_distance_pct}%"
                 )
+            # Cost-basis floor — an independent rule from the distance margin
+            # above (PRD #209 §R3). A strike below the cost-basis floor locks
+            # in a share loss if assigned. Gated on the per-request toggle.
+            if req.cost_basis_floor_enabled:
+                floor_pct = req.min_call_distance_from_cost_basis_pct or 0.0
+                cost_basis_floor = req.cost_basis * (1 + floor_pct / 100)
+                if strike < cost_basis_floor:
+                    reasons.append(
+                        f"below_cost_basis: strike ${strike:.2f} < "
+                        f"floor ${cost_basis_floor:.2f}"
+                    )
         else:  # cash_secured_put
             if strike > current_price:
                 reasons.append(
@@ -366,13 +451,40 @@ class OptionScanner:
                     f"[{req.min_delta}, {req.max_delta}]"
                 )
 
-        # Liquidity filter
-        if oi < 50:
-            reasons.append(f"low_open_interest: {oi} < 50")
+        # Liquidity filter — open-interest floor from rules_config.
+        if oi < req.min_open_interest:
+            reasons.append(f"low_open_interest: {oi} < {req.min_open_interest}")
         if bid <= 0:
             reasons.append("zero_bid")
 
+        # Bid/ask spread filter — a wide spread makes a strike costly to
+        # enter/exit. Threshold from rules_config (universe.max_bid_ask_spread_pct).
+        if req.max_bid_ask_spread_pct is not None and mid > 0 and ask > 0:
+            spread_pct = ((ask - bid) / mid) * 100
+            if spread_pct > req.max_bid_ask_spread_pct:
+                reasons.append(
+                    f"wide_bid_ask_spread: {spread_pct:.1f}% > "
+                    f"{req.max_bid_ask_spread_pct}%"
+                )
+
         return reasons
+
+    def _check_iv_rank(
+        self, req: OptionScanRequest, iv_rank: Optional[float]
+    ) -> list[str]:
+        """Return an ``iv_rank_below_floor`` reason when IV rank is too low.
+
+        The check is guarded on ``iv_rank is not None``. Because no IV-rank
+        data source is wired today (``iv_rank`` is always ``None``), this
+        returns an empty list in practice — the gate is plumbed but inert
+        (ADR-002 OQ4 / issue #156). Wiring a real IV-rank feed activates it
+        with no further scanner change.
+        """
+        if iv_rank is None or req.min_iv_rank is None:
+            return []
+        if iv_rank < req.min_iv_rank:
+            return [f"iv_rank_below_floor: {iv_rank:.1f} < {req.min_iv_rank}"]
+        return []
 
     def _passes_10pct_rule(self, req: OptionScanRequest, strike: float) -> bool:
         if req.strategy != "covered_call" or not req.cost_basis:

--- a/backend/app/services/recovery_engine.py
+++ b/backend/app/services/recovery_engine.py
@@ -49,10 +49,6 @@ WHEEL_MONTHLY_PREMIUM_PCT: float = 0.015
 # worst case: 30% lower (slower grind).
 WHEEL_BE_MULTIPLIERS: tuple[float, float, float] = (0.8, 1.0, 1.3)
 
-# Hard-coded sizing cap used when ``okr_sizing_cap_dollars`` is unset. Per
-# the plan §5: defaults are documented in the Assumptions panel.
-DEFAULT_SIZING_CAP_DOLLARS: float = 5000.0
-
 # Canonical display labels. Stable per slug; rendered verbatim by the
 # frontend.
 _PATH_LABELS: dict[str, str] = {
@@ -356,7 +352,7 @@ def compute_recovery_paths(
     position: dict,
     current_price: float,
     target_yield: float | None,
-    sizing_cap_dollars: float | None,
+    sizing_cap_dollars: float,
 ) -> list[dict]:
     """Compute the four candidate recovery paths for a flagged position.
 
@@ -370,8 +366,9 @@ def compute_recovery_paths(
         target_yield: OKR target yield as a fraction (e.g. ``0.18``).
             ``None`` suppresses the sell-redeploy path and zeroes out
             opportunity-cost columns that depend on it.
-        sizing_cap_dollars: OKR per-position sizing cap in dollars. ``None``
-            falls back to :data:`DEFAULT_SIZING_CAP_DOLLARS`.
+        sizing_cap_dollars: Per-position sizing cap in dollars. The caller
+            resolves it from ``rules_config.position.sizing_cap_dollars``
+            (issue #156) and always supplies a concrete value.
 
     Returns:
         Four-element list in canonical order (sell-redeploy, wheel-cc,
@@ -385,11 +382,7 @@ def compute_recovery_paths(
         adjusted_cost_basis = float(position.get("broker_cost_basis") or 0.0)
 
     current_price = max(float(current_price or 0.0), 0.0)
-    cap = (
-        float(sizing_cap_dollars)
-        if sizing_cap_dollars is not None
-        else DEFAULT_SIZING_CAP_DOLLARS
-    )
+    cap = float(sizing_cap_dollars)
 
     # Realized loss for the sell-redeploy / wheel projections. If the
     # position is above water we still emit paths (the user can audit) but
@@ -443,7 +436,6 @@ def canonical_path_order() -> tuple[str, ...]:
 __all__ = [
     "WHEEL_MONTHLY_PREMIUM_PCT",
     "WHEEL_BE_MULTIPLIERS",
-    "DEFAULT_SIZING_CAP_DOLLARS",
     "compute_recovery_paths",
     "canonical_path_labels",
     "canonical_path_order",

--- a/backend/app/services/rejection_messages.py
+++ b/backend/app/services/rejection_messages.py
@@ -50,6 +50,18 @@ _RETURN_ABOVE_RE = re.compile(
     r"^return_above_cap:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*>\s*"
     r"(?P<max>-?\d+(?:\.\d+)?)%\s*$"
 )
+_BELOW_COST_BASIS_RE = re.compile(
+    r"^below_cost_basis:\s*strike\s*\$(?P<strike>-?\d+(?:\.\d+)?)\s*<\s*"
+    r"floor\s*\$(?P<floor>-?\d+(?:\.\d+)?)\s*$"
+)
+_WIDE_SPREAD_RE = re.compile(
+    r"^wide_bid_ask_spread:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*>\s*"
+    r"(?P<max>-?\d+(?:\.\d+)?)%\s*$"
+)
+_IV_RANK_BELOW_RE = re.compile(
+    r"^iv_rank_below_floor:\s*(?P<rank>-?\d+(?:\.\d+)?)\s*<\s*"
+    r"(?P<min>-?\d+(?:\.\d+)?)\s*$"
+)
 
 
 class HumanizeContext(TypedDict, total=False):
@@ -112,6 +124,12 @@ def _humanize_one(raw: str, ctx: HumanizeContext) -> str:
         return _fmt_return_below_target(raw, ctx)
     if raw.startswith("return_above_cap"):
         return _fmt_return_above_cap(raw, ctx)
+    if raw.startswith("below_cost_basis"):
+        return _fmt_below_cost_basis(raw, ctx)
+    if raw.startswith("wide_bid_ask_spread"):
+        return _fmt_wide_bid_ask_spread(raw, ctx)
+    if raw.startswith("iv_rank_below_floor"):
+        return _fmt_iv_rank_below_floor(raw, ctx)
 
     # Unknown code — fall back so we never lose information.
     return raw
@@ -224,4 +242,43 @@ def _fmt_return_above_cap(raw: str, ctx: HumanizeContext) -> str:
         f"Premium is {pct:.2f}% of capital — above your "
         f"{max_pct:.1f}% cap. Usually means the strike is too close to the "
         "money for the risk."
+    )
+
+
+def _fmt_below_cost_basis(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``below_cost_basis: strike $X < floor $Y``."""
+    match = _BELOW_COST_BASIS_RE.match(raw)
+    if not match:
+        return raw
+    strike = float(match.group("strike"))
+    floor = float(match.group("floor"))
+    return (
+        f"Strike ${strike:.2f} is below your ${floor:.2f} cost-basis floor — "
+        "if assigned, you'd lock in a loss on the shares."
+    )
+
+
+def _fmt_wide_bid_ask_spread(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``wide_bid_ask_spread: X% > Y%``."""
+    match = _WIDE_SPREAD_RE.match(raw)
+    if not match:
+        return raw
+    pct = float(match.group("pct"))
+    max_pct = float(match.group("max"))
+    return (
+        f"The bid/ask spread is {pct:.1f}% of the mid price — wider than your "
+        f"{max_pct:.1f}% limit, so entering and exiting would cost too much."
+    )
+
+
+def _fmt_iv_rank_below_floor(raw: str, ctx: HumanizeContext) -> str:
+    """Render ``iv_rank_below_floor: X < Y``."""
+    match = _IV_RANK_BELOW_RE.match(raw)
+    if not match:
+        return raw
+    rank = float(match.group("rank"))
+    min_rank = float(match.group("min"))
+    return (
+        f"IV rank is {rank:.0f} — below your {min_rank:.0f} floor, so the "
+        "premium on offer is likely too thin for selling options."
     )

--- a/backend/app/services/rules_config.py
+++ b/backend/app/services/rules_config.py
@@ -1,0 +1,569 @@
+"""Trading Rules Layer config — the ``rules_config`` keystone (issue #156).
+
+This module is the **single source of truth** for the Trading Rules Layer.
+Every Regress engine — options scanner, recovery engine, action engine, and the
+future OKR engine — resolves its rule values from one configurable object
+(:class:`RulesConfig`) instead of carrying its own hard-coded constants. That
+is what structurally kills the documented DTE / delta / return / earnings-buffer
+drift between engines.
+
+Authoritative build spec: **ADR-002 (Discussion #216)**. Parent taxonomy
+decision: **ADR-001 (#210)**. Source catalog: **PRD #209 (Trading Rules
+Layer)**. The ``okr_config`` namespace and the OKR engine are explicitly out of
+scope here — they are V1.1 (#157).
+
+Persistence (ADR-001 Decision 2 / ADR-002 Option B)
+---------------------------------------------------
+``rules_config`` persists as a **single row** in the existing ``app_settings``
+key/value table under the key :data:`RULES_CONFIG_KEY`. The ``value`` column
+holds a JSON document carrying a :data:`RULES_CONFIG_SCHEMA_VERSION` integer.
+There is **no new SQL table and no migration** — the row is created lazily on
+first write; its absence means "all defaults". The ``Session.config``
+JSON-in-Text column is the in-repo precedent for this pattern.
+
+The schema and the five groups
+------------------------------
+:class:`RulesConfig` is composed of five nested rule groups, each sourced from a
+section of PRD #209:
+
+- :class:`UniverseRules` (PRD #209 §R2) — what is even tradeable: open-interest
+  floor, bid/ask spread cap, IV-rank / IV-percentile floors.
+- :class:`EntryRules` (PRD #209 §R3) — what makes a good entry: DTE band, delta
+  bands, return target, earnings buffer, covered-call cost-basis rules.
+- :class:`PositionRules` (PRD #209 §R4) — how much capital a position may use:
+  per-position sizing cap, ticker-concentration cap, max open positions.
+- :class:`RiskRules` (PRD #209 §R5) — when a losing position must be reviewed:
+  loss-review threshold, hard stop, max consecutive rolls.
+- :class:`ManagementTriggers` (PRD #209 §R6) — when an open position needs
+  attention: profit-review %, DTE-review window, expiration warning window,
+  assignment-risk review level.
+
+Whole-percent convention
+------------------------
+**All percentage fields are whole-percent** — ``10.0`` means 10%, not 0.10 —
+matching the existing ``OptionScanRequest`` convention. Delta values are bare
+fractions in ``[0, 1]``. Dollar fields are plain dollar amounts. Day fields are
+integer counts of calendar days.
+
+Defaults and their PRD #209 source
+----------------------------------
+:data:`DEFAULT_RULES_CONFIG` is :class:`RulesConfig` instantiated with the
+reconciled PRD #209 catalog values. Every field's default and its source
+section is documented on the field below. The four PRD #209 "unset" rules
+(``max_open_positions``, ``hard_max_loss_pct``, ``max_consecutive_rolls``,
+``min_iv_percentile``) are modelled ``Optional`` and default ``None`` — they are
+persisted and validated only; **no engine enforces a `None` value** (PRD #209
+open question Q1 / ADR-002 OQ1).
+
+The reader: merge-over-defaults, never raises
+---------------------------------------------
+:func:`load_rules_config` reads the single ``rules_config`` row, JSON-parses it,
+and **merges it over the typed defaults**, so a partial / older / corrupt /
+missing stored object always yields a complete, valid :class:`RulesConfig`. It
+**never raises** to the caller:
+
+- Missing row / empty value → :data:`DEFAULT_RULES_CONFIG` (one ``INFO`` log).
+- Malformed JSON → :data:`DEFAULT_RULES_CONFIG` + a generic ``WARNING`` log
+  (never ``str(e)`` — per CLAUDE.md).
+- A single out-of-range stored field → that field falls back to its own default
+  via :func:`_coerce_group`; the rest of the config is honored.
+
+Per ADR-002, no rule is ever a hard blocker — a breach is surfaced as a
+warning/flag. This module only stores and validates the thresholds; the engines
+decide how to surface a breach.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator, model_validator
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import AppSetting
+
+logger = logging.getLogger(__name__)
+
+# The single ``app_settings`` key under which the Trading Rules config lives.
+RULES_CONFIG_KEY = "rules_config"
+
+# Schema version embedded in the persisted JSON document. Bump when the shape
+# changes in a way an older reader could not merge-over-defaults safely.
+RULES_CONFIG_SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Nested value type — a min/max range
+# ---------------------------------------------------------------------------
+
+
+class RangeRule(BaseModel):
+    """An inclusive ``[min, max]`` numeric range with a ``min < max`` invariant.
+
+    Used for the DTE band and the delta bands in :class:`EntryRules`. A
+    cross-field ``model_validator`` enforces ``min < max`` so an inverted stored
+    range is rejected as a unit (and reverts as a unit via the per-field
+    fallback in :func:`load_rules_config`).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    min: float
+    max: float
+
+    @model_validator(mode="after")
+    def _min_below_max(self) -> "RangeRule":
+        """Reject an inverted or degenerate range (``min >= max``)."""
+        if self.min >= self.max:
+            raise ValueError("range min must be strictly less than max")
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Five rule groups
+# ---------------------------------------------------------------------------
+
+
+class UniverseRules(BaseModel):
+    """Universe rules — what is even tradeable (PRD #209 §R2).
+
+    These gate a strike on liquidity and volatility quality before any
+    entry-quality rule is considered.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Minimum open interest a strike must show to be considered liquid enough
+    # to trade. PRD #209 §R2.
+    min_open_interest: int = 500
+    # Maximum bid/ask spread as a whole-percent of the mid price; wider spreads
+    # mean a strike is too costly to enter/exit. PRD #209 §R2.
+    max_bid_ask_spread_pct: float = 10.0
+    # Minimum IV rank (whole-percent, 0-100) for selling premium to be worth it.
+    # PRD #209 §R2.
+    min_iv_rank: float = 30.0
+    # Minimum IV percentile (whole-percent, 0-100). PRD #209 §R2 "unset" rule —
+    # default None, no enforcement on None (PRD Q1 / ADR-002 OQ1).
+    min_iv_percentile: float | None = None
+
+    @field_validator("min_open_interest")
+    @classmethod
+    def _oi_non_negative(cls, v: int) -> int:
+        """Open interest cannot be negative."""
+        if v < 0:
+            raise ValueError("min_open_interest must be >= 0")
+        return v
+
+    @field_validator("max_bid_ask_spread_pct")
+    @classmethod
+    def _spread_positive(cls, v: float) -> float:
+        """A spread cap of zero or less would reject every strike."""
+        if v <= 0:
+            raise ValueError("max_bid_ask_spread_pct must be > 0")
+        return v
+
+    @field_validator("min_iv_rank", "min_iv_percentile")
+    @classmethod
+    def _percent_0_100(cls, v: float | None) -> float | None:
+        """IV rank / percentile are whole-percents bounded to ``[0, 100]``."""
+        if v is not None and not 0 <= v <= 100:
+            raise ValueError("IV rank/percentile must be between 0 and 100")
+        return v
+
+
+class EntryRules(BaseModel):
+    """Entry rules — what makes a good entry (PRD #209 §R3).
+
+    Cost-basis-relative covered-call rules
+    --------------------------------------
+    This group carries **two distinct** covered-call cost-basis rules. They are
+    independent rules (PRD #209 §R3 / ADR-002 D3) and both are measured from the
+    position's adjusted **cost basis** — never from spot price. ADR-002's
+    "One correction to PRD #209" established that the scanner already measures
+    the covered-call distance rule from cost basis, not from current price.
+
+    - ``min_call_distance_pct`` — a **percentage margin above cost basis**. A
+      covered-call strike must sit at least this whole-percent *above* the
+      adjusted cost basis to be a recommendation; otherwise the scanner emits
+      the ``fails_10pct_rule`` rejection. The strike floor is
+      ``cost_basis * (1 + min_call_distance_pct / 100)``. Default ``5.0`` →
+      strike must be ≥ 5% above cost basis.
+
+    - ``min_call_distance_from_cost_basis_pct`` — a **bare at-or-above-cost-basis
+      floor**. A covered-call strike below
+      ``cost_basis * (1 + min_call_distance_from_cost_basis_pct / 100)`` would
+      lock in a capital loss on the shares if assigned, so the scanner emits the
+      ``below_cost_basis`` rejection. Default ``0.0`` → the floor is exactly the
+      cost basis (a strike at or above cost basis is acceptable).
+
+    The two are not redundant: ``min_call_distance_pct`` is the *premium-quality*
+    margin a trader wants on a good entry, while
+    ``min_call_distance_from_cost_basis_pct`` is the *hard loss-avoidance* floor
+    below which the trade is structurally bad. With the catalog defaults
+    (``5.0`` and ``0.0``) the margin rule is the stricter of the two; a trader
+    who lowers the margin still keeps the loss-avoidance floor.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Days-to-expiration band for an entry. PRD #209 §R3 — reconciled catalog
+    # value (resolves the scanner's prior 25-50 drift).
+    dte_range: RangeRule = RangeRule(min=21, max=45)
+    # Delta band for a cash-secured put. PRD #209 §R3 — reconciled catalog
+    # value (resolves the scanner's prior 0.15-0.35 drift).
+    delta_range_csp: RangeRule = RangeRule(min=0.20, max=0.30)
+    # Delta band for a covered call. PRD #209 §R3.
+    delta_range_cc: RangeRule = RangeRule(min=0.20, max=0.35)
+    # Minimum monthly return on capital, whole-percent. PRD #209 §R3 —
+    # reconciled catalog value (resolves the scanner's prior 1% drift).
+    min_monthly_return_pct: float = 2.0
+    # Calendar days of buffer to keep clear of an earnings date. PRD #209 §R3 —
+    # reconciled catalog value (resolves the scanner's prior 5-day drift).
+    earnings_buffer_days: int = 7
+    # Covered-call premium-quality margin above cost basis, whole-percent. See
+    # the class docstring. PRD #209 §R3.
+    min_call_distance_pct: float = 5.0
+    # Covered-call hard at-or-above-cost-basis floor, whole-percent. See the
+    # class docstring. PRD #209 §R3.
+    min_call_distance_from_cost_basis_pct: float = 0.0
+
+    @field_validator("dte_range")
+    @classmethod
+    def _dte_non_negative(cls, v: RangeRule) -> RangeRule:
+        """DTE cannot be negative."""
+        if v.min < 0:
+            raise ValueError("dte_range.min must be >= 0")
+        return v
+
+    @field_validator("delta_range_csp", "delta_range_cc")
+    @classmethod
+    def _delta_in_unit_interval(cls, v: RangeRule) -> RangeRule:
+        """Delta bounds are bare fractions in ``[0, 1]``."""
+        if not 0 <= v.min <= 1 or not 0 <= v.max <= 1:
+            raise ValueError("delta range bounds must be between 0 and 1")
+        return v
+
+    @field_validator(
+        "min_monthly_return_pct",
+        "earnings_buffer_days",
+        "min_call_distance_pct",
+        "min_call_distance_from_cost_basis_pct",
+    )
+    @classmethod
+    def _non_negative(cls, v: float) -> float:
+        """Return target, earnings buffer, and call distances cannot be negative."""
+        if v < 0:
+            raise ValueError("value must be >= 0")
+        return v
+
+
+class PositionRules(BaseModel):
+    """Position rules — how much capital a position may use (PRD #209 §R4)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Per-position capital cap in dollars. PRD #209 §R4. Consumed by the
+    # recovery engine's average-down path.
+    sizing_cap_dollars: float = 5000.0
+    # Maximum share of the portfolio a single ticker may occupy, whole-percent.
+    # PRD #209 §R4.
+    max_ticker_concentration_pct: float = 25.0
+    # Maximum number of concurrently open positions. PRD #209 §R4 "unset" rule —
+    # default None, no enforcement on None (PRD Q1 / ADR-002 OQ1).
+    max_open_positions: int | None = None
+
+    @field_validator("sizing_cap_dollars")
+    @classmethod
+    def _cap_positive(cls, v: float) -> float:
+        """A sizing cap of zero or less would suppress every sized path."""
+        if v <= 0:
+            raise ValueError("sizing_cap_dollars must be > 0")
+        return v
+
+    @field_validator("max_ticker_concentration_pct")
+    @classmethod
+    def _concentration_in_range(cls, v: float) -> float:
+        """A concentration cap is a whole-percent in ``(0, 100]``."""
+        if not 0 < v <= 100:
+            raise ValueError("max_ticker_concentration_pct must be in (0, 100]")
+        return v
+
+    @field_validator("max_open_positions")
+    @classmethod
+    def _open_positions_positive(cls, v: int | None) -> int | None:
+        """When set, the open-positions cap must be at least 1."""
+        if v is not None and v < 1:
+            raise ValueError("max_open_positions must be >= 1 when set")
+        return v
+
+
+class RiskRules(BaseModel):
+    """Risk rules — when a losing position must be reviewed (PRD #209 §R5)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Unrealized-loss threshold, whole-percent, that flags a position for
+    # review. Negative because it is a loss. PRD #209 §R5.
+    loss_review_threshold_pct: float = -15.0
+    # Hard maximum tolerated loss, whole-percent. PRD #209 §R5 "unset" rule —
+    # default None, no enforcement on None (PRD Q1 / ADR-002 OQ1).
+    hard_max_loss_pct: float | None = None
+    # Maximum number of consecutive rolls before forcing a decision. PRD #209
+    # §R5 "unset" rule — default None, no enforcement on None.
+    max_consecutive_rolls: int | None = None
+
+    @field_validator("loss_review_threshold_pct", "hard_max_loss_pct")
+    @classmethod
+    def _loss_non_positive(cls, v: float | None) -> float | None:
+        """A loss threshold must be zero or negative — a loss is not a gain."""
+        if v is not None and v > 0:
+            raise ValueError("loss threshold must be <= 0")
+        return v
+
+    @field_validator("max_consecutive_rolls")
+    @classmethod
+    def _rolls_non_negative(cls, v: int | None) -> int | None:
+        """When set, the consecutive-rolls cap cannot be negative."""
+        if v is not None and v < 0:
+            raise ValueError("max_consecutive_rolls must be >= 0 when set")
+        return v
+
+
+class ManagementTriggers(BaseModel):
+    """Management triggers — when an open position needs attention (PRD #209 §R6)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    # Profit captured, whole-percent of max profit, that triggers a review to
+    # close/roll early. PRD #209 §R6.
+    profit_review_pct: float = 50.0
+    # Days-to-expiration at which a roll/close/hold decision is reviewed.
+    # PRD #209 §R6.
+    dte_review_days: int = 21
+    # Days-to-expiration inside which assignment mechanics dominate and an
+    # expiration warning fires. PRD #209 §R6.
+    expiration_warning_days: int = 7
+    # Assignment-risk level at which a position is surfaced for review.
+    # PRD #209 §R6.
+    assignment_risk_review: Literal["High", "Medium", "Low"] = "High"
+
+    @field_validator("profit_review_pct")
+    @classmethod
+    def _profit_in_range(cls, v: float) -> float:
+        """The profit-review trigger is a whole-percent in ``(0, 100]``."""
+        if not 0 < v <= 100:
+            raise ValueError("profit_review_pct must be in (0, 100]")
+        return v
+
+    @field_validator("dte_review_days", "expiration_warning_days")
+    @classmethod
+    def _days_non_negative(cls, v: int) -> int:
+        """Day windows cannot be negative."""
+        if v < 0:
+            raise ValueError("day window must be >= 0")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Top-level config
+# ---------------------------------------------------------------------------
+
+
+class RulesConfig(BaseModel):
+    """The complete Trading Rules Layer config — five nested rule groups.
+
+    Persisted as one JSON document in the ``app_settings`` row keyed
+    :data:`RULES_CONFIG_KEY`. :data:`DEFAULT_RULES_CONFIG` is this model
+    instantiated with all PRD #209 catalog defaults.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = RULES_CONFIG_SCHEMA_VERSION
+    universe: UniverseRules = UniverseRules()
+    entry: EntryRules = EntryRules()
+    position: PositionRules = PositionRules()
+    risk: RiskRules = RiskRules()
+    management: ManagementTriggers = ManagementTriggers()
+
+
+# The model instantiated with all PRD #209 catalog defaults. Returned verbatim
+# by :func:`load_rules_config` whenever no usable stored config is found.
+DEFAULT_RULES_CONFIG = RulesConfig()
+
+# The five nested-group attribute names, in document order. Drives the
+# group-by-group merge and per-field fallback in :func:`load_rules_config`.
+_GROUP_MODELS: dict[str, type[BaseModel]] = {
+    "universe": UniverseRules,
+    "entry": EntryRules,
+    "position": PositionRules,
+    "risk": RiskRules,
+    "management": ManagementTriggers,
+}
+
+
+# ---------------------------------------------------------------------------
+# The shared reader
+# ---------------------------------------------------------------------------
+
+
+def _get_rules_config_row(db: DBSession, key: str) -> str | None:
+    """Read a single ``app_settings`` row by key. ``None`` when missing.
+
+    Mirrors the ``_get_app_setting`` idiom in ``routers/positions.py`` — kept
+    local so the keystone module has no router dependency.
+    """
+    entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+    return entry.value if entry else None
+
+
+def _coerce_group(
+    model_cls: type[BaseModel],
+    group_dict: dict[str, Any],
+    default_group: BaseModel,
+) -> tuple[BaseModel, list[str]]:
+    """Build a rule group, dropping any invalid field back to its default.
+
+    A single out-of-range stored value must not poison the whole group:
+    ``RulesConfig(**merged)`` would reject the entire object on one bad field.
+    This helper instead validates the group, and on a :class:`ValidationError`
+    walks the error locations, resets each offending field to the default
+    group's value, and retries — bounded to one retry per field.
+
+    A cross-field failure (e.g. an inverted :class:`RangeRule`) reports the
+    *range field* as the offending location, so that whole sub-object reverts
+    to its default as a unit, which is the intended behavior.
+
+    Args:
+        model_cls: The group model class to build.
+        group_dict: The merged stored-over-default dict for this group.
+        default_group: The all-defaults instance of this group.
+
+    Returns:
+        A ``(group, dropped_fields)`` tuple. ``group`` always validates.
+        ``dropped_fields`` lists the field names that fell back to defaults
+        (empty when the stored group was fully valid).
+    """
+    defaults = default_group.model_dump()
+    working = dict(group_dict)
+    dropped: list[str] = []
+
+    # At most one retry per field plus a final all-default fallback.
+    for _ in range(len(model_cls.model_fields) + 1):
+        try:
+            return model_cls(**working), dropped
+        except ValidationError as exc:
+            offending = {
+                str(err["loc"][0])
+                for err in exc.errors()
+                if err.get("loc")
+            }
+            if not offending:
+                # No locatable field — give up on the merged dict entirely.
+                break
+            for field in offending:
+                if field in defaults:
+                    working[field] = defaults[field]
+                    if field not in dropped:
+                        dropped.append(field)
+                else:
+                    # An unknown extra key the model forbids — drop it.
+                    working.pop(field, None)
+
+    # Bounded retries exhausted — fall back to the full default group.
+    return default_group, sorted(_GROUP_MODELS) if not dropped else dropped
+
+
+def load_rules_config(db: DBSession) -> RulesConfig:
+    """Read and resolve the Trading Rules config — the single shared reader.
+
+    Reads the one ``app_settings`` row keyed :data:`RULES_CONFIG_KEY`, parses
+    its JSON, and **merges it over** :data:`DEFAULT_RULES_CONFIG` so a partial,
+    older, corrupt, or missing stored object always yields a complete, valid
+    :class:`RulesConfig`. This function **never raises** to the caller.
+
+    Fallback behavior:
+
+    - Missing row / empty value → :data:`DEFAULT_RULES_CONFIG` (``INFO`` log).
+    - Malformed JSON → :data:`DEFAULT_RULES_CONFIG` + generic ``WARNING`` log.
+    - A single out-of-range stored field → that field reverts to its default
+      via :func:`_coerce_group`; the rest of the config is honored (``WARNING``
+      log naming only the dropped field — never a leaked value).
+
+    No exception text (``str(e)``) is ever logged or surfaced, per CLAUDE.md.
+
+    Args:
+        db: A SQLAlchemy session (request-scoped).
+
+    Returns:
+        A fully-populated, validated :class:`RulesConfig`.
+    """
+    raw = _get_rules_config_row(db, RULES_CONFIG_KEY)
+    if raw is None or raw.strip() == "":
+        logger.info("No %s setting found; using default trading rules.", RULES_CONFIG_KEY)
+        return DEFAULT_RULES_CONFIG
+
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, ValueError, TypeError):
+        logger.warning(
+            "Stored %s is not valid JSON; falling back to default trading rules.",
+            RULES_CONFIG_KEY,
+        )
+        return DEFAULT_RULES_CONFIG
+
+    if not isinstance(parsed, dict):
+        logger.warning(
+            "Stored %s is not a JSON object; falling back to default trading rules.",
+            RULES_CONFIG_KEY,
+        )
+        return DEFAULT_RULES_CONFIG
+
+    # Merge-over-defaults at group + field granularity. Each group is validated
+    # independently so a bad field in one group cannot poison the others.
+    groups: dict[str, BaseModel] = {}
+    dropped_any: list[str] = []
+    for name, model_cls in _GROUP_MODELS.items():
+        default_group = getattr(DEFAULT_RULES_CONFIG, name)
+        stored_group = parsed.get(name)
+        if not isinstance(stored_group, dict):
+            # Missing or non-object group — take the default wholesale.
+            groups[name] = default_group
+            continue
+        merged_group = {**default_group.model_dump(), **stored_group}
+        group, dropped = _coerce_group(model_cls, merged_group, default_group)
+        groups[name] = group
+        dropped_any.extend(f"{name}.{field}" for field in dropped)
+
+    if dropped_any:
+        logger.warning(
+            "Stored %s had invalid values for %s; those fields reverted to defaults.",
+            RULES_CONFIG_KEY,
+            ", ".join(sorted(dropped_any)),
+        )
+
+    return RulesConfig(
+        schema_version=RULES_CONFIG_SCHEMA_VERSION,
+        universe=groups["universe"],  # type: ignore[arg-type]
+        entry=groups["entry"],  # type: ignore[arg-type]
+        position=groups["position"],  # type: ignore[arg-type]
+        risk=groups["risk"],  # type: ignore[arg-type]
+        management=groups["management"],  # type: ignore[arg-type]
+    )
+
+
+__all__ = [
+    "RULES_CONFIG_KEY",
+    "RULES_CONFIG_SCHEMA_VERSION",
+    "RangeRule",
+    "UniverseRules",
+    "EntryRules",
+    "PositionRules",
+    "RiskRules",
+    "ManagementTriggers",
+    "RulesConfig",
+    "DEFAULT_RULES_CONFIG",
+    "load_rules_config",
+]

--- a/backend/tests/test_acceptance_phase4.py
+++ b/backend/tests/test_acceptance_phase4.py
@@ -105,12 +105,12 @@ class TestAC2_EarningsExclusionWorksInScanner:
                            "totalVolume": 5000000},
             "putExpDateMap": {
                 f"{exp_near}:30": {
-                    "90.0": [{"strikePrice": 90.0, "bid": 1.0, "ask": 1.2, "mark": 1.1,
+                    "90.0": [{"strikePrice": 90.0, "bid": 1.05, "ask": 1.15, "mark": 1.1,
                               "delta": -0.25, "gamma": 0.02, "theta": -0.03, "vega": 0.05,
                               "openInterest": 500, "totalVolume": 100, "volatility": 30.0}],
                 },
                 f"{exp_safe}:45": {
-                    "90.0": [{"strikePrice": 90.0, "bid": 1.5, "ask": 1.7, "mark": 1.6,
+                    "90.0": [{"strikePrice": 90.0, "bid": 1.55, "ask": 1.65, "mark": 1.6,
                               "delta": -0.25, "gamma": 0.02, "theta": -0.03, "vega": 0.05,
                               "openInterest": 500, "totalVolume": 100, "volatility": 30.0}],
                 },
@@ -163,7 +163,7 @@ class TestAC3_ScannerCompletesWhenAlphaVantageReturnsNone:
                            "totalVolume": 5000000},
             "putExpDateMap": {
                 f"{exp_date}:{dte}": {
-                    "90.0": [{"strikePrice": 90.0, "bid": 1.0, "ask": 1.2, "mark": 1.1,
+                    "90.0": [{"strikePrice": 90.0, "bid": 1.05, "ask": 1.15, "mark": 1.1,
                               "delta": -0.25, "gamma": 0.02, "theta": -0.03, "vega": 0.05,
                               "openInterest": 500, "totalVolume": 100, "volatility": 30.0}],
                 },

--- a/backend/tests/test_no_hardcoded_rule_constants.py
+++ b/backend/tests/test_no_hardcoded_rule_constants.py
@@ -1,0 +1,103 @@
+"""Static guard — no hard-coded trading-rule constant survives (issue #156).
+
+After the engine wiring, every entry / position / risk / management rule value
+must come from ``rules_config`` — never from a module constant or a literal
+default. This test fails CI if a migrated constant reappears, so an incomplete
+or reverted migration cannot land silently.
+
+Intentionally retained literals — ``WHEEL_MONTHLY_PREMIUM_PCT``,
+``WHEEL_BE_MULTIPLIERS``, ``LARGE_LOSER_*``, ``TOKEN_EXPIRING_DAYS``,
+``MAX_ACTIONS``, ``ITM_SHORT_DTE_CAP`` — are internal heuristics and display
+caps, explicitly NOT trader-facing trading rules (ADR-002 "We will NOT"). The
+allow-list below is kept narrow so they do not trip the guard.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from app.models import schemas
+from app.models.schemas import OptionScanRequest
+from app.services import action_engine, recovery_engine
+
+
+# The rule constants that issue #156 removed. Each must no longer exist as a
+# module attribute on its engine.
+def test_recovery_engine_default_sizing_cap_constant_removed():
+    """``DEFAULT_SIZING_CAP_DOLLARS`` no longer exists on the recovery engine."""
+    assert not hasattr(recovery_engine, "DEFAULT_SIZING_CAP_DOLLARS"), (
+        "DEFAULT_SIZING_CAP_DOLLARS must be gone — the sizing cap is resolved "
+        "from rules_config.position.sizing_cap_dollars (issue #156)."
+    )
+    assert "DEFAULT_SIZING_CAP_DOLLARS" not in recovery_engine.__all__
+
+
+def test_action_engine_itm_short_dte_max_constant_removed():
+    """``ITM_SHORT_DTE_MAX_DTE`` no longer exists on the action engine."""
+    assert not hasattr(action_engine, "ITM_SHORT_DTE_MAX_DTE"), (
+        "ITM_SHORT_DTE_MAX_DTE must be gone — the threshold is resolved from "
+        "rules_config.management.expiration_warning_days (issue #156)."
+    )
+
+
+def test_option_scan_request_rule_fields_default_to_none():
+    """The seven ``OptionScanRequest`` rule fields default to ``None``.
+
+    A ``None`` default means the value is resolved from ``rules_config`` by the
+    scan router — no hard-coded literal default remains on the contract.
+    """
+    fields = OptionScanRequest.model_fields
+    rule_fields = [
+        "min_dte",
+        "max_dte",
+        "min_return_pct",
+        "min_call_distance_pct",
+        "max_delta",
+        "min_delta",
+        "exclude_earnings_dte",
+    ]
+    for name in rule_fields:
+        assert name in fields, f"{name} missing from OptionScanRequest"
+        assert fields[name].default is None, (
+            f"OptionScanRequest.{name} must default to None (resolved from "
+            f"rules_config), not a hard-coded literal."
+        )
+
+
+def test_option_scan_request_has_universe_rule_fields():
+    """``OptionScanRequest`` carries the universe-rule fields, all default ``None``."""
+    fields = OptionScanRequest.model_fields
+    for name in ("min_open_interest", "max_bid_ask_spread_pct", "min_iv_rank"):
+        assert name in fields, f"{name} missing from OptionScanRequest"
+        assert fields[name].default is None
+
+
+def test_no_migrated_constant_name_in_source():
+    """A source-text scan confirms the migrated constant names are gone.
+
+    The allow-list is intentionally narrow: the retained heuristics
+    (WHEEL_*, LARGE_LOSER_*, etc.) are not in the banned set, so they do not
+    trip this guard.
+    """
+    banned = {
+        "schemas": (schemas, []),
+        "action_engine": (action_engine, ["ITM_SHORT_DTE_MAX_DTE"]),
+        "recovery_engine": (recovery_engine, ["DEFAULT_SIZING_CAP_DOLLARS"]),
+    }
+    for label, (module, banned_names) in banned.items():
+        source = inspect.getsource(module)
+        for name in banned_names:
+            # Allow the name to appear in a comment that explains the removal
+            # (e.g. "resolved from rules_config" docstrings reference history).
+            for line in source.splitlines():
+                stripped = line.strip()
+                if name in stripped and not (
+                    stripped.startswith("#")
+                    or stripped.startswith('"')
+                    or stripped.startswith("'")
+                    or "rules_config" in stripped
+                ):
+                    raise AssertionError(
+                        f"{label}: migrated rule constant '{name}' still "
+                        f"referenced in code: {stripped!r}"
+                    )

--- a/backend/tests/test_options_scanner.py
+++ b/backend/tests/test_options_scanner.py
@@ -75,6 +75,11 @@ def scanner():
     return OptionScanner()
 
 
+# Rule fields are explicit on these fixtures so the scanner can be exercised
+# in isolation (these tests bypass the router that would otherwise backfill
+# the universe rules from rules_config — see issue #156). The cost-basis
+# floor is disabled so the existing fails_10pct_rule assertions are not
+# perturbed by the new below_cost_basis rule.
 @pytest.fixture()
 def cc_request():
     return OptionScanRequest(
@@ -88,6 +93,10 @@ def cc_request():
         min_call_distance_pct=10.0,
         max_delta=0.35,
         min_delta=0.15,
+        min_open_interest=50,
+        max_bid_ask_spread_pct=10.0,
+        min_iv_rank=30.0,
+        cost_basis_floor_enabled=False,
     )
 
 
@@ -102,6 +111,9 @@ def csp_request():
         min_return_pct=0.5,
         max_delta=0.35,
         min_delta=0.15,
+        min_open_interest=50,
+        max_bid_ask_spread_pct=10.0,
+        min_iv_rank=30.0,
     )
 
 
@@ -127,7 +139,7 @@ class TestRejectionFilters:
         # Strike $16 is only 6.7% above $15 cost basis, needs 10%
         reasons = scanner._check_rejection(
             cc_request, strike=16.0, current_price=14.0,
-            delta=-0.20, oi=100, bid=0.30, mid=0.35, dte=30,
+            delta=-0.20, oi=100, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert any("fails_10pct_rule" in r for r in reasons)
 
@@ -135,42 +147,42 @@ class TestRejectionFilters:
         # Strike $17 is 13.3% above $15 cost basis
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
-            delta=-0.20, oi=100, bid=0.30, mid=0.35, dte=30,
+            delta=-0.20, oi=100, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert not any("fails_10pct_rule" in r for r in reasons)
 
     def test_delta_out_of_range_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
-            delta=-0.05, oi=100, bid=0.30, mid=0.35, dte=30,
+            delta=-0.05, oi=100, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert any("delta_out_of_range" in r for r in reasons)
 
     def test_delta_in_range_passes(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
-            delta=-0.25, oi=100, bid=0.30, mid=0.35, dte=30,
+            delta=-0.25, oi=100, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert not any("delta_out_of_range" in r for r in reasons)
 
     def test_missing_delta_not_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
-            delta=None, oi=100, bid=0.30, mid=0.35, dte=30,
+            delta=None, oi=100, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert not any("delta" in r for r in reasons)
 
     def test_low_oi_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
-            delta=-0.20, oi=10, bid=0.30, mid=0.35, dte=30,
+            delta=-0.20, oi=10, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert any("low_open_interest" in r for r in reasons)
 
     def test_zero_bid_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
-            delta=-0.20, oi=100, bid=0.0, mid=0.10, dte=30,
+            delta=-0.20, oi=100, bid=0.0, ask=0.10, mid=0.10, dte=30,
         )
         assert any("zero_bid" in r for r in reasons)
 
@@ -178,7 +190,7 @@ class TestRejectionFilters:
         # Put strike $15 > current price $14
         reasons = scanner._check_rejection(
             csp_request, strike=15.0, current_price=14.0,
-            delta=-0.50, oi=100, bid=1.50, mid=1.60, dte=30,
+            delta=-0.50, oi=100, bid=1.50, ask=1.55, mid=1.60, dte=30,
         )
         assert any("itm_put" in r for r in reasons)
 
@@ -186,7 +198,7 @@ class TestRejectionFilters:
         # Put strike $13 < current price $14
         reasons = scanner._check_rejection(
             csp_request, strike=13.0, current_price=14.0,
-            delta=-0.25, oi=100, bid=0.30, mid=0.35, dte=30,
+            delta=-0.25, oi=100, bid=0.30, ask=0.32, mid=0.35, dte=30,
         )
         assert not any("itm_put" in r for r in reasons)
 
@@ -310,8 +322,10 @@ class TestScanWithSchwabChain:
         dte = 30
         exp_date = (datetime.now().date() + timedelta(days=dte)).strftime("%Y-%m-%d")
 
+        # Spread kept inside the 10% bid/ask rule so the new
+        # wide_bid_ask_spread check (issue #156) does not reject the strike.
         contract = _make_schwab_contract(
-            strike=17.0, bid=0.40, ask=0.50, mark=0.45,
+            strike=17.0, bid=0.43, ask=0.47, mark=0.45,
             delta=-0.20, gamma=0.03, theta=-0.02, vega=0.04,
             oi=500, volume=100, volatility=35.0, dte=dte,
         )
@@ -347,8 +361,9 @@ class TestScanWithSchwabChain:
         dte = 30
         exp_date = (datetime.now().date() + timedelta(days=dte)).strftime("%Y-%m-%d")
 
+        # Spread kept inside the 10% bid/ask rule (issue #156).
         contract = _make_schwab_contract(
-            strike=13.0, bid=0.35, ask=0.45, mark=0.40,
+            strike=13.0, bid=0.38, ask=0.42, mark=0.40,
             delta=-0.25, gamma=0.02, theta=-0.01, vega=0.03,
             oi=200, volume=50, volatility=40.0, dte=dte,
         )
@@ -607,9 +622,11 @@ class TestHumanReasonsPopulated:
         dte = 30
         exp_date = (datetime.now().date() + timedelta(days=dte)).strftime("%Y-%m-%d")
 
-        # Strike $17 passes filters but premium yields tiny return (below cc_request.min_return_pct=0.5)
+        # Strike $17 passes filters but premium yields tiny return (below
+        # cc_request.min_return_pct=0.5). Spread kept inside the 10% bid/ask
+        # rule so the new wide_bid_ask_spread check (#156) is not the reason.
         contract = _make_schwab_contract(
-            strike=17.0, bid=0.01, ask=0.02, mark=0.015,
+            strike=17.0, bid=0.0145, ask=0.0155, mark=0.015,
             delta=-0.20, oi=500, dte=dte,
         )
         chain_resp = _make_schwab_chain_response(

--- a/backend/tests/test_recovery_engine.py
+++ b/backend/tests/test_recovery_engine.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import pytest
 
 from app.services.recovery_engine import (
-    DEFAULT_SIZING_CAP_DOLLARS,
     WHEEL_BE_MULTIPLIERS,
     WHEEL_MONTHLY_PREMIUM_PCT,
     canonical_path_order,
@@ -242,18 +241,19 @@ class TestAverageDownPath:
         # opp_cost = additional_capital * target_yield = $800 * 0.18 = $144
         assert avg["opportunity_cost_vs_baseline"] == pytest.approx(144.0)
 
-    def test_uses_default_sizing_cap_when_unset(self):
-        # When the OKR cap is None the engine falls back to the documented
-        # default. With the SOFI fixture, $4600 < $5000 default → eligible.
+    def test_uses_supplied_sizing_cap(self):
+        # The engine no longer carries its own default cap (issue #156):
+        # the caller resolves it from rules_config and always supplies a
+        # concrete value. With the SOFI fixture, $4600 < the $5000 catalog
+        # default cap → eligible.
         paths = compute_recovery_paths(
             position=_sofi_position(),
             current_price=8.0,
             target_yield=0.18,
-            sizing_cap_dollars=None,
+            sizing_cap_dollars=5000.0,
         )
         avg = next(p for p in paths if p["path_id"] == "average-down")
         assert avg["eligibility"] == "eligible"
-        assert DEFAULT_SIZING_CAP_DOLLARS == 5000.0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_rules_config.py
+++ b/backend/tests/test_rules_config.py
@@ -1,0 +1,449 @@
+"""Unit tests for the ``rules_config`` keystone module (issue #156).
+
+Covers the schema (PRD #209 catalog defaults, range validators) and the full
+:func:`load_rules_config` reader-behavior matrix: missing row, valid full
+object, valid partial object (merge-over-defaults), malformed JSON, a single
+out-of-range field, an inverted range, and the never-raises guarantee.
+
+These are pure DB-row tests — they use an in-memory SQLite session directly
+(not the ``client`` TestClient fixture) so the reader can be exercised against
+hand-crafted ``app_settings`` values.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from pydantic import ValidationError
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import AppSetting, Base
+from app.services.rules_config import (
+    DEFAULT_RULES_CONFIG,
+    RULES_CONFIG_KEY,
+    RULES_CONFIG_SCHEMA_VERSION,
+    EntryRules,
+    ManagementTriggers,
+    PositionRules,
+    RangeRule,
+    RiskRules,
+    RulesConfig,
+    UniverseRules,
+    load_rules_config,
+)
+
+
+@pytest.fixture()
+def db():
+    """An in-memory SQLite session with the full schema created."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    session_local = sessionmaker(bind=engine)
+    session = session_local()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _store(db, value: str) -> None:
+    """Write a raw ``rules_config`` value into ``app_settings``."""
+    db.add(AppSetting(key=RULES_CONFIG_KEY, value=value))
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_module_constants():
+    """The key and schema-version constants match the ADR-002 spec."""
+    assert RULES_CONFIG_KEY == "rules_config"
+    assert RULES_CONFIG_SCHEMA_VERSION == 1
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_RULES_CONFIG equals the PRD #209 catalog
+# ---------------------------------------------------------------------------
+
+
+def test_default_config_universe_matches_catalog():
+    """Universe defaults equal PRD #209 §R2."""
+    u = DEFAULT_RULES_CONFIG.universe
+    assert u.min_open_interest == 500
+    assert u.max_bid_ask_spread_pct == 10.0
+    assert u.min_iv_rank == 30.0
+    assert u.min_iv_percentile is None
+
+
+def test_default_config_entry_matches_catalog():
+    """Entry defaults equal the reconciled PRD #209 §R3 catalog."""
+    e = DEFAULT_RULES_CONFIG.entry
+    assert (e.dte_range.min, e.dte_range.max) == (21, 45)
+    assert (e.delta_range_csp.min, e.delta_range_csp.max) == (0.20, 0.30)
+    assert (e.delta_range_cc.min, e.delta_range_cc.max) == (0.20, 0.35)
+    assert e.min_monthly_return_pct == 2.0
+    assert e.earnings_buffer_days == 7
+    assert e.min_call_distance_pct == 5.0
+    assert e.min_call_distance_from_cost_basis_pct == 0.0
+
+
+def test_default_config_position_matches_catalog():
+    """Position defaults equal PRD #209 §R4."""
+    p = DEFAULT_RULES_CONFIG.position
+    assert p.sizing_cap_dollars == 5000.0
+    assert p.max_ticker_concentration_pct == 25.0
+    assert p.max_open_positions is None
+
+
+def test_default_config_risk_matches_catalog():
+    """Risk defaults equal PRD #209 §R5."""
+    r = DEFAULT_RULES_CONFIG.risk
+    assert r.loss_review_threshold_pct == -15.0
+    assert r.hard_max_loss_pct is None
+    assert r.max_consecutive_rolls is None
+
+
+def test_default_config_management_matches_catalog():
+    """Management defaults equal PRD #209 §R6."""
+    m = DEFAULT_RULES_CONFIG.management
+    assert m.profit_review_pct == 50.0
+    assert m.dte_review_days == 21
+    assert m.expiration_warning_days == 7
+    assert m.assignment_risk_review == "High"
+
+
+def test_default_config_carries_schema_version():
+    """The top-level model carries the schema-version integer."""
+    assert DEFAULT_RULES_CONFIG.schema_version == RULES_CONFIG_SCHEMA_VERSION
+    dumped = DEFAULT_RULES_CONFIG.model_dump()
+    assert dumped["schema_version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Validators reject out-of-range values
+# ---------------------------------------------------------------------------
+
+
+def test_validator_rejects_negative_dte():
+    """A negative DTE minimum is rejected."""
+    with pytest.raises(ValidationError):
+        EntryRules(dte_range=RangeRule(min=-1, max=45))
+
+
+def test_validator_rejects_delta_above_one():
+    """A delta above 1.0 is rejected."""
+    with pytest.raises(ValidationError):
+        EntryRules(delta_range_csp=RangeRule(min=0.2, max=1.5))
+
+
+def test_validator_rejects_delta_below_zero():
+    """A negative delta bound is rejected."""
+    with pytest.raises(ValidationError):
+        EntryRules(delta_range_csp=RangeRule(min=-0.1, max=0.3))
+
+
+def test_validator_rejects_inverted_range():
+    """A range with ``min >= max`` is rejected."""
+    with pytest.raises(ValidationError):
+        RangeRule(min=45, max=21)
+    with pytest.raises(ValidationError):
+        RangeRule(min=30, max=30)
+
+
+def test_validator_rejects_positive_loss_threshold():
+    """A loss-review threshold above zero is rejected — a loss is not a gain."""
+    with pytest.raises(ValidationError):
+        RiskRules(loss_review_threshold_pct=5.0)
+
+
+def test_validator_rejects_profit_review_over_100():
+    """A profit-review percent above 100 is rejected."""
+    with pytest.raises(ValidationError):
+        ManagementTriggers(profit_review_pct=150.0)
+
+
+def test_validator_rejects_zero_max_open_positions():
+    """A max-open-positions cap below 1 is rejected when set."""
+    with pytest.raises(ValidationError):
+        PositionRules(max_open_positions=0)
+
+
+def test_validator_rejects_negative_open_interest():
+    """A negative open-interest floor is rejected."""
+    with pytest.raises(ValidationError):
+        UniverseRules(min_open_interest=-1)
+
+
+def test_validator_rejects_non_positive_sizing_cap():
+    """A sizing cap of zero or less is rejected."""
+    with pytest.raises(ValidationError):
+        PositionRules(sizing_cap_dollars=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Validators ACCEPT the unset optionals as None (ADR-002 OQ1 / PRD #209 Q1)
+# ---------------------------------------------------------------------------
+
+
+def test_unset_optionals_accept_none():
+    """The four PRD #209 "unset" rules are valid as ``None`` — no enforcement.
+
+    ``max_open_positions``, ``hard_max_loss_pct``, ``max_consecutive_rolls`` and
+    ``min_iv_percentile`` are persisted/validated only. No engine in #156 acts
+    on a ``None`` value — concrete values are PRD #209 Q1 / ADR-002 OQ1,
+    deferred to the trader.
+    """
+    cfg = RulesConfig()
+    assert cfg.position.max_open_positions is None
+    assert cfg.risk.hard_max_loss_pct is None
+    assert cfg.risk.max_consecutive_rolls is None
+    assert cfg.universe.min_iv_percentile is None
+    # And they accept a concrete value too, so a future trader-set value works.
+    assert PositionRules(max_open_positions=5).max_open_positions == 5
+    assert RiskRules(hard_max_loss_pct=-50.0).hard_max_loss_pct == -50.0
+
+
+# ---------------------------------------------------------------------------
+# load_rules_config — missing row
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_row_returns_defaults(db, caplog):
+    """No ``rules_config`` row → the full default config + an INFO log."""
+    with caplog.at_level(logging.INFO):
+        cfg = load_rules_config(db)
+    assert cfg == DEFAULT_RULES_CONFIG
+    assert any("default trading rules" in r.message for r in caplog.records)
+
+
+def test_load_empty_value_returns_defaults(db):
+    """An empty-string stored value is treated as missing → defaults."""
+    _store(db, "   ")
+    assert load_rules_config(db) == DEFAULT_RULES_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# load_rules_config — valid full object
+# ---------------------------------------------------------------------------
+
+
+def test_load_valid_full_object_returns_stored_values(db):
+    """A valid full stored object → exactly those values are returned."""
+    stored = {
+        "schema_version": 1,
+        "universe": {
+            "min_open_interest": 1000,
+            "max_bid_ask_spread_pct": 5.0,
+            "min_iv_rank": 40.0,
+            "min_iv_percentile": 50.0,
+        },
+        "entry": {
+            "dte_range": {"min": 30, "max": 60},
+            "delta_range_csp": {"min": 0.10, "max": 0.25},
+            "delta_range_cc": {"min": 0.15, "max": 0.40},
+            "min_monthly_return_pct": 3.5,
+            "earnings_buffer_days": 10,
+            "min_call_distance_pct": 8.0,
+            "min_call_distance_from_cost_basis_pct": 2.0,
+        },
+        "position": {
+            "sizing_cap_dollars": 8000.0,
+            "max_ticker_concentration_pct": 15.0,
+            "max_open_positions": 10,
+        },
+        "risk": {
+            "loss_review_threshold_pct": -20.0,
+            "hard_max_loss_pct": -50.0,
+            "max_consecutive_rolls": 3,
+        },
+        "management": {
+            "profit_review_pct": 75.0,
+            "dte_review_days": 30,
+            "expiration_warning_days": 5,
+            "assignment_risk_review": "Medium",
+        },
+    }
+    _store(db, json.dumps(stored))
+    cfg = load_rules_config(db)
+
+    assert cfg.universe.min_open_interest == 1000
+    assert cfg.entry.dte_range.min == 30 and cfg.entry.dte_range.max == 60
+    assert cfg.entry.min_monthly_return_pct == 3.5
+    assert cfg.position.sizing_cap_dollars == 8000.0
+    assert cfg.position.max_open_positions == 10
+    assert cfg.risk.hard_max_loss_pct == -50.0
+    assert cfg.management.assignment_risk_review == "Medium"
+
+
+# ---------------------------------------------------------------------------
+# load_rules_config — valid partial object (merge-over-defaults)
+# ---------------------------------------------------------------------------
+
+
+def test_load_partial_object_merges_over_defaults(db):
+    """A partial stored object → stored fields honored, the rest defaulted."""
+    _store(db, json.dumps({"entry": {"min_monthly_return_pct": 4.0}}))
+    cfg = load_rules_config(db)
+
+    # The one stored field is honored.
+    assert cfg.entry.min_monthly_return_pct == 4.0
+    # Sibling entry fields fall back to the catalog default.
+    assert cfg.entry.dte_range.min == 21 and cfg.entry.dte_range.max == 45
+    # The four other groups are entirely defaulted.
+    assert cfg.universe == DEFAULT_RULES_CONFIG.universe
+    assert cfg.position == DEFAULT_RULES_CONFIG.position
+    assert cfg.risk == DEFAULT_RULES_CONFIG.risk
+    assert cfg.management == DEFAULT_RULES_CONFIG.management
+
+
+def test_load_partial_group_only(db):
+    """An older build that stored only ``entry`` → other four groups defaulted."""
+    _store(db, json.dumps({"entry": {"dte_range": {"min": 25, "max": 50}}}))
+    cfg = load_rules_config(db)
+    assert (cfg.entry.dte_range.min, cfg.entry.dte_range.max) == (25, 50)
+    assert cfg.position == DEFAULT_RULES_CONFIG.position
+
+
+# ---------------------------------------------------------------------------
+# load_rules_config — malformed JSON
+# ---------------------------------------------------------------------------
+
+
+def test_load_malformed_json_returns_defaults_and_warns(db, caplog):
+    """Malformed JSON → defaults + a generic WARNING that leaks no exception text."""
+    _store(db, "{not valid json")
+    with caplog.at_level(logging.WARNING):
+        cfg = load_rules_config(db)
+    assert cfg == DEFAULT_RULES_CONFIG
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, "expected a WARNING log on malformed JSON"
+    joined = " ".join(r.message for r in warnings)
+    assert "not valid JSON" in joined
+    # CLAUDE.md: no str(e) — the Python JSON-decode error text must not leak.
+    assert "Expecting" not in joined
+    assert "line 1" not in joined
+    assert "char" not in joined
+
+
+def test_load_non_object_json_returns_defaults(db):
+    """Valid JSON that is not an object (e.g. a list) → defaults."""
+    _store(db, json.dumps([1, 2, 3]))
+    assert load_rules_config(db) == DEFAULT_RULES_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# load_rules_config — single out-of-range field (per-field fallback)
+# ---------------------------------------------------------------------------
+
+
+def test_load_single_bad_field_falls_back_that_field_only(db):
+    """One out-of-range field reverts to its default; the rest is honored."""
+    _store(
+        db,
+        json.dumps(
+            {
+                "entry": {
+                    "min_monthly_return_pct": -9,  # invalid — must be >= 0
+                    "earnings_buffer_days": 14,  # valid — must be honored
+                }
+            }
+        ),
+    )
+    cfg = load_rules_config(db)
+    # The bad field reverted to the catalog default.
+    assert cfg.entry.min_monthly_return_pct == 2.0
+    # The valid sibling field was honored.
+    assert cfg.entry.earnings_buffer_days == 14
+
+
+def test_load_inverted_range_reverts_range_only(db, caplog):
+    """An inverted ``dte_range`` reverts as a unit; other fields are honored."""
+    _store(
+        db,
+        json.dumps(
+            {
+                "entry": {
+                    "dte_range": {"min": 99, "max": 1},  # inverted — invalid
+                    "min_monthly_return_pct": 3.0,  # valid — honored
+                }
+            }
+        ),
+    )
+    with caplog.at_level(logging.WARNING):
+        cfg = load_rules_config(db)
+    # The inverted range reverted to the catalog default.
+    assert (cfg.entry.dte_range.min, cfg.entry.dte_range.max) == (21, 45)
+    # The valid sibling field was honored.
+    assert cfg.entry.min_monthly_return_pct == 3.0
+    # A WARNING names the dropped field but leaks no stored value.
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("entry.dte_range" in r.message for r in warnings)
+
+
+def test_load_bad_field_in_one_group_does_not_poison_others(db):
+    """A bad field in ``risk`` does not discard a valid ``position`` group."""
+    _store(
+        db,
+        json.dumps(
+            {
+                "risk": {"loss_review_threshold_pct": 99},  # invalid (> 0)
+                "position": {"sizing_cap_dollars": 1234.0},  # valid
+            }
+        ),
+    )
+    cfg = load_rules_config(db)
+    assert cfg.risk.loss_review_threshold_pct == -15.0  # reverted
+    assert cfg.position.sizing_cap_dollars == 1234.0  # honored
+
+
+# ---------------------------------------------------------------------------
+# load_rules_config — never raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stored_value",
+    [
+        "{not json",
+        "",
+        "null",
+        "42",
+        '"a string"',
+        json.dumps([1, 2]),
+        json.dumps({"entry": "not an object"}),
+        json.dumps({"entry": {"dte_range": {"min": -5, "max": -1}}}),
+        json.dumps({"universe": {"min_open_interest": "abc"}}),
+        json.dumps({"position": {"sizing_cap_dollars": -100}}),
+        json.dumps({"unknown_group": {"foo": 1}}),
+        json.dumps({"entry": {"unknown_field": 123}}),
+    ],
+)
+def test_load_never_raises(db, stored_value):
+    """``load_rules_config`` never raises, whatever the stored value is."""
+    _store(db, stored_value)
+    cfg = load_rules_config(db)  # must not raise
+    assert isinstance(cfg, RulesConfig)
+
+
+# ---------------------------------------------------------------------------
+# Documented-as-comment: enforcement of the unset rules is out of scope.
+#
+# ``max_open_positions`` / ``hard_max_loss_pct`` / ``max_consecutive_rolls`` /
+# ``min_iv_percentile`` are persisted and validated by RulesConfig (covered by
+# ``test_unset_optionals_accept_none`` above), but NO engine enforces a None or
+# a set value for them in #156. Concrete enforced values and their semantics
+# are PRD #209 open question Q1 / ADR-002 OQ1, deferred to the trader. There is
+# intentionally no enforcement test here because there is no enforcement to
+# test — inventing one would be a stop-and-ask violation.
+# ---------------------------------------------------------------------------

--- a/backend/tests/test_rules_config_integration.py
+++ b/backend/tests/test_rules_config_integration.py
@@ -1,0 +1,416 @@
+"""Integration tests for the ``rules_config`` engine wiring (issue #156).
+
+Exercises the three resolution sites — the scan router, the recovery
+endpoint, and the dashboard's action engine — against a stored ``rules_config``
+``app_settings`` row. Uses the in-memory SQLite ``client`` TestClient fixture
+from ``conftest.py``.
+
+Covered:
+
+- Scan with no stored row → catalog defaults backfilled onto the request.
+- Scan with a stored config → stored values backfilled.
+- Scan with an explicit per-request rule value → the override wins.
+- A covered-call scan surfaces ``below_cost_basis``; the candidate stays in
+  the response (never dropped); ``cost_basis_floor_enabled=False`` suppresses it.
+- A stored ``min_open_interest`` rejects a strike the default floor would pass.
+- The recovery endpoint honors a stored ``sizing_cap_dollars``.
+- A fresh DB with no ``rules_config`` row still yields working scans (rollout
+  AC — no migration required).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from app.models.database import AppSetting, Position, get_db
+from app.models.schemas import OptionScanRequest
+from app.services.options_scanner import OptionScanner
+from app.services.rules_config import RULES_CONFIG_KEY
+from app.services.schwab_client import SchwabClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_setting(client, key: str, value: str) -> None:
+    """Write an ``app_settings`` row through the test DB session."""
+    from app.main import app
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        db.add(AppSetting(key=key, value=value))
+        db.commit()
+    finally:
+        db.close()
+
+
+def _seed_position(client, *, pos_id: str = "pos-sofi", broker_cost_basis: float) -> None:
+    """Insert an open position row into the in-memory test DB."""
+    from app.main import app
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        db.add(
+            Position(
+                id=pos_id,
+                ticker="SOFI",
+                shares=100,
+                broker_cost_basis=broker_cost_basis,
+                status="open",
+                strategy="csp",
+                opened_at="2024-01-01",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+class _CaptureScanner(OptionScanner):
+    """A scanner subclass that records the request it was handed.
+
+    Lets a router-resolution test assert which rule values were backfilled
+    without needing a mocked Schwab chain.
+    """
+
+    captured: OptionScanRequest | None = None
+
+    def scan(self, request: OptionScanRequest) -> dict:  # noqa: D102
+        type(self).captured = request
+        return {
+            "ticker": request.ticker,
+            "current_price": 14.0,
+            "strategy": request.strategy,
+            "scan_time": datetime.now().isoformat(),
+            "earnings_date": None,
+            "iv_rank": None,
+            "recommendations": [],
+            "rejected": [],
+            "market_context": {},
+        }
+
+
+def _scan(client, body: dict) -> OptionScanRequest:
+    """POST a scan, returning the OptionScanRequest the scanner received.
+
+    Overrides the ``_get_scanner`` dependency with a capturing scanner so the
+    router's ``rules_config`` backfill can be inspected directly.
+    """
+    from app.main import app
+    from app.routers.options import _get_scanner
+
+    _CaptureScanner.captured = None
+    app.dependency_overrides[_get_scanner] = lambda: _CaptureScanner()
+    try:
+        resp = client.post("/api/options/scan", json=body)
+    finally:
+        app.dependency_overrides.pop(_get_scanner, None)
+    assert resp.status_code == 200, resp.text
+    assert _CaptureScanner.captured is not None
+    return _CaptureScanner.captured
+
+
+def _full_rules_config(**overrides) -> str:
+    """Build a JSON string for a stored ``rules_config`` with overrides."""
+    base = {
+        "schema_version": 1,
+        "universe": {
+            "min_open_interest": 500,
+            "max_bid_ask_spread_pct": 10.0,
+            "min_iv_rank": 30.0,
+        },
+        "entry": {
+            "dte_range": {"min": 21, "max": 45},
+            "delta_range_csp": {"min": 0.20, "max": 0.30},
+            "delta_range_cc": {"min": 0.20, "max": 0.35},
+            "min_monthly_return_pct": 2.0,
+            "earnings_buffer_days": 7,
+            "min_call_distance_pct": 5.0,
+            "min_call_distance_from_cost_basis_pct": 0.0,
+        },
+        "position": {
+            "sizing_cap_dollars": 5000.0,
+            "max_ticker_concentration_pct": 25.0,
+        },
+    }
+    for group, fields in overrides.items():
+        base.setdefault(group, {}).update(fields)
+    return json.dumps(base)
+
+
+# ---------------------------------------------------------------------------
+# Scan router — backfill from rules_config
+# ---------------------------------------------------------------------------
+
+
+def test_scan_no_stored_row_uses_catalog_defaults(client):
+    """With no ``rules_config`` row, the catalog defaults are backfilled.
+
+    Resolves the four documented entry-rule inconsistencies: DTE 21-45,
+    delta 0.20-0.30 (CSP), min return 2%, earnings buffer 7d.
+    """
+    req = _scan(
+        client,
+        {"ticker": "SOFI", "strategy": "cash_secured_put", "capital_available": 5000.0},
+    )
+    assert req.min_dte == 21 and req.max_dte == 45
+    assert req.min_delta == 0.20 and req.max_delta == 0.30
+    assert req.min_return_pct == 2.0
+    assert req.exclude_earnings_dte == 7
+    assert req.min_open_interest == 500
+    assert req.max_bid_ask_spread_pct == 10.0
+    assert req.min_iv_rank == 30.0
+
+
+def test_scan_covered_call_uses_cc_delta_band(client):
+    """A covered-call scan with no delta override gets the CC band (0.20-0.35)."""
+    req = _scan(
+        client,
+        {"ticker": "AMD", "strategy": "covered_call", "cost_basis": 95.0},
+    )
+    assert req.min_delta == 0.20 and req.max_delta == 0.35
+
+
+def test_scan_stored_config_is_honored(client):
+    """A stored ``rules_config`` is backfilled onto the request."""
+    _seed_setting(
+        client,
+        RULES_CONFIG_KEY,
+        _full_rules_config(
+            entry={"dte_range": {"min": 30, "max": 40}, "min_monthly_return_pct": 3.0}
+        ),
+    )
+    req = _scan(
+        client,
+        {"ticker": "SOFI", "strategy": "cash_secured_put", "capital_available": 5000.0},
+    )
+    assert req.min_dte == 30 and req.max_dte == 40
+    assert req.min_return_pct == 3.0
+
+
+def test_scan_explicit_per_request_value_overrides_stored_config(client):
+    """An explicit per-request rule value wins over the stored config."""
+    _seed_setting(
+        client,
+        RULES_CONFIG_KEY,
+        _full_rules_config(entry={"dte_range": {"min": 30, "max": 40}}),
+    )
+    req = _scan(
+        client,
+        {
+            "ticker": "SOFI",
+            "strategy": "cash_secured_put",
+            "capital_available": 5000.0,
+            "min_dte": 14,
+            "max_dte": 28,
+        },
+    )
+    # Explicit request values are kept; only the un-set fields are backfilled.
+    assert req.min_dte == 14 and req.max_dte == 28
+    assert req.min_return_pct == 2.0  # not overridden → from config
+
+
+def test_fresh_db_yields_working_scan_no_migration(client):
+    """Rollout AC: a fresh DB with no ``rules_config`` row still scans.
+
+    No migration is required — ``load_rules_config`` treats the absent row as
+    "all defaults" and the scan completes with a valid response shape.
+    """
+    from app.main import app
+    from app.routers.options import _get_scanner
+
+    _CaptureScanner.captured = None
+    app.dependency_overrides[_get_scanner] = lambda: _CaptureScanner()
+    try:
+        resp = client.post(
+            "/api/options/scan",
+            json={
+                "ticker": "SOFI",
+                "strategy": "cash_secured_put",
+                "capital_available": 5000.0,
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(_get_scanner, None)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ticker"] == "SOFI"
+    assert body["recommendations"] == []
+    assert body["rejected"] == []
+
+
+# ---------------------------------------------------------------------------
+# Scanner — below_cost_basis + min_open_interest, end to end
+# ---------------------------------------------------------------------------
+
+
+def _schwab_call_chain(strike: float, *, oi: int, dte: int = 30):
+    """Build a one-strike Schwab CALL chain response."""
+    exp_date = (datetime.now().date() + timedelta(days=dte)).strftime("%Y-%m-%d")
+    contract = {
+        "strikePrice": strike,
+        "bid": 0.43,
+        "ask": 0.47,
+        "mark": 0.45,
+        "delta": -0.25,
+        "gamma": 0.03,
+        "theta": -0.02,
+        "vega": 0.04,
+        "openInterest": oi,
+        "totalVolume": 100,
+        "volatility": 35.0,
+        "daysToExpiration": dte,
+    }
+    return {
+        "symbol": "TEST",
+        "status": "SUCCESS",
+        "underlying": {"last": 14.0, "close": 14.0, "totalVolume": 1_000_000},
+        "callExpDateMap": {f"{exp_date}:{dte}": {str(strike): [contract]}},
+        "putExpDateMap": {},
+    }
+
+
+def test_cc_scan_surfaces_below_cost_basis_reason(client):
+    """A CC strike below cost basis is flagged ``below_cost_basis``, not dropped."""
+    # Strike $14 sits below the $20 cost basis.
+    chain = _schwab_call_chain(14.0, oi=500)
+    with patch.object(OptionScanner, "_get_vix", return_value=None), patch(
+        "app.services.options_scanner.get_next_earnings_date", return_value=None
+    ), patch.object(SchwabClient, "get_option_chain", return_value=chain):
+        resp = client.post(
+            "/api/options/scan",
+            json={"ticker": "TEST", "strategy": "covered_call", "cost_basis": 20.0},
+        )
+    assert resp.status_code == 200
+    rejected = resp.json()["rejected"]
+    below = [
+        r
+        for r in rejected
+        if any("below_cost_basis" in code for code in r["rejection_reasons"])
+    ]
+    assert below, "expected a below_cost_basis rejection"
+    # The candidate is present (not silently dropped) with a human sentence.
+    assert below[0]["strike"] == 14.0
+    assert any("cost-basis floor" in s for s in below[0]["human_reasons"])
+
+
+def test_cc_scan_below_cost_basis_suppressed_when_floor_disabled(client):
+    """``cost_basis_floor_enabled=False`` suppresses the ``below_cost_basis`` reason."""
+    chain = _schwab_call_chain(14.0, oi=500)
+    with patch.object(OptionScanner, "_get_vix", return_value=None), patch(
+        "app.services.options_scanner.get_next_earnings_date", return_value=None
+    ), patch.object(SchwabClient, "get_option_chain", return_value=chain):
+        resp = client.post(
+            "/api/options/scan",
+            json={
+                "ticker": "TEST",
+                "strategy": "covered_call",
+                "cost_basis": 20.0,
+                "cost_basis_floor_enabled": False,
+            },
+        )
+    assert resp.status_code == 200
+    rejected = resp.json()["rejected"]
+    assert not any(
+        "below_cost_basis" in code
+        for r in rejected
+        for code in r["rejection_reasons"]
+    )
+
+
+def test_scan_min_open_interest_rejects_thin_strike(client):
+    """A stored ``min_open_interest`` of 1000 rejects a 600-OI strike.
+
+    The default 500 floor would pass the same strike — confirms the inline
+    ``oi < 50`` literal is gone and the floor comes from ``rules_config``.
+    """
+    _seed_setting(
+        client,
+        RULES_CONFIG_KEY,
+        _full_rules_config(universe={"min_open_interest": 1000}),
+    )
+    # Strike well above the $10 cost basis so only the OI rule can reject it.
+    chain = _schwab_call_chain(20.0, oi=600)
+    with patch.object(OptionScanner, "_get_vix", return_value=None), patch(
+        "app.services.options_scanner.get_next_earnings_date", return_value=None
+    ), patch.object(SchwabClient, "get_option_chain", return_value=chain):
+        resp = client.post(
+            "/api/options/scan",
+            json={"ticker": "TEST", "strategy": "covered_call", "cost_basis": 10.0},
+        )
+    assert resp.status_code == 200
+    rejected = resp.json()["rejected"]
+    assert any(
+        "low_open_interest: 600 < 1000" in code
+        for r in rejected
+        for code in r["rejection_reasons"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recovery endpoint — sizing cap from rules_config.position
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_endpoint_honors_stored_sizing_cap(client):
+    """The recovery endpoint resolves its sizing cap from ``rules_config``.
+
+    With a stored ``position.sizing_cap_dollars`` of $500, the average-down
+    path is suppressed at a capital level the default $5,000 cap would allow.
+    """
+    _seed_position(client, broker_cost_basis=3800.0)
+    _seed_setting(client, "okr_target_yield", "0.18")
+    _seed_setting(
+        client,
+        RULES_CONFIG_KEY,
+        _full_rules_config(position={"sizing_cap_dollars": 500.0}),
+    )
+    with patch.object(SchwabClient, "get_quote", return_value={"lastPrice": 8.0}):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["state"] == "populated"
+    # The resolved cap is surfaced on the inputs block.
+    assert payload["inputs"]["okr"]["sizing_cap_dollars"] == pytest.approx(500.0)
+    # $800+ of fresh capital would breach the $500 cap → average-down suppressed.
+    avg = next(p for p in payload["paths"] if p["path_id"] == "average-down")
+    assert avg["eligibility"] == "suppressed"
+
+
+def test_recovery_endpoint_default_sizing_cap_with_no_rules_row(client):
+    """With no ``rules_config`` row the recovery endpoint uses the $5,000 default."""
+    _seed_position(client, broker_cost_basis=3800.0)
+    _seed_setting(client, "okr_target_yield", "0.18")
+    with patch.object(SchwabClient, "get_quote", return_value={"lastPrice": 8.0}):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["inputs"]["okr"]["sizing_cap_dollars"] == pytest.approx(5000.0)
+
+
+# ---------------------------------------------------------------------------
+# IV-rank gate — plumbed but inert (ADR-002 OQ4 / issue #156)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason="iv_rank has no data source — the gate is plumbed but inert (ADR-002 OQ4). "
+    "Wiring a real IV-rank feed is a data-pipeline change beyond #156."
+)
+def test_iv_rank_gate_rejects_low_rank_strike():
+    """The iv_rank_below_floor gate cannot be tested end to end yet.
+
+    ``OptionScanResponse.iv_rank`` is hard-coded ``None`` because no IV-rank
+    data source is wired. The ``min_iv_rank`` field, the ``iv_rank_below_floor``
+    rejection code, and the humanizer are all in place (see
+    ``OptionScanner._check_iv_rank`` and ``rejection_messages``), so a future
+    IV-rank feed activates the gate with no scanner change. There is no
+    end-to-end assertion to make until that feed exists.
+    """

--- a/backend/tests/test_rules_config_integration.py
+++ b/backend/tests/test_rules_config_integration.py
@@ -14,6 +14,9 @@ Covered:
   the response (never dropped); ``cost_basis_floor_enabled=False`` suppresses it.
 - A stored ``min_open_interest`` rejects a strike the default floor would pass.
 - The recovery endpoint honors a stored ``sizing_cap_dollars``.
+- The action engine's ITM/short-DTE card honors a non-default
+  ``management.expiration_warning_days`` — the boundary shifts with the stored
+  value, not the catalog default.
 - A fresh DB with no ``rules_config`` row still yields working scans (rollout
   AC — no migration required).
 """
@@ -28,8 +31,9 @@ import pytest
 
 from app.models.database import AppSetting, Position, get_db
 from app.models.schemas import OptionScanRequest
+from app.services.action_engine import compute_next_actions
 from app.services.options_scanner import OptionScanner
-from app.services.rules_config import RULES_CONFIG_KEY
+from app.services.rules_config import DEFAULT_RULES_CONFIG, RULES_CONFIG_KEY, RulesConfig
 from app.services.schwab_client import SchwabClient
 
 
@@ -414,3 +418,65 @@ def test_iv_rank_gate_rejects_low_rank_strike():
     IV-rank feed activates the gate with no scanner change. There is no
     end-to-end assertion to make until that feed exists.
     """
+
+
+# ---------------------------------------------------------------------------
+# Action engine — ITM/short-DTE card honors rules_config.management
+# ---------------------------------------------------------------------------
+
+
+def _itm_short_dte_ids(rules: RulesConfig) -> list[str]:
+    """Run ``compute_next_actions`` for a single 10-DTE ITM leg under ``rules``.
+
+    The leg's 10 DTE deliberately sits *between* the catalog default
+    ``expiration_warning_days`` (7) and the non-default threshold exercised
+    below (14), so the presence of the ``expiration.itm_short_dte`` card is a
+    direct readout of which threshold the engine actually resolved.
+    """
+    status = {
+        "schwab": {"configured": True, "valid": True, "expires_at": None},
+        "cache": {"fresh": 0, "stale": 0, "very_stale": 0, "total": 0},
+    }
+    leg = {
+        "id": "leg-1",
+        "ticker": "SOFI",
+        "type": "put",
+        "strike": 14.0,
+        "expiration": "2026-05-27",
+        "dte": 10,
+        "moneyness": {"state": "ITM", "distance_pct": 0.01, "distance_dollars": 0.5},
+        "position_id": "pos-sofi",
+    }
+    actions = compute_next_actions(
+        status=status,
+        kpis={"open_legs": 1, "open_positions": 1},
+        positions=[],
+        open_legs=[leg],
+        rules=rules,
+    )
+    return [a["action_id"] for a in actions]
+
+
+def test_action_engine_default_threshold_excludes_10dte_itm_leg():
+    """With the default 7-day window, a 10-DTE ITM leg is outside the warning.
+
+    Pins the lower side of the boundary: ``DEFAULT_RULES_CONFIG`` resolves
+    ``expiration_warning_days = 7``, so a leg at 10 DTE does NOT emit the card.
+    """
+    assert "expiration.itm_short_dte" not in _itm_short_dte_ids(DEFAULT_RULES_CONFIG)
+
+
+def test_action_engine_honors_non_default_expiration_warning_days():
+    """A stored ``expiration_warning_days`` of 14 shifts the ITM/short-DTE boundary.
+
+    Issue #156 requires the action engine to honor the stored management
+    thresholds — not the catalog default. With ``expiration_warning_days``
+    raised from the default 7 to 14, a 10-DTE ITM leg now falls inside the
+    warning window and the ``expiration.itm_short_dte`` card appears. Paired
+    with :func:`test_action_engine_default_threshold_excludes_10dte_itm_leg`,
+    this pins the boundary on both sides and would catch a regression that
+    ignored ``rules`` and silently fell back to the hard-coded ``7``.
+    """
+    rules = RulesConfig(management={"expiration_warning_days": 14})
+    assert rules.management.expiration_warning_days == 14
+    assert "expiration.itm_short_dte" in _itm_short_dte_ids(rules)


### PR DESCRIPTION
Closes #156

Adds the **Trading Rules Layer keystone** for V1.0 — a single configurable `rules_config` object that every Regress engine reads its rule values from instead of carrying its own hard-coded constants. Built per **ADR-002 (Discussion #216)** Option B (the authoritative build spec), with parent taxonomy decision **ADR-001 (#210)** and source catalog **PRD #209**.

## What changed

**Commit 1 — keystone module + unit tests**
- New `backend/app/services/rules_config.py`: the `RulesConfig` Pydantic v2 model (five nested rule groups — `universe`, `entry`, `position`, `risk`, `management` — each with range / cross-field validators), `DEFAULT_RULES_CONFIG` (reconciled PRD #209 catalog), `load_rules_config(db)`, and the `RULES_CONFIG_KEY` / `RULES_CONFIG_SCHEMA_VERSION` constants.
- `load_rules_config` is a merge-over-defaults shared reader that **never raises**: missing row → defaults (INFO); malformed JSON → defaults (generic WARNING, no `str(e)`); a single out-of-range field → that field reverts via per-group `_coerce_group` while the rest is honored.
- Persistence is a single `app_settings` row keyed `rules_config` — **no new SQL table, no migration** (ADR-001 Decision 2).
- `backend/tests/test_rules_config.py`: 39 unit tests.

**Commit 2 — engine wiring + integration tests**
- **Scanner** — `OptionScanRequest`'s 7 rule-field defaults flip to `None` + 5 new fields added; `routers/options.py` backfills from `load_rules_config(db)` (explicit per-request value still wins). The inline `oi < 50` literal is replaced by `min_open_interest`; `wide_bid_ask_spread` and `below_cost_basis` rejection checks added; `iv_rank_below_floor` plumbed but inert (no IV-rank data source — ADR-002 OQ4).
- **Recovery engine** — `DEFAULT_SIZING_CAP_DOLLARS` removed; sizing cap resolved from `rules_config.position.sizing_cap_dollars`. `okr_target_yield` stays an OKR read.
- **Action engine** — `ITM_SHORT_DTE_MAX_DTE` removed; `compute_next_actions` takes a `RulesConfig` (uses `management.expiration_warning_days`, catalog value 7 → no behavior change). The engine stays pure; `dashboard.py` resolves and passes the config.
- `rejection_messages.py` — humanizers for the three new rejection codes.
- `backend/tests/test_rules_config_integration.py` + `test_no_hardcoded_rule_constants.py` (static guard).

## Schema-clarity resolution — the two cost-basis covered-call fields

The `entry` group carries two cost-basis-relative covered-call fields. They are **independent, non-redundant rules** (PRD #209 §R3 / ADR-002 D3), both measured from adjusted **cost basis** — never from spot price (confirmed against `options_scanner._check_rejection` / `_passes_10pct_rule`; this is ADR-002's "One correction to PRD #209"):

- **`min_call_distance_pct`** (default `5.0`) — a percentage **margin above cost basis**. A CC strike must sit ≥ this whole-percent above adjusted cost basis; otherwise the scanner emits `fails_10pct_rule`. Strike floor: `cost_basis * (1 + min_call_distance_pct/100)`. This is the *premium-quality* rule.
- **`min_call_distance_from_cost_basis_pct`** (default `0.0`) — a **bare at-or-above-cost-basis floor**. A CC strike below `cost_basis * (1 + min_call_distance_from_cost_basis_pct/100)` would lock in a share loss if assigned, so the scanner emits `below_cost_basis`. This is the *loss-avoidance* rule.

They are not redundant: with the catalog defaults (`5.0` and `0.0`) the margin rule is the stricter; a trader who lowers the margin still keeps the loss-avoidance floor. The new `below_cost_basis` check is wired to `min_call_distance_from_cost_basis_pct` so the field is genuinely load-bearing — both fields ship distinct and the #158 Settings UI can present them as two separate rules.

## Acceptance criteria

### Schema + persistence
- [x] New `rules_config.py` exposes `RulesConfig`, `DEFAULT_RULES_CONFIG`, `load_rules_config(db)`, `RULES_CONFIG_KEY`, `RULES_CONFIG_SCHEMA_VERSION`.
- [x] `RulesConfig` field validators enforce ranges (`min_dte>=0`, `0<=delta<=1`, `min<max` on ranges, `loss_review_threshold_pct<=0`).
- [x] `DEFAULT_RULES_CONFIG` equals the PRD #209 catalog.
- [x] The persisted JSON carries a `schema_version` integer.
- [x] Single `app_settings` row, key `rules_config`; no new SQL table; no migration.

### Reader behaviour
- [x] Missing row → full defaults.
- [x] Valid full object → those values.
- [x] Valid partial object → merge-over-defaults.
- [x] Malformed JSON → defaults + generic WARNING (no `str(e)`).
- [x] Single out-of-range value → that field reverts to default; rest honored.
- [x] `load_rules_config` never raises.

### Engine wiring
- [x] Scanner request defaults flip to `None`; router backfills; explicit override preserved.
- [x] Reconciled scanner defaults — DTE 21–45, delta 0.20–0.30 (CSP), return 2%, earnings 7d.
- [x] `min_open_interest` replaces `oi < 50`; `max_bid_ask_spread_pct` check; `cost_basis_floor_enabled` flag.
- [x] CC strike below cost basis → `below_cost_basis` rejection (human sentence); candidate stays in response.
- [x] Recovery engine resolves sizing cap from `rules_config.position.sizing_cap_dollars`; `DEFAULT_SIZING_CAP_DOLLARS` gone.
- [x] Action engine resolves `ITM_SHORT_DTE_MAX_DTE` from a passed-in `RulesConfig`; no DB dependency.
- [x] Static guard test confirms no hard-coded rule constant remains.
- [x] No write path from OKR code into `rules_config`.

### Tests + documentation
- [x] Unit, integration, static-guard, and fresh-DB rollout coverage on this PR.
- [x] `rules_config.py` docstring documents the schema, five groups, every default + PRD source, whole-percent convention, merge-over-defaults / fallback behavior.

## Deviations from the plan

- **PR structure** — the plan suggested PR-A / PR-B; per the SDLC instruction and CLAUDE.md "one issue per PR", this is delivered as **one PR with two clean commits** (keystone, then wiring).
- **`min_call_distance_from_cost_basis_pct`** was added to `OptionScanRequest` (the plan listed only 4 new request fields). It was required to make the `below_cost_basis` floor configurable rather than hard-zero, so the field is genuinely distinct from `min_call_distance_pct`.
- **Scanner defensive resolution** — `OptionScanner.scan()` backfills still-`None` rule fields from `DEFAULT_RULES_CONFIG`. The plan put resolution only in the router; existing acceptance tests call `scanner.scan()` directly, so a safety-net was needed to keep the engine callable without a DB.
- **Scanner-test fixtures** — three synthetic option contracts had unrealistically wide bid/ask spreads (18–22%) that the new (intended) `wide_bid_ask_spread` rule now rejects. Per the ADR-002 R7 stop-and-ask, this was confirmed an intended catalog rule, not a regression; the fixtures were tightened to realistic spreads.

## Testing notes

`cd backend && python -m pytest` — **967 passed, 9 skipped** (8 pre-existing + 1 new documented skip for the inert IV-rank gate). To verify manually: `PUT /api/settings` a `rules_config` JSON value, then `POST /api/options/scan` with rule fields omitted and confirm the stored values are applied; delete the row and confirm catalog defaults are used.

## API changes

`POST /api/options/scan` — `OptionScanRequest` flips 7 rule-field defaults to `None` and gains 5 fields (`min_open_interest`, `max_bid_ask_spread_pct`, `min_iv_rank`, `cost_basis_floor_enabled`, `min_call_distance_from_cost_basis_pct`). Backward compatible — omitted fields resolve from `rules_config`. New rejection codes surfaced in `RejectedStrike`: `below_cost_basis`, `wide_bid_ask_spread`, `iv_rank_below_floor`. No new endpoint; `rules_config` is written via the existing generic `PUT /api/settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)