### PR TITLE
Set extra="ignore" on Settings model_config (closes #222)

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,6 +4,13 @@ from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
+    """Application configuration loaded from environment variables and ``.env``.
+
+    Only backend-owned settings are declared as fields. Undeclared keys in
+    ``.env`` (such as the frontend-only NextAuth credentials) are ignored
+    rather than rejected — see ``model_config`` and issue #222.
+    """
+
     fred_api_key: str = ""
     schwab_app_key: str = ""
     schwab_app_secret: str = ""
@@ -17,7 +24,16 @@ class Settings(BaseSettings):
     cache_ttl_monthly_days: int = 7
     cors_origins: str = "http://localhost:3000,http://localhost:5173"
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    # ``extra="ignore"`` so undeclared keys in ``.env`` (e.g. the
+    # frontend-only NextAuth ``GITHUB_ID`` / ``GITHUB_SECRET``) do not trip
+    # pydantic-settings v2's default ``extra="forbid"`` — which raises a
+    # ``ValidationError`` at import and echoes the offending secret value
+    # into the traceback. See issue #222.
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 settings = Settings()

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -13,7 +13,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
-from app.config import get_fred_api_key, get_schwab_credentials
+from app.config import Settings, get_fred_api_key, get_schwab_credentials
 from app.models.database import AppSetting, Base
 from app.services.encryption import encrypt_value
 
@@ -230,3 +230,34 @@ class TestGetSchwabCredentials:
             mock_settings.schwab_app_key = ""
             mock_settings.schwab_app_secret = ""
             assert get_schwab_credentials() == ("", "")
+
+
+class TestSettingsExtraIgnore:
+    """``Settings`` must tolerate undeclared environment keys. See issue #222.
+
+    ``backend/.env`` carries frontend-only NextAuth credentials
+    (``GITHUB_ID`` / ``GITHUB_SECRET``). pydantic-settings v2 defaults to
+    ``extra="forbid"``, which would raise a ``ValidationError`` at
+    construction — breaking ``pytest`` collection and echoing the real
+    ``GITHUB_SECRET`` into the traceback. ``extra="ignore"`` prevents this.
+    """
+
+    def test_model_config_sets_extra_ignore(self):
+        """``Settings`` ``model_config`` declares ``extra="ignore"``."""
+        assert Settings.model_config.get("extra") == "ignore"
+
+    def test_undeclared_env_keys_do_not_raise(self, monkeypatch):
+        """Constructing ``Settings()`` with undeclared env keys does not raise.
+
+        Simulates a developer ``.env`` carrying the frontend NextAuth
+        credentials. With ``extra="ignore"`` the keys are silently dropped
+        instead of triggering ``extra_forbidden``.
+        """
+        monkeypatch.setenv("GITHUB_ID", "frontend-only-id")
+        monkeypatch.setenv("GITHUB_SECRET", "frontend-only-secret")
+        monkeypatch.setenv("SOME_OTHER_UNDECLARED_KEY", "value")
+        # ``_env_file=None`` so the test does not depend on a local ``.env``.
+        settings = Settings(_env_file=None)
+        # Undeclared keys are ignored, not absorbed as attributes.
+        assert not hasattr(settings, "github_id")
+        assert not hasattr(settings, "github_secret")


### PR DESCRIPTION
Closes #222

## Summary

`backend/app/config.py` defined a pydantic-settings `Settings` model with no `extra=` set in `model_config`. pydantic-settings v2 defaults to `extra="forbid"`, so undeclared keys in `backend/.env` — notably the frontend-only NextAuth credentials `GITHUB_ID` / `GITHUB_SECRET` — caused the module-level `settings = Settings()` to raise `ValidationError` at import time.

Two consequences, both local-development-only (CI and agent worktrees have no `.env`):

1. **Broke `pytest` collection from `backend/`** — `conftest.py` import failed for any developer whose `.env` carried undeclared keys.
2. **Minor secret leak** — pydantic's `extra_forbidden` error echoes the offending value, printing the real `GITHUB_SECRET` into the traceback.

### Fix

- Set `extra="ignore"` on the `Settings` `model_config` so undeclared `.env` keys are silently dropped instead of rejected.
- `GITHUB_ID` / `GITHUB_SECRET` are **not** declared as backend fields — they remain frontend-only NextAuth credentials (`frontend/auth.js`), as the issue requires.
- Added a class docstring to `Settings` (the class was modified and previously had none).

## Files touched

- `backend/app/config.py` — `extra="ignore"` in `model_config`; `Settings` class docstring.
- `backend/tests/test_config.py` — new `TestSettingsExtraIgnore` test class.

## Acceptance criteria

- [x] `Settings` `model_config` sets `extra="ignore"`.
- [x] `python -m pytest` collects and runs from `backend/` with a `.env` containing undeclared keys (`GITHUB_ID` / `GITHUB_SECRET`).
- [x] A test asserts undeclared env keys do not raise at `Settings()` construction.

## Testing

- `cd backend && python -m pytest` — **995 passed, 9 skipped**, no regressions.
- New tests: `TestSettingsExtraIgnore::test_model_config_sets_extra_ignore` and `::test_undeclared_env_keys_do_not_raise` (uses `monkeypatch` to inject `GITHUB_ID` / `GITHUB_SECRET` and `_env_file=None` so it does not depend on a local `.env`).

No new dependencies. No API contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)