### PR TITLE
V1.0: Settings page — Trading Rules section (closes #158)

### DIFF
--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -22,6 +22,12 @@ from app.services.schwab_auth import (
 from app.models.database import AppSetting, CacheEntry, get_db
 from app.models.schemas import CacheStatsResponse, SettingUpdate, SettingsResponse
 from app.services.backup import create_backup, list_backups, restore_backup
+from app.services.rules_config import (
+    RULES_CONFIG_KEY,
+    RULES_CONFIG_SCHEMA_VERSION,
+    RulesConfig,
+    load_rules_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +67,43 @@ def update_setting(req: SettingUpdate, db: DBSession = Depends(get_db)):
         db.add(entry)
     db.commit()
     return {"status": "ok", "key": req.key}
+
+
+# --- Trading Rules config (issue #158 — edit surface for the #156 keystone) ---
+
+
+@router.get("/rules", response_model=RulesConfig)
+def get_rules_config(db: DBSession = Depends(get_db)):
+    """Get the Trading Rules config.
+
+    Backed by :func:`app.services.rules_config.load_rules_config`, which
+    merges any stored ``rules_config`` row over the typed defaults and never
+    raises — so this endpoint always returns a complete, valid config.
+    """
+    return load_rules_config(db)
+
+
+@router.put("/rules", response_model=RulesConfig)
+def update_rules_config(config: RulesConfig, db: DBSession = Depends(get_db)):
+    """Persist the Trading Rules config.
+
+    FastAPI validates the body against :class:`RulesConfig` (the same Pydantic
+    model the engines read), so out-of-range values are rejected with a 422
+    before anything is written. The validated config is stored as a single
+    JSON document in the ``app_settings`` row keyed ``rules_config``.
+    """
+    # Re-stamp the schema version so a client cannot persist a stale value.
+    config = config.model_copy(update={"schema_version": RULES_CONFIG_SCHEMA_VERSION})
+    payload = config.model_dump_json()
+
+    entry = db.query(AppSetting).filter(AppSetting.key == RULES_CONFIG_KEY).first()
+    if entry:
+        entry.value = payload
+    else:
+        entry = AppSetting(key=RULES_CONFIG_KEY, value=payload)
+        db.add(entry)
+    db.commit()
+    return config
 
 
 @router.get("/cache", response_model=CacheStatsResponse)

--- a/backend/tests/test_settings_rules_endpoint.py
+++ b/backend/tests/test_settings_rules_endpoint.py
@@ -1,0 +1,159 @@
+"""Tests for the Trading Rules config endpoints (issue #158).
+
+``GET``/``PUT /api/settings/rules`` is the typed read/write surface the V1.0
+Settings page uses to edit the ``rules_config`` keystone (#156). The generic
+``GET /api/settings`` returns a fixed ``SettingsResponse`` and cannot read
+``rules_config`` back, so #158 adds this typed pair backed by
+:func:`app.services.rules_config.load_rules_config` and the existing
+``app_settings`` key/value persistence — no new table, no migration.
+"""
+
+import json
+
+from app.models.database import AppSetting, get_db
+from app.services.rules_config import (
+    DEFAULT_RULES_CONFIG,
+    RULES_CONFIG_KEY,
+    RULES_CONFIG_SCHEMA_VERSION,
+)
+
+
+def _read_rules_row(client) -> str | None:
+    """Read the raw ``rules_config`` value straight from the test DB."""
+    from app.main import app
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        entry = db.query(AppSetting).filter(AppSetting.key == RULES_CONFIG_KEY).first()
+        return entry.value if entry else None
+    finally:
+        db.close()
+
+
+class TestGetRulesConfig:
+    """GET /api/settings/rules — read the Trading Rules config."""
+
+    def test_returns_defaults_when_unset(self, client):
+        """With no stored row, the endpoint returns the catalog defaults."""
+        response = client.get("/api/settings/rules")
+        assert response.status_code == 200
+        data = response.json()
+        assert data == DEFAULT_RULES_CONFIG.model_dump()
+        # Spot-check a few catalog defaults and the whole-percent convention.
+        assert data["schema_version"] == RULES_CONFIG_SCHEMA_VERSION
+        assert data["universe"]["min_open_interest"] == 500
+        assert data["entry"]["dte_range"] == {"min": 21, "max": 45}
+        assert data["risk"]["loss_review_threshold_pct"] == -15.0
+        assert data["management"]["assignment_risk_review"] == "High"
+
+    def test_optional_fields_default_to_null(self, client):
+        """The four Optional/unset rules come back as null, not 0."""
+        data = client.get("/api/settings/rules").json()
+        assert data["universe"]["min_iv_percentile"] is None
+        assert data["position"]["max_open_positions"] is None
+        assert data["risk"]["hard_max_loss_pct"] is None
+        assert data["risk"]["max_consecutive_rolls"] is None
+
+    def test_returns_stored_config(self, client):
+        """A stored row is merged over defaults and returned."""
+        stored = DEFAULT_RULES_CONFIG.model_dump()
+        stored["entry"]["dte_range"] = {"min": 30, "max": 60}
+        from app.main import app
+
+        db = next(app.dependency_overrides[get_db]())
+        try:
+            db.add(AppSetting(key=RULES_CONFIG_KEY, value=json.dumps(stored)))
+            db.commit()
+        finally:
+            db.close()
+
+        data = client.get("/api/settings/rules").json()
+        assert data["entry"]["dte_range"] == {"min": 30, "max": 60}
+
+
+class TestPutRulesConfig:
+    """PUT /api/settings/rules — persist the Trading Rules config."""
+
+    def test_persists_and_round_trips(self, client):
+        """A valid PUT is stored and the next GET reflects it."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["entry"]["dte_range"] = {"min": 14, "max": 35}
+        config["position"]["max_open_positions"] = 8
+
+        put = client.put("/api/settings/rules", json=config)
+        assert put.status_code == 200
+        assert put.json()["entry"]["dte_range"] == {"min": 14, "max": 35}
+
+        got = client.get("/api/settings/rules").json()
+        assert got["entry"]["dte_range"] == {"min": 14, "max": 35}
+        assert got["position"]["max_open_positions"] == 8
+
+    def test_optional_field_persists_as_null(self, client):
+        """An Optional field sent as null is stored as null — never invented."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["risk"]["hard_max_loss_pct"] = None
+
+        client.put("/api/settings/rules", json=config)
+        got = client.get("/api/settings/rules").json()
+        assert got["risk"]["hard_max_loss_pct"] is None
+
+        raw = _read_rules_row(client)
+        assert raw is not None
+        assert json.loads(raw)["risk"]["hard_max_loss_pct"] is None
+
+    def test_schema_version_is_restamped(self, client):
+        """A stale schema_version in the body is overwritten on save."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["schema_version"] = 999
+
+        put = client.put("/api/settings/rules", json=config)
+        assert put.status_code == 200
+        assert put.json()["schema_version"] == RULES_CONFIG_SCHEMA_VERSION
+
+    def test_inverted_range_rejected(self, client):
+        """A range with min >= max is rejected with 422 (Pydantic validator)."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["entry"]["dte_range"] = {"min": 45, "max": 21}
+
+        response = client.put("/api/settings/rules", json=config)
+        assert response.status_code == 422
+
+    def test_out_of_range_delta_rejected(self, client):
+        """A delta bound outside [0, 1] is rejected with 422."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["entry"]["delta_range_csp"] = {"min": 0.2, "max": 1.5}
+
+        response = client.put("/api/settings/rules", json=config)
+        assert response.status_code == 422
+
+    def test_positive_loss_threshold_rejected(self, client):
+        """A loss threshold must be <= 0 — a positive value is rejected."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["risk"]["loss_review_threshold_pct"] = 15.0
+
+        response = client.put("/api/settings/rules", json=config)
+        assert response.status_code == 422
+
+    def test_invalid_save_does_not_persist(self, client):
+        """A rejected PUT writes nothing — the next GET is still defaults."""
+        config = DEFAULT_RULES_CONFIG.model_dump()
+        config["universe"]["min_open_interest"] = -1
+
+        bad = client.put("/api/settings/rules", json=config)
+        assert bad.status_code == 422
+        assert _read_rules_row(client) is None
+        assert client.get("/api/settings/rules").json() == DEFAULT_RULES_CONFIG.model_dump()
+
+    def test_overwrites_existing_row(self, client):
+        """A second PUT overwrites the first stored config."""
+        first = DEFAULT_RULES_CONFIG.model_dump()
+        first["management"]["profit_review_pct"] = 40.0
+        client.put("/api/settings/rules", json=first)
+
+        second = DEFAULT_RULES_CONFIG.model_dump()
+        second["management"]["profit_review_pct"] = 60.0
+        client.put("/api/settings/rules", json=second)
+
+        got = client.get("/api/settings/rules").json()
+        assert got["management"]["profit_review_pct"] == 60.0

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -135,6 +135,20 @@ export async function updateSetting(key, value) {
   return data;
 }
 
+// Trading Rules config (issue #158) — typed read/write for the `rules_config`
+// keystone (#156). The generic `GET /api/settings` returns a fixed shape and
+// cannot read `rules_config` back, so #158 added `GET`/`PUT /api/settings/rules`.
+// These helpers keep the component agnostic of the endpoint shape.
+export async function getRulesConfig() {
+  const { data } = await api.get('/api/settings/rules');
+  return data;
+}
+
+export async function saveRulesConfig(config) {
+  const { data } = await api.put('/api/settings/rules', config);
+  return data;
+}
+
 export async function getCacheStats() {
   const { data } = await api.get('/api/settings/cache');
   return data;

--- a/frontend/components/settings/RuleField.jsx
+++ b/frontend/components/settings/RuleField.jsx
@@ -1,0 +1,158 @@
+/**
+ * RuleField — one labeled number field in the Trading Rules section (#158).
+ *
+ * Renders a single `rules_config` scalar: a `<label>`, a `<input type="number">`
+ * or a `<select>` (for the `assignment_risk_review` enum), an optional units
+ * affix (`$` leading, or `%` / `days` / `contracts` / `×` trailing), helper
+ * text, and an inline validation error.
+ *
+ * Whole-percent convention: `rules_config` stores percentages as whole numbers
+ * (`25` means 25%, per backend `rules_config.py`). This component is 1:1 with
+ * the stored value — it does no human↔fraction conversion. If the model ever
+ * switched to fractions, the conversion would live in `TradingRulesSection`'s
+ * load/save mapping, not here.
+ *
+ * Optional fields (`optional` prop): blank is a valid, honest "unset" state.
+ * The input renders empty with a non-numeric placeholder, carries an `Optional`
+ * pill, and shows a `Clear` button when it has a value. The value is held as a
+ * string so `""` (unset) is distinguishable from `"0"` (a real entered zero) —
+ * `TradingRulesSection` saves `""` as `null`, never as `0` or a default.
+ *
+ * Accessibility: the `<label htmlFor>` is bound to the input id; `aria-invalid`
+ * reflects the error state; `aria-describedby` links the helper text and, when
+ * present, the error message.
+ */
+export default function RuleField({
+  fieldKey,
+  label,
+  value,
+  onChange,
+  onBlur,
+  helper,
+  error,
+  suffix = null,
+  suffixLeading = false,
+  placeholder = '',
+  optional = false,
+  options = null,
+  disabled = false,
+  step = 'any',
+}) {
+  const inputId = `rules-field-${fieldKey}`;
+  const helpId = `${inputId}-help`;
+  const errorId = `${inputId}-error`;
+  const describedBy = error ? `${helpId} ${errorId}` : helpId;
+  const hasValue = value !== '' && value !== null && value !== undefined;
+
+  const baseInput =
+    'px-3 py-2 text-sm border rounded-lg bg-white dark:bg-slate-700 ' +
+    'text-slate-900 dark:text-slate-100 outline-none focus:ring-2 ' +
+    'disabled:opacity-50 disabled:cursor-not-allowed';
+  const stateClasses = error
+    ? 'border-red-400 dark:border-red-500 focus:ring-red-500'
+    : 'border-slate-300 dark:border-slate-600 focus:ring-blue-500';
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label
+          htmlFor={inputId}
+          className="text-sm text-slate-700 dark:text-slate-300"
+        >
+          {label}
+          {optional && (
+            <span className="ml-2 text-xs text-slate-500 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 rounded-full px-2 py-0.5">
+              Optional
+            </span>
+          )}
+        </label>
+        {optional && hasValue && !disabled && (
+          <button
+            type="button"
+            data-testid={`${inputId}-clear`}
+            onClick={() => onChange('')}
+            className="text-xs text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <div className="flex items-stretch">
+        {suffix && suffixLeading && (
+          <span
+            aria-hidden="true"
+            className="inline-flex items-center px-2.5 text-xs text-slate-500 dark:text-slate-400 border border-r-0 border-slate-300 dark:border-slate-600 rounded-l-lg bg-slate-100 dark:bg-slate-800"
+          >
+            {suffix}
+          </span>
+        )}
+
+        {options ? (
+          <select
+            id={inputId}
+            data-testid={inputId}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onBlur={onBlur}
+            disabled={disabled}
+            aria-invalid={error ? 'true' : 'false'}
+            aria-describedby={describedBy}
+            className={`w-full ${baseInput} ${stateClasses}`}
+          >
+            {options.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <input
+            id={inputId}
+            data-testid={inputId}
+            type="number"
+            inputMode="decimal"
+            step={step}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            onBlur={onBlur}
+            disabled={disabled}
+            placeholder={placeholder}
+            aria-invalid={error ? 'true' : 'false'}
+            aria-describedby={describedBy}
+            className={[
+              'w-full',
+              baseInput,
+              stateClasses,
+              suffix && suffixLeading ? 'rounded-l-none' : '',
+              suffix && !suffixLeading ? 'rounded-r-none' : '',
+            ].join(' ')}
+          />
+        )}
+
+        {suffix && !suffixLeading && (
+          <span
+            aria-hidden="true"
+            className="inline-flex items-center px-2.5 text-xs text-slate-500 dark:text-slate-400 border border-l-0 border-slate-300 dark:border-slate-600 rounded-r-lg bg-slate-100 dark:bg-slate-800 whitespace-nowrap"
+          >
+            {suffix}
+          </span>
+        )}
+      </div>
+
+      <p id={helpId} className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+        {helper}
+      </p>
+      {error && (
+        <p
+          id={errorId}
+          data-testid={errorId}
+          role="alert"
+          className="text-xs text-red-600 dark:text-red-400 mt-1"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/settings/RuleRangeField.jsx
+++ b/frontend/components/settings/RuleRangeField.jsx
@@ -1,0 +1,125 @@
+/**
+ * RuleRangeField — a `{min, max}` range row in the Trading Rules section (#158).
+ *
+ * Renders the three `rules_config` range rules — `dte_range`, `delta_range_csp`,
+ * `delta_range_cc` — as two `<input type="number">` joined by "to", with a
+ * shared visible group label and a visually-hidden per-input label so screen
+ * readers can distinguish minimum from maximum.
+ *
+ * The two inputs share one validation slot: `error` is the combined message for
+ * the pair (e.g. "Minimum must be less than maximum.", or a bounds error). When
+ * present, both inputs get the red ring and `aria-invalid="true"`, and both
+ * reference the single error id via `aria-describedby`.
+ *
+ * Values are held as strings (mirroring `RuleField`) so an in-progress empty
+ * input does not get coerced; `TradingRulesSection` owns the numeric parse.
+ */
+export default function RuleRangeField({
+  fieldKey,
+  label,
+  minValue,
+  maxValue,
+  onChangeMin,
+  onChangeMax,
+  onBlur,
+  helper,
+  error,
+  minLabel,
+  maxLabel,
+  suffix = null,
+  minPlaceholder = '',
+  maxPlaceholder = '',
+  disabled = false,
+  step = 'any',
+}) {
+  const base = `rules-field-${fieldKey}`;
+  const minId = `${base}_min`;
+  const maxId = `${base}_max`;
+  const helpId = `${base}-help`;
+  const errorId = `${base}-error`;
+  const describedBy = error ? `${helpId} ${errorId}` : helpId;
+
+  const inputClass = [
+    'w-full px-3 py-2 text-sm border rounded-lg bg-white dark:bg-slate-700',
+    'text-slate-900 dark:text-slate-100 outline-none focus:ring-2',
+    'disabled:opacity-50 disabled:cursor-not-allowed',
+    error
+      ? 'border-red-400 dark:border-red-500 focus:ring-red-500'
+      : 'border-slate-300 dark:border-slate-600 focus:ring-blue-500',
+  ].join(' ');
+
+  return (
+    <div>
+      <label
+        htmlFor={minId}
+        className="block text-sm text-slate-700 dark:text-slate-300 mb-1"
+      >
+        {label}
+      </label>
+
+      <div className="flex items-center gap-2">
+        <label htmlFor={minId} className="sr-only">
+          {minLabel}
+        </label>
+        <input
+          id={minId}
+          data-testid={minId}
+          type="number"
+          inputMode="decimal"
+          step={step}
+          value={minValue}
+          onChange={(e) => onChangeMin(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder={minPlaceholder}
+          aria-invalid={error ? 'true' : 'false'}
+          aria-describedby={describedBy}
+          className={inputClass}
+        />
+        <span className="text-xs text-slate-500 dark:text-slate-400 shrink-0">
+          to
+        </span>
+        <label htmlFor={maxId} className="sr-only">
+          {maxLabel}
+        </label>
+        <input
+          id={maxId}
+          data-testid={maxId}
+          type="number"
+          inputMode="decimal"
+          step={step}
+          value={maxValue}
+          onChange={(e) => onChangeMax(e.target.value)}
+          onBlur={onBlur}
+          disabled={disabled}
+          placeholder={maxPlaceholder}
+          aria-invalid={error ? 'true' : 'false'}
+          aria-describedby={describedBy}
+          className={inputClass}
+        />
+        {suffix && (
+          <span
+            aria-hidden="true"
+            className="text-xs text-slate-500 dark:text-slate-400 shrink-0"
+          >
+            {suffix}
+          </span>
+        )}
+      </div>
+
+      <p id={helpId} className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+        {helper}
+      </p>
+      {error && (
+        <p
+          id={errorId}
+          data-testid={errorId}
+          role="alert"
+          className="text-xs text-red-600 dark:text-red-400 mt-1"
+        >
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/settings/SettingsPage.jsx
+++ b/frontend/components/settings/SettingsPage.jsx
@@ -8,6 +8,7 @@ import {
 } from '../../api/client';
 import DangerZone from './DangerZone';
 import ReconcileJournal from './ReconcileJournal';
+import TradingRulesSection from './TradingRulesSection';
 import { useJournal } from '../../hooks/useJournal';
 
 function freshnessColor(freshness) {
@@ -29,6 +30,10 @@ export default function SettingsPage() {
   // ``positions`` is also used as the gate for the Reconcile journal section
   // (issue #139) so it disables both buttons on an empty journal.
   const { clearAllData, reconcilePreview, reconcileApply, positions } = useJournal();
+  // Page-scoped tab state (issue #158, Option B). "General" holds the existing
+  // infrastructure/data settings; "Trading Rules" holds the rules_config edit
+  // surface. A V1.1 "Trading OKRs" tab slots in here with zero rework.
+  const [activeTab, setActiveTab] = useState('general');
   const [settings, setSettings] = useState(null);
   const [cacheStats, setCacheStats] = useState(null);
   const [fredKey, setFredKey] = useState('');
@@ -155,24 +160,20 @@ export default function SettingsPage() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-white dark:bg-slate-900 flex items-center justify-center">
-        <svg className="w-8 h-8 animate-spin text-blue-600" viewBox="0 0 24 24" fill="none">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-        </svg>
-      </div>
-    );
-  }
-
   const cacheSizeKB = cacheStats ? (cacheStats.total_size_bytes / 1024).toFixed(1) : 0;
+
+  const tabClass = (tab) =>
+    `px-4 py-2 text-sm font-medium rounded-lg ${
+      activeTab === tab
+        ? 'bg-blue-600 text-white'
+        : 'text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800'
+    }`;
 
   return (
     <div className="min-h-screen bg-white dark:bg-slate-900">
       <div className="max-w-2xl mx-auto px-6 py-8">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center justify-between mb-6">
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Settings</h1>
           <Link
             href="/"
@@ -182,7 +183,47 @@ export default function SettingsPage() {
           </Link>
         </div>
 
-        <div className="space-y-8">
+        {/* Page-scoped tab bar (issue #158). "Trading OKRs" joins here in V1.1. */}
+        <div
+          role="tablist"
+          aria-label="Settings sections"
+          className="flex gap-2 mb-8 border-b border-slate-200 dark:border-slate-700 pb-4"
+        >
+          <button
+            type="button"
+            role="tab"
+            data-testid="settings-tab-general"
+            aria-selected={activeTab === 'general'}
+            onClick={() => setActiveTab('general')}
+            className={tabClass('general')}
+          >
+            General
+          </button>
+          <button
+            type="button"
+            role="tab"
+            data-testid="settings-rules-tab"
+            aria-selected={activeTab === 'rules'}
+            onClick={() => setActiveTab('rules')}
+            className={tabClass('rules')}
+          >
+            Trading Rules
+          </button>
+        </div>
+
+        {activeTab === 'rules' ? (
+          <div role="tabpanel" aria-label="Trading Rules">
+            <TradingRulesSection />
+          </div>
+        ) : loading ? (
+          <div className="flex items-center justify-center py-24">
+            <svg className="w-8 h-8 animate-spin text-blue-600" viewBox="0 0 24 24" fill="none">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+          </div>
+        ) : (
+        <div role="tabpanel" aria-label="General" className="space-y-8">
           {/* Data Source Status */}
           <section className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700">
             <h2 className="text-lg font-semibold text-slate-900 dark:text-white mb-4">Data Source Status</h2>
@@ -591,6 +632,7 @@ export default function SettingsPage() {
           {/* Danger Zone — destructive cross-cutting actions (clear all journal data) */}
           <DangerZone onClear={clearAllData} />
         </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/components/settings/TradingRulesSection.jsx
+++ b/frontend/components/settings/TradingRulesSection.jsx
@@ -1,0 +1,475 @@
+import { useEffect, useMemo, useState } from 'react';
+import toast from 'react-hot-toast';
+import { getRulesConfig, saveRulesConfig } from '../../api/client';
+import ConfirmDialog from '../common/ConfirmDialog';
+import RuleField from './RuleField';
+import RuleRangeField from './RuleRangeField';
+import { FIELDS, GROUP_META, GROUP_ORDER } from './rulesFieldCatalog';
+import { validateRange, validateScalar } from './rulesValidation';
+
+/**
+ * Settings → Trading Rules section (issue #158).
+ *
+ * The frontend edit surface for the `rules_config` keystone (#156): five group
+ * cards (Universe, Entry, Position, Risk, Management triggers, ~24 fields), a
+ * single Save and a single Reset-to-defaults control, inline per-field
+ * validation that mirrors the backend Pydantic validators, and the standard
+ * loading / saving / success / failure states.
+ *
+ * Reads and writes via the typed `GET`/`PUT /api/settings/rules` endpoint
+ * (chosen over the generic `{key,value}` upsert because the generic
+ * `GET /api/settings` returns a fixed shape and cannot read `rules_config`
+ * back). The `getRulesConfig` / `saveRulesConfig` helpers in `api/client.js`
+ * keep this component agnostic of the endpoint shape.
+ *
+ * Form state: every field value is held as a *string* so an empty Optional
+ * field (`""`, the honest "unset" signal) stays distinct from a real entered
+ * zero (`"0"`). On save, blank Optional fields serialize to `null` — never to
+ * `0` and never to a default. Percentages are whole-percent, 1:1 with the
+ * stored value (no human↔fraction conversion — `rules_config` standardises on
+ * whole-percent per #156).
+ *
+ * Failure copy is fixed generic text (CLAUDE.md) — a raw exception is never
+ * surfaced.
+ */
+
+const LOAD_ERROR = "Couldn't load your trading rules.";
+const SAVE_ERROR = "Couldn't save your trading rules. Please try again.";
+
+/** Flatten a `RulesConfig` object into a `{ "<group>.<key>": <string> }` form
+ * state. Range fields expand to `<key>_min` / `<key>_max`. `null`/missing →
+ * `""` so Optional fields render blank. */
+function configToForm(config) {
+  const form = {};
+  GROUP_ORDER.forEach((group) => {
+    const stored = (config && config[group]) || {};
+    FIELDS[group].forEach((field) => {
+      if (field.kind === 'range') {
+        const r = stored[field.key] || {};
+        form[`${group}.${field.key}_min`] =
+          r.min === null || r.min === undefined ? '' : String(r.min);
+        form[`${group}.${field.key}_max`] =
+          r.max === null || r.max === undefined ? '' : String(r.max);
+      } else {
+        const v = stored[field.key];
+        form[`${group}.${field.key}`] =
+          v === null || v === undefined ? '' : String(v);
+      }
+    });
+  });
+  return form;
+}
+
+/** Build a `{ "<group>.<key>": <string> }` form state from catalog defaults.
+ * Optional fields reset to unset (`""`), not to a proposed number. */
+function defaultsToForm() {
+  const form = {};
+  GROUP_ORDER.forEach((group) => {
+    FIELDS[group].forEach((field) => {
+      if (field.kind === 'range') {
+        form[`${group}.${field.key}_min`] = String(field.default.min);
+        form[`${group}.${field.key}_max`] = String(field.default.max);
+      } else {
+        form[`${group}.${field.key}`] =
+          field.default === null ? '' : String(field.default);
+      }
+    });
+  });
+  return form;
+}
+
+/** Serialize the string-keyed form back into a `RulesConfig` payload.
+ * Blank Optional scalars → `null`; non-enum scalars → `Number`. */
+function formToConfig(form, schemaVersion) {
+  const config = { schema_version: schemaVersion };
+  GROUP_ORDER.forEach((group) => {
+    config[group] = {};
+    FIELDS[group].forEach((field) => {
+      if (field.kind === 'range') {
+        config[group][field.key] = {
+          min: Number(form[`${group}.${field.key}_min`]),
+          max: Number(form[`${group}.${field.key}_max`]),
+        };
+      } else if (field.kind === 'enum') {
+        config[group][field.key] = form[`${group}.${field.key}`];
+      } else {
+        const raw = form[`${group}.${field.key}`];
+        if (field.optional && (raw === '' || raw === null || raw === undefined)) {
+          config[group][field.key] = null;
+        } else {
+          config[group][field.key] = Number(raw);
+        }
+      }
+    });
+  });
+  return config;
+}
+
+/** Run every field's validator over the form. Returns a `{ "<group>.<key>":
+ * <message> }` map of just the invalid fields. Enum fields never fail here. */
+function validateForm(form) {
+  const errors = {};
+  GROUP_ORDER.forEach((group) => {
+    FIELDS[group].forEach((field) => {
+      const id = `${group}.${field.key}`;
+      if (field.kind === 'range') {
+        const err = validateRange(
+          field.validate,
+          form[`${id}_min`],
+          form[`${id}_max`],
+        );
+        if (err) errors[id] = err;
+      } else if (field.kind !== 'enum') {
+        const err = validateScalar(field.validate, form[id], field.optional);
+        if (err) errors[id] = err;
+      }
+    });
+  });
+  return errors;
+}
+
+function SkeletonRow() {
+  return (
+    <div className="space-y-2">
+      <div className="h-3 w-40 bg-slate-200 dark:bg-slate-700 rounded" />
+      <div className="h-9 w-full bg-slate-200 dark:bg-slate-700 rounded-lg" />
+    </div>
+  );
+}
+
+export default function TradingRulesSection() {
+  const [form, setForm] = useState(null);
+  const [savedForm, setSavedForm] = useState(null);
+  const [schemaVersion, setSchemaVersion] = useState(1);
+  const [errors, setErrors] = useState({});
+  const [touched, setTouched] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [lastSaved, setLastSaved] = useState(null);
+  const [hasEverSaved, setHasEverSaved] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const load = () => {
+    setLoading(true);
+    setLoadError(false);
+    getRulesConfig()
+      .then((config) => {
+        const f = configToForm(config);
+        setForm(f);
+        setSavedForm(f);
+        setSchemaVersion(config?.schema_version || 1);
+      })
+      .catch(() => setLoadError(true))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const dirty = useMemo(() => {
+    if (!form || !savedForm) return false;
+    return JSON.stringify(form) !== JSON.stringify(savedForm);
+  }, [form, savedForm]);
+
+  const errorCount = Object.keys(errors).length;
+  const canSave = dirty && errorCount === 0 && !saving;
+
+  const setField = (id, value) => {
+    setForm((prev) => ({ ...prev, [id]: value }));
+    setSaveError(false);
+    setSaveSuccess(false);
+  };
+
+  // Re-validate on blur so errors surface as the trader leaves a field; once
+  // they've attempted a save, validate live so fixes clear the error.
+  const revalidate = () => {
+    if (form) setErrors(validateForm(form));
+  };
+
+  useEffect(() => {
+    if (touched && form) setErrors(validateForm(form));
+  }, [form, touched]);
+
+  const handleSave = async () => {
+    if (!form) return;
+    setTouched(true);
+    const found = validateForm(form);
+    setErrors(found);
+    if (Object.keys(found).length > 0) return;
+
+    setSaving(true);
+    setSaveError(false);
+    try {
+      const payload = formToConfig(form, schemaVersion);
+      const saved = await saveRulesConfig(payload);
+      const f = configToForm(saved);
+      setForm(f);
+      setSavedForm(f);
+      setSchemaVersion(saved?.schema_version || schemaVersion);
+      setLastSaved(new Date());
+      setHasEverSaved(true);
+      setSaveSuccess(true);
+      toast.success('Trading rules saved');
+      setTimeout(() => setSaveSuccess(false), 2500);
+    } catch {
+      setSaveError(true);
+      toast.error('Failed to save trading rules');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleResetConfirm = () => {
+    setForm(defaultsToForm());
+    setErrors({});
+    setSaveError(false);
+    setSaveSuccess(false);
+    setConfirmOpen(false);
+  };
+
+  const header = (
+    <div>
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+        Trading Rules
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        Configure your system. Set once.
+      </p>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div data-testid="settings-rules-loading" className="space-y-8">
+        {header}
+        {GROUP_ORDER.map((group) => (
+          <div
+            key={group}
+            className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700 animate-pulse"
+          >
+            <div className="h-5 w-32 bg-slate-200 dark:bg-slate-700 rounded mb-4" />
+            <div className="space-y-5">
+              {[0, 1, 2].map((i) => (
+                <SkeletonRow key={i} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="space-y-8">
+        {header}
+        <div
+          data-testid="settings-rules-load-error"
+          role="alert"
+          className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-lg px-4 py-3 flex items-center justify-between gap-4"
+        >
+          <span className="text-sm">{LOAD_ERROR}</span>
+          <button
+            type="button"
+            onClick={load}
+            className="px-3 py-1.5 text-xs border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/50"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      data-testid="settings-rules-form"
+      className="space-y-8"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+    >
+      {header}
+
+      {!hasEverSaved && (
+        <p
+          data-testid="settings-rules-defaults-note"
+          className="text-sm text-slate-500 dark:text-slate-400"
+        >
+          You haven&apos;t changed any rules yet — these are the recommended
+          defaults.
+        </p>
+      )}
+
+      {saveError && (
+        <div
+          data-testid="settings-rules-save-error"
+          role="alert"
+          className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-lg px-4 py-3 flex items-center justify-between gap-4"
+        >
+          <span className="text-sm">{SAVE_ERROR}</span>
+          <button
+            type="button"
+            onClick={() => setSaveError(false)}
+            className="text-xs text-red-500 hover:text-red-700 dark:hover:text-red-300"
+            aria-label="Dismiss error"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {GROUP_ORDER.map((group) => (
+        <div
+          key={group}
+          data-testid={`rules-group-${group}`}
+          className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700"
+        >
+          <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-1">
+            {GROUP_META[group].title}
+          </h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mb-4 pb-4 border-b border-slate-200 dark:border-slate-700">
+            {GROUP_META[group].description}
+          </p>
+
+          <div className="space-y-5">
+            {FIELDS[group].map((field) => {
+              const id = `${group}.${field.key}`;
+              if (field.kind === 'range') {
+                return (
+                  <RuleRangeField
+                    key={field.key}
+                    fieldKey={field.key}
+                    label={field.label}
+                    helper={field.helper}
+                    suffix={field.suffix}
+                    minLabel={field.minLabel}
+                    maxLabel={field.maxLabel}
+                    step={field.step}
+                    minValue={form[`${id}_min`]}
+                    maxValue={form[`${id}_max`]}
+                    minPlaceholder={String(field.default.min)}
+                    maxPlaceholder={String(field.default.max)}
+                    onChangeMin={(v) => setField(`${id}_min`, v)}
+                    onChangeMax={(v) => setField(`${id}_max`, v)}
+                    onBlur={revalidate}
+                    error={errors[id]}
+                    disabled={saving}
+                  />
+                );
+              }
+              return (
+                <RuleField
+                  key={field.key}
+                  fieldKey={field.key}
+                  label={field.label}
+                  helper={field.helper}
+                  suffix={field.suffix}
+                  suffixLeading={field.suffixLeading}
+                  optional={field.optional}
+                  options={field.options}
+                  step={field.step}
+                  value={form[id]}
+                  placeholder={
+                    field.optional
+                      ? 'Not set — no limit'
+                      : field.default === null
+                        ? ''
+                        : String(field.default)
+                  }
+                  onChange={(v) => setField(id, v)}
+                  onBlur={revalidate}
+                  error={errors[id]}
+                  disabled={saving}
+                />
+              );
+            })}
+          </div>
+        </div>
+      ))}
+
+      {/* Action footer */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            data-testid="settings-reset-rules"
+            onClick={() => setConfirmOpen(true)}
+            disabled={saving}
+            className="px-4 py-2 text-sm border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Reset to defaults
+          </button>
+          {dirty && (
+            <span
+              data-testid="settings-rules-unsaved-hint"
+              className="text-xs text-slate-500 dark:text-slate-400"
+            >
+              You have unsaved changes
+            </span>
+          )}
+          {!dirty && lastSaved && (
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              Last saved{' '}
+              {lastSaved.toLocaleTimeString([], {
+                hour: 'numeric',
+                minute: '2-digit',
+              })}
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-3">
+          {errorCount > 0 && touched && (
+            <span className="text-xs text-red-600 dark:text-red-400">
+              Fix {errorCount} field{errorCount === 1 ? '' : 's'} before saving
+            </span>
+          )}
+          {saveSuccess && (
+            <span
+              data-testid="settings-rules-save-success"
+              className="text-green-600 dark:text-green-400"
+              aria-label="Saved"
+            >
+              <svg
+                className="w-5 h-5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            </span>
+          )}
+          <button
+            type="submit"
+            data-testid="settings-save-rules"
+            disabled={!canSave}
+            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed"
+          >
+            {saving ? 'Saving…' : 'Save trading rules'}
+          </button>
+        </div>
+      </div>
+
+      {confirmOpen && (
+        <ConfirmDialog
+          title="Reset trading rules"
+          message="Reset every trading rule to its recommended default? This discards your unsaved edits. Nothing is saved until you click Save."
+          confirmLabel="Reset to defaults"
+          confirmVariant="primary"
+          onConfirm={handleResetConfirm}
+          onCancel={() => setConfirmOpen(false)}
+        />
+      )}
+    </form>
+  );
+}

--- a/frontend/components/settings/rulesFieldCatalog.js
+++ b/frontend/components/settings/rulesFieldCatalog.js
@@ -1,0 +1,310 @@
+/**
+ * Trading Rules field catalog (issue #158).
+ *
+ * The single source of the per-field UI metadata for the Settings → Trading
+ * Rules section: label, helper text, units suffix, the catalog default shown
+ * as a placeholder, the Optional flag, and the validation kind. The five
+ * groups, the field keys, the whole-percent convention, the Optional set, and
+ * the catalog defaults all mirror the backend `RulesConfig` model
+ * (`backend/app/services/rules_config.py`, #156) — keep them in sync.
+ *
+ * Helper text is sourced from PRD #209 §R2–R6 and the design spec §5–§8.
+ * `assignment_risk_review` is an enum — the backend models it as
+ * `Literal["High", "Medium", "Low"]` (no "Off"); the select offers exactly
+ * those three values.
+ *
+ * Q6 — the two cost-basis fields are distinct rules (#156 `EntryRules`
+ * docstring): `min_call_distance_pct` is a *premium-quality margin above
+ * adjusted cost basis*; `min_call_distance_from_cost_basis_pct` is a *bare
+ * at-or-above-cost-basis loss-avoidance floor*. Their labels and helper text
+ * below reflect those definitions.
+ *
+ * `validate` kinds (checked against the backend Pydantic validators):
+ *   - 'oi'         : >= 0 (open interest, integer)
+ *   - 'spreadPct'  : > 0 (a spread cap of 0 rejects every strike)
+ *   - 'pct0to100'  : 0 <= x <= 100
+ *   - 'pctOpen100' : 0 < x <= 100 (cap that cannot be 0)
+ *   - 'nonNeg'     : >= 0
+ *   - 'capPos'     : > 0 (sizing cap)
+ *   - 'lossPct'    : <= 0 (a loss threshold is negative)
+ *   - 'posInt'     : >= 1 when set (Optional)
+ *   - 'nonNegInt'  : >= 0 when set (Optional)
+ *   - 'delta'      : range, 0 <= bound <= 1, min < max
+ *   - 'dte'        : range, min >= 0, min < max
+ */
+
+export const ASSIGNMENT_RISK_OPTIONS = ['Low', 'Medium', 'High'];
+
+/** Group order matches the backend `_GROUP_MODELS` document order. */
+export const GROUP_ORDER = ['universe', 'entry', 'position', 'risk', 'management'];
+
+export const GROUP_META = {
+  universe: {
+    title: 'Universe',
+    description:
+      'May I trade this underlying at all? Checked before any option chain is scanned.',
+  },
+  entry: {
+    title: 'Entry',
+    description:
+      'What trade may I open? Checked when a new option trade is opened or previewed in the scanner.',
+  },
+  position: {
+    title: 'Position',
+    description:
+      'How big, how many? Caps on the capital tied up in any one position.',
+  },
+  risk: {
+    title: 'Risk',
+    description:
+      'When do I intervene? Thresholds that flag a position for a deliberate look.',
+  },
+  management: {
+    title: 'Management triggers',
+    description:
+      'When do I act on an open leg? Thresholds that fire Next Actions on positions you already hold.',
+  },
+};
+
+/**
+ * Per-group ordered field lists. `kind: 'range'` fields carry `{min, max}`;
+ * everything else is a scalar. `default` is the catalog default (placeholder
+ * for required fields; the value Reset-to-defaults restores).
+ */
+export const FIELDS = {
+  universe: [
+    {
+      key: 'min_open_interest',
+      label: 'Min option open interest',
+      suffix: 'contracts',
+      default: 500,
+      optional: false,
+      validate: 'oi',
+      step: '1',
+      helper:
+        'Below this, bid-ask spreads widen enough to erode the edge. The standard liquidity floor for retail premium sellers.',
+    },
+    {
+      key: 'max_bid_ask_spread_pct',
+      label: 'Max bid-ask spread',
+      suffix: '%',
+      default: 10,
+      optional: false,
+      validate: 'spreadPct',
+      helper:
+        'A wider spread means you give up too much on entry and exit. A cheap proxy for tradeable liquidity.',
+    },
+    {
+      key: 'min_iv_rank',
+      label: 'IV Rank floor',
+      suffix: null,
+      default: 30,
+      optional: false,
+      validate: 'pct0to100',
+      helper:
+        'Below IV Rank 30, options are historically cheap and selling premium has no statistical edge. 30 is the minimum gate; 50+ is preferred.',
+    },
+    {
+      key: 'min_iv_percentile',
+      label: 'IV Percentile floor',
+      suffix: null,
+      default: null,
+      optional: true,
+      validate: 'pct0to100',
+      helper:
+        'Complementary to IV Rank — more stable against outlier spikes. Leave blank to skip this check.',
+    },
+  ],
+  entry: [
+    {
+      key: 'dte_range',
+      kind: 'range',
+      label: 'DTE range',
+      suffix: 'days',
+      default: { min: 21, max: 45 },
+      minLabel: 'DTE minimum',
+      maxLabel: 'DTE maximum',
+      validate: 'dte',
+      step: '1',
+      helper:
+        'The wheel sweet spot — far enough for meaningful theta decay, near enough to avoid locking capital for months. Below 21 days gamma risk dominates.',
+    },
+    {
+      key: 'delta_range_csp',
+      kind: 'range',
+      label: 'Delta range (cash-secured puts)',
+      suffix: null,
+      default: { min: 0.2, max: 0.3 },
+      minLabel: 'CSP delta minimum',
+      maxLabel: 'CSP delta maximum',
+      validate: 'delta',
+      helper:
+        'A probability-of-assignment proxy. 0.20–0.30 is roughly a 70–80% chance the put expires worthless — the mainstream CSP consensus.',
+    },
+    {
+      key: 'delta_range_cc',
+      kind: 'range',
+      label: 'Delta range (covered calls)',
+      suffix: null,
+      default: { min: 0.2, max: 0.35 },
+      minLabel: 'Covered-call delta minimum',
+      maxLabel: 'Covered-call delta maximum',
+      validate: 'delta',
+      helper:
+        'Slightly wider — a higher delta is fine when you want shares called away above cost basis. Tighten it when you want to keep the shares.',
+    },
+    {
+      key: 'min_monthly_return_pct',
+      label: 'Min monthly return',
+      suffix: '%',
+      default: 2,
+      optional: false,
+      validate: 'nonNeg',
+      helper:
+        "A premium-yield floor. A trade earning under 2%/month doesn't justify the capital lockup and assignment risk.",
+    },
+    {
+      key: 'earnings_buffer_days',
+      label: 'Earnings buffer',
+      suffix: 'days',
+      default: 7,
+      optional: false,
+      validate: 'nonNeg',
+      step: '1',
+      helper:
+        "Don't open within this many days of earnings — earnings gaps blow straight through strikes.",
+    },
+    {
+      key: 'min_call_distance_pct',
+      label: 'Min call distance above cost basis (margin)',
+      suffix: '%',
+      default: 5,
+      optional: false,
+      validate: 'nonNeg',
+      helper:
+        'The premium-quality margin: a covered-call strike must sit at least this far above your adjusted cost basis to be recommended. Measured from cost basis, not spot.',
+    },
+    {
+      key: 'min_call_distance_from_cost_basis_pct',
+      label: 'Min call distance — hard cost-basis floor',
+      suffix: '%',
+      default: 0,
+      optional: false,
+      validate: 'nonNeg',
+      helper:
+        'The hard loss-avoidance floor: never sell a covered call below this margin over cost basis — it locks in a loss if assigned. 0 means "at or above cost basis."',
+    },
+  ],
+  position: [
+    {
+      key: 'sizing_cap_dollars',
+      label: 'Per-position sizing cap',
+      suffix: '$',
+      suffixLeading: true,
+      default: 5000,
+      optional: false,
+      validate: 'capPos',
+      helper:
+        'An absolute-dollar ceiling on capital tied up in one position — caps worst-case single-name loss regardless of account size.',
+    },
+    {
+      key: 'max_ticker_concentration_pct',
+      label: 'Ticker concentration cap',
+      suffix: '%',
+      default: 25,
+      optional: false,
+      validate: 'pctOpen100',
+      helper:
+        'No single ticker exceeds this share of total notional — survives a single-name blow-up.',
+    },
+    {
+      key: 'max_open_positions',
+      label: 'Max open positions',
+      suffix: null,
+      default: null,
+      optional: true,
+      validate: 'posInt',
+      step: '1',
+      helper:
+        'A breadth guardrail — beyond a manageable count, monitoring discipline degrades. Leave blank for no cap. Most wheel practitioners cite 8–10.',
+    },
+  ],
+  risk: [
+    {
+      key: 'loss_review_threshold_pct',
+      label: 'Loss-review threshold',
+      suffix: '%',
+      default: -15,
+      optional: false,
+      validate: 'lossPct',
+      helper:
+        'A position down this much unrealized warrants a deliberate look — is the thesis still intact? Enter a negative number.',
+    },
+    {
+      key: 'hard_max_loss_pct',
+      label: 'Hard max-loss / stop',
+      suffix: '%',
+      default: null,
+      optional: true,
+      validate: 'lossPct',
+      helper:
+        'Past this loss, the position is a capital trap — decide via the recovery plan rather than hoping. Leave blank for no hard stop.',
+    },
+    {
+      key: 'max_consecutive_rolls',
+      label: 'Max consecutive rolls',
+      suffix: '×',
+      default: null,
+      optional: true,
+      validate: 'nonNegInt',
+      step: '1',
+      helper:
+        'Rolling more than 2–3 times on the same loser usually just delays an inevitable assignment. At the cap, the system forces a decision. Leave blank for no cap.',
+    },
+  ],
+  management: [
+    {
+      key: 'profit_review_pct',
+      label: 'Profit-take review',
+      suffix: '%',
+      default: 50,
+      optional: false,
+      validate: 'pctOpen100',
+      helper:
+        'Buy back a short option at this share of max profit — locks gains, frees capital, sheds tail risk. Research across 200K+ trades supports 50%.',
+    },
+    {
+      key: 'dte_review_days',
+      label: 'DTE review',
+      suffix: 'days',
+      default: 21,
+      optional: false,
+      validate: 'nonNeg',
+      step: '1',
+      helper:
+        'At this DTE, decide roll vs close vs hold. Inside it, gamma risk accelerates and a small adverse move can wipe out weeks of theta.',
+    },
+    {
+      key: 'expiration_warning_days',
+      label: 'Expiration warning',
+      suffix: 'days',
+      default: 7,
+      optional: false,
+      validate: 'nonNeg',
+      step: '1',
+      helper:
+        'Inside this many days to expiry, assignment mechanics dominate and the position needs attention.',
+    },
+    {
+      key: 'assignment_risk_review',
+      label: 'Assignment-risk review',
+      suffix: null,
+      default: 'High',
+      optional: false,
+      kind: 'enum',
+      options: ASSIGNMENT_RISK_OPTIONS,
+      helper:
+        'The sensitivity for flagging ITM-near-expiry positions that need an explicit decision.',
+    },
+  ],
+};

--- a/frontend/components/settings/rulesValidation.js
+++ b/frontend/components/settings/rulesValidation.js
@@ -1,0 +1,108 @@
+/**
+ * Trading Rules client-side validation (issue #158).
+ *
+ * Mirrors the backend Pydantic validators in
+ * `backend/app/services/rules_config.py` so a value rejected by the form would
+ * also be rejected by `PUT /api/settings/rules`. The form blocks Save while any
+ * field is invalid; the backend remains the final authority.
+ *
+ * Messages are fixed, generic, human copy (design spec §10.2) — they never
+ * interpolate an API exception or a raw value.
+ *
+ * The form holds every value as a string so `""` (Optional unset) is
+ * distinguishable from `"0"` (a real entered zero). These helpers therefore
+ * take raw string input.
+ */
+
+const MSG = {
+  number: 'Enter a number.',
+  integer: 'Enter a whole number.',
+  nonNeg: 'Enter a value of 0 or greater.',
+  positive: 'Enter a value greater than 0.',
+  pct0to100: 'Enter a percentage between 0 and 100.',
+  pctOpen100: 'Enter a percentage greater than 0 and up to 100.',
+  delta: 'Delta must be between 0 and 1.',
+  loss: 'Enter a loss as a negative percentage (0 or below).',
+  posInt: 'Enter a whole number of 1 or greater.',
+  nonNegInt: 'Enter a whole number of 0 or greater.',
+  rangeOrder: 'Minimum must be less than maximum.',
+};
+
+/** True when the string is empty / whitespace — the Optional "unset" signal. */
+export function isBlank(v) {
+  return v === '' || v === null || v === undefined || String(v).trim() === '';
+}
+
+function asNumber(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Validate one scalar field. Returns an error string, or `null` when valid.
+ *
+ * @param {string} kind   - the `validate` kind from the field catalog.
+ * @param {string} value  - the raw input string.
+ * @param {boolean} optional - when true, a blank value is always valid.
+ */
+export function validateScalar(kind, value, optional = false) {
+  if (isBlank(value)) {
+    // A required field left blank is invalid; an Optional one is honest unset.
+    return optional ? null : MSG.number;
+  }
+  const n = asNumber(value);
+  if (n === null) return MSG.number;
+
+  const isInt = Number.isInteger(n);
+
+  switch (kind) {
+    case 'oi':
+      if (!isInt) return MSG.integer;
+      return n < 0 ? MSG.nonNeg : null;
+    case 'spreadPct':
+      return n <= 0 ? MSG.positive : null;
+    case 'pct0to100':
+      return n < 0 || n > 100 ? MSG.pct0to100 : null;
+    case 'pctOpen100':
+      return n <= 0 || n > 100 ? MSG.pctOpen100 : null;
+    case 'nonNeg':
+      return n < 0 ? MSG.nonNeg : null;
+    case 'capPos':
+      return n <= 0 ? MSG.positive : null;
+    case 'lossPct':
+      return n > 0 ? MSG.loss : null;
+    case 'posInt':
+      if (!isInt) return MSG.integer;
+      return n < 1 ? MSG.posInt : null;
+    case 'nonNegInt':
+      if (!isInt) return MSG.integer;
+      return n < 0 ? MSG.nonNegInt : null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Validate one `{min, max}` range field. Returns an error string, or `null`.
+ *
+ * @param {'dte'|'delta'} kind
+ * @param {string} minValue
+ * @param {string} maxValue
+ */
+export function validateRange(kind, minValue, maxValue) {
+  if (isBlank(minValue) || isBlank(maxValue)) return MSG.number;
+  const lo = asNumber(minValue);
+  const hi = asNumber(maxValue);
+  if (lo === null || hi === null) return MSG.number;
+
+  if (kind === 'dte') {
+    if (lo < 0) return MSG.nonNeg;
+  } else if (kind === 'delta') {
+    if (lo < 0 || lo > 1 || hi < 0 || hi > 1) return MSG.delta;
+  }
+  // `min < max` is the shared cross-field invariant (RangeRule model_validator).
+  if (lo >= hi) return MSG.rangeOrder;
+  return null;
+}
+
+export { MSG as RULE_ERROR_MESSAGES };

--- a/frontend/design-specs/issue-158-trading-rules-settings-mock.html
+++ b/frontend/design-specs/issue-158-trading-rules-settings-mock.html
@@ -1,0 +1,739 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Trading Rules settings — mock for Issue #158</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['ui-sans-serif', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
+            mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    /* Match the app's body styles from frontend/app/globals.css */
+    body { margin: 0; min-height: 100vh; }
+    html.dark body { background-color: rgb(15 23 42); color: rgb(241 245 249); }
+  </style>
+</head>
+<body class="antialiased font-sans">
+
+<!-- =========================================================================
+     SELF-DOCUMENTATION
+     ========================================================================= -->
+<section class="border-b-4 border-blue-600 bg-slate-800/60">
+  <div class="max-w-3xl mx-auto px-6 py-5">
+    <div class="flex items-start justify-between flex-wrap gap-3">
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-blue-400 mb-1">Static design mock — not production code</div>
+        <h1 class="text-xl font-semibold text-white">Settings — Trading Rules section — Issue #158</h1>
+        <p class="text-sm text-slate-400 mt-1 max-w-3xl">
+          Read-only HTML/Tailwind mock of the new Trading Rules editing surface on the Settings page. Each state below is
+          rendered as its own stacked section. Click-throughs are visual cues only — nothing is interactive. Layout follows
+          Option B from the spec §3 (Settings becomes a tabbed page; Trading Rules is its own tab).
+        </p>
+        <p class="text-xs text-slate-500 mt-2">
+          States covered:
+          <span class="text-slate-300">1. Populated (all five rule groups, defaults + edits)</span> ·
+          <span class="text-slate-300">2. Optional fields — unset vs set</span> ·
+          <span class="text-slate-300">3. Inline validation errors</span> ·
+          <span class="text-slate-300">4. Saving (form disabled)</span> ·
+          <span class="text-slate-300">5. Save success</span> ·
+          <span class="text-slate-300">6. Save failure banner</span> ·
+          <span class="text-slate-300">7. Loading skeleton</span> ·
+          <span class="text-slate-300">8. Load error</span>.
+        </p>
+      </div>
+      <div class="text-xs text-slate-400 text-right space-y-0.5">
+        <div>Last updated <span class="text-slate-200 font-medium">2026-05-17</span></div>
+        <div>Issue: <span class="text-blue-400">#158 — Settings page Trading Rules section</span></div>
+        <div>Spec: <span class="font-mono text-slate-300">frontend/design-specs/issue-158-trading-rules-settings.md</span></div>
+        <div>Mock: <span class="font-mono text-slate-300">frontend/design-specs/issue-158-trading-rules-settings-mock.html</span></div>
+        <div>Field source: <span class="font-mono text-slate-300">PRD #209 §R2–R6 · ADR-002 #216</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- =========================================================================
+     PRODUCTION-LIKE APP HEADER (rendered once; identical chrome wraps every state)
+     Mirrors frontend/components/layout/Header.jsx so the page chrome reads as real.
+     ========================================================================= -->
+<header class="h-14 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 flex items-center justify-between px-4 shrink-0">
+  <a href="#" class="text-lg font-semibold text-slate-900 dark:text-white hover:text-blue-400">Regression Analysis Tool</a>
+  <div class="flex items-center gap-3">
+    <span class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-medium">Account ▾</span>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Dashboard</a>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Analysis</a>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Options</a>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Journal</a>
+    <a href="#" class="p-2 rounded-lg bg-slate-700 text-slate-200" aria-label="Settings">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+    </a>
+    <a href="#" class="p-2 rounded-lg hover:bg-slate-700 text-slate-300" aria-label="Help">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
+    </a>
+    <button class="p-2 rounded-lg hover:bg-slate-700 text-slate-300" aria-label="Toggle dark mode">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" /></svg>
+    </button>
+  </div>
+</header>
+
+
+<!-- ============================================================
+     STATE 1 — POPULATED (all five rule groups)
+     Spec §4–§8, §11.4 · the normal resting state
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-green-900/40 text-green-300 border border-green-700">State 1</span>
+      <h2 class="text-base font-semibold text-white">Populated — all five rule groups, required fields valued, no errors</h2>
+      <span class="text-xs text-slate-400 ml-auto">Tabbed page §3.2 · Groups §5–§7 · Footer §10.3</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <!-- Page header -->
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold text-white">Settings</h1>
+      <a href="#" class="text-sm text-blue-400 hover:text-blue-300">Back to Analysis</a>
+    </div>
+
+    <!-- Page-scoped tab bar (spec §3.1 Option B — first tabbed page, not a shared primitive) -->
+    <div role="tablist" class="flex items-center gap-1 border-b border-slate-700 mb-6">
+      <button role="tab" aria-selected="false" data-testid="settings-tab-general"
+        class="px-4 py-2 text-sm font-medium text-slate-400 hover:text-slate-200 border-b-2 border-transparent">General</button>
+      <button role="tab" aria-selected="true" data-testid="settings-rules-tab"
+        class="px-4 py-2 text-sm font-medium text-white border-b-2 border-blue-500">Trading Rules</button>
+      <!-- V1.1 adds a third tab here — "Trading OKRs" — zero rework -->
+      <span class="px-4 py-2 text-sm font-medium text-slate-600 italic">Trading OKRs <span class="text-[10px] not-italic">(V1.1)</span></span>
+    </div>
+
+    <!-- ===== Trading Rules section ===== -->
+    <form data-testid="settings-rules-form" class="space-y-8">
+      <!-- Section header — the mental model from the issue -->
+      <div>
+        <h2 class="text-lg font-semibold text-white">Trading Rules</h2>
+        <p class="text-sm text-slate-400">Configure your system. Set once.</p>
+        <!-- defaults note (§11.2) — shown until first save -->
+        <p data-testid="settings-rules-defaults-note" class="text-xs text-slate-500 mt-2 bg-slate-800/60 border border-slate-700 rounded-lg px-3 py-2">
+          You haven't changed any rules yet — these are the recommended defaults. Edit any field and save to make them yours.
+        </p>
+      </div>
+
+      <!-- ===== GROUP 1 — UNIVERSE ===== -->
+      <section data-testid="rules-group-universe" class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+        <h3 class="text-lg font-semibold text-white">Universe</h3>
+        <p class="text-sm text-slate-400 mb-4">May I trade this underlying at all? Checked before any option chain is scanned.</p>
+        <div class="space-y-5 border-t border-slate-700 pt-5">
+
+          <!-- field: min_open_interest -->
+          <div>
+            <label for="f-min_open_interest" class="block text-sm text-slate-300 mb-1">Min option open interest</label>
+            <div class="flex">
+              <input id="f-min_open_interest" data-testid="rules-field-min_open_interest" type="number" value="500"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <!-- trailing units affix -->
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">contracts</span>
+            </div>
+            <p id="f-min_open_interest-help" class="text-xs text-slate-500 mt-1">Below this, bid-ask spreads widen enough to erode the edge. The standard liquidity floor for retail premium sellers.</p>
+          </div>
+
+          <!-- field: max_bid_ask_spread_pct -->
+          <div>
+            <label for="f-max_bid_ask_spread_pct" class="block text-sm text-slate-300 mb-1">Max bid-ask spread</label>
+            <div class="flex">
+              <input id="f-max_bid_ask_spread_pct" data-testid="rules-field-max_bid_ask_spread_pct" type="number" value="10"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">A wider spread means you give up too much on entry and exit. A cheap proxy for tradeable liquidity.</p>
+          </div>
+
+          <!-- field: min_iv_rank -->
+          <div>
+            <label for="f-min_iv_rank" class="block text-sm text-slate-300 mb-1">IV Rank floor</label>
+            <input id="f-min_iv_rank" data-testid="rules-field-min_iv_rank" type="number" value="30"
+              class="w-full px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+            <p class="text-xs text-slate-500 mt-1">Below IV Rank 30, options are historically cheap and selling premium has no statistical edge. 30 is the minimum gate; 50+ is preferred.</p>
+          </div>
+
+          <!-- field: min_iv_percentile — OPTIONAL, shown UNSET here. Full unset/set treatment in State 2. -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <label for="f-min_iv_percentile" class="block text-sm text-slate-300">IV Percentile floor</label>
+              <span class="text-xs text-slate-400 bg-slate-700 rounded-full px-2 py-0.5">Optional</span>
+            </div>
+            <input id="f-min_iv_percentile" data-testid="rules-field-min_iv_percentile" type="number" placeholder="Not set — no limit"
+              class="w-full px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-500 placeholder-slate-500 outline-none focus:ring-2 focus:ring-blue-500" />
+            <p class="text-xs text-slate-500 mt-1">Complementary to IV Rank — more stable against outlier spikes. Leave blank to skip this check. Proposed value if you set it: 30.</p>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ===== GROUP 2 — ENTRY ===== -->
+      <section data-testid="rules-group-entry" class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+        <h3 class="text-lg font-semibold text-white">Entry</h3>
+        <p class="text-sm text-slate-400 mb-4">What trade may I open? Checked when a new option trade is opened or previewed in the scanner.</p>
+        <div class="space-y-5 border-t border-slate-700 pt-5">
+
+          <!-- range field: dte_range — one row, two inputs joined by "to" (§4.3) -->
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">DTE range</label>
+            <div class="flex items-center gap-2">
+              <input data-testid="rules-field-dte_range_min" type="number" value="21" aria-label="DTE minimum"
+                class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="text-xs text-slate-500">to</span>
+              <input data-testid="rules-field-dte_range_max" type="number" value="45" aria-label="DTE maximum"
+                class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="text-xs text-slate-400">days</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">The wheel sweet spot — far enough for meaningful theta decay, near enough to avoid locking capital for months. Below 21 days gamma risk dominates.</p>
+          </div>
+
+          <!-- range field: delta_range_csp -->
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">Delta range (cash-secured puts)</label>
+            <div class="flex items-center gap-2">
+              <input data-testid="rules-field-delta_range_csp_min" type="number" step="0.01" value="0.20" aria-label="CSP delta minimum"
+                class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="text-xs text-slate-500">to</span>
+              <input data-testid="rules-field-delta_range_csp_max" type="number" step="0.01" value="0.30" aria-label="CSP delta maximum"
+                class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <p class="text-xs text-slate-500 mt-1">A probability-of-assignment proxy. 0.20–0.30 is roughly a 70–80% chance the put expires worthless — the mainstream CSP consensus.</p>
+          </div>
+
+          <!-- range field: delta_range_cc -->
+          <div>
+            <label class="block text-sm text-slate-300 mb-1">Delta range (covered calls)</label>
+            <div class="flex items-center gap-2">
+              <input data-testid="rules-field-delta_range_cc_min" type="number" step="0.01" value="0.20" aria-label="CC delta minimum"
+                class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="text-xs text-slate-500">to</span>
+              <input data-testid="rules-field-delta_range_cc_max" type="number" step="0.01" value="0.35" aria-label="CC delta maximum"
+                class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Slightly wider — a higher delta is fine when you want shares called away above cost basis. Tighten it when you want to keep the shares.</p>
+          </div>
+
+          <!-- field: min_monthly_return_pct — EDITED value (23 vs default 2) to show default-as-placeholder is overridden -->
+          <!-- annotation: the value 23 is a trader edit; placeholder 2 would show only when empty -->
+          <div>
+            <label for="f-min_monthly_return_pct" class="block text-sm text-slate-300 mb-1">Min monthly return</label>
+            <div class="flex">
+              <input id="f-min_monthly_return_pct" data-testid="rules-field-min_monthly_return_pct" type="number" value="3" placeholder="2"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">A premium-yield floor. A trade earning under 2%/month doesn't justify the capital lockup and assignment risk.</p>
+          </div>
+
+          <!-- field: earnings_buffer_days -->
+          <div>
+            <label for="f-earnings_buffer_days" class="block text-sm text-slate-300 mb-1">Earnings buffer</label>
+            <div class="flex">
+              <input id="f-earnings_buffer_days" data-testid="rules-field-earnings_buffer_days" type="number" value="7"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">days</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Don't open within this many days of earnings — earnings gaps blow straight through strikes.</p>
+          </div>
+
+          <!-- field: min_call_distance_pct -->
+          <div>
+            <label for="f-min_call_distance_pct" class="block text-sm text-slate-300 mb-1">Min call distance</label>
+            <div class="flex">
+              <input id="f-min_call_distance_pct" data-testid="rules-field-min_call_distance_pct" type="number" value="5"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">The covered-call strike must sit at least this far above the trader's adjusted cost basis — the scanner measures this from cost basis, not from spot price.</p>
+          </div>
+
+          <!-- field: min_call_distance_from_cost_basis_pct -->
+          <div>
+            <label for="f-min_call_distance_from_cost_basis_pct" class="block text-sm text-slate-300 mb-1">Min call distance from cost basis</label>
+            <div class="flex">
+              <input id="f-min_call_distance_from_cost_basis_pct" data-testid="rules-field-min_call_distance_from_cost_basis_pct" type="number" value="0"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Never sell a covered call below your adjusted cost basis — that locks in a guaranteed loss if called away. 0 means "at or above cost basis."</p>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ===== GROUP 3 — POSITION ===== -->
+      <section data-testid="rules-group-position" class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+        <h3 class="text-lg font-semibold text-white">Position</h3>
+        <p class="text-sm text-slate-400 mb-4">How big, how many? Caps on the capital tied up in any one position.</p>
+        <div class="space-y-5 border-t border-slate-700 pt-5">
+
+          <!-- field: sizing_cap_dollars — $ renders as a LEADING affix (§4.2) -->
+          <div>
+            <label for="f-sizing_cap_dollars" class="block text-sm text-slate-300 mb-1">Per-position sizing cap</label>
+            <div class="flex">
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-r-0 border-slate-600 rounded-l-lg bg-slate-700/50">$</span>
+              <input id="f-sizing_cap_dollars" data-testid="rules-field-sizing_cap_dollars" type="number" value="5000"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-r-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <p class="text-xs text-slate-500 mt-1">An absolute-dollar ceiling on capital tied up in one position — caps worst-case single-name loss regardless of account size.</p>
+          </div>
+
+          <!-- field: max_ticker_concentration_pct -->
+          <div>
+            <label for="f-max_ticker_concentration_pct" class="block text-sm text-slate-300 mb-1">Ticker concentration cap</label>
+            <div class="flex">
+              <input id="f-max_ticker_concentration_pct" data-testid="rules-field-max_ticker_concentration_pct" type="number" value="25"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">No single ticker exceeds this share of total notional — survives a single-name blow-up.</p>
+          </div>
+
+          <!-- field: max_open_positions — OPTIONAL, shown UNSET here -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <label for="f-max_open_positions" class="block text-sm text-slate-300">Max open positions</label>
+              <span class="text-xs text-slate-400 bg-slate-700 rounded-full px-2 py-0.5">Optional</span>
+            </div>
+            <input id="f-max_open_positions" data-testid="rules-field-max_open_positions" type="number" placeholder="Not set — no limit"
+              class="w-full px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-500 placeholder-slate-500 outline-none focus:ring-2 focus:ring-blue-500" />
+            <p class="text-xs text-slate-500 mt-1">A breadth guardrail — beyond a manageable count, monitoring discipline degrades. Leave blank for no cap. Most wheel practitioners cite 8–10.</p>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ===== GROUP 4 — RISK ===== -->
+      <section data-testid="rules-group-risk" class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+        <h3 class="text-lg font-semibold text-white">Risk</h3>
+        <p class="text-sm text-slate-400 mb-4">When do I intervene? Thresholds that flag a position for a deliberate look.</p>
+        <div class="space-y-5 border-t border-slate-700 pt-5">
+
+          <!-- field: loss_review_threshold_pct -->
+          <div>
+            <label for="f-loss_review_threshold_pct" class="block text-sm text-slate-300 mb-1">Loss-review threshold</label>
+            <div class="flex">
+              <input id="f-loss_review_threshold_pct" data-testid="rules-field-loss_review_threshold_pct" type="number" value="-15"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">A position down this much unrealized warrants a deliberate look — is the thesis still intact? Enter a negative number.</p>
+          </div>
+
+          <!-- field: hard_max_loss_pct — OPTIONAL, shown UNSET here -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <label for="f-hard_max_loss_pct" class="block text-sm text-slate-300">Hard max-loss / stop</label>
+              <span class="text-xs text-slate-400 bg-slate-700 rounded-full px-2 py-0.5">Optional</span>
+            </div>
+            <div class="flex">
+              <input id="f-hard_max_loss_pct" data-testid="rules-field-hard_max_loss_pct" type="number" placeholder="Not set — no hard stop"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-500 placeholder-slate-500 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Past this loss, the position is a capital trap — decide via the recovery plan rather than hoping. Leave blank for no hard stop. Proposed: -25.</p>
+          </div>
+
+          <!-- field: max_consecutive_rolls — OPTIONAL, shown UNSET here -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <label for="f-max_consecutive_rolls" class="block text-sm text-slate-300">Max consecutive rolls</label>
+              <span class="text-xs text-slate-400 bg-slate-700 rounded-full px-2 py-0.5">Optional</span>
+            </div>
+            <div class="flex">
+              <input id="f-max_consecutive_rolls" data-testid="rules-field-max_consecutive_rolls" type="number" placeholder="Not set — no cap"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-500 placeholder-slate-500 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">×</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Rolling more than 2–3 times on the same loser usually just delays an inevitable assignment. At the cap, the system forces a decision. Leave blank for no cap.</p>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ===== GROUP 5 — MANAGEMENT TRIGGERS ===== -->
+      <section data-testid="rules-group-management" class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+        <h3 class="text-lg font-semibold text-white">Management triggers</h3>
+        <p class="text-sm text-slate-400 mb-4">When do I act on an open leg? Thresholds that fire Next Actions on positions you already hold.</p>
+        <div class="space-y-5 border-t border-slate-700 pt-5">
+
+          <!-- field: profit_review_pct -->
+          <div>
+            <label for="f-profit_review_pct" class="block text-sm text-slate-300 mb-1">Profit-take review</label>
+            <div class="flex">
+              <input id="f-profit_review_pct" data-testid="rules-field-profit_review_pct" type="number" value="50"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Buy back a short option at this share of max profit — locks gains, frees capital, sheds tail risk. Research across 200K+ trades supports 50%.</p>
+          </div>
+
+          <!-- field: dte_review_days -->
+          <div>
+            <label for="f-dte_review_days" class="block text-sm text-slate-300 mb-1">DTE review</label>
+            <div class="flex">
+              <input id="f-dte_review_days" data-testid="rules-field-dte_review_days" type="number" value="21"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">days</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">At this DTE, decide roll vs close vs hold. Inside it, gamma risk accelerates and a small adverse move can wipe out weeks of theta.</p>
+          </div>
+
+          <!-- field: expiration_warning_days -->
+          <div>
+            <label for="f-expiration_warning_days" class="block text-sm text-slate-300 mb-1">Expiration warning</label>
+            <div class="flex">
+              <input id="f-expiration_warning_days" data-testid="rules-field-expiration_warning_days" type="number" value="7"
+                class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+              <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">days</span>
+            </div>
+            <p class="text-xs text-slate-500 mt-1">Inside this many days to expiry, assignment mechanics dominate and the position needs attention.</p>
+          </div>
+
+          <!-- field: assignment_risk_review — enum select (§4.4 decision point) -->
+          <div>
+            <label for="f-assignment_risk_review" class="block text-sm text-slate-300 mb-1">Assignment-risk review</label>
+            <select id="f-assignment_risk_review" data-testid="rules-field-assignment_risk_review"
+              class="w-full px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500">
+              <option>Off</option><option>Low</option><option>Medium</option><option selected>High</option>
+            </select>
+            <p class="text-xs text-slate-500 mt-1">The sensitivity for flagging ITM-near-expiry positions that need an explicit decision. <span class="text-amber-400">Designer-proposed enum — confirm vs #156 model.</span></p>
+          </div>
+
+        </div>
+      </section>
+
+      <!-- ===== ACTION FOOTER (§10.3) — sticky on a real long form ===== -->
+      <div class="flex items-center justify-between gap-3 bg-slate-800 rounded-xl p-4 border border-slate-700">
+        <button type="button" data-testid="settings-reset-rules"
+          class="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-700">Reset to defaults</button>
+        <div class="flex items-center gap-3">
+          <span class="text-xs text-slate-500">Last saved 3:14 PM</span>
+          <button type="button" data-testid="settings-save-rules"
+            class="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700">Save trading rules</button>
+        </div>
+      </div>
+    </form>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 2 — OPTIONAL FIELDS: UNSET vs SET (clearable)
+     Spec §8 · the four Optional rules render blank-and-clearable
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-blue-900/40 text-blue-300 border border-blue-700">State 2</span>
+      <h2 class="text-base font-semibold text-white">Optional fields — unset (no default invented) vs set (with Clear)</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §8 · unset ≠ 0</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <p class="text-xs text-slate-400 mb-4 bg-slate-800/60 border border-slate-700 rounded-lg px-3 py-2">
+      Detail view of <span class="font-mono text-slate-300">max_open_positions</span> in both states. The unset placeholder is a
+      non-numeric hint ("Not set — no limit"), never a proposed number, so empty is unambiguous. A set Optional field shows a
+      "Clear" affordance that returns it to unset. Saving keeps unset as <span class="font-mono">null</span> — never 0.
+    </p>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700 space-y-6">
+
+      <!-- UNSET -->
+      <div>
+        <div class="text-[11px] uppercase tracking-wider text-slate-500 mb-2">Unset — input empty, greyed non-numeric placeholder</div>
+        <div class="flex items-center gap-2 mb-1">
+          <label class="block text-sm text-slate-300">Max open positions</label>
+          <span class="text-xs text-slate-400 bg-slate-700 rounded-full px-2 py-0.5">Optional</span>
+        </div>
+        <input type="number" placeholder="Not set — no limit"
+          class="w-full px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-500 placeholder-slate-500 outline-none" />
+        <p class="text-xs text-slate-500 mt-1">A breadth guardrail … Leave blank for no cap. Most wheel practitioners cite 8–10.</p>
+      </div>
+
+      <div class="border-t border-slate-700"></div>
+
+      <!-- SET — Clear button appears at the row's right edge -->
+      <div>
+        <div class="text-[11px] uppercase tracking-wider text-slate-500 mb-2">Set — value entered, Clear affordance shown</div>
+        <div class="flex items-center justify-between mb-1">
+          <div class="flex items-center gap-2">
+            <label class="block text-sm text-slate-300">Max open positions</label>
+            <span class="text-xs text-slate-400 bg-slate-700 rounded-full px-2 py-0.5">Optional</span>
+          </div>
+          <!-- Clear returns field to unset; data-testid rules-field-{key}-clear -->
+          <button type="button" data-testid="rules-field-max_open_positions-clear" class="text-xs text-slate-500 hover:text-slate-300">Clear</button>
+        </div>
+        <input type="number" value="10"
+          class="w-full px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none" />
+        <p class="text-xs text-slate-500 mt-1">A breadth guardrail … Leave blank for no cap. Most wheel practitioners cite 8–10.</p>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 3 — INLINE VALIDATION ERRORS
+     Spec §10.2 · aria-invalid + aria-describedby; Save blocked
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-rose-900/40 text-rose-300 border border-rose-700">State 3</span>
+      <h2 class="text-base font-semibold text-white">Inline validation — red ring, error text, Save blocked with fix count</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §10.2 · validators mirror backend Pydantic</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8 space-y-5">
+
+    <!-- error 1: range min not < max -->
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <label class="block text-sm text-slate-300 mb-1">DTE range</label>
+      <div class="flex items-center gap-2">
+        <!-- annotation: invalid input gets red ring + aria-invalid="true" -->
+        <input type="number" value="45" aria-invalid="true" aria-describedby="dte-help dte-err" aria-label="DTE minimum"
+          class="w-28 px-3 py-2 text-sm border border-rose-500 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-rose-500" />
+        <span class="text-xs text-slate-500">to</span>
+        <input type="number" value="21" aria-invalid="true" aria-describedby="dte-help dte-err" aria-label="DTE maximum"
+          class="w-28 px-3 py-2 text-sm border border-rose-500 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-rose-500" />
+        <span class="text-xs text-slate-400">days</span>
+      </div>
+      <p id="dte-help" class="text-xs text-slate-500 mt-1">The wheel sweet spot — far enough for meaningful theta decay, near enough to avoid locking capital for months.</p>
+      <p id="dte-err" data-testid="rules-field-dte_range-error" role="alert" class="text-xs text-rose-400 mt-1">Minimum must be less than maximum.</p>
+    </div>
+
+    <!-- error 2: delta out of 0–1 range -->
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <label for="e-delta" class="block text-sm text-slate-300 mb-1">Delta range (cash-secured puts)</label>
+      <div class="flex items-center gap-2">
+        <input type="number" step="0.01" value="0.20" aria-label="CSP delta minimum"
+          class="w-28 px-3 py-2 text-sm border border-slate-600 rounded-lg bg-slate-700 text-slate-100 outline-none" />
+        <span class="text-xs text-slate-500">to</span>
+        <input id="e-delta" type="number" step="0.01" value="1.40" aria-invalid="true" aria-describedby="delta-help delta-err" aria-label="CSP delta maximum"
+          class="w-28 px-3 py-2 text-sm border border-rose-500 rounded-lg bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-rose-500" />
+      </div>
+      <p id="delta-help" class="text-xs text-slate-500 mt-1">A probability-of-assignment proxy. 0.20–0.30 is the mainstream CSP consensus.</p>
+      <p id="delta-err" data-testid="rules-field-delta_range_csp-error" role="alert" class="text-xs text-rose-400 mt-1">Delta must be between 0 and 1.</p>
+    </div>
+
+    <!-- footer with Save disabled + fix count -->
+    <div class="flex items-center justify-between gap-3 bg-slate-800 rounded-xl p-4 border border-slate-700">
+      <button type="button" class="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-700">Reset to defaults</button>
+      <div class="flex items-center gap-3">
+        <span class="text-xs text-rose-400">Fix 2 fields before saving</span>
+        <!-- Save disabled while any field invalid (§10.2) -->
+        <button type="button" disabled class="px-4 py-2 text-sm bg-blue-600/50 text-white/70 rounded-lg cursor-not-allowed">Save trading rules</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 4 — SAVING (form disabled, button pending)
+     Spec §10.4 · all fields + buttons disabled mid-write
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-900/40 text-amber-300 border border-amber-700">State 4</span>
+      <h2 class="text-base font-semibold text-white">Saving — fields and buttons disabled, Save shows pending spinner</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §10.4</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8 space-y-5">
+    <!-- representative group card, dimmed -->
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700 opacity-50">
+      <h3 class="text-lg font-semibold text-white">Risk</h3>
+      <p class="text-sm text-slate-400 mb-4">When do I intervene? Thresholds that flag a position for a deliberate look.</p>
+      <div class="space-y-5 border-t border-slate-700 pt-5">
+        <div>
+          <label class="block text-sm text-slate-300 mb-1">Loss-review threshold</label>
+          <div class="flex">
+            <input type="number" value="-15" disabled class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg bg-slate-700 text-slate-100" />
+            <span class="inline-flex items-center px-3 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-700/50">%</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- footer: Save shows spinner + "Saving…", both buttons disabled -->
+    <div class="flex items-center justify-between gap-3 bg-slate-800 rounded-xl p-4 border border-slate-700">
+      <button type="button" disabled class="px-4 py-2 text-sm border border-slate-600 text-slate-500 rounded-lg cursor-not-allowed">Reset to defaults</button>
+      <button type="button" disabled class="inline-flex items-center gap-2 px-4 py-2 text-sm bg-blue-600/70 text-white rounded-lg cursor-not-allowed">
+        <svg class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
+        Saving…
+      </button>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 5 — SAVE SUCCESS (toast + inline glyph)
+     Spec §10.4 · react-hot-toast success + green checkmark
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-green-900/40 text-green-300 border border-green-700">State 5</span>
+      <h2 class="text-base font-semibold text-white">Save success — toast, brief inline confirmation glyph, last-saved updated</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §10.4</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8 relative">
+    <!-- simulated react-hot-toast (top-right) -->
+    <div class="absolute top-4 right-6 flex items-center gap-2 bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 shadow-lg">
+      <svg class="w-4 h-4 text-green-400" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-8 8a1 1 0 01-1.4 0l-4-4a1 1 0 011.4-1.4L8 12.6l7.3-7.3a1 1 0 011.4 0z" clip-rule="evenodd"/></svg>
+      <span class="text-sm text-slate-100">Trading rules saved</span>
+    </div>
+
+    <!-- footer: inline green checkmark next to Save, last-saved refreshed, unsaved hint cleared -->
+    <div class="flex items-center justify-between gap-3 bg-slate-800 rounded-xl p-4 border border-slate-700 mt-8">
+      <button type="button" class="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-700">Reset to defaults</button>
+      <div class="flex items-center gap-3">
+        <span class="text-xs text-slate-500">Saved just now</span>
+        <!-- brief confirmation glyph (~2s) — data-testid settings-rules-save-success -->
+        <span data-testid="settings-rules-save-success" class="inline-flex items-center gap-1 text-xs text-green-400">
+          <svg class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-8 8a1 1 0 01-1.4 0l-4-4a1 1 0 011.4-1.4L8 12.6l7.3-7.3a1 1 0 011.4 0z" clip-rule="evenodd"/></svg>
+          Saved
+        </span>
+        <button type="button" class="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700">Save trading rules</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 6 — SAVE FAILURE (generic inline banner)
+     Spec §10.4 · CLAUDE.md — never surface raw exception text
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-rose-900/40 text-rose-300 border border-rose-700">State 6</span>
+      <h2 class="text-base font-semibold text-white">Save failure — generic inline error banner, fields re-enabled for retry</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §10.4 · generic message only</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8 space-y-5">
+    <!-- inline failure banner at the top of the section -->
+    <div data-testid="settings-rules-save-error" role="alert"
+      class="flex items-start justify-between gap-3 bg-red-900/30 border border-red-800 text-red-300 rounded-lg px-4 py-3">
+      <div>
+        <div class="text-sm font-medium">Couldn't save your trading rules.</div>
+        <div class="text-xs text-red-300/80 mt-0.5">Please try again. <!-- generic copy — no str(e) leak per CLAUDE.md --></div>
+      </div>
+      <button type="button" class="text-red-300/70 hover:text-red-200 text-sm" aria-label="Dismiss">✕</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h3 class="text-lg font-semibold text-white">Universe</h3>
+      <p class="text-sm text-slate-400">Fields are re-enabled so the trader can adjust and retry.</p>
+    </div>
+
+    <div class="flex items-center justify-between gap-3 bg-slate-800 rounded-xl p-4 border border-slate-700">
+      <button type="button" class="px-4 py-2 text-sm border border-slate-600 text-slate-300 rounded-lg hover:bg-slate-700">Reset to defaults</button>
+      <div class="flex items-center gap-3">
+        <span class="text-xs text-amber-400">You have unsaved changes</span>
+        <button type="button" class="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700">Save trading rules</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 7 — LOADING SKELETON
+     Spec §11.1 · skeleton form while config GET resolves
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-slate-700 text-slate-300 border border-slate-600">State 7</span>
+      <h2 class="text-base font-semibold text-white">Loading — skeleton form (not a bare spinner) while the config GET resolves</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §11.1</span>
+    </div>
+  </div>
+
+  <div data-testid="settings-rules-loading" class="max-w-3xl mx-auto px-6 py-8 space-y-8">
+    <!-- two skeleton group cards, each with shimmer rows -->
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <div class="h-5 w-32 bg-slate-700 rounded animate-pulse mb-2"></div>
+      <div class="h-3 w-80 bg-slate-700/60 rounded animate-pulse mb-5"></div>
+      <div class="space-y-5 border-t border-slate-700 pt-5">
+        <div><div class="h-3 w-40 bg-slate-700 rounded animate-pulse mb-2"></div><div class="h-9 w-full bg-slate-700/70 rounded-lg animate-pulse"></div></div>
+        <div><div class="h-3 w-36 bg-slate-700 rounded animate-pulse mb-2"></div><div class="h-9 w-full bg-slate-700/70 rounded-lg animate-pulse"></div></div>
+        <div><div class="h-3 w-44 bg-slate-700 rounded animate-pulse mb-2"></div><div class="h-9 w-full bg-slate-700/70 rounded-lg animate-pulse"></div></div>
+      </div>
+    </div>
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <div class="h-5 w-24 bg-slate-700 rounded animate-pulse mb-2"></div>
+      <div class="h-3 w-72 bg-slate-700/60 rounded animate-pulse mb-5"></div>
+      <div class="space-y-5 border-t border-slate-700 pt-5">
+        <div><div class="h-3 w-40 bg-slate-700 rounded animate-pulse mb-2"></div><div class="h-9 w-full bg-slate-700/70 rounded-lg animate-pulse"></div></div>
+        <div><div class="h-3 w-36 bg-slate-700 rounded animate-pulse mb-2"></div><div class="h-9 w-full bg-slate-700/70 rounded-lg animate-pulse"></div></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================================
+     STATE 8 — LOAD ERROR
+     Spec §11.3 · GET failed — error block + Retry, no guessed form
+     ============================================================ -->
+<section class="border-b border-slate-700">
+  <div class="bg-slate-800/40 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-rose-900/40 text-rose-300 border border-rose-700">State 8</span>
+      <h2 class="text-base font-semibold text-white">Load error — config GET failed; error block + Retry, form not rendered</h2>
+      <span class="text-xs text-slate-400 ml-auto">Spec §11.3 · generic message only</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <!-- no form rendered with guessed values — only the error + retry -->
+    <div data-testid="settings-rules-load-error" role="alert"
+      class="bg-red-900/30 border border-red-800 rounded-lg px-5 py-6 text-center">
+      <div class="text-sm font-medium text-red-300">Couldn't load your trading rules.</div>
+      <p class="text-xs text-red-300/80 mt-1">The configuration could not be retrieved. Your saved rules are safe.</p>
+      <button type="button" class="mt-4 px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700">Retry</button>
+    </div>
+  </div>
+</section>
+
+
+<!-- =========================================================================
+     FOOTER
+     ========================================================================= -->
+<footer class="max-w-3xl mx-auto px-6 py-8 text-xs text-slate-500">
+  <p>Static design mock for Issue #158 — Settings Trading Rules section. Generated by the Designer agent, 2026-05-17.
+     Not production code; fixture data only. See <span class="font-mono text-slate-400">issue-158-trading-rules-settings.md</span> for the full spec, including the §3 Option A/B decision point.</p>
+</footer>
+
+</body>
+</html>

--- a/frontend/design-specs/issue-158-trading-rules-settings.md
+++ b/frontend/design-specs/issue-158-trading-rules-settings.md
@@ -1,0 +1,517 @@
+# Design Spec: Settings — Trading Rules section
+
+- **Issue:** [#158 — V1.0: Settings page — Trading Rules section](https://github.com/ssandy33/regress/issues/158)
+- **Milestone:** V1.0 — Trading Rules Layer + Ship-Ready Hardening (#6)
+- **Date:** 2026-05-17
+- **Author:** Designer agent
+- **Status:** Draft — for user review before implementation
+- **Scope:** Frontend visual + structural spec for the Trading Rules editing surface on the Settings page. No code, no PR yet. The backend endpoint shape (generic `{key,value}` vs typed `/api/settings/rules`) is deliberately left open — see §10; it is a data-flow detail, not a layout concern.
+
+---
+
+## 1. Overview
+
+The V1.0 rules layer (#156 / ADR-002 #216) introduces a single persisted `rules_config` object that every engine reads from — universe, entry, position, risk, and management-trigger rules. #156 builds the model and persistence; **#158 builds the surface that lets the trader edit it without touching JSON.** A config the trader cannot edit is only half-shipped, so the edit surface lands in V1.0 alongside the model.
+
+This spec adds a **"Trading Rules" section** to the Settings page. It is a long, grouped form: five field groups, ~24 fields, each with a label, a number input, a units suffix, helper text, and the catalog default rendered as a placeholder. Four fields are `Optional`/unset rules — they render blank-and-clearable and never invent a default. The section has a single Save and a single Reset to defaults control, inline per-field validation matching the backend Pydantic validators, and the standard loading / saving / success / failure states.
+
+The section header states the mental model the PRD asks for: **"Configure your system. Set once."**
+
+The design is built so a sibling **"Trading OKRs"** section (V1.1, edits `okr_config`, derived from PRD #215) can be added alongside it **without rework** — see §3 for the routing/layout decision that makes this true.
+
+Design language matches the existing Settings page slate palette, dark-mode aware. No new visual vocabulary is introduced — the section reuses the established Settings-card shell, the `bg-blue-600` primary button, and the `react-hot-toast` toast plumbing already wired into `SettingsPage.jsx`.
+
+### Naming decision
+
+The issue suggests the nav label "Trading Rules". **Decision: use "Trading Rules"** as both the nav label and the section title. It matches the PRD's `rules_config` namespace and ADR-001's "Trading Rules" layer name, and it reads as a sibling to the future "Trading OKRs" — the two share the "Trading …" prefix so the V1.1 addition slots in as an obvious pair.
+
+---
+
+## 2. Stack context (detected)
+
+Detected from the repo before authoring — do not assume conventions from other projects:
+
+- **Framework:** Next.js 16.2.4, App Router (`frontend/app/`).
+- **Language:** JavaScript / JSX. `jsconfig.json` only — **no TypeScript.** The "Data Shape" in §9 is documented as JSDoc-style notes, not a `.ts` interface; the implementing component is a `.jsx` file.
+- **Styling:** Tailwind CSS v4 (`@tailwindcss/postcss`). **No `tailwind.config.js`** — the project uses Tailwind's default token scale. Dark mode is **class-based** (`.dark` on `<html>`), re-bound via `@custom-variant dark` in `app/globals.css`.
+- **Toasts:** `react-hot-toast` — already imported and used throughout `SettingsPage.jsx` (`toast.success` / `toast.error`).
+- **Path alias:** `@/*` → repo `frontend/` root.
+- **No `docs/DESIGN_SYSTEM.md`** exists. Tokens in §11 were derived from the codebase (`app/globals.css` + the existing Settings sections + `components/common/*`). Recommendation: extract a `docs/DESIGN_SYSTEM.md` in a future one-shot so future designs share one canonical token reference; not a blocker for this issue.
+
+---
+
+## 3. Routing & layout — and the V1.1 forward-compatibility decision
+
+### 3.1 The decision
+
+The issue's hard constraint is: *"Built so a sibling 'Trading OKRs' section can be added alongside it in V1.1 without rework."* There are two ways to satisfy this; the choice determines the whole layout.
+
+⚠️ **DECISION NEEDED — confirm before implementation. Recommended option in bold.**
+
+- **Option A — One Settings page, Trading Rules is a long section in the existing single column.**
+  The new section is appended to the `space-y-8` column in `SettingsPage.jsx`, exactly like Reconcile Journal (#139) was. "Trading OKRs" later becomes the next section below it. *Forward-compat is free — V1.1 just appends another section.* But: the Settings page is already 8 sections of infrastructure/data settings (FRED key, Schwab, cache, backups). Adding ~24 trading-rule fields makes a very long scroll, and mixes "set up the app's plumbing" with "configure my trading strategy" — two different mental modes on one page.
+
+- **Option B — Promote Settings to a tabbed page; Trading Rules is its own tab. ✅ RECOMMENDED.**
+  Introduce a horizontal tab bar at the top of the Settings page. Tab 1 **"General"** holds everything that is on the page today (Data Source Status, FRED, Schwab, Data Freshness, Cache, Backups, Preferences, Reconcile, Danger Zone — unchanged). Tab 2 **"Trading Rules"** holds the new section. V1.1 adds Tab 3 **"Trading OKRs"** — a pure addition, zero rework, which is exactly the issue's requirement. It also separates "app plumbing" from "my trading system," and keeps each tab a manageable scroll.
+
+**Recommendation: Option B.** It is the cleanest literal satisfaction of "added alongside without rework" — V1.1 is a one-line tab registration. It also fits the project's own trajectory: this is the first tabbed page, and per the established convention the tab bar should be **page-scoped** (defined inside the Settings page, not lifted into a shared `components/common/Tabs.jsx` primitive) until a second tabbed page exists elsewhere in the app. If a second tabbed surface appears later, lift then.
+
+If the user prefers Option A for V1.0 speed, the field-group design in §5–§8 is **identical either way** — only the page wrapper differs. The spec below is written for Option B; §3.3 notes the Option A delta.
+
+### 3.2 Option B — page structure
+
+```
+/settings  (app/settings/page.jsx → components/settings/SettingsPage.jsx)
+
+Settings                                            [Back to Analysis]
+┌─────────────────────────────────────────────────────────────────────┐
+│  [ General ]  [ Trading Rules ]      ← page-scoped tab bar (new)      │
+└─────────────────────────────────────────────────────────────────────┘
+
+  ── when "General" active ──
+  (the entire current SettingsPage column, unchanged)
+
+  ── when "Trading Rules" active ──
+  Trading Rules                                                          
+  Configure your system. Set once.                                       
+                                                                         
+  [Universe group card]                                                  
+  [Entry group card]                                                     
+  [Position group card]                                                  
+  [Risk group card]                                                      
+  [Management triggers group card]                                       
+                                                                         
+  [ Reset to defaults ]                       [ Save trading rules ]     
+```
+
+- The tab bar is the only structural change to the General experience — its sections are untouched and stay in their current `space-y-8` column.
+- The Trading Rules tab is a **new component** `components/settings/TradingRulesSection.jsx`, rendered when its tab is active.
+- Page width: keep the existing `max-w-2xl mx-auto px-6 py-8` constraint of `SettingsPage.jsx`. The form is single-column; `max-w-2xl` is comfortable for label + input + helper rows.
+
+### 3.3 Option A delta (if chosen instead)
+
+No tab bar. `TradingRulesSection` is appended to the existing `space-y-8` column, placed **after Preferences and before Reconcile Journal** (group it with "configure the app" sections, keep the data-management/destructive sections — Reconcile, Danger Zone — as the page terminator). Everything in §4–§12 is otherwise unchanged.
+
+---
+
+## 4. Section anatomy
+
+The Trading Rules tab/section is a vertical stack of **five group cards** followed by a **sticky action footer**.
+
+```
+┌─ Trading Rules ─────────────────────────────────────────────────────┐
+│  Trading Rules                                                       │
+│  Configure your system. Set once.                                    │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌─ Group card: Universe ──────────────────────────────────────────────┐
+│  Universe                                                            │
+│  May I trade this underlying at all? Checked before any option       │
+│  chain is scanned.                                                    │
+│  ─────────────────────────────────────────────────────────────────  │
+│  ┌ field row ┐  ┌ field row ┐  ...                                   │
+└──────────────────────────────────────────────────────────────────────┘
+   (Entry, Position, Risk, Management triggers — same shape)
+
+┌─ Action footer ─────────────────────────────────────────────────────┐
+│  [ Reset to defaults ]                       [ Save trading rules ]  │
+│  (last-saved timestamp / unsaved-changes hint sits here)             │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.1 Group card
+
+Each of the five groups is one card using the **Settings-card shell** — `bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700` — the same shell every existing Settings section uses (`ReconcileJournal.jsx`, FRED, Schwab, …). Do **not** use the `components/common/Card.jsx` primitive here — that primitive is `bg-white` and is the dashboard card; the Settings page has its own `bg-slate-50` shell and the new section must match its siblings, not the dashboard.
+
+Card header:
+- `h2` title — group name (`text-lg font-semibold text-slate-900 dark:text-white`).
+- One-line description (`text-sm text-slate-500 dark:text-slate-400`) — the "may I trade this?" / "what trade?" framing from PRD §R2–R6, so the trader understands when the group's rules fire.
+
+Card body: a vertical list of **field rows**, `space-y-5`.
+
+### 4.2 Field row
+
+Each field is one row. Layout:
+
+```
+Label text                                              [help ⓘ hover]
+┌──────────────────────────────────┐ ┌──────┐
+│  25                              │ │  %   │   ← input + units suffix
+└──────────────────────────────────┘ └──────┘
+Helper text explaining what the rule controls.            (slate-400, xs)
+```
+
+- **Label** — `<label htmlFor>` bound to the input id. `text-sm text-slate-700 dark:text-slate-300 mb-1`.
+- **Input** — a `<input type="number">` styled to match the existing Settings inputs: `px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 outline-none focus:ring-2 focus:ring-blue-500`. Width: `w-full` within the row, but the row caps input width so the suffix can sit to its right (see §4.3).
+- **Units suffix** — a small static affix to the right of the input showing `$`, `%`, `days`, `contracts`, or `×` (for max-consecutive-rolls). Rendered as a non-interactive trailing addon, `text-xs text-slate-500 dark:text-slate-400`, in a bordered box that visually joins the input (left border removed / `rounded-l-none`). `$` renders as a **leading** affix (before the input) because that is the natural reading order for currency; `%`, `days`, `contracts`, `×` render **trailing**.
+- **Default-as-placeholder** — the input's `placeholder` is the catalog default value (e.g. `21`, `45`, `500`). When the field has a stored value, the value fills the input and the placeholder is hidden as usual. When the field is empty, the greyed default is visible — it shows the trader what the system uses if they leave it blank, without that default being a real entered value.
+- **Helper text** — `text-xs text-slate-500 dark:text-slate-400 mt-1`, sourced verbatim (lightly trimmed) from the PRD #209 "Why" column. This is the per-field explanation the issue's AC requires.
+
+### 4.3 Range fields (min/max pairs)
+
+`dte_range`, `delta_range_csp`, `delta_range_cc` are `{min, max}` pairs. Render them as **one row with two inputs** joined by an en-dash:
+
+```
+DTE range                                                [help ⓘ]
+┌────────────┐        ┌────────────┐
+│  21        │   to   │  45        │  days
+└────────────┘        └────────────┘
+The wheel sweet spot — far enough for theta decay, near enough to
+avoid locking capital for months.
+```
+
+- Two `<input type="number">`, each with its own id (`rules-field-dte_range_min` / `_max`), a shared visible group label, and a visually-hidden per-input label ("DTE minimum" / "DTE maximum") for screen readers.
+- The units suffix (`days`, or none for delta) sits after the max input.
+- `min < max` validation: see §10.2.
+
+### 4.4 Boolean / enum field — `assignment_risk_review`
+
+`assignment_risk_review` in PRD §R6 has default "High" — it is not a number. Model it as a small `<select>` (`Off` / `Low` / `Medium` / `High`) matching the existing Preferences `<select>` style in `SettingsPage.jsx`. Same field-row layout (label, control, helper), no units suffix.
+
+⚠️ **DECISION NEEDED:** PRD §R6 lists `assignment_risk_review` with default "High" but does not enumerate its allowed values. The `Off/Low/Medium/High` set above is a designer-proposed default — confirm against the `RulesConfig` Pydantic model in #156 before wiring. If #156 models it as a boolean toggle instead, render a checkbox/switch; the field-row layout is otherwise unchanged.
+
+---
+
+## 5. Group 1 — Universe
+
+Card description: *"May I trade this underlying at all? Checked before any option chain is scanned."*
+
+| Field key | Label | Input | Suffix | Default (placeholder) | Optional? | Helper text |
+|---|---|---|---|---|---|---|
+| `min_open_interest` | Min option open interest | number | `contracts` | `500` | required | Below this, bid-ask spreads widen enough to erode the edge. The standard liquidity floor for retail premium sellers. |
+| `max_bid_ask_spread_pct` | Max bid-ask spread | number | `%` | `10` | required | A wider spread means you give up too much on entry and exit. A cheap proxy for tradeable liquidity. |
+| `min_iv_rank` | IV Rank floor | number | (none) | `30` | required | Below IV Rank 30, options are historically cheap and selling premium has no statistical edge. 30 is the minimum gate; 50+ is preferred. |
+| `min_iv_percentile` | IV Percentile floor | number | (none) | — *(unset)* | **Optional** | Complementary to IV Rank — more stable against outlier spikes. Leave blank to skip this check. Proposed value if you set it: 30. |
+
+`min_iv_percentile` is one of the four Optional fields — see §8 for its blank/clearable rendering.
+
+---
+
+## 6. Group 2 — Entry
+
+Card description: *"What trade may I open? Checked when a new option trade is opened or previewed in the scanner."*
+
+| Field key | Label | Input | Suffix | Default (placeholder) | Optional? | Helper text |
+|---|---|---|---|---|---|---|
+| `dte_range` | DTE range | number range `{min,max}` | `days` | `21` to `45` | required | The wheel sweet spot — far enough for meaningful theta decay, near enough to avoid locking capital for months. Below 21 days gamma risk dominates. |
+| `delta_range_csp` | Delta range (cash-secured puts) | number range `{min,max}` | (none) | `0.20` to `0.30` | required | A probability-of-assignment proxy. 0.20–0.30 is roughly a 70–80% chance the put expires worthless — the mainstream CSP consensus. |
+| `delta_range_cc` | Delta range (covered calls) | number range `{min,max}` | (none) | `0.20` to `0.35` | required | Slightly wider — a higher delta is fine when you want shares called away above cost basis. Tighten it when you want to keep the shares. |
+| `min_monthly_return_pct` | Min monthly return | number | `%` | `2` | required | A premium-yield floor. A trade earning under 2%/month doesn't justify the capital lockup and assignment risk. |
+| `earnings_buffer_days` | Earnings buffer | number | `days` | `7` | required | Don't open within this many days of earnings — earnings gaps blow straight through strikes. |
+| `min_call_distance_pct` | Min call distance | number | `%` | `5` | required | The covered-call strike must sit at least this far above the trader's **adjusted cost basis** — the scanner measures this from cost basis, *not* from spot price. ⚠️ See the note below this table and §18 Q6. |
+| `min_call_distance_from_cost_basis_pct` | Min call distance from cost basis | number | `%` | `0` | required | Never sell a covered call below your adjusted cost basis — that locks in a guaranteed loss if called away. 0 means "at or above cost basis." |
+
+> ⚠️ **`min_call_distance_pct` vs `min_call_distance_from_cost_basis_pct` — Q6, unresolved.** Both fields are measured from the trader's adjusted **cost basis** — verified against `backend/app/services/options_scanner.py`, and consistent with the #217 reconciliation of PRD #209 (an earlier draft of this spec wrongly described `min_call_distance_pct` as a distance "from spot"). Their distinct roles — a percentage margin above basis vs a bare at-or-above-basis floor — are too close to label legibly until #156 fixes the precise semantics of each. The label and helper text for `min_call_distance_pct` above are provisional pending that decision.
+
+---
+
+## 7. Group 3 — Position · Group 4 — Risk · Group 5 — Management triggers
+
+### 7.1 Position
+
+Card description: *"How big, how many? Caps on the capital tied up in any one position."*
+
+| Field key | Label | Input | Suffix | Default (placeholder) | Optional? | Helper text |
+|---|---|---|---|---|---|---|
+| `sizing_cap_dollars` | Per-position sizing cap | number | `$` *(leading)* | `5000` | required | An absolute-dollar ceiling on capital tied up in one position — caps worst-case single-name loss regardless of account size. |
+| `max_ticker_concentration_pct` | Ticker concentration cap | number | `%` | `25` | required | No single ticker exceeds this share of total notional — survives a single-name blow-up. |
+| `max_open_positions` | Max open positions | number | (none) | — *(unset)* | **Optional** | A breadth guardrail — beyond a manageable count, monitoring discipline degrades. Leave blank for no cap. Most wheel practitioners cite 8–10. |
+
+### 7.2 Risk
+
+Card description: *"When do I intervene? Thresholds that flag a position for a deliberate look."*
+
+| Field key | Label | Input | Suffix | Default (placeholder) | Optional? | Helper text |
+|---|---|---|---|---|---|---|
+| `loss_review_threshold_pct` | Loss-review threshold | number | `%` | `-15` | required | A position down this much unrealized warrants a deliberate look — is the thesis still intact? Enter a negative number. |
+| `hard_max_loss_pct` | Hard max-loss / stop | number | `%` | — *(unset)* | **Optional** | Past this loss, the position is a capital trap — decide via the recovery plan rather than hoping. Leave blank for no hard stop. Proposed: -25. |
+| `max_consecutive_rolls` | Max consecutive rolls | number | `×` | — *(unset)* | **Optional** | Rolling more than 2–3 times on the same loser usually just delays an inevitable assignment. At the cap, the system forces a decision. Leave blank for no cap. |
+
+### 7.3 Management triggers
+
+Card description: *"When do I act on an open leg? Thresholds that fire Next Actions on positions you already hold."*
+
+| Field key | Label | Input | Suffix | Default (placeholder) | Optional? | Helper text |
+|---|---|---|---|---|---|---|
+| `profit_review_pct` | Profit-take review | number | `%` | `50` | required | Buy back a short option at this share of max profit — locks gains, frees capital, sheds tail risk. Research across 200K+ trades supports 50%. |
+| `dte_review_days` | DTE review | number | `days` | `21` | required | At this DTE, decide roll vs close vs hold. Inside it, gamma risk accelerates and a small adverse move can wipe out weeks of theta. |
+| `expiration_warning_days` | Expiration warning | number | `days` | `7` | required | Inside this many days to expiry, assignment mechanics dominate and the position needs attention. |
+| `assignment_risk_review` | Assignment-risk review | select | (none) | `High` | required | The sensitivity for flagging ITM-near-expiry positions that need an explicit decision. See §4.4 decision point. |
+
+---
+
+## 8. Optional / unset fields — blank & clearable rendering
+
+Four fields are backed by an `Optional` rule in `RulesConfig` (PRD #209 Q1 / ADR-002 D-OQ1): **`min_iv_percentile`, `max_open_positions`, `hard_max_loss_pct`, `max_consecutive_rolls`.** For these, *blank is a valid, honest state* — the rule is simply not enforced. The UI must not invent a default value for them.
+
+Rendering rules for an Optional field:
+
+1. **Unset → input is empty.** No value, no fallback number. The placeholder shows a non-numeric hint — `"Not set — no limit"` — **not** a proposed number, so the empty input is unambiguous. (Contrast required fields, whose placeholder *is* the default number.)
+2. **Optional badge.** A small `Optional` pill (`text-xs text-slate-500 bg-slate-100 dark:bg-slate-700 rounded-full px-2 py-0.5`) sits next to the label so the trader knows blank is allowed.
+3. **Clear affordance.** When an Optional field *has* a value, show a small "Clear" text button (`text-xs text-slate-500 hover:text-slate-700`) at the row's right edge. Clicking it returns the field to the unset state. The helper text mentions "Leave blank for no cap / no hard stop."
+4. **Save semantics.** An empty Optional field is saved as unset (`null` in `rules_config`), never as `0` and never as the proposed default. The implementing component must distinguish "" (unset) from "0" (a real entered zero) — `0` is a legitimate value for some required percent fields, so empty-string is the only unset signal.
+5. **Validation.** An empty Optional field is always valid (it is allowed to be unset). Validation only runs on Optional fields when they contain a value.
+
+Visual treatment of a set vs unset Optional field:
+
+```
+unset:
+  Max open positions   [Optional]
+  ┌──────────────────────────────────┐
+  │  Not set — no limit              │   ← placeholder, greyed
+  └──────────────────────────────────┘
+  A breadth guardrail … Leave blank for no cap.
+
+set:
+  Max open positions   [Optional]                            [Clear]
+  ┌──────────────────────────────────┐
+  │  10                              │
+  └──────────────────────────────────┘
+  A breadth guardrail … Leave blank for no cap.
+```
+
+---
+
+## 9. Data shape
+
+JSDoc-style (the project is JSX, not TS). `rules_config` is the object the section reads and writes; shape per ADR-002 D1.
+
+```js
+/**
+ * @typedef {Object} RulesConfig
+ * @property {number}  schema_version          - 1 (ADR-002 RULES_CONFIG_SCHEMA_VERSION)
+ * @property {Object}  universe
+ * @property {number}  universe.min_open_interest
+ * @property {number}  universe.max_bid_ask_spread_pct
+ * @property {number}  universe.min_iv_rank
+ * @property {?number} universe.min_iv_percentile          - Optional, null = unset
+ * @property {Object}  entry
+ * @property {{min:number,max:number}} entry.dte_range
+ * @property {{min:number,max:number}} entry.delta_range_csp
+ * @property {{min:number,max:number}} entry.delta_range_cc
+ * @property {number}  entry.min_monthly_return_pct
+ * @property {number}  entry.earnings_buffer_days
+ * @property {number}  entry.min_call_distance_pct
+ * @property {number}  entry.min_call_distance_from_cost_basis_pct
+ * @property {Object}  position
+ * @property {number}  position.sizing_cap_dollars
+ * @property {number}  position.max_ticker_concentration_pct
+ * @property {?number} position.max_open_positions          - Optional, null = unset
+ * @property {Object}  risk
+ * @property {number}  risk.loss_review_threshold_pct
+ * @property {?number} risk.hard_max_loss_pct               - Optional, null = unset
+ * @property {?number} risk.max_consecutive_rolls           - Optional, null = unset
+ * @property {Object}  management
+ * @property {number}  management.profit_review_pct
+ * @property {number}  management.dte_review_days
+ * @property {number}  management.expiration_warning_days
+ * @property {string}  management.assignment_risk_review    - enum; confirm vs #156 model
+ */
+```
+
+Percent convention: `rules_config` standardises on **whole-percent** (per #156 / issue #158). The form takes and shows whole-percent (`25`, `-15`, `2`) directly — `1`-to-`1` with the stored value, no human↔fraction conversion. **The issue's "percent fields convert human ↔ stored convention" AC and its component test still apply** as a guard: the component must confirm whole-percent against the `RulesConfig` model before wiring, and if #156 turns out to store fractions the conversion (`25` ⇄ `0.25`) lives in the form's load/save mapping. Design assumes whole-percent; flag if #156 disagrees.
+
+---
+
+## 10. Data flow & save lifecycle
+
+### 10.1 Endpoint (left open by design)
+
+Per the issue, the endpoint shape is undecided. The UI is built **independent** of it:
+
+- The component calls a thin API helper in `frontend/api/client.js` — propose `getRulesConfig()` and `saveRulesConfig(config)`.
+- Those helpers wrap **whichever endpoint #156 ships**: the generic `GET`/`PUT /api/settings` `{key:"rules_config", value:<json string>}` upsert (ADR-002 OQ3 — sufficient), or the typed `GET`/`PUT /api/settings/rules` if #156 adds it.
+- The component does not care which — it consumes `RulesConfig`-shaped JSON and posts `RulesConfig`-shaped JSON. Confirm available endpoints against the backend before wiring; the layout in this spec does not change either way.
+- On save success, invalidate any cached dashboard data so rule changes reflect on the next dashboard view (issue AC). Mechanism: whatever cache layer the dashboard uses — flag for the Developer agent.
+
+### 10.2 Validation
+
+Inline, per-field, mirroring the backend Pydantic validators (ADR-002 — `RulesConfig` validates ranges). Validation runs on blur and again on Save attempt.
+
+| Rule | Check | Message (generic, no raw exception) |
+|---|---|---|
+| Range fields (`dte_range`, `delta_range_csp`, `delta_range_cc`) | `min < max` | "Minimum must be less than maximum." |
+| Non-negative fields (`min_open_interest`, `dte_*`, `earnings_buffer_days`, `*_distance_pct`, `min_monthly_return_pct`, `sizing_cap_dollars`, `profit_review_pct`, etc.) | `>= 0` | "Enter a value of 0 or greater." |
+| Delta fields | `0 ≤ delta ≤ 1` | "Delta must be between 0 and 1." |
+| Percent caps (`max_bid_ask_spread_pct`, `max_ticker_concentration_pct`, `profit_review_pct`, IV floors) | `0 ≤ x ≤ 100` | "Enter a percentage between 0 and 100." |
+| Loss fields (`loss_review_threshold_pct`, `hard_max_loss_pct`) | `≤ 0` (a loss threshold is negative) | "Enter a loss as a negative percentage." |
+| Optional fields | empty is always valid; validate only when filled | — |
+
+Error rendering on a field row:
+- The input gets a red ring: `border-red-400 dark:border-red-500 focus:ring-red-500`, and `aria-invalid="true"`.
+- An error message renders below the helper text in red (`text-xs text-red-600 dark:text-red-400`), with `id="rules-field-{key}-error"`.
+- The input carries `aria-describedby="rules-field-{key}-help rules-field-{key}-error"` so a screen reader announces both the helper and the error. When valid, `aria-describedby` references only the help id.
+- Save is blocked while any field is invalid — the Save button is disabled and a count ("Fix 2 fields before saving") sits in the action footer.
+
+### 10.3 Save / Reset controls
+
+**Action footer** — sits below the five group cards. On Option B it can be `sticky bottom-0` within the tab's scroll container so Save is always reachable on a long form; on Option A it is a normal in-flow footer.
+
+- **Save trading rules** — primary button, `bg-blue-600 text-white` (matches every primary action in `SettingsPage.jsx`). Disabled when (a) no unsaved changes, or (b) any field invalid. On click → §10.4 saving state.
+- **Reset to defaults** — secondary button, `border border-slate-300 dark:border-slate-600`. Resets *every* field in the section to its catalog default — and resets the four Optional fields back to **unset**, not to their "proposed" numbers. Because this discards edits, it opens a `ConfirmDialog` (the existing `components/common/ConfirmDialog.jsx`) first — non-destructive of persisted data but destructive of in-progress edits, so confirm. Per the established project pattern, this confirm uses the **blue/primary** variant, not the red/danger variant (red is reserved for data-destroying actions like Danger Zone). Reset only changes the form's in-memory state; nothing persists until the trader then clicks Save.
+- An **unsaved-changes hint** ("You have unsaved changes") and a **last-saved line** ("Saved just now" / "Last saved 3:14 PM") sit in the footer next to the buttons.
+
+### 10.4 Save lifecycle states
+
+- **Saving** — Save button shows a pending label ("Saving…") and a spinner; the button and every field in the section are disabled (`disabled` + `opacity-50`) so the form can't be edited mid-write. Matches the `ReconcileJournal` Apply pattern.
+- **Save success** — `toast.success("Trading rules saved")` via `react-hot-toast`; a brief inline confirmation glyph (a checkmark, `text-green-600`) appears next to the Save button for ~2s; the footer's last-saved line updates; the unsaved-changes hint clears; fields re-enable.
+- **Save failure** — `toast.error(...)` **plus** an inline error banner at the top of the section: `bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-lg px-4 py-3`. The message is **generic** ("Couldn't save your trading rules. Please try again.") — per CLAUDE.md, never surface a raw `str(e)` / API exception. Fields re-enable so the trader can retry. The banner has a dismiss affordance and clears on the next save attempt.
+
+---
+
+## 11. States
+
+The section has four required states plus the save-lifecycle states in §10.4.
+
+### 11.1 Loading
+
+While the initial `getRulesConfig()` resolves: render a **skeleton form**, not a bare spinner — the issue AC says "skeleton form while the config GET resolves." Five skeleton group cards, each with 3–4 shimmer rows (a short grey bar for the label, a full-width grey bar for the input). Reuse `components/layout/LoadingSkeleton.jsx` if its shape fits; otherwise a local skeleton row. The action footer renders disabled. `data-testid="settings-rules-loading"`.
+
+### 11.2 Empty
+
+There is no true "empty" state — `load_rules_config` (ADR-002) **always** returns a complete config (defaults merged over any partial stored object), so the form always has values to render. The closest thing is *"never edited — all defaults"*: required fields show their default values, Optional fields show as unset. This is the normal populated form; optionally show a one-line note at the top — *"You haven't changed any rules yet — these are the recommended defaults."* — that disappears once the trader has saved at least once. `data-testid="settings-rules-defaults-note"`.
+
+### 11.3 Error (load failure)
+
+If `getRulesConfig()` fails: render the section with an inline error block (`bg-red-50 …`, same treatment as §10.4 failure) and a **Retry** button. Copy: *"Couldn't load your trading rules."* — generic, no raw exception. Do **not** render the form with guessed values; render only the error + retry. `data-testid="settings-rules-load-error"`.
+
+### 11.4 Populated
+
+The normal state — the five group cards from §5–§8 with values, the action footer from §10.3. This is the layout the rest of the spec describes.
+
+---
+
+## 12. Component mapping
+
+| UI element | Component | Status | Notes |
+|---|---|---|---|
+| Settings tab bar (Option B) | `SettingsPage.jsx` (inline, page-scoped) | Create (inline) | Horizontal tabs; page-scoped, not a shared primitive — first tabbed page in the app. |
+| Trading Rules section | `components/settings/TradingRulesSection.jsx` | **Create** | Top-level section component; owns load/save/validation state. |
+| Group card | inline in `TradingRulesSection` | Create (inline) | Settings-card shell `bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border …`. |
+| Field row | `components/settings/RuleField.jsx` | **Create** | One labeled number field + units suffix + helper + validation. Reused ~21×. |
+| Range field row | `components/settings/RuleRangeField.jsx` | **Create** | Two-input `{min,max}` variant of `RuleField`. Reused 3×. Could be a `variant` prop on `RuleField` instead — implementer's call. |
+| Optional-field badge + Clear | inside `RuleField` (`optional` prop) | Create (inline) | `optional` prop drives the badge, the "Not set" placeholder, the Clear button, and the unset-vs-0 save logic. |
+| Confirm dialog (Reset) | `components/common/ConfirmDialog.jsx` | **Reuse** | Blue/primary variant — non-destructive of persisted data. |
+| Toasts | `react-hot-toast` | **Reuse** | `toast.success` / `toast.error`, already wired in `SettingsPage.jsx`. |
+| Primary / secondary buttons | inline Tailwind | Reuse pattern | `bg-blue-600` primary, `border-slate-300` secondary — exact classes already used across `SettingsPage.jsx`. |
+| Skeleton (loading) | `components/layout/LoadingSkeleton.jsx` | Reuse if shape fits | Else a local skeleton row. |
+| API helpers | `frontend/api/client.js` | **Create** | `getRulesConfig()`, `saveRulesConfig(config)` — wrap whichever endpoint #156 ships. |
+
+**Do not** reuse `components/common/Card.jsx` (dashboard `bg-white` card) or `StatCard.jsx` here — the Settings page has its own `bg-slate-50` card shell and the new section must visually match its siblings.
+
+---
+
+## 13. Design tokens applied
+
+No `docs/DESIGN_SYSTEM.md` exists — tokens below were **derived from the codebase** (`app/globals.css`, the existing Settings sections, `components/common/*`). Tailwind v4 default scale; no custom config.
+
+| Token | Value | Usage |
+|---|---|---|
+| Page background | `bg-white` / `dark:bg-slate-900` | Settings page wrapper |
+| Card shell | `bg-slate-50` / `dark:bg-slate-800` + `border-slate-200 dark:border-slate-700` + `rounded-xl p-6` | Each group card |
+| Card title | `text-lg font-semibold text-slate-900 dark:text-white` | Group headers |
+| Body/helper text | `text-sm` / `text-xs` `text-slate-500 dark:text-slate-400` | Descriptions, helper text |
+| Input | `border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 focus:ring-2 focus:ring-blue-500` | Number inputs |
+| Primary button | `bg-blue-600 text-white hover:bg-blue-700 disabled:bg-blue-400` | Save |
+| Secondary button | `border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-100` | Reset |
+| Error | `border-red-400`, `text-red-600 dark:text-red-400`, `bg-red-50 dark:bg-red-900/30` | Validation + failure banner |
+| Success accent | `text-green-600` | Save-success glyph |
+| Optional pill | `text-xs text-slate-500 bg-slate-100 dark:bg-slate-700 rounded-full px-2 py-0.5` | Optional-field badge |
+| Spacing | `space-y-8` (between cards), `space-y-5` (between field rows) | Matches existing Settings column |
+
+---
+
+## 14. Test-ID inventory
+
+Pattern: `{component}-{element}`. The issue mandates the first four; the rest are derived for component + e2e coverage.
+
+| Test ID | Element |
+|---|---|
+| `settings-rules-form` | The Trading Rules section root (the `<form>`). **(issue-mandated)** |
+| `settings-save-rules` | Save trading rules button. **(issue-mandated)** |
+| `settings-reset-rules` | Reset to defaults button. **(issue-mandated)** |
+| `rules-field-{key}` | Per-field input — one per field key in §5–§8. **(issue-mandated pattern)** |
+| `settings-rules-tab` | The "Trading Rules" tab in the Settings tab bar (Option B). |
+| `settings-tab-general` | The "General" tab (Option B). |
+| `rules-field-{key}-error` | Per-field inline validation error message (also the `aria-describedby` target). |
+| `rules-field-dte_range_min` / `_max` | The two inputs of the DTE range field. |
+| `rules-field-delta_range_csp_min` / `_max` | The two inputs of the CSP delta range field. |
+| `rules-field-delta_range_cc_min` / `_max` | The two inputs of the CC delta range field. |
+| `rules-field-{key}-clear` | Clear button on a set Optional field (`min_iv_percentile`, `max_open_positions`, `hard_max_loss_pct`, `max_consecutive_rolls`). |
+| `rules-group-{universe\|entry\|position\|risk\|management}` | Each group card. |
+| `settings-rules-loading` | Skeleton form (loading state). |
+| `settings-rules-load-error` | Load-failure error block + Retry. |
+| `settings-rules-save-error` | Save-failure inline error banner. |
+| `settings-rules-save-success` | Save-success confirmation glyph. |
+| `settings-rules-defaults-note` | The "all defaults / never edited" note. |
+| `settings-rules-unsaved-hint` | The unsaved-changes hint in the footer. |
+| `settings-rules-reset-confirm` | The Reset `ConfirmDialog` (the dialog component already exposes its own test id — pass this through). |
+
+Per-field key list for `rules-field-{key}` (21 single + 3 range = 24 logical fields):
+`min_open_interest`, `max_bid_ask_spread_pct`, `min_iv_rank`, `min_iv_percentile`, `dte_range` (→ `_min`/`_max`), `delta_range_csp` (→ `_min`/`_max`), `delta_range_cc` (→ `_min`/`_max`), `min_monthly_return_pct`, `earnings_buffer_days`, `min_call_distance_pct`, `min_call_distance_from_cost_basis_pct`, `sizing_cap_dollars`, `max_ticker_concentration_pct`, `max_open_positions`, `loss_review_threshold_pct`, `hard_max_loss_pct`, `max_consecutive_rolls`, `profit_review_pct`, `dte_review_days`, `expiration_warning_days`, `assignment_risk_review`.
+
+---
+
+## 15. Accessibility checklist
+
+- Every input has a programmatically associated `<label htmlFor>`. Range fields have a visible group label plus a visually-hidden per-input label.
+- Error fields set `aria-invalid="true"`; valid fields set `aria-invalid="false"` (or omit).
+- `aria-describedby` links each input to its helper text id and, when invalid, its error id.
+- The save-failure and load-failure banners use `role="alert"` so they're announced.
+- The tab bar (Option B) uses `role="tablist"` / `role="tab"` / `role="tabpanel"` with `aria-selected`.
+- Focus order follows visual order: group by group, top to bottom, footer last.
+- Color is never the only signal — errors carry text, the success glyph carries a checkmark shape, Optional state carries the "Optional" word.
+
+---
+
+## 16. Figma Make prompt
+
+```
+Design a "Trading Rules" settings section for a data-dense engineering / trading dashboard.
+
+Layout:
+- A Settings page with a horizontal tab bar at top: "General" and "Trading Rules" (active).
+- The Trading Rules tab shows a section header: title "Trading Rules", subtitle "Configure your system. Set once."
+- Below it, five stacked group cards: Universe, Entry, Position, Risk, Management triggers.
+- Each card has a title, a one-line grey description, a divider, and a vertical list of field rows.
+- A field row: label on top, a number input with a small units-suffix box on its right ($, %, days, contracts), and grey helper text below. Some fields show two inputs joined by "to" (a min–max range).
+- Four fields show an "Optional" pill next to the label, an empty input with placeholder "Not set — no limit", and a small "Clear" link when filled.
+- One field shows a red-ringed input with a red error message below it (invalid state).
+- A footer with a grey "Reset to defaults" button (left) and a blue "Save trading rules" button (right), plus a small "You have unsaved changes" line.
+- Also show: a loading skeleton variant (shimmer rows) and an inline red error banner variant.
+
+Tokens:
+- Page background: white / dark slate-900
+- Card background: slate-50 / dark slate-800, 1px slate-200/700 border, rounded-xl, 24px padding
+- Primary accent: blue-600
+- Text: slate-900 headings, slate-500 helper text
+- Error: red-400 border, red-600 text, red-50 background
+- Font: system sans-serif
+- Border radius: rounded-lg inputs, rounded-xl cards
+
+Context: data-dense personal wheel-strategy trading dashboard, Next.js 16, React 19, Tailwind CSS 4, class-based dark mode. Match a dense, utilitarian settings-form density — compact rows, small text, no decorative imagery.
+```
+
+---
+
+## 17. Implementation notes for the Developer agent
+
+1. **Confirm the §3 decision first.** Option B (tabbed Settings page) is recommended; Option A (long single section) is the fallback. The field-group design is identical either way — only the page wrapper differs. Do not start until the user has picked.
+2. **Confirm against #156's `RulesConfig` model before wiring:** (a) percent convention — whole-percent assumed (§9); (b) `assignment_risk_review` type — enum `Off/Low/Medium/High` assumed (§4.4); (c) field key names exactly. If #156 isn't merged yet, this issue depends on it — sequence accordingly.
+3. **Endpoint is intentionally abstracted** (§10.1). Build `getRulesConfig()` / `saveRulesConfig()` in `api/client.js` against whichever endpoint #156 ships. The component must not hard-code the `{key,value}` vs typed-route choice.
+4. **Unset ≠ 0.** The four Optional fields (§8) save as `null` when blank. Empty-string is the only unset signal — `0` is a real value for some required fields. The component test for "Optional field renders empty and saves as unset without inventing a default" hangs on this.
+5. **Reuse, don't fork:** Settings-card shell (`bg-slate-50`), `ConfirmDialog`, `react-hot-toast`, the existing button classes. Do not pull in `Card.jsx` / `StatCard.jsx`.
+6. **Reconcile with #207.** #207 ships a V0.5.8.1 stopgap with a subset of these inputs (sizing cap + target yield). When this section lands, those stopgap inputs should be reconciled / removed — note the anchors, confirm with the user, out of scope to fix here but flag it in the PR.
+7. **Tests** (per CLAUDE.md — every AC gets coverage on the implementing PR): component tests for field render (label + helper), whole-percent convention guard, boundary validation (`min<max`, ranges), and the Optional-unset-saves-as-null case; Playwright e2e for edit→save→reload→persists and invalid→save-fails→inline-generic-error; accessibility assertions for label association and `aria-invalid`/`aria-describedby`.
+8. **Generic errors only** (CLAUDE.md): the save/load failure copy is fixed generic text — never interpolate an API exception.
+
+---
+
+## 18. Open questions
+
+1. **§3 — Option A vs Option B.** Tabbed Settings page (recommended) vs long single section. Blocks layout; needs a decision before implementation.
+2. **§4.4 — `assignment_risk_review` shape.** PRD gives default "High" but no value set. Enum `Off/Low/Medium/High` proposed; confirm against #156's `RulesConfig` model.
+3. **§9 — percent convention.** Spec assumes whole-percent per #156. If #156 stores fractions, a conversion layer is needed in the form's load/save mapping.
+4. **§10.1 — endpoint.** Generic `{key,value}` vs typed `/api/settings/rules` — undecided by design; resolved when #156 lands. Not a blocker for this spec.
+5. **Sequencing vs #156.** This issue's form depends on #156's `rules_config` model and persistence. Confirm #156 merges first, or that the field keys/shape are frozen.
+6. **§6 — `min_call_distance_pct` vs `min_call_distance_from_cost_basis_pct`.** Both are cost-basis-relative covered-call distance rules; #156 must define their distinct semantics (percentage margin vs hard floor) before this field's label and helper text can be finalised. An earlier draft's "from spot" description of `min_call_distance_pct` was a factual error, corrected per the #217 reconciliation of PRD #209.

--- a/frontend/e2e/settings-trading-rules.spec.js
+++ b/frontend/e2e/settings-trading-rules.spec.js
@@ -1,0 +1,480 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Settings → Trading Rules section (issue #158).
+ *
+ * Covers the issue's automated-coverage ACs:
+ *  - field renders with the correct label + helper text;
+ *  - the whole-percent convention is preserved 1:1 (no fraction conversion);
+ *  - boundary validation triggers (`min < max`, ranges, delta 0–1);
+ *  - an Optional/unset field renders empty and saves as `null` — not `0`;
+ *  - edit → save → reload → value persists;
+ *  - invalid value → save blocked → inline generic error;
+ *  - accessibility: label association, `aria-invalid` / `aria-describedby`.
+ *
+ * The `GET`/`PUT /api/settings/rules` endpoint is mocked so the spec is
+ * deterministic and exercises the frontend in isolation. A server-side `store`
+ * makes the round-trip test (save → reload → persists) real against the mock.
+ */
+
+/** The catalog-default `rules_config` payload the mocked GET returns. */
+function defaultRulesConfig() {
+  return {
+    schema_version: 1,
+    universe: {
+      min_open_interest: 500,
+      max_bid_ask_spread_pct: 10.0,
+      min_iv_rank: 30.0,
+      min_iv_percentile: null,
+    },
+    entry: {
+      dte_range: { min: 21, max: 45 },
+      delta_range_csp: { min: 0.2, max: 0.3 },
+      delta_range_cc: { min: 0.2, max: 0.35 },
+      min_monthly_return_pct: 2.0,
+      earnings_buffer_days: 7,
+      min_call_distance_pct: 5.0,
+      min_call_distance_from_cost_basis_pct: 0.0,
+    },
+    position: {
+      sizing_cap_dollars: 5000.0,
+      max_ticker_concentration_pct: 25.0,
+      max_open_positions: null,
+    },
+    risk: {
+      loss_review_threshold_pct: -15.0,
+      hard_max_loss_pct: null,
+      max_consecutive_rolls: null,
+    },
+    management: {
+      profit_review_pct: 50.0,
+      dte_review_days: 21,
+      expiration_warning_days: 7,
+      assignment_risk_review: 'High',
+    },
+  };
+}
+
+/**
+ * Mock the rules endpoint with a persistent in-memory store so PUT then a
+ * fresh GET (page reload) reflects the saved value. When `failSave` is set,
+ * the PUT responds 500 so the failure path can be exercised.
+ */
+function mockRulesEndpoint(page, { failSave = false } = {}) {
+  const store = { config: defaultRulesConfig() };
+  return page.route('**/api/settings/rules', (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(store.config),
+      });
+    }
+    if (method === 'PUT') {
+      if (failSave) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      const body = route.request().postDataJSON();
+      store.config = body;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/** Open the Settings page and switch to the Trading Rules tab. */
+async function openTradingRulesTab(page) {
+  await page.goto('/settings');
+  await page.getByTestId('settings-rules-tab').click();
+  await expect(page.getByTestId('settings-rules-form')).toBeVisible();
+}
+
+test.describe('Settings → Trading Rules — page & tabs', () => {
+  test('tab bar exposes General and Trading Rules tabs', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await page.goto('/settings');
+
+    await expect(page.getByTestId('settings-tab-general')).toBeVisible();
+    await expect(page.getByTestId('settings-rules-tab')).toBeVisible();
+
+    await page.getByTestId('settings-rules-tab').click();
+    const tab = page.getByTestId('settings-rules-tab');
+    await expect(tab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('section header states the mental model', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+    await expect(
+      page.getByText('Configure your system. Set once.'),
+    ).toBeVisible();
+  });
+
+  test('renders all five group cards', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+    for (const group of ['universe', 'entry', 'position', 'risk', 'management']) {
+      await expect(page.getByTestId(`rules-group-${group}`)).toBeVisible();
+    }
+  });
+});
+
+test.describe('Settings → Trading Rules — field render', () => {
+  test('a field renders with its label, helper text and value', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    const input = page.getByTestId('rules-field-min_open_interest');
+    await expect(input).toHaveValue('500');
+
+    const group = page.getByTestId('rules-group-universe');
+    await expect(group.getByText('Min option open interest')).toBeVisible();
+    await expect(
+      group.getByText(/standard liquidity floor for retail premium sellers/),
+    ).toBeVisible();
+  });
+
+  test('the two cost-basis fields have distinct labels (Q6)', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+    const group = page.getByTestId('rules-group-entry');
+    await expect(
+      group.getByText('Min call distance above cost basis (margin)'),
+    ).toBeVisible();
+    await expect(
+      group.getByText('Min call distance — hard cost-basis floor'),
+    ).toBeVisible();
+  });
+
+  test('whole-percent values render 1:1 with no fraction conversion', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+    // 25% stored as the whole number 25 — not 0.25.
+    await expect(
+      page.getByTestId('rules-field-max_ticker_concentration_pct'),
+    ).toHaveValue('25');
+    // Negative whole-percent loss threshold.
+    await expect(
+      page.getByTestId('rules-field-loss_review_threshold_pct'),
+    ).toHaveValue('-15');
+  });
+
+  test('assignment_risk_review renders as a Low/Medium/High select', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+    const select = page.getByTestId('rules-field-assignment_risk_review');
+    await expect(select).toHaveValue('High');
+    await expect(select.locator('option')).toHaveText([
+      'Low',
+      'Medium',
+      'High',
+    ]);
+  });
+});
+
+test.describe('Settings → Trading Rules — Optional fields', () => {
+  test('an unset Optional field renders empty with a non-numeric placeholder', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    const input = page.getByTestId('rules-field-max_open_positions');
+    await expect(input).toHaveValue('');
+    await expect(input).toHaveAttribute('placeholder', 'Not set — no limit');
+    // The Optional pill marks blank as a valid state.
+    const group = page.getByTestId('rules-group-position');
+    await expect(group.getByText('Optional', { exact: true })).toBeVisible();
+  });
+
+  test('an Optional field saves as null when left blank — not 0', async ({
+    page,
+  }) => {
+    let savedBody = null;
+    const store = { config: defaultRulesConfig() };
+    await page.route('**/api/settings/rules', (route) => {
+      const method = route.request().method();
+      if (method === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(store.config),
+        });
+      }
+      savedBody = route.request().postDataJSON();
+      store.config = savedBody;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(savedBody),
+      });
+    });
+
+    await openTradingRulesTab(page);
+    // Make an unrelated edit so Save enables, leaving the Optional field blank.
+    await page.getByTestId('rules-field-min_open_interest').fill('600');
+    await page.getByTestId('settings-save-rules').click();
+    await expect(page.getByTestId('settings-rules-save-success')).toBeVisible();
+
+    expect(savedBody).not.toBeNull();
+    expect(savedBody.position.max_open_positions).toBeNull();
+    expect(savedBody.risk.hard_max_loss_pct).toBeNull();
+    expect(savedBody.risk.max_consecutive_rolls).toBeNull();
+    expect(savedBody.universe.min_iv_percentile).toBeNull();
+  });
+
+  test('a Clear button returns a set Optional field to unset', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    const input = page.getByTestId('rules-field-max_open_positions');
+    await input.fill('8');
+    await expect(
+      page.getByTestId('rules-field-max_open_positions-clear'),
+    ).toBeVisible();
+    await page.getByTestId('rules-field-max_open_positions-clear').click();
+    await expect(input).toHaveValue('');
+  });
+});
+
+test.describe('Settings → Trading Rules — validation', () => {
+  test('an inverted range (min >= max) shows an inline error and blocks save', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-dte_range_min').fill('60');
+    await page.getByTestId('rules-field-dte_range_max').fill('30');
+    await page.getByTestId('rules-field-dte_range_max').blur();
+
+    const error = page.getByTestId('rules-field-dte_range-error');
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText('Minimum must be less than maximum.');
+    await expect(page.getByTestId('settings-save-rules')).toBeDisabled();
+  });
+
+  test('a delta bound outside 0–1 shows an inline error', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-delta_range_csp_max').fill('1.5');
+    await page.getByTestId('rules-field-delta_range_csp_max').blur();
+
+    const error = page.getByTestId('rules-field-delta_range_csp-error');
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText('Delta must be between 0 and 1.');
+  });
+
+  test('a positive loss threshold is rejected', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-loss_review_threshold_pct').fill('15');
+    await page.getByTestId('rules-field-loss_review_threshold_pct').blur();
+
+    const error = page.getByTestId(
+      'rules-field-loss_review_threshold_pct-error',
+    );
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText(
+      'Enter a loss as a negative percentage (0 or below).',
+    );
+  });
+
+  test('a percent over 100 is rejected', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-min_iv_rank').fill('150');
+    await page.getByTestId('rules-field-min_iv_rank').blur();
+
+    await expect(page.getByTestId('rules-field-min_iv_rank-error')).toHaveText(
+      'Enter a percentage between 0 and 100.',
+    );
+  });
+
+  test('a blank Optional field is always valid', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    // Set then clear an Optional field — never an error.
+    await page.getByTestId('rules-field-hard_max_loss_pct').fill('-25');
+    await page.getByTestId('rules-field-hard_max_loss_pct').fill('');
+    await page.getByTestId('rules-field-hard_max_loss_pct').blur();
+    await expect(
+      page.getByTestId('rules-field-hard_max_loss_pct-error'),
+    ).toHaveCount(0);
+  });
+});
+
+test.describe('Settings → Trading Rules — save lifecycle', () => {
+  test('edit → save → reload → value persists', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-dte_range_max').fill('60');
+    await page.getByTestId('settings-save-rules').click();
+    await expect(page.getByTestId('settings-rules-save-success')).toBeVisible();
+
+    // Reload the page — the mock store keeps the saved value.
+    await openTradingRulesTab(page);
+    await expect(page.getByTestId('rules-field-dte_range_max')).toHaveValue(
+      '60',
+    );
+  });
+
+  test('save failure shows a generic inline error, never a raw exception', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page, { failSave: true });
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-dte_range_max').fill('50');
+    await page.getByTestId('settings-save-rules').click();
+
+    const banner = page.getByTestId('settings-rules-save-error');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(
+      "Couldn't save your trading rules. Please try again.",
+    );
+    // The raw exception text from the mock 500 must not leak.
+    await expect(banner).not.toContainText('Internal Server Error');
+  });
+
+  test('Save is disabled until there is an unsaved change', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await expect(page.getByTestId('settings-save-rules')).toBeDisabled();
+    await page.getByTestId('rules-field-min_open_interest').fill('600');
+    await expect(page.getByTestId('settings-save-rules')).toBeEnabled();
+    await expect(
+      page.getByTestId('settings-rules-unsaved-hint'),
+    ).toBeVisible();
+  });
+
+  test('Reset to defaults opens a confirm dialog and restores defaults', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    await page.getByTestId('rules-field-min_open_interest').fill('999');
+    await page.getByTestId('settings-reset-rules').click();
+    await expect(page.getByTestId('confirm-dialog')).toBeVisible();
+    await page.getByTestId('confirm-dialog-confirm').click();
+
+    await expect(
+      page.getByTestId('rules-field-min_open_interest'),
+    ).toHaveValue('500');
+    // Optional fields reset to unset, not to a proposed number.
+    await expect(
+      page.getByTestId('rules-field-max_open_positions'),
+    ).toHaveValue('');
+  });
+});
+
+test.describe('Settings → Trading Rules — load failure', () => {
+  test('a failed config GET shows a generic error block with Retry', async ({
+    page,
+  }) => {
+    let calls = 0;
+    await page.route('**/api/settings/rules', (route) => {
+      calls += 1;
+      if (route.request().method() === 'GET' && calls === 1) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(defaultRulesConfig()),
+      });
+    });
+
+    await page.goto('/settings');
+    await page.getByTestId('settings-rules-tab').click();
+
+    const errorBlock = page.getByTestId('settings-rules-load-error');
+    await expect(errorBlock).toBeVisible();
+    await expect(errorBlock).toContainText(
+      "Couldn't load your trading rules.",
+    );
+    await expect(errorBlock).not.toContainText('Internal Server Error');
+
+    // Retry succeeds — the form renders.
+    await errorBlock.getByRole('button', { name: 'Retry' }).click();
+    await expect(page.getByTestId('settings-rules-form')).toBeVisible();
+  });
+});
+
+test.describe('Settings → Trading Rules — accessibility', () => {
+  test('every input is associated with a label', async ({ page }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    // A labelled scalar input.
+    await expect(
+      page.getByLabel('Min option open interest'),
+    ).toBeVisible();
+    // A range field's visually-hidden per-input labels.
+    await expect(page.getByLabel('DTE minimum')).toBeVisible();
+    await expect(page.getByLabel('DTE maximum')).toBeVisible();
+  });
+
+  test('a valid field has aria-invalid=false and aria-describedby its help', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    const input = page.getByTestId('rules-field-min_open_interest');
+    await expect(input).toHaveAttribute('aria-invalid', 'false');
+    await expect(input).toHaveAttribute(
+      'aria-describedby',
+      'rules-field-min_open_interest-help',
+    );
+  });
+
+  test('an invalid field announces via aria-invalid and aria-describedby', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await openTradingRulesTab(page);
+
+    const input = page.getByTestId('rules-field-min_iv_rank');
+    await input.fill('150');
+    await input.blur();
+
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    await expect(input).toHaveAttribute(
+      'aria-describedby',
+      'rules-field-min_iv_rank-help rules-field-min_iv_rank-error',
+    );
+  });
+});


### PR DESCRIPTION
Closes #158.

Adds the frontend edit surface for the `rules_config` keystone (#156) — a tabbed Settings page (`General` | `Trading Rules`) where the trader can edit the universe, entry, position, risk, and management-trigger rules without touching JSON. Built to the approved design spec (`frontend/design-specs/issue-158-trading-rules-settings.md`, Option B).

## Endpoint decision — added a typed endpoint

The generic `GET /api/settings` returns a fixed `SettingsResponse` and cannot read `rules_config` back; the generic `PUT` is write-only `{key,value}`. So this PR adds a minimal **typed `GET`/`PUT /api/settings/rules`** pair backed by `load_rules_config` + the existing `app_settings` key/value row (no new table, no migration). `PUT` validates the body against the `RulesConfig` Pydantic model — out-of-range values are rejected `422` before anything is written — and re-stamps the schema version.

## Design-spec open questions, resolved against the #156 model

- **Q2 — `assignment_risk_review`:** #156 models it `Literal["High","Medium","Low"]`. There is **no "Off"** value — the select offers exactly Low / Medium / High.
- **Q3 — percent convention:** `rules_config` standardises on **whole-percent** (`10.0` == 10%). The form is 1:1 with the stored value — no human↔fraction conversion.
- **Q6 — the two cost-basis fields:** per the #156 `EntryRules` docstring, `min_call_distance_pct` is the *premium-quality margin above adjusted cost basis*; `min_call_distance_from_cost_basis_pct` is the *hard at-or-above-cost-basis loss-avoidance floor*. They now carry distinct labels and helper text reflecting those definitions.

## Acceptance criteria

- [x] Trading Rules surface reachable from Settings; header states "Configure your system. Set once."
- [x] Built so a sibling "Trading OKRs" tab slots in for V1.1 with no rework (page-scoped tab bar).
- [x] All five `rules_config` groups (Universe / Entry / Position / Risk / Management triggers) with their fields.
- [x] Optional fields (`min_iv_percentile`, `max_open_positions`, `hard_max_loss_pct`, `max_consecutive_rolls`) render clearable/empty and save as `null` — never `0`, never an invented default.
- [x] Each field: label, input, units suffix, helper text, default-as-placeholder.
- [x] Percent inputs accept human values and persist whole-percent.
- [x] Inline validation mirroring the backend Pydantic validators (`min < max`, ranges, delta 0–1); errors announce via `aria-invalid` + `aria-describedby`.
- [x] Reset to defaults (blue-variant `ConfirmDialog`).
- [x] Loading skeleton / saving / success toast+glyph / generic failure banner.
- [x] Reads/writes `rules_config` via `getRulesConfig` / `saveRulesConfig` helpers.
- [x] Test IDs: `settings-rules-form`, `settings-save-rules`, `settings-reset-rules`, `rules-field-{key}`.
- [x] Component-level tests, e2e tests, and accessibility assertions.

## Tests

- `backend/tests/test_settings_rules_endpoint.py` — 11 tests: round-trip, `null` persistence, schema re-stamp, and `422` rejection of inverted ranges / out-of-range deltas / positive loss thresholds.
- `frontend/e2e/settings-trading-rules.spec.js` — 23 tests: field render (label + helper), the whole-percent guard, boundary validation, Optional-unset-saves-as-`null`, edit→save→reload→persists, invalid→save-blocked→generic inline error, load-failure→Retry, and accessibility.

**Results:** `npm run lint` clean (1 pre-existing unrelated warning), `npm run build` passes, 23/23 Playwright specs pass, 11/11 new backend tests pass (96 passed across the rules/settings suites — no regressions).

## Notes / follow-ups

- **Dashboard cache invalidation:** the dashboard uses a per-mount fetch (`useDashboard`) with no persistent cache layer, so rule changes already reflect on the next dashboard view — no explicit invalidation hook needed.
- **#207 reconciliation (out of scope, flagged):** #207 ships a V0.5.8.1 stopgap with a subset of these inputs (sizing cap + target yield). Those stopgap inputs should be reconciled/removed once this page lands — noted here per the issue's cross-reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)