### PR TITLE
Hotfix: force-dynamic rendering so nonce CSP reaches inline scripts (closes #229)

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -12,6 +12,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/frontend/app/layout.jsx
+++ b/frontend/app/layout.jsx
@@ -6,6 +6,26 @@ export const metadata = {
   description: 'Financial regression analysis tool',
 };
 
+/**
+ * Force every route to render per-request (issue #229).
+ *
+ * `frontend/middleware.js` mints a fresh per-request CSP nonce and emits
+ * `script-src 'nonce-…'` on every response. For that nonce to be honoured the
+ * inline framework `<script>` tags must carry the *same* nonce — and Next.js
+ * only stamps it onto them when the page is rendered per-request.
+ *
+ * Statically prerendered pages bake their HTML (and nonce-less inline scripts)
+ * at build time, before the middleware exists. The browser then blocks those
+ * inline scripts against the per-request nonce CSP, hydration never runs, and
+ * the page hangs on its loading skeleton (the v1.0.0 production outage).
+ *
+ * Setting `force-dynamic` on the root layout cascades to all routes, so the
+ * nonce always reaches render. This app is per-user and authenticated — it has
+ * no meaningful static content, so opting out of static optimization costs
+ * nothing. Do not remove this without also removing the nonce CSP.
+ */
+export const dynamic = 'force-dynamic';
+
 export default function RootLayout({ children }) {
   return (
     <html lang="en" suppressHydrationWarning>

--- a/frontend/e2e/csp-nonce.prod.spec.js
+++ b/frontend/e2e/csp-nonce.prod.spec.js
@@ -24,8 +24,9 @@ import { test, expect } from '@playwright/test';
  *
  * Auth-aware (mirrors `csp-nonce.spec.js`): with `NEXTAUTH_SECRET` set when the
  * server starts, `/dashboard` 307s to `/auth/signin` (matcher-excluded) and the
- * rendered-page assertions skip with a documented reason. The full suite runs
- * when auth is off (the CI default).
+ * rendered-page assertions skip with a documented reason. Run with auth off
+ * (`NEXTAUTH_SECRET` unset) to exercise the full suite — CI does not run this
+ * suite today (see issue #231 to wire it in).
  */
 
 /**

--- a/frontend/e2e/csp-nonce.prod.spec.js
+++ b/frontend/e2e/csp-nonce.prod.spec.js
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #229 — production regression guard for the nonce-based CSP (#33).
+ *
+ * The v1.0.0 release shipped nonce-based CSP (`frontend/middleware.js`, #33). It
+ * broke production: `/dashboard` was statically prerendered at build time, so
+ * its inline framework `<script>` tags carried no nonce — while the middleware
+ * still emits a fresh per-request `script-src 'nonce-…'` CSP on every response.
+ * The browser blocked the nonce-less inline `__next_f` hydration scripts, React
+ * never hydrated, and the page hung forever on its loading skeleton.
+ *
+ * `csp-nonce.spec.js` could not catch this: it runs against `next dev`, which
+ * never statically prerenders, so its inline-script nonce check always passed.
+ * This suite runs against a *production build* (`next build && next start`, see
+ * `playwright.prod.config.js`) — the only environment where the bug reproduces.
+ * Run pre-fix, the second and third tests below FAIL.
+ *
+ * The fix (`app/layout.jsx`) sets `export const dynamic = 'force-dynamic'`,
+ * which forces every route to render per-request so the middleware nonce
+ * reaches Next.js at render time and is stamped onto the inline scripts.
+ *
+ * Run: `npm run test:e2e:prod`.
+ *
+ * Auth-aware (mirrors `csp-nonce.spec.js`): with `NEXTAUTH_SECRET` set when the
+ * server starts, `/dashboard` 307s to `/auth/signin` (matcher-excluded) and the
+ * rendered-page assertions skip with a documented reason. The full suite runs
+ * when auth is off (the CI default).
+ */
+
+/**
+ * Extract the `script-src` directive substring from a CSP header value.
+ * @param {string | undefined} csp - The raw Content-Security-Policy header.
+ * @returns {string} The `script-src` directive, or '' if absent.
+ */
+function scriptSrcDirective(csp) {
+  if (!csp) return '';
+  const directive = csp
+    .split(';')
+    .map((part) => part.trim())
+    .find((part) => part.startsWith('script-src'));
+  return directive ?? '';
+}
+
+/**
+ * Parse the nonce value out of a CSP header's `script-src` directive.
+ * @param {string | undefined} csp - The raw Content-Security-Policy header.
+ * @returns {string | null} The nonce, or null if no nonce token is present.
+ */
+function parseNonce(csp) {
+  const match = scriptSrcDirective(csp).match(/'nonce-([A-Za-z0-9+/=]+)'/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Fetch `/dashboard` without following redirects, so the captured response is
+ * the one the Next.js middleware produced for this request.
+ * @param {import('@playwright/test').APIRequestContext} request
+ * @returns {Promise<import('@playwright/test').APIResponse>}
+ */
+function fetchDashboard(request) {
+  return request.get('/dashboard', { maxRedirects: 0 });
+}
+
+test.describe('Nonce CSP — production build (#229)', () => {
+  test('/dashboard is rendered dynamically, not statically prerendered', async ({
+    request,
+  }) => {
+    const response = await fetchDashboard(request);
+    test.skip(
+      response.status() >= 300 && response.status() < 400,
+      'Auth enforced — /dashboard redirects; dynamic-render check needs a rendered page',
+    );
+
+    expect(response.status()).toBe(200);
+    // A statically prerendered route is served with the `x-nextjs-prerender`
+    // header. `force-dynamic` (app/layout.jsx) renders the route per-request
+    // instead — which is what lets the middleware's per-request nonce reach
+    // render. If this header reappears, the #229 outage is back.
+    expect(
+      response.headers()['x-nextjs-prerender'],
+      '/dashboard must not be statically prerendered (issue #229)',
+    ).toBeUndefined();
+  });
+
+  test('inline framework scripts carry the per-request nonce in production HTML', async ({
+    request,
+  }) => {
+    const response = await fetchDashboard(request);
+    test.skip(
+      response.status() >= 300 && response.status() < 400,
+      'Auth enforced — /dashboard redirects; inline-script check needs a rendered page',
+    );
+
+    const headerNonce = parseNonce(
+      response.headers()['content-security-policy'],
+    );
+    expect(headerNonce, 'response CSP carries a nonce').toBeTruthy();
+
+    // Assert against the raw server-emitted HTML. On the pre-fix production
+    // build, `/dashboard` is prerendered and its inline `__next_f` scripts have
+    // no nonce attribute at all — so `nonceAttrs` is empty and this fails.
+    const html = await response.text();
+    const nonceAttrs = [
+      ...html.matchAll(/<script[^>]*\snonce="([A-Za-z0-9+/=]+)"/gi),
+    ].map((m) => m[1]);
+
+    expect(
+      nonceAttrs.length,
+      'at least one inline <script> in the production HTML carries a nonce',
+    ).toBeGreaterThan(0);
+    // Every nonce Next.js stamped must equal the one in the response header,
+    // or the browser blocks the script.
+    for (const attr of nonceAttrs) {
+      expect(
+        attr,
+        'each inline script nonce matches the response CSP nonce',
+      ).toBe(headerNonce);
+    }
+  });
+
+  test('the dashboard hydrates under the nonce CSP with no script-src violations', async ({
+    page,
+    request,
+  }) => {
+    const probe = await fetchDashboard(request);
+    test.skip(
+      probe.status() >= 300 && probe.status() < 400,
+      'Auth enforced — /dashboard redirects; hydration covered when auth is off',
+    );
+
+    const cspViolations = [];
+    page.on('console', (msg) => {
+      const text = msg.text();
+      if (/content security policy/i.test(text) && /script/i.test(text)) {
+        cspViolations.push(text);
+      }
+    });
+
+    await page.goto('/dashboard');
+
+    // The dark-mode toggle lives inside the client-only DashboardPage. A
+    // working toggle proves React hydrated — i.e. the inline framework scripts
+    // executed under the nonce CSP. Pre-fix, those scripts were blocked, the
+    // client bundle never booted, and the toggle never appeared.
+    const toggle = page.getByTestId('dark-mode-toggle');
+    await expect(toggle).toBeVisible({ timeout: 15000 });
+
+    const html = page.locator('html');
+    const hadDark = await html.evaluate((el) => el.classList.contains('dark'));
+    await toggle.click();
+    if (hadDark) {
+      await expect(html).not.toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    } else {
+      await expect(html).toHaveClass(/(?:^|\s)dark(?:\s|$)/);
+    }
+
+    expect(
+      cspViolations,
+      `no script-src CSP violations: ${cspViolations.join(' | ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test:e2e": "playwright test",
+    "test:e2e:prod": "playwright test --config playwright.prod.config.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -2,6 +2,9 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './e2e',
+  // `*.prod.spec.js` needs a production build — it runs under
+  // `playwright.prod.config.js` (`npm run test:e2e:prod`), not `next dev`.
+  testIgnore: /.*\.prod\.spec\.js/,
   timeout: 60000,
   use: {
     baseURL: 'http://localhost:3000',

--- a/frontend/playwright.prod.config.js
+++ b/frontend/playwright.prod.config.js
@@ -1,0 +1,37 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * Production-build Playwright config — regression guard for issue #229.
+ *
+ * The default config (`playwright.config.js`) runs against `npm run dev`, which
+ * never statically prerenders pages. The v1.0.0 nonce-CSP outage (#229) only
+ * reproduces on a *production* build, where routes are prerendered at build
+ * time and their inline framework scripts are baked without a nonce.
+ *
+ * This config runs `next build && next start` so `e2e/*.prod.spec.js` exercises
+ * real production rendering. It is a separate config (not a project in the
+ * default one) because the two need different web servers and base URLs.
+ *
+ * Run: `npm run test:e2e:prod`.
+ */
+const PORT = 3100;
+
+export default defineConfig({
+  testDir: './e2e',
+  // Only the production-build specs — the default config runs everything else.
+  testMatch: /.*\.prod\.spec\.js/,
+  timeout: 60000,
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+  },
+  webServer: {
+    // A fresh production build, then serve it exactly as production does.
+    command: `npm run build && npm run start -- --port ${PORT}`,
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+    // `next build` is slow on a cold cache — allow generous startup time.
+    timeout: 240000,
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});


### PR DESCRIPTION
## Production incident — v1.0.0 dashboard never loads

Closes #229. `https://regression.shawnjsandy.com/` returns HTTP 200 but hangs forever on the loading skeleton — React never hydrates.

### Root cause

PR #223 (issue #33) added nonce-based CSP in `frontend/middleware.js`: a fresh per-request nonce is minted and `script-src 'self' 'nonce-…' 'wasm-unsafe-eval'` is emitted on **every** response.

`/dashboard` is **statically prerendered at build time** (`x-nextjs-prerender: 1`, `cache-control: s-maxage=31536000`). Its HTML — including the inline `__next_f` React hydration scripts — was rendered once at build time, before any middleware/nonce existed, so those inline scripts carry **no `nonce` attribute**.

A nonce in `script-src` makes the browser block every inline `<script>` without a matching nonce. The blocked `__next_f` payload means no RSC data → no hydration → permanent skeleton.

`/` worked because it is dynamically rendered (per-request redirect), so the middleware nonce reached its inline scripts.

### Fix

`export const dynamic = 'force-dynamic'` on the root layout (`app/layout.jsx`). It cascades to every route, forcing per-request rendering so the middleware nonce reaches render and is stamped onto the inline scripts — the path `/` already used. Build output confirms: every route is now `ƒ (Dynamic)`; none `○ (Static)`. This app is per-user and authenticated, so it had no meaningful static content to lose. Issue #33's CSP hardening is fully preserved.

### Why it shipped undetected

- `e2e/csp-nonce.spec.js` runs against `next dev`, which **never statically prerenders** — its inline-script nonce check always passed in dev.
- CI runs frontend `lint` + `build` only, not e2e.
- The compose healthcheck hits `/`, which 307-redirects (status < 400 = "healthy"), masking the dead app.

### Regression test

New `e2e/csp-nonce.prod.spec.js` runs against a **real production build** via `playwright.prod.config.js` (`npm run test:e2e:prod`) — the only environment where the bug reproduces. It asserts `/dashboard` is not statically prerendered, its inline scripts carry the per-request nonce, and the page hydrates with no `script-src` CSP violations.

Verified locally (auth off):
- **Pre-fix build** (`/dashboard` = `○ Static`): all 3 tests **fail** — `dark-mode-toggle` never appears, exactly the production symptom.
- **With the fix** (`/dashboard` = `ƒ Dynamic`): all 3 tests **pass**; runtime curl confirms all 4 inline scripts carry the matching nonce (pre-fix: 0).

### Test plan

- [x] `npm run lint` — clean (1 pre-existing unrelated warning)
- [x] `npm run build` — every route `ƒ (Dynamic)`
- [x] `npm run test:e2e:prod` — 3/3 pass with fix, 3/3 fail without
- [ ] Redeploy and confirm `https://regression.shawnjsandy.com/dashboard` hydrates

### Follow-ups (not in this hotfix)

- CI runs no e2e — add a `test:e2e:prod` job so prerender regressions are caught before release.
- The compose healthcheck should probe a route that proves hydration, not `/`'s redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)