### PR TITLE
Recovery page honors the Trading Rules Layer — flag gate + sizing-cap relabel (closes #235)

### DIFF
--- a/backend/app/routers/positions.py
+++ b/backend/app/routers/positions.py
@@ -9,9 +9,12 @@ Branch shape:
 - 404 — ``Position not found``
 - ``state == "not-applicable"`` — option-only positions (``shares == 0``)
   or closed positions; engine never runs.
-- ``state == "not-flagged"`` — position above the review threshold (-5% or
-  -$1,000); engine never runs. Returned with the position summary so the
-  frontend can render the EmptyState.
+- ``state == "not-flagged"`` — position above the review threshold; engine
+  never runs. The percentage threshold is the configured
+  ``rules_config.risk.loss_review_threshold_pct`` (Trading Rules Layer,
+  issue #156); the -$1,000 dollar trigger is a retained absolute-loss floor.
+  Returned with the position summary so the frontend can render the
+  EmptyState.
 - ``state == "populated"`` — full payload with paths + recommendation.
 - 500 — Schwab quote failure. Generic detail message per CLAUDE.md; no
   ``str(e)`` leaks.
@@ -34,7 +37,7 @@ from app.services.recovery_engine import (
     WHEEL_MONTHLY_PREMIUM_PCT,
     compute_recovery_paths,
 )
-from app.services.rules_config import load_rules_config
+from app.services.rules_config import RulesConfig, load_rules_config
 from app.services.recovery_scoring import DISCLAIMER_TEXT, score_recovery_paths
 from app.services.schwab_client import SchwabClient
 
@@ -42,10 +45,16 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/positions", tags=["positions"])
 
-# Largest-loser flag thresholds — must mirror
+# Largest-loser dollar flag threshold. The *percentage* side of the flag
+# gate is the configured ``rules_config.risk.loss_review_threshold_pct``
+# (Trading Rules Layer, issue #156) — resolved per-request and passed into
+# :func:`_is_flagged`. This dollar threshold is an intentionally-retained
+# absolute-loss secondary OR-trigger: PRD #209 §R5 models the loss-review
+# rule as a percentage only, so a large-share position with a shallow
+# percentage loss still flags on absolute dollars. It is a hardcoded
+# heuristic, not a trader-facing rule (ADR-002), and must mirror
 # :mod:`app.services.action_engine` so the dashboard CTA and the recovery
 # page agree on what "flagged" means.
-LARGE_LOSER_PCT_THRESHOLD: float = -0.05
 LARGE_LOSER_DOLLAR_THRESHOLD: float = -1000.0
 
 # Cost-basis-zero positions can't be meaningfully underwater (recovery
@@ -64,7 +73,7 @@ def _get_app_setting(db: DBSession, key: str) -> str | None:
     return entry.value if entry else None
 
 
-def _read_okr_settings(db: DBSession) -> dict[str, Any]:
+def _read_okr_settings(db: DBSession, rules: RulesConfig) -> dict[str, Any]:
     """Read the recovery-engine scoring inputs from settings.
 
     Two of these are OKR reads on flat ``app_settings`` keys (ADR-001: target
@@ -74,10 +83,10 @@ def _read_okr_settings(db: DBSession) -> dict[str, Any]:
     - ``okr_strategy_preference`` → ``None`` (dormant bonus row in V0.5.8)
 
     The per-position sizing cap is **no longer** an ``okr_*`` flat key. Per
-    ADR-001 it is a Trading Rule, so it is resolved from
-    ``rules_config.position.sizing_cap_dollars`` via
-    :func:`app.services.rules_config.load_rules_config` (issue #156). With no
-    stored ``rules_config`` row that resolves to the catalog default ($5,000).
+    ADR-001 it is a Trading Rule, so it is read from the already-resolved
+    ``rules.position.sizing_cap_dollars`` (issue #156). The caller resolves
+    the :class:`RulesConfig` once and passes it in; with no stored
+    ``rules_config`` row it carries the catalog default ($5,000).
     """
     target_raw = _get_app_setting(db, "okr_target_yield")
     pref_raw = _get_app_setting(db, "okr_strategy_preference")
@@ -89,7 +98,7 @@ def _read_okr_settings(db: DBSession) -> dict[str, Any]:
         target_yield = None
 
     # Sizing cap comes from rules_config (issue #156), not an okr_* flat key.
-    sizing_cap = load_rules_config(db).position.sizing_cap_dollars
+    sizing_cap = rules.position.sizing_cap_dollars
 
     strategy_preference = pref_raw if pref_raw not in (None, "") else None
 
@@ -140,13 +149,27 @@ def _build_position_summary(
     }
 
 
-def _is_flagged(unrealized_pl: float | None, pl_pct: float | None) -> bool:
-    """Mirror the action-engine flag rule: either threshold trips it."""
+def _is_flagged(
+    unrealized_pl: float | None,
+    pl_pct: float | None,
+    loss_review_threshold_pct: float,
+) -> bool:
+    """Decide whether a position is flagged for a recovery plan.
+
+    Mirrors the action-engine largest-loser rule: either trigger trips it.
+
+    - ``loss_review_threshold_pct`` is the configured
+      ``rules_config.risk.loss_review_threshold_pct`` — a *whole-percent*
+      value (e.g. ``-15.0`` for −15%). ``pl_pct`` is a *fraction* (e.g.
+      ``-0.15``), so the threshold is divided by 100 before comparison.
+    - :data:`LARGE_LOSER_DOLLAR_THRESHOLD` is the retained absolute-loss
+      secondary OR-trigger.
+    """
     if unrealized_pl is None:
         return False
     if unrealized_pl <= LARGE_LOSER_DOLLAR_THRESHOLD:
         return True
-    if pl_pct is not None and pl_pct <= LARGE_LOSER_PCT_THRESHOLD:
+    if pl_pct is not None and pl_pct <= loss_review_threshold_pct / 100.0:
         return True
     return False
 
@@ -185,7 +208,7 @@ def _build_assumptions_panel(
         {
             "label": "Sizing cap (Average down)",
             "value": _format_dollar(okr.get("sizing_cap_dollars")),
-            "source": "Settings → OKRs",
+            "source": "Settings → Trading Rules",
         },
         {
             "label": "Strategy preference",
@@ -265,8 +288,16 @@ def build_recovery_plan(
             content={"detail": GENERIC_RECOVERY_500_DETAIL},
         )
 
+    # Resolve the Trading Rules config once (issue #156) — the flag gate's
+    # loss-review threshold and the sizing cap both come from it.
+    rules = load_rules_config(db)
+
     summary = _build_position_summary(position, current_price, cost_basis=cost_basis)
-    if not _is_flagged(summary["unrealized_pl"], summary["pl_pct"]):
+    if not _is_flagged(
+        summary["unrealized_pl"],
+        summary["pl_pct"],
+        rules.risk.loss_review_threshold_pct,
+    ):
         return RecoveryPlanResponse(
             position_id=position_id,
             as_of=as_of,
@@ -279,7 +310,7 @@ def build_recovery_plan(
             disclaimer=DISCLAIMER_TEXT,
         )
 
-    okr = _read_okr_settings(db)
+    okr = _read_okr_settings(db, rules)
 
     paths = compute_recovery_paths(
         position=position,

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -38,8 +38,16 @@ MAX_ACTIONS = 8
 # Mirrors the 48-hour log threshold in ``schwab_auth.py:_refresh_tokens``.
 TOKEN_EXPIRING_DAYS = 2
 
-# Large-loser thresholds (spec §2.2 / Q1). Whichever fires first.
-LARGE_LOSER_PCT_THRESHOLD = -0.05  # -5%
+# Large-loser dollar threshold (spec §2.2 / Q1). The *percentage* side of the
+# largest-loser trigger is the configured
+# ``rules_config.risk.loss_review_threshold_pct`` (Trading Rules Layer, issue
+# #156), resolved by the dashboard and passed into ``_largest_loser_action``.
+# This dollar threshold is an intentionally-retained absolute-loss secondary
+# OR-trigger — PRD #209 §R5 models the loss-review rule as a percentage only,
+# so a large-share position with a shallow percentage loss still flags on
+# absolute dollars. It is a hardcoded heuristic, not a trader-facing rule
+# (ADR-002), and mirrors :mod:`app.routers.positions` so the dashboard CTA and
+# the recovery page agree on what "flagged" means.
 LARGE_LOSER_DOLLAR_THRESHOLD = -1000.0  # -$1,000
 
 # Cap on per-leg ITM short-DTE cards. Spec §2.2: "one card per leg, capped
@@ -234,12 +242,21 @@ def _schwab_token_expiring_action(
     }
 
 
-def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
+def _largest_loser_action(
+    positions: Iterable[dict], loss_review_threshold_pct: float
+) -> dict | None:
     """Build a ``position.large_loser`` card for the single worst loser.
 
     Spec §2.2: surface only the single largest loser per cycle, even when
     multiple positions breach the threshold. Trigger is whichever-fires-first
-    between ``unrealized_pl_pct <= -5%`` and ``unrealized_pl <= -$1,000``.
+    between the configured loss-review threshold and ``-$1,000``.
+
+    ``loss_review_threshold_pct`` is the configured
+    ``rules_config.risk.loss_review_threshold_pct`` — a *whole-percent* value
+    (e.g. ``-15.0`` for −15%). ``pl_pct`` is a *fraction* (e.g. ``-0.15``), so
+    the threshold is divided by 100 before comparison. This mirrors
+    :func:`app.routers.positions._is_flagged` so the dashboard largest-loser
+    card and the recovery flag gate agree.
     """
     candidates: list[tuple[float, dict]] = []
     for row in positions:
@@ -248,7 +265,7 @@ def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
             continue
         pct = row.get("pl_pct")
         triggered = unrealized_pl <= LARGE_LOSER_DOLLAR_THRESHOLD or (
-            pct is not None and pct <= LARGE_LOSER_PCT_THRESHOLD
+            pct is not None and pct <= loss_review_threshold_pct / 100.0
         )
         if not triggered:
             continue
@@ -274,7 +291,10 @@ def _largest_loser_action(positions: Iterable[dict]) -> dict | None:
         "priority": "P0",
         "title": f"Review {ticker}",
         "subject": {"ticker": ticker, "amount": amount},
-        "reason": "Position is below your review threshold (-5% or -$1,000).",
+        "reason": (
+            f"Position is below your {loss_review_threshold_pct:g}% "
+            "review threshold (or -$1,000 absolute)."
+        ),
         # V0.5.8 (#182): the CTA destination moved from the Journal filter
         # page to the new Recovery Plan route. Same PR ships the
         # destination so the link never 404s mid-deploy.
@@ -526,7 +546,9 @@ def compute_next_actions(
     if token_card is not None:
         candidates.append(token_card)
 
-    loser_card = _largest_loser_action(positions)
+    loser_card = _largest_loser_action(
+        positions, rules.risk.loss_review_threshold_pct
+    )
     if loser_card is not None:
         candidates.append(loser_card)
 

--- a/backend/app/services/recovery_engine.py
+++ b/backend/app/services/recovery_engine.py
@@ -234,7 +234,8 @@ def _average_down_path(
 
     # Sizing cap gate. Per design spec §3.3 the reason text contains the
     # word "sizing cap" so the frontend CTA mapper routes the user to
-    # /settings#okrs.
+    # the Settings → Trading Rules tab (/settings?tab=rules) — the sizing
+    # cap is a Trading Rule (issue #156), not an OKR.
     if capital_tied_up > sizing_cap_dollars:
         return {
             "path_id": "average-down",
@@ -248,7 +249,7 @@ def _average_down_path(
             "months_to_breakeven": _empty_range(),
             "opportunity_cost_vs_baseline": None,
             "assumptions": [
-                f"Sizing cap from Settings → OKRs: {_format_dollar(sizing_cap_dollars)}.",
+                f"Sizing cap from Settings → Trading Rules: {_format_dollar(sizing_cap_dollars)}.",
                 (
                     f"Adding {_format_dollar(additional_capital)} would tie up "
                     f"{_format_dollar(capital_tied_up)} total."

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -20,6 +20,19 @@ from app.services.action_engine import (
     MAX_ACTIONS,
     compute_next_actions,
 )
+from app.services.rules_config import RiskRules, RulesConfig
+
+
+def _rules(loss_review_threshold_pct: float) -> RulesConfig:
+    """Build a :class:`RulesConfig` with a custom loss-review threshold.
+
+    Other rule groups keep their catalog defaults — only the largest-loser
+    flag threshold (``rules_config.risk.loss_review_threshold_pct``) varies.
+    The value is whole-percent (e.g. ``-15.0`` for −15%).
+    """
+    return RulesConfig(
+        risk=RiskRules(loss_review_threshold_pct=loss_review_threshold_pct)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -218,13 +231,15 @@ class TestSchwabTokenExpiringTrigger:
 
 
 class TestLargeLoserTrigger:
-    def test_emits_at_pct_threshold_minus_five_pct(self):
-        # Whichever-fires-first: -5% trips even when dollars are small.
+    def test_emits_at_default_pct_threshold_minus_fifteen_pct(self):
+        # Whichever-fires-first: the default loss-review threshold (-15%)
+        # trips even when dollars are small. With no `rules` override the
+        # engine uses the catalog default (issue #235).
         actions = compute_next_actions(
             status=_status(),
             kpis=_kpis(open_legs=1),
             positions=[
-                _position("p-loser", "TSLA", unrealized_pl=-50.0, pl_pct=-0.05),
+                _position("p-loser", "TSLA", unrealized_pl=-50.0, pl_pct=-0.15),
             ],
             open_legs=[],
         )
@@ -232,7 +247,8 @@ class TestLargeLoserTrigger:
         assert "position.large_loser" in ids
 
     def test_emits_at_dollar_threshold_minus_1000(self):
-        # Whichever-fires-first: -$1000 trips even at -1% basis.
+        # Whichever-fires-first: -$1000 trips even at -1% basis. The dollar
+        # trigger is a hardcoded heuristic, independent of the rules config.
         actions = compute_next_actions(
             status=_status(),
             kpis=_kpis(open_legs=1),
@@ -245,17 +261,77 @@ class TestLargeLoserTrigger:
         assert "position.large_loser" in ids
 
     def test_does_not_emit_just_below_thresholds(self):
-        # -4.9% and -$999 should NOT trigger.
+        # -14.9% and -$999 should NOT trigger under the default -15% rule.
         actions = compute_next_actions(
             status=_status(),
             kpis=_kpis(open_legs=1),
             positions=[
-                _position("p-ok", "MSFT", unrealized_pl=-999.0, pl_pct=-0.049),
+                _position("p-ok", "MSFT", unrealized_pl=-999.0, pl_pct=-0.149),
             ],
             open_legs=[],
         )
         ids = {a["action_id"] for a in actions}
         assert "position.large_loser" not in ids
+
+    def test_default_rule_does_not_emit_between_5_and_15_pct(self):
+        # Issue #235: the old hardcoded -5% constant is gone. An -8% loser
+        # — between the retired -5% and the configured -15% — must NOT flag
+        # under default rules, proving the migration to rules_config landed.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-mild", "NVDA", unrealized_pl=-200.0, pl_pct=-0.08),
+            ],
+            open_legs=[],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "position.large_loser" not in ids
+
+    def test_largest_loser_honors_configured_loss_review_threshold(self):
+        # Issue #235: a stricter-than-default threshold (-5%) flags an -8%
+        # loser that the default -15% rule would leave alone — proving the
+        # card is wired to rules_config.risk.loss_review_threshold_pct.
+        position = _position("p-mild", "NVDA", unrealized_pl=-200.0, pl_pct=-0.08)
+        # Default -15% rule: not flagged.
+        default_actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[position],
+            open_legs=[],
+        )
+        assert "position.large_loser" not in {
+            a["action_id"] for a in default_actions
+        }
+        # Stored -5% rule: flagged.
+        strict_actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[position],
+            open_legs=[],
+            rules=_rules(-5.0),
+        )
+        assert "position.large_loser" in {
+            a["action_id"] for a in strict_actions
+        }
+
+    def test_reason_copy_reflects_configured_threshold_no_hardcoded_pct(self):
+        # Issue #235: the card's `reason` string must report the configured
+        # threshold, never a hardcoded "-5%". Here a stored -20% rule.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-loser", "TSLA", unrealized_pl=-3000.0, pl_pct=-0.25),
+            ],
+            open_legs=[],
+            rules=_rules(-20.0),
+        )
+        loser_card = next(
+            a for a in actions if a["action_id"] == "position.large_loser"
+        )
+        assert "-20%" in loser_card["reason"]
+        assert "-5%" not in loser_card["reason"]
 
     def test_only_single_largest_loser_emitted(self):
         # Three losers — engine surfaces only the worst.
@@ -263,9 +339,9 @@ class TestLargeLoserTrigger:
             status=_status(),
             kpis=_kpis(open_legs=1),
             positions=[
-                _position("p-a", "AAA", unrealized_pl=-500.0, pl_pct=-0.10),
-                _position("p-b", "BBB", unrealized_pl=-2000.0, pl_pct=-0.20),
-                _position("p-c", "CCC", unrealized_pl=-1500.0, pl_pct=-0.15),
+                _position("p-a", "AAA", unrealized_pl=-500.0, pl_pct=-0.20),
+                _position("p-b", "BBB", unrealized_pl=-2000.0, pl_pct=-0.30),
+                _position("p-c", "CCC", unrealized_pl=-1500.0, pl_pct=-0.25),
             ],
             open_legs=[],
         )

--- a/backend/tests/test_no_hardcoded_rule_constants.py
+++ b/backend/tests/test_no_hardcoded_rule_constants.py
@@ -6,10 +6,17 @@ default. This test fails CI if a migrated constant reappears, so an incomplete
 or reverted migration cannot land silently.
 
 Intentionally retained literals — ``WHEEL_MONTHLY_PREMIUM_PCT``,
-``WHEEL_BE_MULTIPLIERS``, ``LARGE_LOSER_*``, ``TOKEN_EXPIRING_DAYS``,
-``MAX_ACTIONS``, ``ITM_SHORT_DTE_CAP`` — are internal heuristics and display
-caps, explicitly NOT trader-facing trading rules (ADR-002 "We will NOT"). The
-allow-list below is kept narrow so they do not trip the guard.
+``WHEEL_BE_MULTIPLIERS``, ``LARGE_LOSER_DOLLAR_THRESHOLD``,
+``TOKEN_EXPIRING_DAYS``, ``MAX_ACTIONS``, ``ITM_SHORT_DTE_CAP`` — are internal
+heuristics and display caps, explicitly NOT trader-facing trading rules
+(ADR-002 "We will NOT"). The allow-list below is kept narrow so they do not
+trip the guard.
+
+``LARGE_LOSER_PCT_THRESHOLD`` is **no longer** a retained heuristic: issue #235
+migrated it to ``rules_config.risk.loss_review_threshold_pct``. It is in the
+banned set for both the ``action_engine`` and the ``positions`` router so a
+reverted migration cannot land silently. Only the *dollar* large-loser
+threshold remains a hardcoded heuristic.
 """
 
 from __future__ import annotations
@@ -18,6 +25,7 @@ import inspect
 
 from app.models import schemas
 from app.models.schemas import OptionScanRequest
+from app.routers import positions as positions_router
 from app.services import action_engine, recovery_engine
 
 
@@ -38,6 +46,29 @@ def test_action_engine_itm_short_dte_max_constant_removed():
         "ITM_SHORT_DTE_MAX_DTE must be gone — the threshold is resolved from "
         "rules_config.management.expiration_warning_days (issue #156)."
     )
+
+
+def test_large_loser_pct_threshold_constant_removed():
+    """``LARGE_LOSER_PCT_THRESHOLD`` no longer exists on either consumer.
+
+    Issue #235 migrated the percentage flag threshold to
+    ``rules_config.risk.loss_review_threshold_pct``. Only the *dollar*
+    large-loser threshold remains a hardcoded heuristic.
+    """
+    for module, label in (
+        (action_engine, "action engine"),
+        (positions_router, "positions router"),
+    ):
+        assert not hasattr(module, "LARGE_LOSER_PCT_THRESHOLD"), (
+            f"LARGE_LOSER_PCT_THRESHOLD must be gone from the {label} — the "
+            "percentage flag threshold is resolved from "
+            "rules_config.risk.loss_review_threshold_pct (issue #235)."
+        )
+        # The retained dollar heuristic must still be present.
+        assert hasattr(module, "LARGE_LOSER_DOLLAR_THRESHOLD"), (
+            f"LARGE_LOSER_DOLLAR_THRESHOLD must remain on the {label} — it is "
+            "an intentionally-retained absolute-loss heuristic (ADR-002)."
+        )
 
 
 def test_option_scan_request_rule_fields_default_to_none():
@@ -75,14 +106,19 @@ def test_option_scan_request_has_universe_rule_fields():
 def test_no_migrated_constant_name_in_source():
     """A source-text scan confirms the migrated constant names are gone.
 
-    The allow-list is intentionally narrow: the retained heuristics
-    (WHEEL_*, LARGE_LOSER_*, etc.) are not in the banned set, so they do not
-    trip this guard.
+    The allow-list is intentionally narrow: the remaining retained heuristics
+    (WHEEL_*, LARGE_LOSER_DOLLAR_THRESHOLD, etc.) are not in the banned set,
+    so they do not trip this guard. ``LARGE_LOSER_PCT_THRESHOLD`` *is* banned
+    (issue #235) on both the action engine and the positions router.
     """
     banned = {
         "schemas": (schemas, []),
-        "action_engine": (action_engine, ["ITM_SHORT_DTE_MAX_DTE"]),
+        "action_engine": (
+            action_engine,
+            ["ITM_SHORT_DTE_MAX_DTE", "LARGE_LOSER_PCT_THRESHOLD"],
+        ),
         "recovery_engine": (recovery_engine, ["DEFAULT_SIZING_CAP_DOLLARS"]),
+        "positions_router": (positions_router, ["LARGE_LOSER_PCT_THRESHOLD"]),
     }
     for label, (module, banned_names) in banned.items():
         source = inspect.getsource(module)

--- a/backend/tests/test_recovery_router.py
+++ b/backend/tests/test_recovery_router.py
@@ -18,11 +18,13 @@ Covers:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import patch
 
 import pytest
 
 from app.models.database import AppSetting, Position
+from app.services.rules_config import RULES_CONFIG_KEY
 from app.services.schwab_client import SchwabClient
 
 
@@ -78,6 +80,20 @@ def _seed_setting(client, key: str, value: str) -> None:
         db.commit()
     finally:
         db.close()
+
+
+def _seed_rules_config(client, *, loss_review_threshold_pct: float) -> None:
+    """Persist a ``rules_config`` row overriding the loss-review threshold.
+
+    ``loss_review_threshold_pct`` is whole-percent (e.g. ``-5.0`` for −5%).
+    Only the ``risk`` group is provided; :func:`load_rules_config` merges it
+    onto the catalog defaults for every other group.
+    """
+    document = {
+        "schema_version": 1,
+        "risk": {"loss_review_threshold_pct": loss_review_threshold_pct},
+    }
+    _seed_setting(client, RULES_CONFIG_KEY, json.dumps(document))
 
 
 def _quote(last_price: float) -> dict:
@@ -140,6 +156,105 @@ def test_recovery_plan_not_flagged_above_threshold(client):
     # Header summary IS rendered (per spec — frontend EmptyState wants the
     # ticker / shares / basis context).
     assert payload["position"]["ticker"] == "SOFI"
+
+
+# ---------------------------------------------------------------------------
+# Flag gate honors rules_config.risk.loss_review_threshold_pct (issue #235)
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_flag_gate_uses_configured_loss_review_threshold(client):
+    """The flag gate resolves its loss-review percentage from ``rules_config``.
+
+    An −8% loser is between the retired hardcoded −5% constant and the
+    default −15% rule. With a stored −5% rule it is ``populated``; with a
+    stored −15% rule the same position is ``not-flagged``. This is the
+    headline AC for issue #235.
+
+    A $3,800 basis at $34.96 → $3,496 notional → −$304 / −8%.
+    """
+    # Stored -5% rule → -8% loser IS flagged.
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    _seed_rules_config(client, loss_review_threshold_pct=-5.0)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(34.96)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "populated"
+
+
+def test_recovery_flag_gate_not_flagged_when_rule_stricter_than_loss(client):
+    """A −8% loser is ``not-flagged`` when the stored rule is −15%."""
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    _seed_rules_config(client, loss_review_threshold_pct=-15.0)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(34.96)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "not-flagged"
+
+
+def test_recovery_default_rules_not_flagged_between_5_and_15_pct(client):
+    """With no ``rules_config`` row the default −15% rule applies.
+
+    A −8% loser — between the retired −5% constant and the −15% default —
+    is ``not-flagged``, proving the old hardcoded −5% behavior is gone.
+    """
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    # No rules_config row seeded → catalog default -15%.
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(34.96)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "not-flagged"
+
+
+def test_recovery_default_rules_flagged_below_15_pct(client):
+    """A −39% loser flags under the default −15% rule (conversion check).
+
+    Pins the whole-percent → fraction conversion: −0.39 ``pl_pct`` vs the
+    −15.0 whole-percent rule must compare as ``-0.39 <= -15.0 / 100``.
+    A $3,800 basis at $23.18 → $2,318 notional → −39%.
+    """
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(23.18)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "populated"
+
+
+def test_recovery_dollar_secondary_trigger_still_fires(client):
+    """The −$1,000 absolute trigger flags a shallow-percent large position.
+
+    A $100,000 basis at $98.50 → $98,500 notional → −$1,500 / −1.5%. The
+    percentage is far above any loss-review rule, but the retained dollar
+    trigger still flags it — proving the secondary OR-trigger survives.
+    """
+    _seed_position(client, broker_cost_basis=100000.0, shares=1000)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(98.50)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    assert resp.json()["state"] == "populated"
+
+
+def test_recovery_assumptions_sizing_cap_source_is_trading_rules(client):
+    """The Sizing-cap assumption row is attributed to Settings → Trading Rules.
+
+    Strategy-preference and target-yield rows stay attributed to OKRs —
+    those are genuine OKRs, not Trading Rules (issue #235).
+    """
+    _seed_position(client, broker_cost_basis=3800.0, shares=100)
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["state"] == "populated"
+    by_label = {a["label"]: a for a in payload["assumptions"]}
+    assert by_label["Sizing cap (Average down)"]["source"] == (
+        "Settings → Trading Rules"
+    )
+    # Genuine OKRs are untouched.
+    assert by_label["Target yield (Sell & redeploy)"]["source"] == (
+        "Settings → OKRs"
+    )
+    assert by_label["Strategy preference"]["source"] == "Settings → OKRs (V0.6)"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_rules_config_integration.py
+++ b/backend/tests/test_rules_config_integration.py
@@ -400,6 +400,58 @@ def test_recovery_endpoint_default_sizing_cap_with_no_rules_row(client):
 
 
 # ---------------------------------------------------------------------------
+# Loss-review threshold — recovery flag gate ↔ dashboard largest-loser card
+# must agree (issue #235, AC2 "no new drift")
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("loss_review_threshold_pct", "pl_pct"),
+    [
+        (-15.0, -0.08),  # default rule, mild loser → neither flags
+        (-15.0, -0.20),  # default rule, deep loser → both flag
+        (-5.0, -0.08),   # strict rule, mild loser → both flag
+        (-20.0, -0.18),  # lenient rule, -18% loser → neither flags
+    ],
+)
+def test_flag_gate_and_largest_loser_card_agree(
+    loss_review_threshold_pct, pl_pct
+):
+    """The recovery flag gate and the dashboard largest-loser card agree.
+
+    Issue #235 AC2: both surfaces honor the same configured
+    ``loss_review_threshold_pct``. A user must never click a dashboard
+    "Review" card and land on a ``not-flagged`` recovery empty state. This
+    runs the same P/L through ``_is_flagged`` (recovery) and
+    ``_largest_loser_action`` (dashboard) and asserts an identical verdict.
+    """
+    from app.routers.positions import _is_flagged
+    from app.services.action_engine import _largest_loser_action
+
+    # An unrealized_pl too small to trip the -$1,000 dollar trigger, so the
+    # percentage rule alone decides — isolating the loss_review comparison.
+    unrealized_pl = -100.0
+
+    recovery_flagged = _is_flagged(
+        unrealized_pl, pl_pct, loss_review_threshold_pct
+    )
+    card = _largest_loser_action(
+        [
+            {
+                "id": "p-1",
+                "ticker": "SOFI",
+                "unrealized_pl": unrealized_pl,
+                "pl_pct": pl_pct,
+            }
+        ],
+        loss_review_threshold_pct,
+    )
+    dashboard_flagged = card is not None
+
+    assert recovery_flagged == dashboard_flagged
+
+
+# ---------------------------------------------------------------------------
 # IV-rank gate — plumbed but inert (ADR-002 OQ4 / issue #156)
 # ---------------------------------------------------------------------------
 

--- a/frontend/app/settings/page.jsx
+++ b/frontend/app/settings/page.jsx
@@ -1,7 +1,16 @@
 "use client";
 
+import { Suspense } from 'react';
 import SettingsPage from '@/components/settings/SettingsPage';
 
 export default function Settings() {
-  return <SettingsPage />;
+  // SettingsPage calls useSearchParams() to read the `?tab=` deep-link
+  // param (issue #235). The App Router de-opts to client-side rendering
+  // without a Suspense boundary around a useSearchParams() consumer, so
+  // wrap it here. fallback={null} matches the page's own loading states.
+  return (
+    <Suspense fallback={null}>
+      <SettingsPage />
+    </Suspense>
+  );
 }

--- a/frontend/components/recovery/RecoveryRecommendationBanner.jsx
+++ b/frontend/components/recovery/RecoveryRecommendationBanner.jsx
@@ -148,8 +148,8 @@ export default function RecoveryRecommendationBanner({
             <>
               <p className="text-sm text-amber-700 dark:text-amber-300 mt-2">
                 Every path violates your per-position sizing cap or another
-                configured constraint. Adjust your caps in Settings → OKRs, or
-                evaluate paths manually using the matrix below.
+                configured constraint. Adjust your caps in Settings → Trading
+                Rules, or evaluate paths manually using the matrix below.
               </p>
               <ul
                 data-testid="recovery-recommendation-reasons"
@@ -168,7 +168,7 @@ export default function RecoveryRecommendationBanner({
               </ul>
               <div className="mt-3">
                 <Link
-                  href="/settings#okrs"
+                  href="/settings?tab=rules"
                   data-testid="recovery-recommendation-adjust-caps"
                   className="text-sm font-medium text-amber-800 dark:text-amber-200 hover:underline"
                 >

--- a/frontend/components/recovery/suppressionReasonCta.js
+++ b/frontend/components/recovery/suppressionReasonCta.js
@@ -9,9 +9,15 @@ export function suppressionReasonToCta(reason) {
   if (!reason || typeof reason !== 'string') return null;
   const low = reason.toLowerCase();
   if (low.includes('sizing cap') || low.includes('sizing rule')) {
-    return { label: 'Adjust cap →', href: '/settings#okrs' };
+    // The sizing cap is a Trading Rule (issue #156) — route to the Settings
+    // → Trading Rules tab via the `?tab=rules` deep link (issue #235).
+    return { label: 'Adjust cap →', href: '/settings?tab=rules' };
   }
   if (low.includes('target yield')) {
+    // Target yield is a genuine OKR. Intentionally left pointing at
+    // `/settings#okrs`: there is no Settings → OKRs UI until V1.1, so this
+    // CTA still dead-ends — that half of #207 stays open and out of scope
+    // for #235 (which only fixes the sizing-cap CTA).
     return { label: 'Set target yield →', href: '/settings#okrs' };
   }
   return null;

--- a/frontend/components/settings/SettingsPage.jsx
+++ b/frontend/components/settings/SettingsPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
 import {
   getSettings, updateSetting, getCacheStats, clearCache, checkFredHealth,
@@ -33,7 +34,17 @@ export default function SettingsPage() {
   // Page-scoped tab state (issue #158, Option B). "General" holds the existing
   // infrastructure/data settings; "Trading Rules" holds the rules_config edit
   // surface. A V1.1 "Trading OKRs" tab slots in here with zero rework.
-  const [activeTab, setActiveTab] = useState('general');
+  //
+  // Lazy-initialized from the `?tab=` query param (issue #235) so a deep link
+  // such as /settings?tab=rules — e.g. a recovery-page "Adjust cap →" CTA —
+  // lands directly on the Trading Rules tab. Query params are the established
+  // codebase pattern (useOptionScanner, JournalPage); URL hashes are used
+  // nowhere. Lazy init runs once on mount; later in-page tab clicks are not
+  // re-overridden by the param.
+  const searchParams = useSearchParams();
+  const [activeTab, setActiveTab] = useState(() =>
+    searchParams?.get('tab') === 'rules' ? 'rules' : 'general'
+  );
   const [settings, setSettings] = useState(null);
   const [cacheStats, setCacheStats] = useState(null);
   const [fredKey, setFredKey] = useState('');

--- a/frontend/e2e/recovery-plan.spec.js
+++ b/frontend/e2e/recovery-plan.spec.js
@@ -49,7 +49,8 @@ function assumptions() {
     {
       label: 'Sizing cap (Average down)',
       value: '$5,000',
-      source: 'Settings → OKRs',
+      // The sizing cap is a Trading Rule (issue #235), not an OKR.
+      source: 'Settings → Trading Rules',
     },
     {
       label: 'Strategy preference',
@@ -207,6 +208,31 @@ function noClearBestFitPayload() {
       { path_id: 'sell-redeploy', score: 6, rank: 1, suppression_reason: null },
       { path_id: 'wheel-cc', score: 6, rank: 2, suppression_reason: null },
       { path_id: 'hold-monitor', score: 3, rank: 3, suppression_reason: null },
+      {
+        path_id: 'average-down',
+        score: null,
+        rank: null,
+        suppression_reason:
+          'Exceeds per-position sizing cap ($4,752 vs $5,000 — would breach)',
+      },
+    ],
+    path_scores: pathScores(),
+    tie_epsilon: 1.0,
+    disclaimer: DISCLAIMER,
+  };
+  return base;
+}
+
+// no-eligible-path payload: every path is suppressed by the sizing cap, so
+// the banner renders the amber "Adjust caps →" CTA (issue #235 routes it at
+// the Settings → Trading Rules tab).
+function noEligiblePathPayload() {
+  const base = populatedPayload();
+  base.recommendation = {
+    recommended_path_id: null,
+    recommendation_label: 'No eligible path under current sizing rules',
+    recommendation_reasons: [],
+    ranked_paths: [
       {
         path_id: 'average-down',
         score: null,
@@ -447,6 +473,56 @@ test.describe('Recovery Plan panel', () => {
     await expect(page.getByTestId('recovery-plan-error')).toContainText(
       'Failed to build recovery plan',
     );
+  });
+
+  test('sizing-cap suppression CTA routes to Settings → Trading Rules', async ({
+    page,
+  }) => {
+    // Issue #235 Bug 2: the suppressed average-down card's "Adjust cap →"
+    // CTA must route to /settings?tab=rules, never the dead /settings#okrs.
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const cta = page.getByTestId('recovery-path-card-average-down-suppression-cta');
+    await expect(cta).toBeVisible();
+    await expect(cta).toContainText('Adjust cap');
+    await expect(cta).toHaveAttribute('href', '/settings?tab=rules');
+    const href = await cta.getAttribute('href');
+    expect(href).not.toContain('#okrs');
+  });
+
+  test('no-eligible-path banner CTA routes to Settings → Trading Rules', async ({
+    page,
+  }) => {
+    // Issue #235 Bug 2: the amber banner's "Adjust caps →" CTA points at the
+    // Trading Rules tab — caps are Trading Rules, not OKRs.
+    await mockRecoveryPlan(page, noEligiblePathPayload());
+    await openRecoveryPlan(page);
+
+    const banner = page.getByTestId('recovery-recommendation-banner');
+    await expect(banner).toHaveAttribute('data-state', 'no-eligible-path');
+    await expect(banner).toContainText('Settings → Trading Rules');
+
+    const cta = page.getByTestId('recovery-recommendation-adjust-caps');
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute('href', '/settings?tab=rules');
+    const href = await cta.getAttribute('href');
+    expect(href).not.toContain('#okrs');
+  });
+
+  test('assumptions panel attributes the sizing cap to Trading Rules', async ({
+    page,
+  }) => {
+    // Issue #235 Bug 2: the Sizing-cap assumption row reads "Settings →
+    // Trading Rules"; the target-yield row stays attributed to OKRs.
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const panel = page.getByTestId('recovery-assumptions-panel');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText('Settings → Trading Rules');
+    // Target yield is a genuine OKR — still attributed to OKRs.
+    await expect(panel).toContainText('Settings → OKRs');
   });
 
   // Manual AC (CLAUDE.md — document non-automatable steps as a skipped test).

--- a/frontend/e2e/settings-trading-rules.spec.js
+++ b/frontend/e2e/settings-trading-rules.spec.js
@@ -128,6 +128,55 @@ test.describe('Settings → Trading Rules — page & tabs', () => {
   });
 });
 
+test.describe('Settings → Trading Rules — deep link (issue #235)', () => {
+  test('/settings?tab=rules opens the Trading Rules tab without a click', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await page.goto('/settings?tab=rules');
+
+    // The Trading Rules tab is active on arrival — the recovery-page
+    // "Adjust cap →" CTAs deep-link here.
+    await expect(page.getByTestId('settings-rules-tab')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    await expect(page.getByTestId('settings-rules-form')).toBeVisible();
+  });
+
+  test('/settings with no param still defaults to the General tab', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await page.goto('/settings');
+
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByTestId('settings-rules-tab')).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  test('an unrecognized tab param falls back to the General tab', async ({
+    page,
+  }) => {
+    await mockRulesEndpoint(page);
+    await page.goto('/settings?tab=bogus');
+
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+});
+
 test.describe('Settings → Trading Rules — field render', () => {
   test('a field renders with its label, helper text and value', async ({
     page,


### PR DESCRIPTION
Closes #235

## Summary

The Recovery Plan page only partially consumed the V1.0 Trading Rules Layer. This PR wires the recovery surface fully into `rules_config` by fixing the two defects in #235.

**Bug 1 — flag gate hardcoded.** Whether a position got a recovery plan (`populated` vs `not-flagged`) — and whether the dashboard's largest-loser card appeared — was decided by a hardcoded `-5%` constant, leaving `rules_config.risk.loss_review_threshold_pct` completely inert. Editing the loss-review threshold in Settings changed nothing.

**Bug 2 — sizing cap mislabeled as an OKR.** The per-position sizing cap is a Trading Rule, but the recovery surface attributed it to "Settings → OKRs" and routed CTAs to a dead `/settings#okrs` anchor.

## ⚠️ User-visible behavior change (for v1.0.2 release notes)

The default loss-review threshold (`-15%`) is **stricter** than the retired hardcoded `-5%`. Default-rules users who previously saw a recovery plan / largest-loser card for a position down 5–15% will now see the `not-flagged` empty state — recovery plans render only at `-15%` or `-$1,000`. This is correct per PRD #209 §R5. Fastest mitigation if unwanted: set `risk.loss_review_threshold_pct = -5.0` in Settings → Trading Rules — which now actually works.

## Backend changes

- **`app/routers/positions.py`** — `_is_flagged()` takes the resolved loss-review threshold; `build_recovery_plan()` resolves `load_rules_config(db)` once and passes `rules.risk.loss_review_threshold_pct` into the gate. Whole-percent rule (`-15.0`) converted to a fraction (`/ 100.0`) for comparison with `pl_pct`. `LARGE_LOSER_PCT_THRESHOLD` removed; the sizing-cap assumption-panel `source` now reads "Settings → Trading Rules".
- **`app/services/action_engine.py`** — `_largest_loser_action()` takes the threshold from the `rules` param already on `compute_next_actions()`; the `reason` copy reflects the configured threshold instead of a hardcoded "-5%". `LARGE_LOSER_PCT_THRESHOLD` removed.
- **`app/services/recovery_engine.py`** — average-down suppression assumption copy attributed to "Settings → Trading Rules".
- `LARGE_LOSER_DOLLAR_THRESHOLD` (the `-$1,000` absolute-loss secondary OR-trigger) is **kept** in both modules, documented as an intentional non-rule heuristic per ADR-002.

## Frontend changes

- **`components/settings/SettingsPage.jsx`** — lazy-initializes the active tab from a `?tab=` query param via `useSearchParams`, so `/settings?tab=rules` lands directly on the Trading Rules tab.
- **`app/settings/page.jsx`** — Settings route wrapped in `<Suspense>` for the App Router `useSearchParams` de-opt.
- **`components/recovery/suppressionReasonCta.js`** — the sizing-cap CTA routes to `/settings?tab=rules`. The target-yield CTA stays at `/settings#okrs` (genuine OKR; no OKR UI until V1.1 — that half of #207 remains open).
- **`components/recovery/RecoveryRecommendationBanner.jsx`** — the "no-eligible-path" banner copy and "Adjust caps →" CTA point at Settings → Trading Rules.
- `RecoveryScoringMatrix.jsx` left unchanged — its only `/settings#okrs` link is the strategy-preference link, a genuine OKR.

## API changes

No API contract changes. `POST /api/positions/{id}/recovery-plan` is unchanged in shape; only the threshold deciding `state: populated` vs `not-flagged` now comes from `rules_config`. The dashboard payload's largest-loser card carries the same change.

## Tests

- **Backend pytest** (`test_recovery_router.py`, `test_action_engine.py`, `test_rules_config_integration.py`): flag-gate threshold resolution (the headline AC: an -8% loser is `populated` at a stored -5% rule, `not-flagged` at -15%), default-rules behavior proving the old -5% is gone, whole-percent→fraction conversion, the `-$1,000` dollar secondary trigger, and a parametrized action_engine ↔ recovery agreement cross-check (AC2 "no new drift").
- **Static guard** (`test_no_hardcoded_rule_constants.py`): extended to ban `LARGE_LOSER_PCT_THRESHOLD` on both the action engine and the positions router, with the retained-heuristic list narrowed to `LARGE_LOSER_DOLLAR_THRESHOLD`.
- **Frontend Playwright** (`recovery-plan.spec.js`, `settings-trading-rules.spec.js`): CTA hrefs resolve to `/settings?tab=rules` (not `#okrs`), the assumptions panel attributes the sizing cap to Trading Rules, and `/settings?tab=rules` activates the Trading Rules tab on arrival.

## Testing notes

- `cd backend && python -m pytest` — **1020 passed, 9 skipped**.
- `cd frontend && npm run lint` — clean (one pre-existing unrelated `<img>` warning); `npm run build` — succeeds.
- `cd frontend && npx playwright test recovery-plan.spec.js settings-trading-rules.spec.js` — **38 passed, 1 skipped** (the skip is the pre-existing manual visual-review placeholder).
- Manual: set Settings → Trading Rules → Risk → loss-review threshold to -5%, confirm an -8% position renders a recovery plan; set it to -20%, confirm the same position shows `not-flagged`. Click a suppression "Adjust cap →" CTA → lands on Settings with the Trading Rules tab active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)