### PR TITLE
Recovery Plan: Trading Objectives tab + target-yield stopgap (closes #207)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -198,6 +198,11 @@ class SettingsResponse(BaseModel):
     theme: str
     schwab_configured: bool = False
     schwab_token_expires: Optional[str] = None
+    # Target yield drives the Recovery Plan's Sell & redeploy path (#207).
+    # Stored as a fraction (e.g. 0.12 == 12%); the frontend converts to/from
+    # whole-percent. Flat key for the V1.0.3 stopgap — migrates into the typed
+    # okr_config namespace in V1.1 (ADR-001 / Discussion #210).
+    okr_target_yield: Optional[float] = None
 
 
 class CacheStatsResponse(BaseModel):

--- a/backend/app/routers/settings.py
+++ b/backend/app/routers/settings.py
@@ -1,10 +1,11 @@
 import logging
+import math
 import os
 from datetime import datetime, timezone
 from urllib.parse import parse_qs, quote, urlparse
 
 import httpx
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session as DBSession
@@ -44,6 +45,17 @@ def get_settings(db: DBSession = Depends(get_db)):
         entry = db.query(AppSetting).filter(AppSetting.key == key).first()
         return entry.value if entry else default
 
+    # Target yield (#207). Stored as a fraction string in the flat
+    # `okr_target_yield` app_settings row; parse defensively to float|None so a
+    # malformed row never breaks the settings read (same pattern as
+    # positions.py's OKR read). This flat key migrates into the typed
+    # `okr_config` namespace in V1.1 (ADR-001 / Discussion #210).
+    target_raw = _get("okr_target_yield", "")
+    try:
+        target_yield = float(target_raw) if target_raw not in (None, "") else None
+    except (TypeError, ValueError):
+        target_yield = None
+
     schwab_mgr = SchwabTokenManager()
     return SettingsResponse(
         fred_api_key_set=bool(fred_key),
@@ -53,12 +65,35 @@ def get_settings(db: DBSession = Depends(get_db)):
         theme=_get("theme", "system"),
         schwab_configured=schwab_mgr.is_configured(),
         schwab_token_expires=schwab_mgr.get_refresh_token_expiry(),
+        okr_target_yield=target_yield,
     )
+
+
+# Generic error copy for the okr_target_yield boundary check — never leak the
+# raw parse exception (CLAUDE.md).
+_TARGET_YIELD_ERROR = "Target yield must be between 0% and 100%."
 
 
 @router.put("")
 def update_setting(req: SettingUpdate, db: DBSession = Depends(get_db)):
-    """Update a single application setting."""
+    """Update a single application setting.
+
+    The store is a generic `{key, value}` upsert. `okr_target_yield` (#207) is
+    the one key with a value contract — it is a fraction in `0.0 < x <= 1.0`
+    consumed by the Recovery Plan engine — so it gets a boundary check here.
+    This flat key migrates into the typed `okr_config` namespace in V1.1
+    (ADR-001 / Discussion #210).
+    """
+    if req.key == "okr_target_yield":
+        try:
+            value = float(req.value)
+        except (TypeError, ValueError):
+            raise HTTPException(status_code=422, detail=_TARGET_YIELD_ERROR)
+        if math.isnan(value) or math.isinf(value):
+            raise HTTPException(status_code=422, detail=_TARGET_YIELD_ERROR)
+        if not (0.0 < value <= 1.0):
+            raise HTTPException(status_code=422, detail=_TARGET_YIELD_ERROR)
+
     entry = db.query(AppSetting).filter(AppSetting.key == req.key).first()
     if entry:
         entry.value = req.value

--- a/backend/tests/test_recovery_router.py
+++ b/backend/tests/test_recovery_router.py
@@ -328,6 +328,30 @@ def test_recovery_plan_uses_default_sizing_cap_when_unset(client):
     assert payload["inputs"]["okr"]["sizing_cap_dollars"] == pytest.approx(5000.0)
 
 
+def test_recovery_plan_sell_redeploy_populated_after_target_yield_set(client):
+    """Issue #207 AC3 — once a target yield is set, the Sell & redeploy path
+    is eligible and its metrics compute (capital tied up + months to
+    breakeven), un-suppressing the path the stopgap exists to unblock."""
+    # broker_cost_basis 3800 vs a $8.00 quote on 100 shares → a realized loss,
+    # so the breakeven horizon is a positive finite number.
+    _seed_position(client, broker_cost_basis=3800.0)
+    _seed_setting(client, "okr_target_yield", "0.12")
+    with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
+        resp = client.post("/api/positions/pos-sofi/recovery-plan")
+    payload = resp.json()
+
+    sell = next(p for p in payload["paths"] if p["path_id"] == "sell-redeploy")
+    assert sell["eligibility"] == "eligible"
+    assert sell["suppression_reason"] is None
+    # Capital tied up is computed (non-null) — not the suppressed-state blank.
+    assert sell["capital_tied_up"] is not None
+    assert sell["capital_tied_up"] >= 0
+    # A positive realized loss + a positive yield → a finite, positive
+    # expected months-to-breakeven (no longer the empty {best,expected,worst}).
+    assert sell["months_to_breakeven"]["expected"] is not None
+    assert sell["months_to_breakeven"]["expected"] > 0
+
+
 # ---------------------------------------------------------------------------
 # Quote failure → generic 500 + no str(e) leak
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_settings_target_yield.py
+++ b/backend/tests/test_settings_target_yield.py
@@ -1,0 +1,144 @@
+"""Tests for the okr_target_yield read/write plumbing (issue #207).
+
+The V1.0.3 stopgap that gives the Recovery Plan "Set target yield →" CTA a
+real destination. Covers AC1 — the value round-trips through the generic
+settings endpoints — and the CLAUDE.md boundary-validation discipline.
+
+Uses the in-memory SQLite ``client`` fixture from ``conftest.py``.
+"""
+
+from app.models.database import AppSetting, get_db
+
+
+def _stored_target_yield(client) -> object:
+    """Return the raw okr_target_yield app_settings value, or None if absent."""
+    from app.main import app
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        entry = (
+            db.query(AppSetting)
+            .filter(AppSetting.key == "okr_target_yield")
+            .first()
+        )
+        return entry.value if entry else None
+    finally:
+        db.close()
+
+
+class TestTargetYieldRead:
+    """GET /api/settings carries okr_target_yield (AC1)."""
+
+    def test_get_settings_target_yield_none_when_unseeded(self, client):
+        """No stored row → okr_target_yield is null."""
+        response = client.get("/api/settings")
+        assert response.status_code == 200
+        assert response.json()["okr_target_yield"] is None
+
+    def test_put_then_get_round_trips_fraction(self, client):
+        """PUT a fraction, then GET returns the same fraction (AC1)."""
+        put_resp = client.put(
+            "/api/settings",
+            json={"key": "okr_target_yield", "value": "0.12"},
+        )
+        assert put_resp.status_code == 200
+        assert put_resp.json()["key"] == "okr_target_yield"
+
+        get_resp = client.get("/api/settings")
+        assert get_resp.status_code == 200
+        assert get_resp.json()["okr_target_yield"] == 0.12
+
+    def test_get_settings_target_yield_none_when_row_malformed(self, client):
+        """A non-numeric stored row degrades to None — never breaks the read."""
+        client.put(
+            "/api/settings",
+            json={"key": "okr_target_yield", "value": "not-a-number"},
+        )
+        # The PUT itself is rejected (see TestTargetYieldValidation), so seed
+        # the malformed row directly to exercise the defensive GET parse.
+        from app.main import app
+
+        override = app.dependency_overrides[get_db]
+        db = next(override())
+        try:
+            db.add(AppSetting(key="okr_target_yield", value="garbage"))
+            db.commit()
+        finally:
+            db.close()
+
+        response = client.get("/api/settings")
+        assert response.status_code == 200
+        assert response.json()["okr_target_yield"] is None
+
+
+class TestTargetYieldValidation:
+    """PUT /api/settings boundary validation for okr_target_yield (AC1)."""
+
+    def test_put_above_upper_bound_rejected(self, client):
+        """A fraction > 1.0 is rejected with a generic 422."""
+        response = client.put(
+            "/api/settings",
+            json={"key": "okr_target_yield", "value": "1.5"},
+        )
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail == "Target yield must be between 0% and 100%."
+        # No row written on a rejected value.
+        assert _stored_target_yield(client) is None
+
+    def test_put_at_or_below_zero_rejected(self, client):
+        """A non-positive fraction is rejected (0% is meaningless / out of bounds)."""
+        for bad in ("-0.1", "0", "0.0"):
+            response = client.put(
+                "/api/settings",
+                json={"key": "okr_target_yield", "value": bad},
+            )
+            assert response.status_code == 422, bad
+            assert (
+                response.json()["detail"]
+                == "Target yield must be between 0% and 100%."
+            )
+        assert _stored_target_yield(client) is None
+
+    def test_put_non_numeric_rejected_without_leaking_exception(self, client):
+        """A non-numeric value is rejected; the raw parse exception never leaks."""
+        response = client.put(
+            "/api/settings",
+            json={"key": "okr_target_yield", "value": "abc"},
+        )
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert detail == "Target yield must be between 0% and 100%."
+        # CLAUDE.md — generic copy only, no raw ValueError text.
+        assert "could not convert" not in detail
+        assert "float" not in detail
+        assert _stored_target_yield(client) is None
+
+    def test_put_nan_and_inf_rejected(self, client):
+        """NaN / inf parse as floats but are out of bounds — rejected."""
+        for bad in ("nan", "inf", "-inf"):
+            response = client.put(
+                "/api/settings",
+                json={"key": "okr_target_yield", "value": bad},
+            )
+            assert response.status_code == 422, bad
+        assert _stored_target_yield(client) is None
+
+    def test_put_at_bounds_accepted(self, client):
+        """The inclusive upper bound (1.0) and small positive values are accepted."""
+        for good in ("1.0", "0.0001"):
+            response = client.put(
+                "/api/settings",
+                json={"key": "okr_target_yield", "value": good},
+            )
+            assert response.status_code == 200, good
+
+    def test_other_keys_pass_through_unchanged(self, client):
+        """The boundary check only gates okr_target_yield — other keys are blind upserts."""
+        response = client.put(
+            "/api/settings",
+            json={"key": "theme", "value": "dark"},
+        )
+        assert response.status_code == 200
+        assert client.get("/api/settings").json()["theme"] == "dark"

--- a/frontend/components/recovery/suppressionReasonCta.js
+++ b/frontend/components/recovery/suppressionReasonCta.js
@@ -14,11 +14,11 @@ export function suppressionReasonToCta(reason) {
     return { label: 'Adjust cap →', href: '/settings?tab=rules' };
   }
   if (low.includes('target yield')) {
-    // Target yield is a genuine OKR. Intentionally left pointing at
-    // `/settings#okrs`: there is no Settings → OKRs UI until V1.1, so this
-    // CTA still dead-ends — that half of #207 stays open and out of scope
-    // for #235 (which only fixes the sizing-cap CTA).
-    return { label: 'Set target yield →', href: '/settings#okrs' };
+    // Target yield is a genuine OKR — route to the Settings → Trading
+    // Objectives tab via the `?tab=` deep link (issue #207, the same pattern
+    // #235 introduced for the sizing cap). The old `/settings#okrs` anchor
+    // dead-ended; #207 added the Trading Objectives tab as its destination.
+    return { label: 'Set target yield →', href: '/settings?tab=objectives' };
   }
   return null;
 }

--- a/frontend/components/settings/SettingsPage.jsx
+++ b/frontend/components/settings/SettingsPage.jsx
@@ -10,6 +10,7 @@ import {
 import DangerZone from './DangerZone';
 import ReconcileJournal from './ReconcileJournal';
 import TradingRulesSection from './TradingRulesSection';
+import TradingObjectivesSection from './TradingObjectivesSection';
 import { useJournal } from '../../hooks/useJournal';
 
 function freshnessColor(freshness) {
@@ -33,18 +34,23 @@ export default function SettingsPage() {
   const { clearAllData, reconcilePreview, reconcileApply, positions } = useJournal();
   // Page-scoped tab state (issue #158, Option B). "General" holds the existing
   // infrastructure/data settings; "Trading Rules" holds the rules_config edit
-  // surface. A V1.1 "Trading OKRs" tab slots in here with zero rework.
+  // surface; "Trading Objectives" holds the target-yield objective (issue #207,
+  // shipped V1.0.3). Target yield is an OKR/objective, not a Trading Rule
+  // (ADR-001 / Discussion #210) — hence a separate tab.
   //
   // Lazy-initialized from the `?tab=` query param (issue #235) so a deep link
-  // such as /settings?tab=rules — e.g. a recovery-page "Adjust cap →" CTA —
-  // lands directly on the Trading Rules tab. Query params are the established
-  // codebase pattern (useOptionScanner, JournalPage); URL hashes are used
-  // nowhere. Lazy init runs once on mount; later in-page tab clicks are not
-  // re-overridden by the param.
+  // such as /settings?tab=rules or /settings?tab=objectives — e.g. a
+  // recovery-page "Adjust cap →" / "Set target yield →" CTA — lands directly
+  // on the matching tab. Query params are the established codebase pattern
+  // (useOptionScanner, JournalPage); URL hashes are used nowhere. Lazy init
+  // runs once on mount; later in-page tab clicks are not re-overridden.
   const searchParams = useSearchParams();
-  const [activeTab, setActiveTab] = useState(() =>
-    searchParams?.get('tab') === 'rules' ? 'rules' : 'general'
-  );
+  const [activeTab, setActiveTab] = useState(() => {
+    const t = searchParams?.get('tab');
+    if (t === 'rules') return 'rules';
+    if (t === 'objectives') return 'objectives';
+    return 'general';
+  });
   const [settings, setSettings] = useState(null);
   const [cacheStats, setCacheStats] = useState(null);
   const [fredKey, setFredKey] = useState('');
@@ -194,7 +200,8 @@ export default function SettingsPage() {
           </Link>
         </div>
 
-        {/* Page-scoped tab bar (issue #158). "Trading OKRs" joins here in V1.1. */}
+        {/* Page-scoped tab bar (issue #158). "Trading Objectives" joined in
+            V1.0.3 (issue #207). */}
         <div
           role="tablist"
           aria-label="Settings sections"
@@ -220,9 +227,23 @@ export default function SettingsPage() {
           >
             Trading Rules
           </button>
+          <button
+            type="button"
+            role="tab"
+            data-testid="settings-objectives-tab"
+            aria-selected={activeTab === 'objectives'}
+            onClick={() => setActiveTab('objectives')}
+            className={tabClass('objectives')}
+          >
+            Trading Objectives
+          </button>
         </div>
 
-        {activeTab === 'rules' ? (
+        {activeTab === 'objectives' ? (
+          <div role="tabpanel" aria-label="Trading Objectives">
+            <TradingObjectivesSection />
+          </div>
+        ) : activeTab === 'rules' ? (
           <div role="tabpanel" aria-label="Trading Rules">
             <TradingRulesSection />
           </div>

--- a/frontend/components/settings/TradingObjectivesSection.jsx
+++ b/frontend/components/settings/TradingObjectivesSection.jsx
@@ -1,0 +1,319 @@
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { getSettings, updateSetting } from '../../api/client';
+import { isBlank, validateScalar } from './rulesValidation';
+
+/**
+ * Settings → Trading Objectives section (issue #207).
+ *
+ * The V1.0.3 minimal stopgap that gives the dead-ending Recovery Plan
+ * "Set target yield →" CTA a real destination and un-suppresses the
+ * Sell & redeploy path. A single field — Target yield.
+ *
+ * This is NOT the full V1.1 OKR Scorecard. The flat `okr_target_yield`
+ * app-setting key migrates into the typed `okr_config` namespace in V1.1
+ * (ADR-001 / Discussion #210); this tab is the seed of that surface — V1.1
+ * extends it rather than replacing it.
+ *
+ * Unit convention (design spec §4): the field accepts/displays WHOLE PERCENT
+ * (the trader types `12`); the backend stores `okr_target_yield` as a FRACTION
+ * (`0.12`). The conversion lives only in this component — `*100` on load (with
+ * a `toFixed(4)` clean-up for float artefacts) and `/100` on save. The backend
+ * storage and the recovery engine stay untouched.
+ *
+ * Form state holds the value as a *string* so blank `""` (the honest "unset"
+ * signal) stays distinct from a real entered `"0"`. Validation reuses the pure
+ * `validateScalar('pctOpen100', …)` / `isBlank` helpers from `rulesValidation`
+ * — no new validator. Failure copy is fixed generic text (CLAUDE.md).
+ */
+
+const LOAD_ERROR = "Couldn't load your target yield.";
+const SAVE_ERROR = "Couldn't save your target yield. Please try again.";
+
+/** Convert the stored fraction (or null) into the whole-percent form string.
+ * `0.12 * 100` is `12.000000000000002` in JS floating point — `toFixed(4)`
+ * cleans the artefact, then `Number` strips trailing zeros. */
+function fractionToFormValue(fraction) {
+  if (fraction === null || fraction === undefined) return '';
+  return String(Number((fraction * 100).toFixed(4)));
+}
+
+export default function TradingObjectivesSection() {
+  // `value` / `savedValue` are whole-percent strings. `""` is the unset state.
+  const [value, setValue] = useState('');
+  const [savedValue, setSavedValue] = useState('');
+  const [error, setError] = useState(null);
+  const [touched, setTouched] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [lastSaved, setLastSaved] = useState(null);
+
+  const load = () => {
+    setLoading(true);
+    setLoadError(false);
+    getSettings()
+      .then((settings) => {
+        const v = fractionToFormValue(settings?.okr_target_yield);
+        setValue(v);
+        setSavedValue(v);
+      })
+      .catch(() => setLoadError(true))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  const dirty = value !== savedValue;
+  // Blank is the legitimate unset state — it disables Save rather than showing
+  // an error. Any non-blank value runs through the `pctOpen100` validator.
+  const canSave = dirty && !isBlank(value) && !error && !saving;
+
+  // Re-validate once the field has been touched (blur) so a fix clears the
+  // error live — the `touched`/`revalidate` pattern from TradingRulesSection.
+  useEffect(() => {
+    if (!touched) return;
+    setError(isBlank(value) ? null : validateScalar('pctOpen100', value));
+  }, [value, touched]);
+
+  const handleChange = (next) => {
+    setValue(next);
+    setSaveError(false);
+    setSaveSuccess(false);
+  };
+
+  const handleBlur = () => {
+    setTouched(true);
+    setError(isBlank(value) ? null : validateScalar('pctOpen100', value));
+  };
+
+  const handleSave = async () => {
+    setTouched(true);
+    if (isBlank(value)) return;
+    const found = validateScalar('pctOpen100', value);
+    setError(found);
+    if (found) return;
+
+    setSaving(true);
+    setSaveError(false);
+    try {
+      // Whole-percent → fraction at the one boundary (design spec §4.2).
+      const fraction = Number(value) / 100;
+      await updateSetting('okr_target_yield', String(fraction));
+      setSavedValue(value);
+      setLastSaved(new Date());
+      setSaveSuccess(true);
+      toast.success('Target yield saved');
+      setTimeout(() => setSaveSuccess(false), 2500);
+    } catch {
+      setSaveError(true);
+      toast.error('Failed to save target yield');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const header = (
+    <div>
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+        Trading Objectives
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+    </div>
+  );
+
+  if (loading) {
+    return (
+      <div
+        data-testid="settings-objectives-loading"
+        className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700 animate-pulse"
+      >
+        <div className="h-5 w-44 bg-slate-200 dark:bg-slate-700 rounded mb-4" />
+        <div className="space-y-2">
+          <div className="h-3 w-24 bg-slate-200 dark:bg-slate-700 rounded" />
+          <div className="h-9 w-48 bg-slate-200 dark:bg-slate-700 rounded-lg" />
+        </div>
+        <div className="h-9 w-32 bg-slate-200 dark:bg-slate-700 rounded-lg mt-6" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700">
+        {header}
+        <div
+          data-testid="settings-objectives-load-error"
+          role="alert"
+          className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-lg px-4 py-3 mt-4 flex items-center justify-between gap-4"
+        >
+          <span className="text-sm">{LOAD_ERROR}</span>
+          <button
+            type="button"
+            onClick={load}
+            className="px-3 py-1.5 text-xs border border-red-300 dark:border-red-700 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/50"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      data-testid="settings-objectives-section"
+      className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSave();
+      }}
+    >
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+        Trading Objectives
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mb-4 pb-4 border-b border-slate-200 dark:border-slate-700">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+
+      {saveError && (
+        <div
+          data-testid="settings-objectives-save-error"
+          role="alert"
+          className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-lg px-4 py-3 mb-5 flex items-center justify-between gap-4"
+        >
+          <span className="text-sm">{SAVE_ERROR}</span>
+          <button
+            type="button"
+            onClick={() => setSaveError(false)}
+            className="text-xs text-red-500 hover:text-red-700 dark:hover:text-red-300"
+            aria-label="Dismiss error"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      <label
+        htmlFor="settings-objectives-target-yield"
+        className="block text-sm text-slate-700 dark:text-slate-300 mb-1"
+      >
+        Target yield
+      </label>
+      <div className={`flex items-stretch w-48 ${saving ? 'opacity-50' : ''}`}>
+        <input
+          id="settings-objectives-target-yield"
+          data-testid="settings-objectives-target-yield"
+          type="number"
+          inputMode="decimal"
+          step="any"
+          value={value}
+          placeholder="e.g. 12"
+          disabled={saving}
+          onChange={(e) => handleChange(e.target.value)}
+          onBlur={handleBlur}
+          aria-invalid={error ? 'true' : 'false'}
+          aria-describedby={
+            error
+              ? 'settings-objectives-target-yield-help settings-objectives-target-yield-error'
+              : 'settings-objectives-target-yield-help'
+          }
+          className={`w-full px-3 py-2 text-sm border rounded-l-lg rounded-r-none bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 outline-none focus:ring-2 disabled:cursor-not-allowed ${
+            error
+              ? 'border-red-400 dark:border-red-500 focus:ring-red-500'
+              : 'border-slate-300 dark:border-slate-600 focus:ring-blue-500'
+          }`}
+        />
+        <span
+          aria-hidden="true"
+          className="inline-flex items-center px-2.5 text-xs text-slate-500 dark:text-slate-400 border border-l-0 border-slate-300 dark:border-slate-600 rounded-r-lg bg-slate-100 dark:bg-slate-800"
+        >
+          %
+        </span>
+      </div>
+      <p
+        id="settings-objectives-target-yield-help"
+        className="text-xs text-slate-500 dark:text-slate-400 mt-1 max-w-xl"
+      >
+        The annual return you expect redeployed capital to earn. The Recovery
+        Plan uses this to score the Sell &amp; redeploy path — how a position&apos;s
+        trapped capital would perform if freed and put to work elsewhere.
+      </p>
+      {error && (
+        <p
+          id="settings-objectives-target-yield-error"
+          data-testid="settings-objectives-target-yield-error"
+          role="alert"
+          className="text-xs text-red-600 dark:text-red-400 mt-1"
+        >
+          {error}
+        </p>
+      )}
+
+      {/* Unset note — the analogue of TradingRulesSection's defaults-note.
+          Shown until a value is saved. Closes the loop for the trader who
+          arrived via the recovery "Set target yield →" CTA. */}
+      {isBlank(savedValue) && (
+        <p
+          data-testid="settings-objectives-unset-note"
+          className="text-sm text-slate-500 dark:text-slate-400 mt-4"
+        >
+          No target yield set yet. Until you set one, the Recovery Plan&apos;s
+          Sell &amp; redeploy path stays unavailable.
+        </p>
+      )}
+
+      {/* Action footer */}
+      <div className="flex items-center gap-3 mt-6 pt-5 border-t border-slate-200 dark:border-slate-700">
+        <button
+          type="submit"
+          data-testid="settings-objectives-save"
+          data-state={saving ? 'saving' : 'idle'}
+          disabled={!canSave}
+          className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed"
+        >
+          {saving ? 'Saving…' : 'Save objective'}
+        </button>
+        {saveSuccess && (
+          <span
+            data-testid="settings-objectives-save-success"
+            className="text-green-600 dark:text-green-400"
+            aria-label="Saved"
+          >
+            <svg
+              className="w-5 h-5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </span>
+        )}
+        {dirty && !saving && (
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            You have unsaved changes
+          </span>
+        )}
+        {!dirty && lastSaved && (
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            Last saved{' '}
+            {lastSaved.toLocaleTimeString([], {
+              hour: 'numeric',
+              minute: '2-digit',
+            })}
+          </span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/frontend/design-specs/issue-207-target-yield-objective-mock.html
+++ b/frontend/design-specs/issue-207-target-yield-objective-mock.html
@@ -1,0 +1,585 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Trading Objectives — Target Yield — mock for Issue #207</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['ui-sans-serif', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
+            mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    /* Match the app's body styles from frontend/app/globals.css */
+    body { margin: 0; min-height: 100vh; }
+    html.dark body { background-color: rgb(15 23 42); color: rgb(241 245 249); }
+  </style>
+</head>
+<body class="antialiased font-sans">
+
+<!-- =========================================================================
+     SELF-DOCUMENTATION
+     ========================================================================= -->
+<section class="border-b-4 border-blue-600 bg-slate-800/60">
+  <div class="max-w-3xl mx-auto px-6 py-5">
+    <div class="flex items-start justify-between flex-wrap gap-3">
+      <div>
+        <div class="text-[11px] font-semibold uppercase tracking-wider text-blue-400 mb-1">Static design mock — not production code</div>
+        <h1 class="text-xl font-semibold text-white">Settings — Trading Objectives tab (Target Yield) — Issue #207</h1>
+        <p class="text-sm text-slate-400 mt-1 max-w-3xl">
+          Read-only HTML/Tailwind mock of the V1.0.3 stopgap that fixes the dead-ending "Set target yield →"
+          Recovery Plan CTA. A new third Settings tab — <strong>Trading Objectives</strong> — holds a single
+          field, <strong>Target Yield</strong>. Each state below is rendered as its own stacked section.
+          Click-throughs are visual cues only — nothing is interactive. This is the minimal stopgap, NOT the
+          full V1.1 OKR Scorecard.
+        </p>
+        <p class="text-xs text-slate-500 mt-2">
+          States covered:
+          <span class="text-slate-300">1. Unset / empty (first run)</span> ·
+          <span class="text-slate-300">2. Populated (value set)</span> ·
+          <span class="text-slate-300">3. Inline validation error</span> ·
+          <span class="text-slate-300">4. Saving (form disabled)</span> ·
+          <span class="text-slate-300">5. Save success</span> ·
+          <span class="text-slate-300">6. Save failure banner</span> ·
+          <span class="text-slate-300">7. Loading skeleton</span> ·
+          <span class="text-slate-300">8. Load error</span> ·
+          <span class="text-slate-300">9. Recovery CTA — before / after</span>.
+        </p>
+      </div>
+      <div class="text-xs text-slate-400 text-right space-y-0.5">
+        <div>Last updated <span class="text-slate-200 font-medium">2026-05-18</span></div>
+        <div>Issue: <span class="text-blue-400">#207 — "Set target yield →" CTA dead-ends</span></div>
+        <div>Milestone: <span class="text-slate-300">V1.0.3 — Recovery Plan bug fixes</span></div>
+        <div>Spec: <span class="font-mono text-slate-300">frontend/design-specs/issue-207-target-yield-objective.md</span></div>
+        <div>Mock: <span class="font-mono text-slate-300">frontend/design-specs/issue-207-target-yield-objective-mock.html</span></div>
+        <div>Authority: <span class="font-mono text-slate-300">ADR-001 #210 — target yield is an OKR, not a rule</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- =========================================================================
+     PRODUCTION-LIKE APP HEADER (rendered once; identical chrome wraps every state)
+     Mirrors frontend/components/layout/Header.jsx so the page chrome reads as real.
+     ========================================================================= -->
+<header class="h-14 border-b border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 flex items-center justify-between px-4 shrink-0">
+  <a href="#" class="text-lg font-semibold text-slate-900 dark:text-white hover:text-blue-400">Regression Analysis Tool</a>
+  <div class="flex items-center gap-3">
+    <span class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-medium">Account ▾</span>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Dashboard</a>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Analysis</a>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Options</a>
+    <a href="#" class="px-3 py-1.5 rounded-lg hover:bg-slate-700 text-slate-300 text-sm font-medium">Journal</a>
+    <a href="#" class="p-2 rounded-lg bg-slate-700 text-slate-200" aria-label="Settings">
+      <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>
+    </a>
+  </div>
+</header>
+
+
+<!-- ============================================
+     SECTION 1 — UNSET / EMPTY (first-run state)
+     The state every trader sees until they set a value; the state the recovery
+     CTA delivers them into. Blank input, unset note, Save disabled.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-blue-900/40 text-blue-300 border border-blue-700">State 1</span>
+      <span class="text-sm text-slate-300">Unset / empty — no target yield stored yet. Sell &amp; redeploy stays suppressed. Save disabled.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <!-- page header -->
+    <div class="flex items-center justify-between mb-6">
+      <h1 class="text-2xl font-bold text-white">Settings</h1>
+      <a href="#" class="text-sm text-blue-400 hover:text-blue-300">Back to Analysis</a>
+    </div>
+
+    <!-- THREE-TAB BAR — General · Trading Rules · Trading Objectives.
+         "Trading Objectives" is the new third tab, last, after "Trading Rules". -->
+    <div role="tablist" aria-label="Settings sections" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button role="tab" data-testid="settings-tab-general" aria-selected="false"
+        class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button role="tab" data-testid="settings-rules-tab" aria-selected="false"
+        class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <!-- NEW tab — active here. data-testid is exactly settings-objectives-tab (issue req 1) -->
+      <button role="tab" data-testid="settings-objectives-tab" aria-selected="true"
+        class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <!-- ===== Trading Objectives section — UNSET ===== -->
+    <div role="tabpanel" aria-label="Trading Objectives" data-testid="settings-objectives-section">
+      <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+        <h2 class="text-lg font-semibold text-white">Trading Objectives</h2>
+        <p class="text-sm text-slate-400 pb-4 mb-4 border-b border-slate-700">
+          The targets your strategy aims for. Used by the Recovery Plan.
+        </p>
+
+        <!-- field: Target yield — UNSET. Input blank, non-numeric placeholder. -->
+        <label for="ty-1" class="block text-sm text-slate-300 mb-1">Target yield</label>
+        <div class="flex items-stretch w-48">
+          <input id="ty-1" data-testid="settings-objectives-target-yield" type="number"
+            placeholder="e.g. 12"
+            class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg rounded-r-none bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500 placeholder:text-slate-500" />
+          <span aria-hidden="true"
+            class="inline-flex items-center px-2.5 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-800">%</span>
+        </div>
+        <p class="text-xs text-slate-500 mt-1 max-w-xl">
+          The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the
+          Sell &amp; redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere.
+        </p>
+
+        <!-- unset note — analogue of TradingRulesSection's settings-rules-defaults-note -->
+        <p data-testid="settings-objectives-unset-note" class="text-sm text-slate-400 mt-4">
+          No target yield set yet. Until you set one, the Recovery Plan's Sell &amp; redeploy path stays unavailable.
+        </p>
+
+        <!-- action footer — Save DISABLED while field blank -->
+        <div class="flex items-center gap-3 mt-6 pt-5 border-t border-slate-700">
+          <button data-testid="settings-objectives-save" disabled
+            class="px-4 py-2 text-sm bg-blue-400 text-white rounded-lg cursor-not-allowed opacity-90">
+            Save objective
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 2 — POPULATED (a value is set)
+     Input shows 12 (whole percent). Stored as fraction 0.12. "Last saved" line.
+     Save disabled until edited (not dirty).
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-green-900/40 text-green-300 border border-green-700">State 2</span>
+      <span class="text-sm text-slate-300">Populated — value set (input 12% &nbsp;&rarr;&nbsp; stored fraction 0.12). Save idle until edited.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h2 class="text-lg font-semibold text-white">Trading Objectives</h2>
+      <p class="text-sm text-slate-400 pb-4 mb-4 border-b border-slate-700">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+
+      <!-- field: Target yield — POPULATED. Input value 12 (whole-percent). -->
+      <label for="ty-2" class="block text-sm text-slate-300 mb-1">Target yield</label>
+      <div class="flex items-stretch w-48">
+        <input id="ty-2" type="number" value="12"
+          class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg rounded-r-none bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+        <span aria-hidden="true"
+          class="inline-flex items-center px-2.5 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-800">%</span>
+      </div>
+      <p class="text-xs text-slate-500 mt-1 max-w-xl">
+        The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the
+        Sell &amp; redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere.
+      </p>
+
+      <!-- action footer — Save disabled (not dirty), passive "Last saved" line -->
+      <div class="flex items-center gap-3 mt-6 pt-5 border-t border-slate-700">
+        <button class="px-4 py-2 text-sm bg-blue-400 text-white rounded-lg cursor-not-allowed opacity-90">
+          Save objective
+        </button>
+        <span class="text-xs text-slate-400">Last saved 2:14 PM</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 3 — INLINE VALIDATION ERROR
+     Out-of-range value (0) — red ring + inline message. pctOpen100 kind reused
+     from rulesValidation.js. Message before save; Save blocked.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-rose-900/40 text-rose-300 border border-rose-700">State 3</span>
+      <span class="text-sm text-slate-300">Inline validation error — value out of range (0 &lt; x &le; 100). Save blocked.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h2 class="text-lg font-semibold text-white">Trading Objectives</h2>
+      <p class="text-sm text-slate-400 pb-4 mb-4 border-b border-slate-700">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+
+      <!-- field: Target yield — INVALID. value 0 -> out of bounds (0 < x).
+           Red-ring treatment from RuleField: border-red-400 + focus:ring-red-500. -->
+      <label for="ty-3" class="block text-sm text-slate-300 mb-1">Target yield</label>
+      <div class="flex items-stretch w-48">
+        <input id="ty-3" type="number" value="0" aria-invalid="true" aria-describedby="ty-3-err"
+          class="w-full px-3 py-2 text-sm border border-red-400 rounded-l-lg rounded-r-none bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-red-500" />
+        <span aria-hidden="true"
+          class="inline-flex items-center px-2.5 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-800">%</span>
+      </div>
+      <p class="text-xs text-slate-500 mt-1 max-w-xl">
+        The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the
+        Sell &amp; redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere.
+      </p>
+      <!-- inline error — generic pctOpen100 message, role=alert -->
+      <p id="ty-3-err" data-testid="settings-objectives-target-yield-error" role="alert"
+        class="text-xs text-red-400 mt-1">
+        Enter a percentage greater than 0 and up to 100.
+      </p>
+
+      <div class="flex items-center gap-3 mt-6 pt-5 border-t border-slate-700">
+        <button class="px-4 py-2 text-sm bg-blue-400 text-white rounded-lg cursor-not-allowed opacity-90">
+          Save objective
+        </button>
+        <span class="text-xs text-red-400">Fix 1 field before saving</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 4 — SAVING (PUT /api/settings in flight)
+     Input disabled (opacity-50), button reads "Saving…", disabled.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-amber-900/40 text-amber-300 border border-amber-700">State 4</span>
+      <span class="text-sm text-slate-300">Saving — request in flight. Input + button disabled.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h2 class="text-lg font-semibold text-white">Trading Objectives</h2>
+      <p class="text-sm text-slate-400 pb-4 mb-4 border-b border-slate-700">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+
+      <!-- field disabled during save — opacity-50, matches RuleField disabled treatment -->
+      <label for="ty-4" class="block text-sm text-slate-300 mb-1">Target yield</label>
+      <div class="flex items-stretch w-48 opacity-50">
+        <input id="ty-4" type="number" value="15" disabled
+          class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg rounded-r-none bg-slate-700 text-slate-100 cursor-not-allowed" />
+        <span aria-hidden="true"
+          class="inline-flex items-center px-2.5 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-800">%</span>
+      </div>
+      <p class="text-xs text-slate-500 mt-1 max-w-xl">
+        The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the
+        Sell &amp; redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere.
+      </p>
+
+      <div class="flex items-center gap-3 mt-6 pt-5 border-t border-slate-700">
+        <button data-state="saving" disabled
+          class="px-4 py-2 text-sm bg-blue-400 text-white rounded-lg cursor-not-allowed opacity-90">
+          Saving…
+        </button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 5 — SAVE SUCCESS
+     Transient green check beside the button (~2.5s) + toast. "Last saved" updates.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-green-900/40 text-green-300 border border-green-700">State 5</span>
+      <span class="text-sm text-slate-300">Save success — transient green check + toast. Cross-surface: Recovery Plan Sell &amp; redeploy un-suppresses on next load.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8 relative">
+    <!-- toast — react-hot-toast, top-right -->
+    <div class="absolute right-6 top-2 bg-slate-800 border border-slate-600 rounded-lg px-4 py-2.5 shadow-lg flex items-center gap-2">
+      <svg class="w-4 h-4 text-green-400" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+      <span class="text-sm text-slate-200">Target yield saved</span>
+    </div>
+
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h2 class="text-lg font-semibold text-white">Trading Objectives</h2>
+      <p class="text-sm text-slate-400 pb-4 mb-4 border-b border-slate-700">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+
+      <label for="ty-5" class="block text-sm text-slate-300 mb-1">Target yield</label>
+      <div class="flex items-stretch w-48">
+        <input id="ty-5" type="number" value="15"
+          class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg rounded-r-none bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+        <span aria-hidden="true"
+          class="inline-flex items-center px-2.5 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-800">%</span>
+      </div>
+      <p class="text-xs text-slate-500 mt-1 max-w-xl">
+        The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the
+        Sell &amp; redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere.
+      </p>
+
+      <div class="flex items-center gap-3 mt-6 pt-5 border-t border-slate-700">
+        <button class="px-4 py-2 text-sm bg-blue-400 text-white rounded-lg cursor-not-allowed opacity-90">
+          Save objective
+        </button>
+        <!-- transient inline check — settings-objectives-save-success -->
+        <span data-testid="settings-objectives-save-success" class="text-green-400" aria-label="Saved">
+          <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" /></svg>
+        </span>
+        <span class="text-xs text-slate-400">Last saved 2:31 PM</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 6 — SAVE FAILURE
+     Dismissible red banner above the field; entered value retained for retry.
+     Generic copy only (CLAUDE.md) — no raw exception.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-rose-900/40 text-rose-300 border border-rose-700">State 6</span>
+      <span class="text-sm text-slate-300">Save failure — dismissible red banner. Entered value kept for retry. Generic copy.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h2 class="text-lg font-semibold text-white">Trading Objectives</h2>
+      <p class="text-sm text-slate-400 pb-4 mb-4 border-b border-slate-700">
+        The targets your strategy aims for. Used by the Recovery Plan.
+      </p>
+
+      <!-- save-error banner — exact settings-rules-save-error treatment from TradingRulesSection -->
+      <div data-testid="settings-objectives-save-error" role="alert"
+        class="bg-red-900/30 border border-red-800 text-red-300 rounded-lg px-4 py-3 flex items-center justify-between gap-4 mb-5">
+        <span class="text-sm">Couldn't save your target yield. Please try again.</span>
+        <button class="text-xs text-red-400 hover:text-red-300" aria-label="Dismiss error">Dismiss</button>
+      </div>
+
+      <!-- field — entered value 15 RETAINED so the trader can retry without re-typing -->
+      <label for="ty-6" class="block text-sm text-slate-300 mb-1">Target yield</label>
+      <div class="flex items-stretch w-48">
+        <input id="ty-6" type="number" value="15"
+          class="w-full px-3 py-2 text-sm border border-slate-600 rounded-l-lg rounded-r-none bg-slate-700 text-slate-100 outline-none focus:ring-2 focus:ring-blue-500" />
+        <span aria-hidden="true"
+          class="inline-flex items-center px-2.5 text-xs text-slate-400 border border-l-0 border-slate-600 rounded-r-lg bg-slate-800">%</span>
+      </div>
+      <p class="text-xs text-slate-500 mt-1 max-w-xl">
+        The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the
+        Sell &amp; redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere.
+      </p>
+
+      <div class="flex items-center gap-3 mt-6 pt-5 border-t border-slate-700">
+        <button class="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700">
+          Save objective
+        </button>
+        <span class="text-xs text-slate-400">You have unsaved changes</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 7 — LOADING SKELETON
+     Section's own fetch (read okr_target_yield) in flight. Skeleton bars.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-slate-700 text-slate-300 border border-slate-600">State 7</span>
+      <span class="text-sm text-slate-300">Loading — reading the stored target yield. Skeleton placeholder.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <!-- skeleton — SkeletonRow pattern from TradingRulesSection, scoped to one field -->
+    <div data-testid="settings-objectives-loading" class="bg-slate-800 rounded-xl p-6 border border-slate-700 animate-pulse">
+      <div class="h-5 w-44 bg-slate-700 rounded mb-4"></div>
+      <div class="space-y-2 mb-4">
+        <div class="h-3 w-24 bg-slate-700 rounded"></div>
+        <div class="h-9 w-48 bg-slate-700 rounded-lg"></div>
+        <div class="h-3 w-80 bg-slate-700 rounded"></div>
+      </div>
+      <div class="h-9 w-32 bg-slate-700 rounded-lg mt-6"></div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 8 — LOAD ERROR
+     The section's read of okr_target_yield rejected. Red block + Retry.
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-rose-900/40 text-rose-300 border border-rose-700">State 8</span>
+      <span class="text-sm text-slate-300">Load error — reading the stored value failed. Retry available.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8">
+    <div role="tablist" class="flex gap-2 mb-8 border-b border-slate-700 pb-4">
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">General</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg text-slate-400 hover:bg-slate-800">Trading Rules</button>
+      <button class="px-4 py-2 text-sm font-medium rounded-lg bg-blue-600 text-white">Trading Objectives</button>
+    </div>
+
+    <div class="bg-slate-800 rounded-xl p-6 border border-slate-700">
+      <h2 class="text-lg font-semibold text-white mb-4">Trading Objectives</h2>
+      <!-- load-error block — exact settings-rules-load-error treatment -->
+      <div data-testid="settings-objectives-load-error" role="alert"
+        class="bg-red-900/30 border border-red-800 text-red-300 rounded-lg px-4 py-3 flex items-center justify-between gap-4">
+        <span class="text-sm">Couldn't load your target yield.</span>
+        <button class="px-3 py-1.5 text-xs border border-red-700 rounded-lg hover:bg-red-900/50">Retry</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- ============================================
+     SECTION 9 — RECOVERY CTA: before / after
+     The bug, and the fix. The "Set target yield →" CTA on a suppressed
+     Sell & redeploy path. Before: dead /settings#okrs. After: /settings?tab=objectives.
+     Canonical example: SOFI, -$3,048 / -39% (issue #182 fixture).
+     ============================================ -->
+<section>
+  <div class="bg-slate-900 border-y border-slate-700">
+    <div class="max-w-3xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+      <span class="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider bg-indigo-900/40 text-indigo-300 border border-indigo-700">State 9</span>
+      <span class="text-sm text-slate-300">Recovery CTA — the suppressed Sell &amp; redeploy path on /positions/SOFI/recovery. Before vs after the fix.</span>
+    </div>
+  </div>
+
+  <div class="max-w-3xl mx-auto px-6 py-8 space-y-6">
+    <p class="text-sm text-slate-400">
+      Context — the CTA this issue fixes. On the Recovery Plan page, the <strong>Sell &amp; redeploy</strong> path is
+      suppressed because no target yield is set. The card carries a self-remediation CTA. Below: the broken state
+      and the fixed state of that one CTA. Only the <span class="font-mono text-slate-300">href</span> changes.
+    </p>
+
+    <!-- BEFORE — dead link -->
+    <div>
+      <div class="text-[11px] font-semibold uppercase tracking-wider text-rose-400 mb-2">Before — CTA dead-ends</div>
+      <!-- suppressed RecoveryPathCard — Sell & redeploy -->
+      <div class="bg-slate-800/60 rounded-xl p-5 border border-slate-700 opacity-90">
+        <div class="flex items-center justify-between mb-2">
+          <h3 class="text-sm font-semibold text-slate-300">Sell &amp; redeploy</h3>
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-slate-700 text-slate-400 border border-slate-600">Suppressed</span>
+        </div>
+        <div data-testid="recovery-path-card-sell-redeploy-suppression"
+          class="text-xs text-amber-300 bg-amber-900/20 border border-amber-800 rounded-lg px-3 py-2 flex items-center justify-between gap-3">
+          <span>⚠ Target yield not configured</span>
+          <!-- the dead CTA — href="/settings#okrs" routes nowhere -->
+          <a href="#" data-testid="recovery-path-card-sell-redeploy-suppression-cta"
+            class="text-blue-400 hover:text-blue-300 font-medium whitespace-nowrap line-through decoration-rose-500/70">
+            Set target yield →
+          </a>
+        </div>
+        <!-- annotation: href is the bug -->
+        <p class="text-[11px] text-rose-400 mt-2 font-mono">href="/settings#okrs" &mdash; no such anchor; dead-ends</p>
+        <div class="grid grid-cols-3 gap-3 mt-3 text-center">
+          <div><div class="text-sm font-semibold text-slate-600">—</div><div class="text-[10px] text-slate-500">Capital tied up</div></div>
+          <div><div class="text-sm font-semibold text-slate-600">—</div><div class="text-[10px] text-slate-500">Months to breakeven</div></div>
+          <div><div class="text-sm font-semibold text-slate-600">—</div><div class="text-[10px] text-slate-500">Opportunity cost</div></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- AFTER — fixed link -->
+    <div>
+      <div class="text-[11px] font-semibold uppercase tracking-wider text-green-400 mb-2">After — CTA routes to the new tab</div>
+      <div class="bg-slate-800/60 rounded-xl p-5 border border-slate-700">
+        <div class="flex items-center justify-between mb-2">
+          <h3 class="text-sm font-semibold text-slate-300">Sell &amp; redeploy</h3>
+          <span class="text-[11px] px-2 py-0.5 rounded-full bg-slate-700 text-slate-400 border border-slate-600">Suppressed</span>
+        </div>
+        <div class="text-xs text-amber-300 bg-amber-900/20 border border-amber-800 rounded-lg px-3 py-2 flex items-center justify-between gap-3">
+          <span>⚠ Target yield not configured</span>
+          <!-- fixed CTA — href="/settings?tab=objectives", the #235 deep-link pattern -->
+          <a href="#" class="text-blue-400 hover:text-blue-300 font-medium whitespace-nowrap">Set target yield →</a>
+        </div>
+        <p class="text-[11px] text-green-400 mt-2 font-mono">href="/settings?tab=objectives" &mdash; lands on the Trading Objectives tab</p>
+        <p class="text-[11px] text-slate-500 mt-1">
+          Once a target yield is saved and the page reloads, the backend stops emitting this suppression reason —
+          the CTA disappears and the three metrics below populate.
+        </p>
+        <div class="grid grid-cols-3 gap-3 mt-3 text-center">
+          <div><div class="text-sm font-semibold text-slate-300">$8,140</div><div class="text-[10px] text-slate-500">Capital tied up</div></div>
+          <div><div class="text-sm font-semibold text-slate-300">11 mo</div><div class="text-[10px] text-slate-500">Months to breakeven</div></div>
+          <div><div class="text-sm font-semibold text-slate-300">$977/yr</div><div class="text-[10px] text-slate-500">Opportunity cost</div></div>
+        </div>
+        <p class="text-[11px] text-slate-500 mt-2 italic">
+          (Metrics shown for illustration — they compute on the backend once okr_target_yield is set; SOFI position, −$3,048 / −39%.)
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<footer class="max-w-3xl mx-auto px-6 py-8 text-xs text-slate-500 border-t border-slate-800">
+  <p>Static design mock for Issue #207 — Settings Trading Objectives tab (Target Yield). Generated by the Designer agent, 2026-05-18.</p>
+  <p class="mt-1">Spec: <span class="font-mono">frontend/design-specs/issue-207-target-yield-objective.md</span> · Milestone V1.0.3 · Click-throughs are visual cues only.</p>
+</footer>
+
+</body>
+</html>

--- a/frontend/design-specs/issue-207-target-yield-objective.md
+++ b/frontend/design-specs/issue-207-target-yield-objective.md
@@ -1,0 +1,530 @@
+# Design Spec: Settings — Trading Objectives tab (Target Yield)
+
+- **Issue:** [#207 — Recovery Plan "Set target yield →" CTA dead-ends — no way to set a target yield](https://github.com/ssandy33/regress/issues/207)
+- **Milestone:** V1.0.3 — Recovery Plan bug fixes
+- **Date:** 2026-05-18
+- **Author:** Designer agent
+- **Status:** Draft — for user review before implementation
+- **Scope:** Frontend visual + structural spec for a **new third Settings tab, "Trading Objectives"**, holding a **single field — Target Yield**. This is the **V1.0.3 minimal stopgap** that gives the dead-ending "Set target yield →" recovery CTA a real destination and un-suppresses the Recovery Plan's *Sell & redeploy* path. It is **explicitly NOT** the full V1.1 OKR Scorecard — see §1.2 for the line. The backend (`okr_target_yield` read/write plumbing) is referenced where it drives UI states; the only net-new backend ask is a way to *read the current value back* (§7).
+
+---
+
+## 1. Overview
+
+### 1.1 The bug being fixed
+
+On the Recovery Plan page (`/positions/[id]/recovery`), the **Sell & redeploy** path is permanently suppressed with `⚠ Target yield not configured` and a **"Set target yield →"** CTA. The CTA routes to `/settings#okrs` — an anchor that does not exist. There is no UI anywhere in the app to set a target yield, so the Sell & redeploy path computes nothing (capital tied up / months to breakeven / opportunity cost all blank) for every position, and its self-remediation CTA dead-ends.
+
+`#235` (v1.0.2) fixed the sibling "Adjust cap →" CTA and introduced the `/settings?tab=…` deep-link pattern. This spec applies the same pattern to the target-yield half: a real Settings destination, reached via `/settings?tab=objectives`.
+
+### 1.2 What this stopgap is — and is not
+
+| | This V1.0.3 stopgap | The V1.1 OKR Scorecard |
+|---|---|---|
+| Surface | One new Settings tab, **one field** | A full OKR config surface — multiple objectives, scoring, history |
+| Storage | The existing flat `okr_target_yield` app-setting key | The typed `okr_config` namespace (ADR-001) |
+| Goal | Un-dead-end the CTA; let Sell & redeploy compute | Full objectives/scorecard product |
+
+The flat `okr_target_yield` key already exists and is already consumed by the backend recovery engine (`backend/app/routers/positions.py`, `recovery_engine.py`). This stopgap **does not invent storage** — it builds the *missing input UI* for a key the backend already reads. When V1.1 builds the typed `okr_config` layer, this flat key migrates into it; the tab and field designed here are the natural seed of the V1.1 "Objectives" surface, so V1.1 extends rather than replaces.
+
+### 1.3 The hard constraint — objective, not rule
+
+**Target yield is an objective / OKR, not a Trading Rule.** It must read as an objective and must NOT be folded into the existing "Trading Rules" tab. `#235` just corrected exactly this OKR-vs-rule mislabeling (the sizing cap was wrongly treated as an OKR; it is a rule). The inverse error — folding an OKR into Trading Rules — is just as wrong. The whole reason this spec creates a *separate tab* rather than adding a field to `TradingRulesSection` is to keep that line clean. ADR-001 (Discussion #210) is the canonical authority: target yield is an OKR; the sizing cap is a rule.
+
+The two concepts differ in kind:
+- A **Trading Rule** is a *constraint* on what you may do ("never tie up more than X%").
+- An **Objective / OKR** is a *target* you are aiming at ("the redeployed capital should earn X%").
+
+Target yield is the second. The tab label, the section heading, and the field copy must all carry that framing.
+
+---
+
+## 2. Stack context (detected)
+
+Detected from the repo before authoring — confirmed against the live `#158` / `#235` implementation, not assumed:
+
+- **Framework:** Next.js 16.2.4, App Router (`frontend/app/`).
+- **Language:** JavaScript / JSX. `jsconfig.json` only — **no TypeScript.** Data shapes below are JSDoc-style notes.
+- **Styling:** Tailwind CSS v4 (`@tailwindcss/postcss`). No `tailwind.config.js` — default token scale. Dark mode is class-based (`.dark` on `<html>`), re-bound via `@custom-variant dark` in `app/globals.css`.
+- **Toasts:** `react-hot-toast` — already wired in `SettingsPage.jsx` and `TradingRulesSection.jsx`.
+- **Settings page is already tabbed.** `components/settings/SettingsPage.jsx` shipped page-scoped tabs in `#158` (Option B): a `general` tab and a `rules` tab, with `?tab=` deep-link lazy-init added in `#235`. **Its own comments anticipate this exact tab** — `SettingsPage.jsx:36` ("A V1.1 'Trading OKRs' tab slots in here with zero rework") and `:197` ("'Trading OKRs' joins here in V1.1"). This spec fills that slot, **now**, for V1.0.3.
+- **Backend already consumes the key.** `okr_target_yield` is read in `positions.py` via `_get_app_setting` and parsed with `float(...)`; the recovery engine multiplies `capital * target_yield` and renders it with `_format_pct` (`pct * 100`). **The stored value is a fraction** (e.g. `0.12` = 12%). See §4 — this is the crux of the unit decision.
+- **Generic setting write already exists.** `PUT /api/settings` accepts any `{key, value}` and upserts the `app_settings` row; the `updateSetting(key, value)` helper in `api/client.js` wraps it. Writing `okr_target_yield` needs **no new write endpoint**.
+- **No `docs/DESIGN_SYSTEM.md`** exists. Tokens in §10 were derived from the codebase and from the `#158` / `#234` specs, which are the canonical reference for the Settings surface.
+
+---
+
+## 3. Tab — "Trading Objectives"
+
+### 3.1 Label — confirmed: **"Trading Objectives"**
+
+The milestone plan proposed "Trading Objectives". **Confirmed — adopt it.** Rationale:
+
+- It is structurally parallel to the existing **"Trading Rules"** tab (`Trading ___`), which makes the tab bar read as a coherent set: *General · Trading Rules · Trading Objectives*. The shared "Trading " prefix signals these two tabs are siblings — both about *how you trade* — while "Rules" vs "Objectives" carries the constraint-vs-target distinction of §1.3.
+- "Objectives" is the correct register for an OKR (the **O** in OKR). The `SettingsPage.jsx` comments say "Trading OKRs"; **do not use the literal string "OKRs" in the tab label** — "OKRs" is internal jargon, "Objectives" is the plain-language word a trader reads. The code comments can keep saying OKR; the *UI* says Objectives.
+- It scales to V1.1: when the OKR Scorecard adds more objectives, the tab is already correctly named — V1.1 adds fields under the same tab, no rename.
+
+Rejected alternatives: "OKRs" (jargon), "Goals" (less precise than "Objectives", and not parallel with "Rules"), "Targets" (conflates with the field name "Target Yield" — the tab would read "Targets ▸ Target Yield").
+
+### 3.2 Position in the tab bar — **after "Trading Rules"**
+
+The tab bar becomes a three-tab strip, in this order:
+
+```
+[ General ]  [ Trading Rules ]  [ Trading Objectives ]
+```
+
+- **General** stays first — it is the catch-all infrastructure tab and the default landing tab.
+- **Trading Objectives** goes **last, immediately after Trading Rules.** The two "Trading ___" tabs sit adjacent so the sibling relationship is visually obvious.
+- The active-tab default is unchanged: `general` unless a `?tab=` param says otherwise.
+
+### 3.3 Deep-link param — `?tab=objectives`
+
+`SettingsPage.jsx` already lazy-inits `activeTab` from `searchParams.get('tab')` (`#235`). Today it only recognises `'rules'`. Extend the lazy initializer to also recognise `'objectives'`:
+
+```js
+const [activeTab, setActiveTab] = useState(() => {
+  const t = searchParams?.get('tab');
+  if (t === 'rules') return 'rules';
+  if (t === 'objectives') return 'objectives';
+  return 'general';
+});
+```
+
+The recovery CTA (`suppressionReasonCta.js`) is updated in the same PR to point the target-yield reason at `/settings?tab=objectives` (§8). Query params are the established codebase pattern; URL hashes (`#okrs`) are used nowhere — the dead `#okrs` anchor is the bug.
+
+### 3.4 Tab button — markup mirrors the existing two
+
+The new tab button is the existing two with the label and ids swapped. It reuses the existing `tabClass(tab)` helper unchanged.
+
+```jsx
+<button
+  type="button"
+  role="tab"
+  data-testid="settings-objectives-tab"
+  aria-selected={activeTab === 'objectives'}
+  onClick={() => setActiveTab('objectives')}
+  className={tabClass('objectives')}
+>
+  Trading Objectives
+</button>
+```
+
+> **Test-ID naming note.** The existing tabs are inconsistent — `settings-tab-general` (verb-first) vs `settings-rules-tab` (noun-first). The issue specifies `settings-objectives-tab`, which matches the **newer** `settings-rules-tab` form. Adopt `settings-objectives-tab` as the issue states. Do not "fix" the older `settings-tab-general` id in this PR — that is unrelated churn and would break any `#158`-era e2e spec.
+
+The tab panel:
+
+```jsx
+{activeTab === 'objectives' ? (
+  <div role="tabpanel" aria-label="Trading Objectives">
+    <TradingObjectivesSection />
+  </div>
+) : activeTab === 'rules' ? (
+  /* …existing rules panel… */
+) : loading ? ( /* … */ ) : ( /* …general panel… */ )}
+```
+
+`TradingObjectivesSection` mounts independently of the `general`-tab data load — like `TradingRulesSection`, it owns its own fetch and is not gated by the page-level `loading` flag.
+
+---
+
+## 4. Unit convention — RESOLVED
+
+This is the decision the issue flags as "must resolve". It has two halves: what the **field accepts/displays**, and what the **save layer stores**.
+
+### 4.1 The two units in play
+
+- **Backend storage:** `okr_target_yield` is stored as a **fraction**. Confirmed by reading the code, not assumed:
+  - `recovery_engine.py:_format_pct` → `f"{pct * 100:.0f}%"` — multiplies by 100 to display, so the stored value is a fraction.
+  - `recovery_engine.py` → `annual_return = freed_capital * target_yield` — multiplied directly against a dollar amount, which only works if it is a fraction.
+  - So `okr_target_yield = "0.12"` means **12%**.
+- **Existing Trading Rules UI:** standardises on **whole-percent** — `rules_config` stores `25` to mean 25%, and `RuleField` does no human↔fraction conversion (`RuleField.jsx` docblock is explicit about this).
+
+These two conventions disagree. The stopgap field must pick one for the *user-facing input* and convert at the boundary.
+
+### 4.2 Decision — **field accepts WHOLE PERCENT; save layer converts to/from the stored fraction**
+
+**Confirmed — adopt the issue's recommended convention.** The Target Yield field:
+
+- **Displays and accepts a whole percent.** The trader types `12` for 12%. The input carries a trailing **`%` adornment** (the same `RuleField` `suffix: '%'` treatment used by every percent field in Trading Rules).
+- **The save layer converts.** On save: `fraction = wholePercent / 100` → `updateSetting('okr_target_yield', String(fraction))`. On load: `wholePercent = fraction * 100` → shown in the input.
+
+Rationale:
+
+1. **Consistency with the rest of Settings.** Every percentage the trader edits today (in Trading Rules) is whole-percent with a `%` affix. Asking them to type `0.12` in one lone field — when every neighbouring percent field takes `12` — is an inconsistency that *will* cause mis-entry (a trader types `12` meaning 12%, the backend reads it as 1200%). Whole-percent is the convention the user already has in their hands.
+2. **A `%` affix only makes sense next to a whole number.** "`0.12` %" reads as 0.12 percent. "`12` %" reads as 12 percent. The affix and the value must agree.
+3. **The conversion is trivial, total, and lossless** at the one boundary (`/100` on save, `*100` on load) — and it is isolated in the section component, exactly as `RuleField`'s docblock prescribes ("If the model ever switched to fractions, the conversion would live in `TradingRulesSection`'s load/save mapping, not here"). This spec puts that conversion in `TradingObjectivesSection`.
+4. **The backend storage does not change.** `okr_target_yield` stays a fraction; the recovery engine is untouched. The conversion is purely a frontend presentation concern. This keeps the stopgap tight and risk-free on the backend.
+
+**Displayed unit: whole percent, with a trailing `%` affix.** Stored unit: fraction. The conversion lives only in `TradingObjectivesSection`'s load/save mapping.
+
+### 4.3 Precision
+
+- The input accepts **decimals** — `12.5` is valid (→ stored `0.125`). The backend `float` parse accepts it and `_format_pct` rounds to whole-percent for *display in the recovery banner* (`:.0f`), which is acceptable — the stored precision is preserved, only the recovery-banner label rounds. This matches Trading Rules' percent fields, which also accept decimals (§4.4 of the `#234` spec).
+- Step: `step="any"` on the number input (the `RuleField` default) so the spinner does not force integers.
+- On load, `fraction * 100` can produce a float artefact (`0.12 * 100` → `12.000000000000002` in JS). The load mapping must clean this: `Number((fraction * 100).toFixed(4))` → `12`. Specified again in §7 and §11.
+
+---
+
+## 5. The Target Yield field
+
+A single field, rendered inside one Settings card. It reuses the visual vocabulary of `RuleField` (label row, number input, trailing affix, helper text, inline error) — but because the section has exactly **one** field and a different save model (one flat key, not a typed `rules_config` document), it does **not** reuse the `RuleField`/`rulesFieldCatalog` machinery wholesale. See §9 for the build-vs-reuse call. Visually, it is indistinguishable from a Trading Rules percent field.
+
+### 5.1 Anatomy
+
+```
+┌─ Card: Trading Objectives ────────────────────────────────────────────┐
+│  Trading Objectives                                                    │
+│  The targets your strategy aims for. Used by the Recovery Plan.         │
+│  ──────────────────────────────────────────────────────────────────────│
+│                                                                         │
+│  Target yield                                                          │
+│  ┌────────────────────────────────────────────────────┐ ┌─────┐        │
+│  │  12                                                 │ │  %  │        │
+│  └────────────────────────────────────────────────────┘ └─────┘        │
+│  The annual return you expect redeployed capital to earn. The Recovery │
+│  Plan uses this to score the Sell & redeploy path — how a position's    │
+│  trapped capital would perform if freed and put to work elsewhere.      │
+│                                                                         │
+│  [ Save objective ]            You have unsaved changes                 │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Copy
+
+| Element | Copy |
+|---|---|
+| Tab label | **Trading Objectives** |
+| Section heading (`<h2>`) | **Trading Objectives** |
+| Section description | **"The targets your strategy aims for. Used by the Recovery Plan."** |
+| Field label | **Target yield** |
+| Field affix | **`%`** (trailing) |
+| Field placeholder | **`e.g. 12`** — a non-numeric example, so an empty field reads as genuinely unset, not as a real `0` (the same honest-unset principle as `RuleField`'s Optional fields). |
+| Helper text | **"The annual return you expect redeployed capital to earn. The Recovery Plan uses this to score the Sell & redeploy path — how a position's trapped capital would perform if freed and put to work elsewhere."** |
+| Save button | **"Save objective"** |
+
+The helper text does the work the issue asks for in requirement 2 — it explicitly states that *this objective drives the Recovery Plan's Sell & redeploy path*. That sentence is the connective tissue: a trader arriving via the "Set target yield →" CTA reads the helper and immediately understands why they are here.
+
+### 5.3 Input affordance
+
+- `<input type="number" inputMode="decimal" step="any">` — identical to `RuleField`'s number input.
+- Trailing `%` affix box: `inline-flex items-center px-2.5 text-xs text-slate-500 dark:text-slate-400 border border-l-0 border-slate-300 dark:border-slate-600 rounded-r-lg bg-slate-100 dark:bg-slate-800` — the exact affix markup `RuleField` renders for trailing-suffix fields. The input itself gets `rounded-r-none` so input + affix read as one control.
+- Width: the input is **not** full-bleed. A yield is a 2–4 character value; a full-width input looks unbalanced. Constrain the input+affix group to a sensible max width (`max-w-[12rem]` / `w-48`) left-aligned, with the helper text below at full card width. This differs from `RuleField` (which is full-width because it sits in a dense multi-field grid) — a one-field card can afford a right-sized input.
+
+### 5.4 Field framing — why it reads as an objective
+
+Per §1.3, the framing must say "objective", not "rule":
+
+- The section heading is **"Trading Objectives"** (not "OKRs", not "Goals").
+- The description — *"The targets your strategy aims for"* — names them as *targets*, the language of objectives.
+- The helper uses *"expect … to earn"* and *"score"* — aspirational/measurement language, not constraint language. A Trading Rule helper says "the most you may…"; this says "the return you expect…".
+- The save button says **"Save objective"** (singular — there is one), parallel to Trading Rules' "Save trading rules" but unmistakably a different noun.
+
+---
+
+## 6. States
+
+The section mirrors the state conventions of `TradingRulesSection.jsx` exactly — same loading / load-error / saving / save-success / save-failure shapes, same generic-copy discipline (CLAUDE.md), simplified to one field. Because it is one field there is **no** "Reset to defaults" control and **no** per-group machinery.
+
+### 6.1 Loading
+
+The section's own fetch (read the current `okr_target_yield`, §7) is in flight. Render a skeleton: the card shell with a `h-3 w-24` label bar and a `h-9 w-48` input bar, both `bg-slate-200 dark:bg-slate-700 animate-pulse` — the `SkeletonRow` pattern from `TradingRulesSection.jsx`, scoped to one row.
+`data-testid="settings-objectives-loading"`.
+
+### 6.2 Unset / empty — the first-run state
+
+This is the state every trader sees until they set a value, and the state the recovery CTA delivers them into. The backend returns no `okr_target_yield` (or empty string) → `target_yield` is `None` → Sell & redeploy is suppressed.
+
+- The input renders **blank** with the `e.g. 12` placeholder. Blank is honest "unset" — never pre-fill a `0` or a guessed default. `0` is not even a valid value (§7 — `0.0 <` exclusive), and a guessed default would silently un-suppress the recovery path with a number the trader never chose.
+- Below the helper, an **unset note** — the analogue of `TradingRulesSection`'s `settings-rules-defaults-note`:
+  > **"No target yield set yet. Until you set one, the Recovery Plan's Sell & redeploy path stays unavailable."**
+  Styling: `text-sm text-slate-500 dark:text-slate-400`. This closes the loop — the trader who clicked "Set target yield →" sees, in plain words, the consequence of the empty field and what setting it unlocks.
+- `data-testid="settings-objectives-unset-note"`.
+- The Save button is **disabled** while the field is blank (nothing to save) — consistent with `TradingRulesSection`'s `canSave` gate (`dirty && no errors`).
+
+### 6.3 Populated — a value is set
+
+Backend returns a fraction → the load mapping converts to whole-percent (§4.2, §11) → the input shows e.g. `12`. The unset note is gone. The Save button is disabled until the field is edited (`dirty`). When not dirty and a value exists, show a passive **"Last saved {time}"** line — the `TradingRulesSection` pattern (`lastSaved.toLocaleTimeString`).
+
+### 6.4 Saving
+
+The trader clicked Save and the `PUT /api/settings` call is in flight.
+- The input is `disabled` (`disabled:opacity-50`), the Save button shows **"Saving…"** and is disabled. The `RuleField` already styles a disabled input; mirror that.
+- `data-testid` on the button stays `settings-objectives-save`; the implementer may add `data-state="saving"` for e2e.
+
+### 6.5 Save success
+
+The `PUT` resolved.
+- `toast.success('Target yield saved')` — `react-hot-toast`, already wired.
+- A transient inline green check next to the button for ~2.5s — the exact `settings-rules-save-success` SVG-check pattern from `TradingRulesSection.jsx:431`. `data-testid="settings-objectives-save-success"`.
+- The field's value is re-derived from the save response / re-fetch and becomes the new "saved" baseline; `dirty` clears; the "Last saved {time}" line updates.
+- **Cross-surface consequence (not rendered here, but the reason the feature exists):** with a value now stored, the next load of any Recovery Plan page un-suppresses Sell & redeploy. The stopgap does not need to live-refresh the recovery page — a normal navigation/reload picks it up. (If the user is *deep-linked* from the recovery CTA, see §8.3.)
+
+### 6.6 Save failure
+
+The `PUT` rejected (network, server error).
+- A dismissible red banner above the field — the exact `settings-rules-save-error` treatment from `TradingRulesSection.jsx:307`: `bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300`, `role="alert"`, a "Dismiss" button.
+- Copy — **fixed generic text**, per CLAUDE.md ("never return raw exception messages"): **"Couldn't save your target yield. Please try again."**
+- `toast.error('Failed to save target yield')`.
+- The entered value is **retained** in the input (not cleared) so the trader can retry without re-typing.
+- `data-testid="settings-objectives-save-error"`.
+
+### 6.7 Load failure
+
+The section's read of `okr_target_yield` (§7) rejected.
+- The card renders a red error block with a **Retry** button — the exact `settings-rules-load-error` treatment from `TradingRulesSection.jsx:264`.
+- Copy: **"Couldn't load your target yield."**
+- Retry re-runs the fetch.
+- `data-testid="settings-objectives-load-error"`.
+
+---
+
+## 7. Validation
+
+The value is a yield percentage. The backend bound on the **stored fraction** is `0.0 < fraction <= 1.0` (per the issue). Converted to the **whole-percent the field accepts**, that is:
+
+> **Valid: greater than 0 and up to 100 (`0 < x ≤ 100`).** `0` is invalid (a 0% target yield is meaningless and the backend rejects it). `100` is valid (a 100% target — aggressive, but in-bounds). Blank is invalid *for save* (you cannot save an empty objective) but is the legitimate **unset** display state (§6.2) — a blank field simply disables Save rather than showing an error.
+
+This is **exactly the existing `pctOpen100` validation kind** in `rulesValidation.js` (`n <= 0 || n > 100`), with the existing generic message:
+
+> **"Enter a percentage greater than 0 and up to 100."**
+
+### 7.1 Validation behaviour
+
+- **Reuse `validateScalar('pctOpen100', value)`** from `components/settings/rulesValidation.js` — do not write a new validator. It is a pure exported function; importing it into `TradingObjectivesSection` is clean reuse and guarantees the stopgap agrees with the Trading Rules percent fields and (transitively) with the backend Pydantic validators that `rulesValidation.js` mirrors. Note `pctOpen100` treats blank as invalid (`MSG.number`) when `optional=false`; the section treats blank specially (it is the unset state) — so the section checks `isBlank()` *first* and only runs `validateScalar` on a non-blank value. `isBlank` is also exported from `rulesValidation.js`.
+- **When the error shows:** on blur after the trader has touched the field, and live once a save has been attempted — the `touched` / `revalidate` pattern from `TradingRulesSection.jsx`.
+- **Error display:** the inline `RuleField`-style message — `text-xs text-red-600 dark:text-red-400 mt-1`, `role="alert"`, and the input gets the red-ring treatment (`border-red-400 dark:border-red-500 focus:ring-red-500`, `aria-invalid="true"`). `data-testid="settings-objectives-target-yield-error"`.
+- **Save gate:** Save is disabled when the field is blank OR invalid OR not dirty OR currently saving — the `canSave` shape from `TradingRulesSection`.
+- **Inline message before save:** the issue's requirement 5 ("inline validation message before save") is satisfied — the message appears on blur, before the trader ever reaches the Save button, exactly as in Trading Rules.
+
+### 7.2 Backend read — the one net-new backend ask
+
+⚠️ **DECISION NEEDED — implementation constraint, recommended option in bold.**
+
+The generic `GET /api/settings` returns a **fixed `SettingsResponse` Pydantic model** (`backend/app/routers/settings.py:38`) that does **not** include `okr_target_yield`. So the new section **cannot read the current value back via the existing `getSettings()` helper.** The *write* side is fine (`PUT /api/settings` with `{key, value}` is generic and already works); only the *read* is missing. The section needs the current value to render the populated state (§6.3) and to know whether to show the unset note (§6.2).
+
+Options:
+
+- **(a) Add `okr_target_yield` to the `SettingsResponse` model.** One field on an existing Pydantic model, read with the existing `_get(...)` helper in `get_settings`. The frontend's existing `getSettings()` helper then carries it for free. **✅ Recommended** — smallest, most idiomatic change; `SettingsResponse` is already the home for assorted app settings (`default_date_range_years`, `theme`). The field would be `okr_target_yield: float | None` (the stored fraction; the frontend converts to whole-percent per §4.2).
+- (b) A dedicated `GET /api/settings/okr` endpoint. Heavier; parallels `GET /api/settings/rules` but a one-key read does not justify a typed sub-resource for a *stopgap* (the V1.1 OKR Scorecard may well introduce `/api/settings/okr` — but that is V1.1's call, not this stopgap's).
+- (c) Generic key read (`GET /api/settings/{key}`). No such endpoint exists; adding a generic getter is broader surface than needed.
+
+**Recommendation: (a).** It is one line on `SettingsResponse` + one line in `get_settings`. The frontend then reads via the existing `getSettings()`; no new client helper. This is a backend touch but a minimal one, and it is genuinely required — without a read path the section cannot render its populated/unset distinction. Flag for the user; this is the only backend change the stopgap needs beyond what already exists.
+
+> The data-shape and load/save mapping in §11 assume option (a). If the user picks (b) or (c), only the client helper name in §9 / §11 changes.
+
+---
+
+## 8. The recovery CTA — closing the dead-end
+
+The `suppressionReasonToCta` function in `frontend/components/recovery/suppressionReasonCta.js` maps the `target yield` suppression reason to a dead `/settings#okrs` link. This PR updates that one mapping.
+
+### 8.1 The change
+
+```js
+if (low.includes('target yield')) {
+  // Target yield is an OKR/objective. Routes to Settings → Trading Objectives
+  // via the ?tab= deep link (the pattern #235 introduced for the sizing cap).
+  return { label: 'Set target yield →', href: '/settings?tab=objectives' };
+}
+```
+
+- The **label is unchanged** — "Set target yield →" is still correct copy.
+- Only the `href` changes: `/settings#okrs` → `/settings?tab=objectives`.
+- The stale code comment in `suppressionReasonCta.js` (lines 18–21, which explains *why* the link intentionally dead-ends) must be **replaced** — it now describes resolved behaviour, and leaving it would be misleading dead documentation.
+
+### 8.2 No other recovery-page change
+
+The Recovery Plan page, `RecoveryPathCard`, and the suppression banner are otherwise untouched by this spec. `RecoveryPathCard.jsx:179` already renders `cta.href` into an anchor with `data-testid="recovery-path-card-{slug}-suppression-cta"` — it just follows the new href. Once a target yield is set and the recovery page reloads, the backend stops emitting the `target yield` suppression reason for Sell & redeploy, so the CTA naturally disappears and the path's metrics populate. No frontend logic needed for that transition — it falls out of the backend already consuming `okr_target_yield`.
+
+### 8.3 Round-trip back to the recovery page — out of scope, noted
+
+A trader deep-linked from the CTA, who sets and saves a yield, currently has to navigate back to the recovery page manually. A "← Back to recovery" return link would be a nice touch but requires passing the originating position id through the deep link (e.g. `?tab=objectives&from=/positions/SOFI/recovery`). **This is deliberately out of scope for the V1.0.3 stopgap** — it is a polish item, the issue's AC does not ask for it, and it adds a parameter-threading surface. Flagged as open question §13 Q2 for V1.1. The stopgap's job is to make the destination *exist and work*; the return trip is a normal browser back-button away.
+
+---
+
+## 9. Component mapping
+
+| UI element | Component | Status | Notes |
+|---|---|---|---|
+| "Trading Objectives" tab button + panel | `components/settings/SettingsPage.jsx` | **Edit** | Add the third tab button (§3.4), extend the `?tab=` lazy-init to recognise `'objectives'` (§3.3), add the `activeTab === 'objectives'` panel branch. |
+| Trading Objectives section | `components/settings/TradingObjectivesSection.jsx` | **Create** | New component — the card, the one field, all six states (§6). The single new component this spec introduces. |
+| Target-yield field row | inline in `TradingObjectivesSection` | **Create (inline)** | One label + number input + `%` affix + helper + inline error. Visually a `RuleField`, but built inline — see the build-vs-reuse note below. |
+| Validation | `components/settings/rulesValidation.js` | **Reuse** | Import `validateScalar` (kind `pctOpen100`) and `isBlank`. No new validation code. |
+| Setting write | `frontend/api/client.js` → `updateSetting` | **Reuse** | `updateSetting('okr_target_yield', String(fraction))`. The generic `PUT /api/settings` already exists. |
+| Setting read | `frontend/api/client.js` → `getSettings` | **Reuse (after backend §7a)** | Once `okr_target_yield` is added to `SettingsResponse` (§7 option a), `getSettings()` carries it. No new client helper. |
+| CTA mapping | `components/recovery/suppressionReasonCta.js` | **Edit** | One `href`: `/settings#okrs` → `/settings?tab=objectives` (§8). Replace the stale comment. |
+| Toasts | `react-hot-toast` | **Reuse** | Save success / failure. |
+| Backend — settings read | `backend/app/routers/settings.py` `SettingsResponse` + `get_settings` | **Edit** | Add `okr_target_yield: float | None` (§7a). The only backend change. |
+
+**Build-vs-reuse — why `TradingObjectivesSection` is a new component and does NOT reuse `RuleField`/`rulesFieldCatalog`:**
+
+`RuleField` is reusable in principle, but its whole ecosystem (`rulesFieldCatalog.js`, `configToForm`/`formToConfig`/`validateForm` in `TradingRulesSection`) is built around a **typed multi-field `rules_config` document** read/written through `GET`/`PUT /api/settings/rules`. Target yield is **one flat `app_settings` key** with a **fraction↔percent conversion** at the boundary. Threading a single OKR key through the `rules_config` catalog and form-mapping machinery would (a) drag a fraction-valued OKR into the whole-percent `rules_config` model the catalog assumes, and (b) blur the very rule-vs-objective line §1.3 exists to protect. So:
+
+- **Do not** add the field to `rulesFieldCatalog.js` or render it via `TradingRulesSection`.
+- **Do** build `TradingObjectivesSection` as a small standalone component that *visually matches* `RuleField` (same label row, input, `%` affix, helper, error markup — copy the classes) and *reuses the pure validators* from `rulesValidation.js`.
+- Reusing `RuleField` as the inner field *renderer* is acceptable if the implementer prefers (it takes plain `value`/`onChange`/`suffix`/`error` props and is catalog-agnostic). But it is a one-field section; inlining the ~20 lines of field markup is equally fine and avoids importing a component whose docblock is all about `rules_config`. **Either is acceptable; the spec does not mandate one.** What is mandated: no `rulesFieldCatalog` entry, no `TradingRulesSection` coupling.
+
+---
+
+## 10. Design tokens applied
+
+No `docs/DESIGN_SYSTEM.md` — tokens derived from the codebase and the `#158` / `#234` specs (canonical for the Settings surface). Tailwind v4 default scale. Every token below is already in use in `SettingsPage.jsx` / `TradingRulesSection.jsx` / `RuleField.jsx` — this section introduces **no new token**.
+
+| Token | Value | Usage |
+|---|---|---|
+| Card shell | `bg-slate-50 dark:bg-slate-800` + `border border-slate-200 dark:border-slate-700` + `rounded-xl p-6` | The Trading Objectives card |
+| Section heading | `text-lg font-semibold text-slate-900 dark:text-white` | "Trading Objectives" `<h2>` |
+| Section description | `text-sm text-slate-500 dark:text-slate-400` | The description + the divider `border-b border-slate-200 dark:border-slate-700 pb-4` under it |
+| Field label | `text-sm text-slate-700 dark:text-slate-300` | "Target yield" `<label>` |
+| Number input | `px-3 py-2 text-sm border rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-blue-500` | The yield input |
+| Trailing `%` affix | `inline-flex items-center px-2.5 text-xs text-slate-500 dark:text-slate-400 border border-l-0 border-slate-300 dark:border-slate-600 rounded-r-lg bg-slate-100 dark:bg-slate-800` | The `%` adornment box |
+| Helper text | `text-xs text-slate-500 dark:text-slate-400 mt-1` | Field helper |
+| Unset note | `text-sm text-slate-500 dark:text-slate-400` | "No target yield set yet…" (§6.2) |
+| Tab button — active | `bg-blue-600 text-white` (via existing `tabClass`) | Active "Trading Objectives" tab |
+| Tab button — inactive | `text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800` | Inactive tab |
+| Primary button | `bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed` | "Save objective" |
+| Validation error | `border-red-400 dark:border-red-500 focus:ring-red-500`, `text-red-600 dark:text-red-400` | Invalid yield (existing `RuleField` treatment) |
+| Save-error banner | `bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-300 rounded-lg px-4 py-3` | Save-failure banner (§6.6) |
+| Save-success check | `text-green-600 dark:text-green-400` SVG check | Transient success indicator (§6.5) |
+| Skeleton | `bg-slate-200 dark:bg-slate-700 rounded animate-pulse` | Loading state (§6.1) |
+
+---
+
+## 11. Data shape
+
+JSDoc-style (the project is JSX). The stopgap touches one flat `app_settings` key.
+
+```js
+/**
+ * The stored value. `app_settings` row, key "okr_target_yield".
+ * Stored as a FRACTION string — "0.12" means 12%. Consumed as a fraction by
+ * the backend recovery engine (recovery_engine.py multiplies capital * yield).
+ * Absent / "" / null  ==>  no target yield set ==> Sell & redeploy suppressed.
+ * Backend bound on the fraction: 0.0 < value <= 1.0.
+ */
+
+/**
+ * After §7 option (a): the field carried on the existing SettingsResponse.
+ * @typedef {Object} SettingsResponse
+ * @property {?number} okr_target_yield   - the stored FRACTION (e.g. 0.12), or null when unset.
+ *                                          (…plus the existing fields: theme, default_date_range_years, etc.)
+ */
+```
+
+**Load mapping (fraction → whole-percent for the input):**
+
+```js
+// settings.okr_target_yield is a fraction or null.
+const fraction = settings.okr_target_yield;
+const formValue =
+  fraction === null || fraction === undefined
+    ? ''                                        // unset — blank input, show unset note
+    : String(Number((fraction * 100).toFixed(4)));  // 0.12 -> "12", clean float artefacts
+```
+
+**Save mapping (whole-percent input → fraction string):**
+
+```js
+// formValue is the whole-percent string the trader typed, already validated 0 < x <= 100.
+const fraction = Number(formValue) / 100;          // "12" -> 0.12
+await updateSetting('okr_target_yield', String(fraction));   // PUT /api/settings {key,value}
+```
+
+The `toFixed(4)` on load is required — `0.12 * 100` is `12.000000000000002` in JS floating point; without the clean-up the input would show a long ugly decimal. Four places is ample headroom for any realistic yield precision.
+
+---
+
+## 12. Test-ID inventory
+
+Pattern `{component}-{element}`, consistent with `#158` / `#234` and the issue's requirement 1 (`settings-objectives-tab`).
+
+| Test ID | Element |
+|---|---|
+| `settings-objectives-tab` | The "Trading Objectives" tab button. **(Issue requirement 1 — exact id.)** |
+| `settings-objectives-loading` | The loading-skeleton container (§6.1). |
+| `settings-objectives-section` | The Trading Objectives section root (the form/card). |
+| `settings-objectives-target-yield` | The target-yield **number input**. |
+| `settings-objectives-target-yield-error` | The inline validation error message (§7.1). |
+| `settings-objectives-unset-note` | The "No target yield set yet…" note shown in the unset state (§6.2). |
+| `settings-objectives-save` | The "Save objective" button. May carry `data-state="saving"` for e2e. |
+| `settings-objectives-save-success` | The transient green-check success indicator (§6.5). |
+| `settings-objectives-save-error` | The dismissible save-failure banner (§6.6). |
+| `settings-objectives-load-error` | The load-failure block with Retry (§6.7). |
+
+Unchanged / reused: `settings-tab-general`, `settings-rules-tab` (existing tabs — not renamed, §3.4). The recovery CTA test id `recovery-path-card-{slug}-suppression-cta` is unchanged — only the `href` it carries changes (§8).
+
+---
+
+## 13. Open questions
+
+1. **§7 — the backend read path (the one real decision).** `GET /api/settings` does not currently return `okr_target_yield`, so the section cannot read the value back. **Recommended: option (a) — add `okr_target_yield: float | None` to the `SettingsResponse` model** (one line on the model + one line in `get_settings`). Confirm before implementation; the section's populated/unset states depend on it. This is the only backend change the stopgap needs.
+2. **§8.3 — return-to-recovery link.** A trader deep-linked from the recovery CTA must currently use the browser back button to return. A "← Back to recovery" link is possible but needs the originating position id threaded through the deep link. **Recommended: defer to V1.1** — out of scope for the V1.0.3 stopgap; the issue AC does not ask for it.
+3. **§4.3 — integer-only entry.** The field accepts decimals (`12.5`), consistent with the Trading Rules percent fields. The backend `_format_pct` rounds to whole-percent *for the recovery-banner label only* — stored precision is kept. If the product owner wants whole-integer-only entry, that is a small validation tweak (reject non-integers); **default assumption: accept decimals.**
+4. **V1.1 migration.** When the OKR Scorecard builds the typed `okr_config` namespace, the flat `okr_target_yield` key migrates into it. The tab ("Trading Objectives") and this section are designed as the seed of that surface — V1.1 should *extend* `TradingObjectivesSection` (add objectives), not replace it. This is a note for V1.1 planning, not a V1.0.3 decision.
+
+---
+
+## 14. Implementation notes for the Developer agent
+
+1. **Three files change, one is created, one backend file changes.** Edit `SettingsPage.jsx` (third tab + `?tab=objectives` lazy-init + panel branch), create `TradingObjectivesSection.jsx`, edit `suppressionReasonCta.js` (one href + replace the stale comment). Backend: add one field to `SettingsResponse` and read it in `get_settings` (§7a — confirm with the user first per §13 Q1).
+2. **Unit conversion lives in `TradingObjectivesSection` only** (§4.2, §11). The field is whole-percent; storage is a fraction; convert `*100` on load (with `toFixed(4)` clean-up) and `/100` on save. The backend and `RuleField`'s whole-percent assumption are both untouched.
+3. **Do not fold this into Trading Rules** (§1.3, §9). No `rulesFieldCatalog.js` entry, no coupling to `TradingRulesSection`. Target yield is an objective; ADR-001 (#210) is the authority. `#235` corrected the inverse mislabeling — do not reintroduce it.
+4. **Reuse the validators, not the catalog** (§7.1, §9). Import `validateScalar('pctOpen100', …)` and `isBlank` from `rulesValidation.js`. Check `isBlank` first (blank = unset, not an error), then `validateScalar` on a non-blank value. No new validation code.
+5. **Mirror `TradingRulesSection`'s state machinery** (§6) — loading skeleton, load-error + Retry, dirty-gated Save, saving-disabled, transient success check, dismissible save-error banner, "Last saved {time}". Simplified to one field: no Reset-to-defaults, no per-group cards.
+6. **Generic error copy only** (CLAUDE.md). Save failure → "Couldn't save your target yield. Please try again." Load failure → "Couldn't load your target yield." Never surface a raw exception.
+7. **Blank is the honest unset state** (§6.2) — never pre-fill `0` or a guessed default. `0` is out of bounds (`0 < x`), and a guessed default would silently un-suppress the recovery path with a number the trader never chose. Unset → blank input + the unset note + disabled Save.
+8. **The CTA fix is one line + a comment rewrite** (§8). `/settings#okrs` → `/settings?tab=objectives`. Delete the now-false "intentionally left pointing at…" comment block in `suppressionReasonCta.js`.
+9. **Tab test-id is `settings-objectives-tab`** exactly (issue requirement 1) — matches the newer `settings-rules-tab` form. Do not rename the older `settings-tab-general`; that is unrelated churn.
+10. **Tests** (CLAUDE.md — every AC gets coverage on the PR):
+    - **Backend pytest:** `okr_target_yield` round-trips through `PUT /api/settings` and is returned by `GET /api/settings` (after §7a); the recovery endpoint un-suppresses Sell & redeploy once `okr_target_yield` is set (capital tied up / months to breakeven / opportunity cost populate) — this is AC bullet 3, and it exercises the existing `positions.py` path.
+    - **Frontend Playwright (`frontend/e2e/`):** the "Trading Objectives" tab is reachable from the tab bar and via `/settings?tab=objectives`; the "Set target yield →" CTA on a suppressed Recovery Plan path navigates to the Trading Objectives tab (no dead `#okrs`); entering a whole-percent value and saving persists it; reload shows the saved value; an out-of-range value (`0`, `150`) shows the inline error and blocks Save; the unset state shows the unset note.
+    - **Conversion unit test:** `12` (input) ↔ `0.12` (stored) round-trips, and the `toFixed(4)` load mapping cleans `0.12 * 100`.
+11. **`?tab=objectives` lazy-init** — extend, do not rewrite, the existing `useState` initializer in `SettingsPage.jsx` (§3.3). The lazy-init runs once on mount; later in-tab clicks are not re-overridden — that existing behaviour is correct and unchanged.
+12. **Reconcile docs** — `#235` and the `#158` spec / mock describe the two-tab Settings page. They are historical; note in the PR that `#207` adds the third tab. `SettingsPage.jsx`'s own comments (lines 36, 197) already forecast this tab — update them from "V1.1" / "Trading OKRs" to reflect that the tab shipped in V1.0.3 as "Trading Objectives".
+
+---
+
+## 15. Figma Make prompt
+
+```
+Design a new "Trading Objectives" tab for the Settings page of Regress, a
+data-dense wheel-strategy options-trading dashboard.
+
+Context: the Settings page already has two tabs — "General" and "Trading Rules".
+Add a third tab, "Trading Objectives", immediately after "Trading Rules". It holds
+a single objective field. Match the existing Settings page density and visual
+weight exactly — this tab must look like a sibling of the Trading Rules tab.
+
+Layout (single card inside the tab panel):
+- Section heading "Trading Objectives" with a description line
+  "The targets your strategy aims for. Used by the Recovery Plan." and a thin
+  divider under it.
+- One field: label "Target yield", a number input constrained to ~12rem wide
+  (left-aligned, not full bleed) with a trailing "%" adornment box fused to the
+  input's right edge. Placeholder text "e.g. 12".
+- Helper text under the input: "The annual return you expect redeployed capital
+  to earn. The Recovery Plan uses this to score the Sell & redeploy path."
+- A primary "Save objective" button, with an "unsaved changes" hint beside it.
+
+Show four states stacked: (1) unset/empty — blank input, plus a muted note
+"No target yield set yet. Until you set one, the Recovery Plan's Sell & redeploy
+path stays unavailable.", Save disabled; (2) populated — input shows "12",
+"Last saved" line; (3) inline validation error — input "0" with a red ring and
+message "Enter a percentage greater than 0 and up to 100."; (4) save-failure —
+a dismissible red banner "Couldn't save your target yield. Please try again."
+
+Tokens (dark mode is the default):
+- Page / body background: rgb(15 23 42)  (slate-900)
+- Card background: rgb(30 41 59)  (slate-800), border slate-700, rounded-xl, p-6
+- Primary accent / active tab / Save button: blue-600 (#2563eb)
+- Body text: slate-100; secondary text: slate-400; helper text: slate-500
+- Affix box background: slate-800; input background: slate-700
+- Error: red ring border-red-400, message text red-400, banner red-900/30
+- Font: ui-sans-serif / system-ui stack
+- Border radius: rounded-lg on inputs, rounded-xl on cards
+
+Tech context: data-dense engineering dashboard, Next.js 16, React 19,
+Tailwind CSS v4. Match the existing Settings tab bar and Trading Rules card
+chrome.
+```

--- a/frontend/e2e/recovery-plan.spec.js
+++ b/frontend/e2e/recovery-plan.spec.js
@@ -534,3 +534,90 @@ test.describe('Recovery Plan panel', () => {
     // design intent before merge. Not automatable in Playwright assertions.
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #207 — Target Yield CTA + Sell & redeploy populated metrics.
+//
+// Append-only block (self-contained fixture builders included) so the sibling
+// #237 PR, which also appends to this file, resolves only a trivial conflict.
+// ---------------------------------------------------------------------------
+
+test.describe('Recovery Plan — target yield (issue #207)', () => {
+  /** A payload where Sell & redeploy is suppressed for an unset target yield —
+   * the exact state the recovery "Set target yield →" CTA exists to fix. */
+  function targetYieldSuppressedPayload() {
+    const base = populatedPayload();
+    base.inputs.okr.target_yield = null;
+    base.paths = base.paths.map((p) =>
+      p.path_id === 'sell-redeploy'
+        ? {
+            ...p,
+            eligibility: 'suppressed',
+            suppression_reason: 'Target yield not configured',
+            capital_tied_up: null,
+            months_to_breakeven: { best: null, expected: null, worst: null },
+            opportunity_cost_vs_baseline: null,
+          }
+        : p,
+    );
+    base.recommendation.recommended_path_id = 'wheel-cc';
+    base.recommendation.ranked_paths = base.recommendation.ranked_paths.map(
+      (r) =>
+        r.path_id === 'sell-redeploy'
+          ? { ...r, score: null, rank: null, suppression_reason: 'Target yield not configured' }
+          : r,
+    );
+    return base;
+  }
+
+  test('the "Set target yield →" CTA routes to Settings → Trading Objectives', async ({
+    page,
+  }) => {
+    // Issue #207: the suppressed Sell & redeploy card's CTA must route to
+    // /settings?tab=objectives — never the dead /settings#okrs anchor.
+    await mockRecoveryPlan(page, targetYieldSuppressedPayload());
+    await openRecoveryPlan(page);
+
+    const cta = page.getByTestId(
+      'recovery-path-card-sell-redeploy-suppression-cta',
+    );
+    await expect(cta).toBeVisible();
+    await expect(cta).toContainText('Set target yield');
+    await expect(cta).toHaveAttribute('href', '/settings?tab=objectives');
+
+    // The old dead anchor must be gone.
+    const href = await cta.getAttribute('href');
+    expect(href).not.toContain('#okrs');
+  });
+
+  test('the populated Sell & redeploy card renders computed capital / breakeven / opportunity cost (AC3)', async ({
+    page,
+  }) => {
+    // Issue #207 AC3: once a target yield is set, the Sell & redeploy path is
+    // eligible and its three metrics compute — none of them the suppressed
+    // "—" placeholder. populatedPayload()'s sell-redeploy is eligible.
+    await mockRecoveryPlan(page, populatedPayload());
+    await openRecoveryPlan(page);
+
+    const capital = page.getByTestId('recovery-path-card-sell-redeploy-capital');
+    const breakeven = page.getByTestId(
+      'recovery-path-card-sell-redeploy-breakeven-expected',
+    );
+    const oppCost = page.getByTestId(
+      'recovery-path-card-sell-redeploy-opp-cost',
+    );
+
+    await expect(capital).toBeVisible();
+    await expect(breakeven).toBeVisible();
+    await expect(oppCost).toBeVisible();
+
+    // None of the three renders the suppressed-state em-dash placeholder.
+    await expect(capital).not.toHaveText('—');
+    await expect(breakeven).not.toHaveText('—');
+    await expect(oppCost).not.toHaveText('—');
+
+    // The computed values from the eligible fixture are surfaced.
+    await expect(capital).toContainText('$0');
+    await expect(breakeven).toContainText('6 mo');
+  });
+});

--- a/frontend/e2e/settings-objectives.spec.js
+++ b/frontend/e2e/settings-objectives.spec.js
@@ -1,0 +1,349 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Settings → Trading Objectives section (issue #207).
+ *
+ * The V1.0.3 stopgap: a new third Settings tab holding a single field —
+ * Target yield — that un-dead-ends the Recovery Plan "Set target yield →"
+ * CTA. Covers the issue's automated-coverage ACs:
+ *  - `?tab=objectives` deep link selects the Trading Objectives tab;
+ *  - the Target Yield field renders in `settings-objectives-section`, not
+ *    inside a Trading Rules group card;
+ *  - enter a value → save → reload → value persists (whole-percent ↔ the
+ *    fraction the backend stores);
+ *  - an out-of-bounds value shows the inline error and blocks Save.
+ *
+ * The generic `GET`/`PUT /api/settings` endpoint is mocked with a persistent
+ * in-memory store so the round-trip test is real against the mock. The store
+ * holds `okr_target_yield` as a FRACTION (what the backend stores); the UI
+ * converts to/from whole-percent.
+ */
+
+/** A baseline SettingsResponse — the fields the page reads. */
+function settingsResponse(okrTargetYield = null) {
+  return {
+    fred_api_key_set: false,
+    cache_ttl_daily_hours: 24,
+    cache_ttl_monthly_days: 30,
+    default_date_range_years: 5,
+    theme: 'system',
+    schwab_configured: false,
+    schwab_token_expires: null,
+    okr_target_yield: okrTargetYield,
+  };
+}
+
+/**
+ * Mock the generic settings endpoint with a persistent in-memory store so a
+ * PUT then a fresh GET (page reload) reflects the saved value. The store
+ * keeps `okr_target_yield` as the stored fraction. When `failSave` is set the
+ * PUT responds 500 so the failure path can be exercised.
+ */
+function mockSettingsEndpoint(page, { initial = null, failSave = false } = {}) {
+  const store = { okrTargetYield: initial };
+  return page.route('**/api/settings', (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(settingsResponse(store.okrTargetYield)),
+      });
+    }
+    if (method === 'PUT') {
+      if (failSave) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      const body = route.request().postDataJSON();
+      if (body?.key === 'okr_target_yield') {
+        store.okrTargetYield = Number(body.value);
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok', key: body?.key }),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/** Open the Settings page and switch to the Trading Objectives tab. */
+async function openObjectivesTab(page) {
+  await page.goto('/settings');
+  await page.getByTestId('settings-objectives-tab').click();
+  await expect(page.getByTestId('settings-objectives-section')).toBeVisible();
+}
+
+test.describe('Settings → Trading Objectives — tab & deep link', () => {
+  test('the tab bar exposes a third "Trading Objectives" tab', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page);
+    await page.goto('/settings');
+
+    const tab = page.getByTestId('settings-objectives-tab');
+    await expect(tab).toBeVisible();
+    await expect(tab).toHaveText('Trading Objectives');
+  });
+
+  test('/settings?tab=objectives opens the Trading Objectives tab without a click', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page);
+    await page.goto('/settings?tab=objectives');
+
+    // The recovery-page "Set target yield →" CTA deep-links here (issue #207).
+    await expect(page.getByTestId('settings-objectives-tab')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    await expect(page.getByTestId('settings-objectives-section')).toBeVisible();
+  });
+
+  test('/settings with no param still defaults to the General tab', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page);
+    await page.goto('/settings');
+
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByTestId('settings-objectives-tab')).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+});
+
+test.describe('Settings → Trading Objectives — field render', () => {
+  test('the Target Yield field renders inside settings-objectives-section, not a rules group', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page);
+    await openObjectivesTab(page);
+
+    const section = page.getByTestId('settings-objectives-section');
+    // The field lives inside the objectives section.
+    await expect(
+      section.getByTestId('settings-objectives-target-yield'),
+    ).toBeVisible();
+    await expect(
+      section.getByText('Target yield', { exact: true }),
+    ).toBeVisible();
+    // It is NOT folded into a Trading Rules group card (issue #207 / ADR-001 —
+    // target yield is an objective, not a rule).
+    await expect(
+      page.locator('[data-testid^="rules-group-"]'),
+    ).toHaveCount(0);
+  });
+
+  test('an unset target yield renders blank with the unset note', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page, { initial: null });
+    await openObjectivesTab(page);
+
+    const input = page.getByTestId('settings-objectives-target-yield');
+    await expect(input).toHaveValue('');
+    await expect(input).toHaveAttribute('placeholder', 'e.g. 12');
+    // The unset note explains the Recovery Plan consequence.
+    await expect(
+      page.getByTestId('settings-objectives-unset-note'),
+    ).toBeVisible();
+    // Save is disabled while the field is blank.
+    await expect(page.getByTestId('settings-objectives-save')).toBeDisabled();
+  });
+
+  test('a stored fraction renders as whole percent in the input', async ({
+    page,
+  }) => {
+    // The mock store holds 0.12 (fraction); the field shows 12 (whole percent).
+    await mockSettingsEndpoint(page, { initial: 0.12 });
+    await openObjectivesTab(page);
+
+    await expect(
+      page.getByTestId('settings-objectives-target-yield'),
+    ).toHaveValue('12');
+    // A populated value has no unset note.
+    await expect(
+      page.getByTestId('settings-objectives-unset-note'),
+    ).toHaveCount(0);
+  });
+});
+
+test.describe('Settings → Trading Objectives — save lifecycle', () => {
+  test('enter a value → save → reload → value persists', async ({ page }) => {
+    await mockSettingsEndpoint(page, { initial: null });
+    await openObjectivesTab(page);
+
+    await page.getByTestId('settings-objectives-target-yield').fill('15');
+    await page.getByTestId('settings-objectives-save').click();
+    await expect(
+      page.getByTestId('settings-objectives-save-success'),
+    ).toBeVisible();
+
+    // Reload — the mock store kept the saved fraction (0.15); the field
+    // re-renders it as the whole percent 15.
+    await openObjectivesTab(page);
+    await expect(
+      page.getByTestId('settings-objectives-target-yield'),
+    ).toHaveValue('15');
+    await expect(
+      page.getByTestId('settings-objectives-unset-note'),
+    ).toHaveCount(0);
+  });
+
+  test('a decimal whole-percent value round-trips through the fraction store', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page, { initial: null });
+    await openObjectivesTab(page);
+
+    // 12.5% → stored fraction 0.125 → reloads cleanly (no float artefact).
+    await page.getByTestId('settings-objectives-target-yield').fill('12.5');
+    await page.getByTestId('settings-objectives-save').click();
+    await expect(
+      page.getByTestId('settings-objectives-save-success'),
+    ).toBeVisible();
+
+    await openObjectivesTab(page);
+    await expect(
+      page.getByTestId('settings-objectives-target-yield'),
+    ).toHaveValue('12.5');
+  });
+
+  test('Save is disabled until there is an unsaved change', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page, { initial: 0.12 });
+    await openObjectivesTab(page);
+
+    await expect(page.getByTestId('settings-objectives-save')).toBeDisabled();
+    await page.getByTestId('settings-objectives-target-yield').fill('20');
+    await expect(page.getByTestId('settings-objectives-save')).toBeEnabled();
+  });
+
+  test('save failure shows a generic inline error, never a raw exception', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page, { initial: null, failSave: true });
+    await openObjectivesTab(page);
+
+    await page.getByTestId('settings-objectives-target-yield').fill('15');
+    await page.getByTestId('settings-objectives-save').click();
+
+    const banner = page.getByTestId('settings-objectives-save-error');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText(
+      "Couldn't save your target yield. Please try again.",
+    );
+    // CLAUDE.md — the raw 500 exception text must not leak.
+    await expect(banner).not.toContainText('Internal Server Error');
+  });
+});
+
+test.describe('Settings → Trading Objectives — validation', () => {
+  test('an out-of-bounds value shows an inline error and blocks Save', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page, { initial: null });
+    await openObjectivesTab(page);
+
+    // 150% is out of the 0 < x ≤ 100 range.
+    const input = page.getByTestId('settings-objectives-target-yield');
+    await input.fill('150');
+    await input.blur();
+
+    const error = page.getByTestId('settings-objectives-target-yield-error');
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText(
+      'Enter a percentage greater than 0 and up to 100.',
+    );
+    await expect(input).toHaveAttribute('aria-invalid', 'true');
+    await expect(page.getByTestId('settings-objectives-save')).toBeDisabled();
+  });
+
+  test('a zero value is rejected — 0% target yield is out of bounds', async ({
+    page,
+  }) => {
+    await mockSettingsEndpoint(page, { initial: null });
+    await openObjectivesTab(page);
+
+    const input = page.getByTestId('settings-objectives-target-yield');
+    await input.fill('0');
+    await input.blur();
+
+    await expect(
+      page.getByTestId('settings-objectives-target-yield-error'),
+    ).toHaveText('Enter a percentage greater than 0 and up to 100.');
+    await expect(page.getByTestId('settings-objectives-save')).toBeDisabled();
+  });
+
+  test('the inclusive upper bound (100) is valid', async ({ page }) => {
+    await mockSettingsEndpoint(page, { initial: null });
+    await openObjectivesTab(page);
+
+    const input = page.getByTestId('settings-objectives-target-yield');
+    await input.fill('100');
+    await input.blur();
+
+    await expect(
+      page.getByTestId('settings-objectives-target-yield-error'),
+    ).toHaveCount(0);
+    await expect(page.getByTestId('settings-objectives-save')).toBeEnabled();
+  });
+});
+
+test.describe('Settings → Trading Objectives — load failure', () => {
+  test('a failed settings GET shows a generic error block with Retry', async ({
+    page,
+  }) => {
+    let calls = 0;
+    await page.route('**/api/settings', (route) => {
+      if (route.request().method() !== 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 'ok' }),
+        });
+      }
+      calls += 1;
+      if (calls === 1) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(settingsResponse(null)),
+      });
+    });
+
+    await page.goto('/settings?tab=objectives');
+
+    const errorBlock = page.getByTestId('settings-objectives-load-error');
+    await expect(errorBlock).toBeVisible();
+    await expect(errorBlock).toContainText(
+      "Couldn't load your target yield.",
+    );
+    await expect(errorBlock).not.toContainText('Internal Server Error');
+
+    // Retry succeeds — the section renders.
+    await errorBlock.getByRole('button', { name: 'Retry' }).click();
+    await expect(page.getByTestId('settings-objectives-section')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

The Recovery Plan's **Sell & redeploy** path was permanently suppressed
(`⚠ Target yield not configured`) and its "Set target yield →" CTA routed to a
non-existent `/settings#okrs` anchor. There was no UI anywhere to set a target
yield. This PR fixes both halves of #207.

## The stopgap approach

This is the **V1.0.3 minimal stopgap**, not the V1.1 OKR Scorecard. The flat
`okr_target_yield` app-setting key already exists and is already consumed by
the recovery engine — this PR builds the *missing input UI* for it plus a real
CTA destination. No typed `okr_config` model, no DB migration, no new endpoint.
When V1.1 builds the typed `okr_config` namespace the flat key migrates into it
(ADR-001 / Discussion #210); the new "Trading Objectives" tab is the seed of
that surface.

Target yield is an **objective/OKR, not a Trading Rule** — hence a separate
third Settings tab rather than a field folded into Trading Rules (#235 just
corrected the inverse mislabeling).

## Unit convention

- **Field (UI):** whole percent — the trader types `12`, with a trailing `%`
  adornment.
- **Backend storage:** fraction — `okr_target_yield = "0.12"`.
- The conversion lives **only** in `TradingObjectivesSection`: `*100` on load
  (`toFixed(4)` cleans JS float artefacts like `12.000000000000002`), `/100` on
  save. Backend storage and the recovery engine are untouched.

## Backend

- `SettingsResponse` carries `okr_target_yield: Optional[float]` (the stored
  fraction, or `null`).
- `get_settings` reads it defensively — a malformed row degrades to `None`.
- `update_setting` adds a boundary check for `okr_target_yield`: the value must
  be a finite fraction in `0.0 < x <= 1.0`. Failures raise **422** with a fixed
  generic message — no raw exception text leaks (CLAUDE.md). Other keys remain
  unchanged blind upserts.

## Frontend

- New `TradingObjectivesSection.jsx` — a single Target yield field with all six
  states (loading skeleton, load-error + Retry, unset/empty + note, saving,
  transient save-success + toast, dismissible save-failure banner). Reuses
  `validateScalar('pctOpen100')` / `isBlank` — no new validator.
- New third Settings tab **"Trading Objectives"** (`data-testid=settings-objectives-tab`),
  after General and Trading Rules, reached via `/settings?tab=objectives`.
- `suppressionReasonCta.js` target-yield branch now routes to
  `/settings?tab=objectives` instead of the dead `/settings#okrs`.

## AC → test mapping

| AC | Coverage |
|---|---|
| **AC1** — target yield is settable + persisted | `backend/tests/test_settings_target_yield.py` (round-trip + boundary validation, no raw exception leak); `frontend/e2e/settings-objectives.spec.js` (tab + `?tab=objectives` deep link, save→reload persistence, whole-percent↔fraction round-trip, inline validation blocks Save) |
| **AC2** — CTA has a real destination | `frontend/e2e/recovery-plan.spec.js` — the suppressed Sell & redeploy card's CTA has `href="/settings?tab=objectives"` and does **not** contain `#okrs` |
| **AC3** — Sell & redeploy populates once a yield is set | `backend/tests/test_recovery_router.py::test_recovery_plan_sell_redeploy_populated_after_target_yield_set` (eligible, non-null `capital_tied_up`, positive `months_to_breakeven.expected`); `frontend/e2e/recovery-plan.spec.js` — the populated card renders non-`—` capital / breakeven / opportunity-cost |

## V1.1 migration note

The flat `okr_target_yield` key is the V1.0.3 storage. In V1.1 it migrates into
the typed `okr_config` namespace (ADR-001 / Discussion #210). `TradingObjectivesSection`
and the new tab are designed so V1.1 *extends* them (adds objectives) rather
than replacing them. Code comments in `settings.py` and `TradingObjectivesSection.jsx`
point at this.

## Verification

- `cd backend && python -m pytest` — full suite **1030 passed, 9 skipped**, no
  regressions.
- `cd frontend && npx playwright test settings-objectives.spec.js recovery-plan.spec.js`
  — **28 passed, 1 skipped** (the skip is an intentional manual-AC marker).
- `npm run lint` — clean (one pre-existing unrelated `UserMenu.jsx` warning).
- `npm run build` — succeeds.

Note: `recovery-plan.spec.js` additions are a self-contained append-only block
so the sibling #237 PR resolves only a trivial conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)