### PR TITLE
Light up the % CAPT profit-target signal on the dashboard

### DIFF
--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -23,6 +23,7 @@ from app.services import journal as journal_service
 from app.services.action_engine import compute_next_actions
 from app.services.alpha_vantage_client import get_cached_next_earnings_date
 from app.services.dashboard_legs import (
+    build_option_mark_index,
     derive_open_legs,
     filter_upcoming,
     parse_iso_to_utc,
@@ -161,6 +162,69 @@ def _fetch_quotes_parallel(
             if failed:
                 schwab_failed = True
     return prices, schwab_failed
+
+
+def _fetch_option_chains_parallel(
+    tickers: Iterable[str],
+    schwab_configured: bool,
+) -> tuple[dict[str, dict], bool]:
+    """Fetch raw Schwab option chains for `tickers` concurrently.
+
+    Returns ``(chains_by_ticker, schwab_failed_flag)``. ``chains_by_ticker``
+    maps each ticker that resolved to its raw Schwab chains response; tickers
+    whose fetch failed are simply omitted (their legs degrade to ``% CAPT —``).
+
+    Modeled directly on :func:`_fetch_quotes_parallel`: thread pool capped at
+    ``QUOTE_FANOUT_WORKERS``, one ``get_option_chain`` call per distinct
+    open-leg ticker. Any per-ticker failure — known Schwab errors *or*
+    unexpected ones — is caught inside the worker so a single bad ticker
+    cannot 500 the dashboard; ``schwab_failed`` is set so the caller surfaces
+    the partial outage via ``data_meta.sources_unavailable``.
+    KeyboardInterrupt / SystemExit still propagate.
+
+    NOTE: option-chain responses are NOT cached this slice — each dashboard
+    load issues N blocking fetches (N = distinct open-leg tickers), consistent
+    with the existing stock-quote fan-out. An in-process TTL cache is a
+    deferred V1.2 follow-up.
+    """
+    unique = sorted({t for t in tickers if t})
+    chains_by_ticker: dict[str, dict] = {}
+    if not unique or not schwab_configured:
+        # Schwab not configured is a known-unavailable source, not a failure —
+        # the status strip already reports it. Return an empty index.
+        return chains_by_ticker, False
+
+    schwab_failed = False
+    client = SchwabClient()
+
+    def _fetch(ticker: str) -> tuple[str, dict | None, bool]:
+        try:
+            chain = client.get_option_chain(ticker)
+        except (SchwabClientError, SchwabAuthError) as exc:
+            logger.warning(
+                "Dashboard option-chain fetch failed for %s: %s", ticker, exc
+            )
+            return ticker, None, True
+        except Exception:
+            # Defense-in-depth: any other exception (network timeouts that
+            # escape tenacity, malformed payloads, etc.) must not propagate
+            # out of the worker — that would raise from ThreadPoolExecutor.map
+            # and 500 the whole dashboard. Log with traceback; never surface
+            # the raw message in a response (CLAUDE.md).
+            logger.exception(
+                "Unexpected error fetching option chain for %s", ticker
+            )
+            return ticker, None, True
+        return ticker, (chain if isinstance(chain, dict) else None), False
+
+    workers = min(QUOTE_FANOUT_WORKERS, len(unique))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        for ticker, chain, failed in pool.map(_fetch, unique):
+            if chain is not None:
+                chains_by_ticker[ticker] = chain
+            if failed:
+                schwab_failed = True
+    return chains_by_ticker, schwab_failed
 
 
 # Maps the derived ``position.strategy`` lifecycle label to the V0.5 wheel
@@ -584,19 +648,41 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
     closed_positions = journal_service.get_positions(db, status="closed")
     journal_status = {"positions_count": len(open_positions)}
 
+    # Trading rules — resolved once here (the service layer) and reused by
+    # both derive_open_legs (profit-target threshold) and the action engine.
+    rules = load_rules_config(db)
+
     # Quotes (parallelized; deduped by ticker)
     tickers = [p["ticker"] for p in open_positions]
     quotes_by_ticker, schwab_failed = _fetch_quotes_parallel(
         tickers, schwab_configured=schwab_configured
     )
 
-    # Legs derive purely from in-memory data + the quote map. Earnings
+    # Option chains for the % CAPT signal — fetched only for positions that
+    # actually carry an open sell_put/sell_call leg (a strict subset of the
+    # stock-quote ticker set). Parallel fan-out mirrors the quote fetch.
+    open_leg_tickers = {
+        p["ticker"]
+        for p in open_positions
+        for trade in p.get("trades", [])
+        if trade.get("trade_type") in ("sell_put", "sell_call")
+        and not trade.get("closed_at")
+    }
+    option_chains, chains_failed = _fetch_option_chains_parallel(
+        open_leg_tickers, schwab_configured=schwab_configured
+    )
+    schwab_failed = schwab_failed or chains_failed
+    option_marks = build_option_mark_index(option_chains)
+
+    # Legs derive purely from in-memory data + the quote/mark maps. Earnings
     # lookup is cache-hit-only — the request path must not block on AV.
     open_legs = derive_open_legs(
         open_positions,
         quotes_by_ticker,
         today=today,
         earnings_lookup=get_cached_next_earnings_date,
+        option_marks=option_marks,
+        profit_review_pct=rules.management.profit_review_pct,
     )
     upcoming = filter_upcoming(open_legs, horizon_days=14)
 
@@ -623,7 +709,7 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         kpis=kpis,
         positions=position_rows,
         open_legs=open_legs,
-        rules=load_rules_config(db),
+        rules=rules,
     )
     _attach_next_suggested_actions(position_rows, next_actions, open_legs)
 

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Iterable, Literal
 
+from app.utils.parsing import to_float
+
 # A "leg-opening" trade type implies the leg is currently open *unless* the
 # trade row has a non-null closed_at. Exit trades (buy-to-close, assignment,
 # called_away) are not legs themselves — they close prior open legs.
@@ -29,8 +31,9 @@ ProfitTargetState = Literal["captured_50", "in_progress", "underwater", "unknown
 
 # Maps the four existing decision-tag buckets to the V0.5 suggested-action
 # vocabulary. Spec §14.5 locks this mapping; "close" is intentionally absent
-# because the 50% target signal requires live option-chain data (deferred to
-# V0.7).
+# because emitting it as the styled ACTION verdict is still design-gated
+# (issue #240). The 50%-profit signal itself is now live — see
+# build_profit_target_status — but the verdict column that consumes it is not.
 _DECISION_TAG_TO_SUGGESTED_ACTION: dict[DecisionTag, SuggestedAction] = {
     "roll-or-assign": "roll",
     "manage": "manage",
@@ -175,20 +178,102 @@ def compute_suggested_action(decision_tag: DecisionTag) -> SuggestedAction:
     """Map an existing decision tag to a V0.5 suggested-action label.
 
     Per spec §14.5 the V0.5 vocabulary is ``"roll" | "hold" | "manage"``.
-    The ``"close"`` value (50%-profit-target hit) is intentionally never
-    emitted because the underlying signal requires live option-chain data.
+    The ``"close"`` value is intentionally never emitted here because the
+    styled ACTION verdict that would surface a 50%-profit-target hit is
+    still design-gated (issue #240).
     """
     return _DECISION_TAG_TO_SUGGESTED_ACTION.get(decision_tag, "hold")
 
 
-def build_profit_target_status() -> dict:
-    """Return the V0.5 profit-target status payload.
+def build_profit_target_status(
+    premium: float | None,
+    current_mid: float | None,
+    dte: int = 9999,
+    profit_review_pct: float = 50.0,
+) -> dict:
+    """Return the per-leg profit-target status payload (the ``% CAPT`` signal).
 
-    Always ``{"captured_pct": None, "state": "unknown"}`` because the live
-    option-chain integration is deferred. The shape ships so the frontend
-    contract is stable for the V0.7 expansion.
+    Computes ``captured_pct = (premium - current_mid) / premium`` — the
+    fraction of the credit a short option seller has already captured by
+    the option decaying toward zero. The ratio is per-share and therefore
+    quantity-invariant, so ``quantity`` is deliberately not a parameter.
+
+    Args:
+        premium: The credit received per share when the leg was opened
+            (``Trade.premium``). Must be a positive credit to be meaningful.
+        current_mid: The current option mid price per share, from a live
+            Schwab option chain. ``None`` when no live mark is available.
+        dte: Days to expiration. An expired leg (``dte < 0``) yields
+            ``unknown`` — there is no live management decision once expired.
+        profit_review_pct: The user's profit-target threshold as a percent
+            (``rules.management.profit_review_pct``, default 50).
+
+    Returns:
+        ``{"captured_pct": float | None, "state": ProfitTargetState}``.
+        Degrades to ``{"captured_pct": None, "state": "unknown"}`` when an
+        input is missing or non-credit so the dashboard never shows a
+        signal it cannot justify.
     """
-    return {"captured_pct": None, "state": "unknown"}
+    if premium is None or current_mid is None or premium <= 0 or dte < 0:
+        return {"captured_pct": None, "state": "unknown"}
+    captured_pct = round((premium - current_mid) / premium, 4)
+    if captured_pct >= profit_review_pct / 100:
+        state: ProfitTargetState = "captured_50"
+    elif captured_pct < 0:
+        state = "underwater"
+    else:
+        state = "in_progress"
+    return {"captured_pct": captured_pct, "state": state}
+
+
+def build_option_mark_index(
+    chains_by_ticker: dict[str, dict],
+) -> dict[tuple, float]:
+    """Flatten raw Schwab option-chain responses into a flat mid-price index.
+
+    Schwab ``callExpDateMap`` / ``putExpDateMap`` are nested two levels deep:
+    ``{exp_key: {strike_str: [contract, ...]}}`` where ``exp_key`` looks like
+    ``"2026-06-26:38"`` (expiration date plus DTE). This helper flattens them
+    into ``{(ticker, type, round(strike, 4), exp_date): mid}`` so a leg can be
+    matched with a single dict lookup.
+
+    The mid is ``contract["mark"]`` when present, otherwise ``(bid + ask) / 2``
+    (mirrors :mod:`app.services.options_scanner`). Entries with a falsy mid are
+    skipped — a leg with no usable mark degrades to ``unknown`` rather than a
+    misleading 0.
+
+    The function is tolerant of malformed nodes: a single bad contract,
+    missing key, or non-dict entry is skipped and never aborts the index.
+    """
+    index: dict[tuple, float] = {}
+    for ticker, chain in (chains_by_ticker or {}).items():
+        if not isinstance(chain, dict):
+            continue
+        for option_type, map_key in (("call", "callExpDateMap"), ("put", "putExpDateMap")):
+            exp_date_map = chain.get(map_key)
+            if not isinstance(exp_date_map, dict):
+                continue
+            for exp_key, strikes_map in exp_date_map.items():
+                if not isinstance(strikes_map, dict):
+                    continue
+                # exp_key is "YYYY-MM-DD:DTE"; the prefix is the expiration.
+                exp_date = str(exp_key).split(":")[0][:10]
+                for contracts in strikes_map.values():
+                    if not contracts:
+                        continue
+                    contract = contracts[0]
+                    if not isinstance(contract, dict):
+                        continue
+                    strike = to_float(contract.get("strikePrice"), None)
+                    if strike is None:
+                        continue
+                    bid = to_float(contract.get("bid"))
+                    ask = to_float(contract.get("ask"))
+                    mid = to_float(contract.get("mark")) or round((bid + ask) / 2, 4)
+                    if not mid:
+                        continue
+                    index[(ticker, option_type, round(strike, 4), exp_date)] = mid
+    return index
 
 
 def compute_earnings_in_window(
@@ -233,19 +318,28 @@ def derive_open_legs(
     quotes_by_ticker: dict[str, float | None],
     today: date | None = None,
     earnings_lookup=None,
+    option_marks: dict | None = None,
+    profit_review_pct: float = 50.0,
 ) -> list[dict]:
     """Flatten open option legs across the given positions.
 
     A leg is "open" when it was an opening trade (`sell_put` / `sell_call`)
     AND its `closed_at` is None on the trade row. Each leg is enriched with
-    DTE, moneyness, and the V0.5 per-leg signal fields:
-    ``profit_target_status`` (always ``state="unknown"``),
+    DTE, moneyness, and the per-leg signal fields:
+    ``profit_target_status`` (the ``% CAPT`` signal — a real ``captured_pct``
+    when a live mark is available, else ``state="unknown"``),
     ``assignment_risk``, ``suggested_action``, and ``earnings_in_window``.
 
     ``earnings_lookup`` is an optional callable used to populate
     ``earnings_in_window``. It MUST be cache-hit-only — defaults to a
     sentinel that returns ``None`` so the dashboard never blocks on
     Alpha Vantage in the request path.
+
+    ``option_marks`` is the flat ``{(ticker, type, strike, exp): mid}`` index
+    produced by :func:`build_option_mark_index`. It is optional — a missing
+    index (or a leg absent from it) degrades that leg's ``profit_target_status``
+    to ``state="unknown"``. ``profit_review_pct`` is the user's profit-target
+    threshold (``rules.management.profit_review_pct``).
 
     Returns a list ordered by (dte ASC, ticker ASC) — callers that need
     other orderings should re-sort.
@@ -254,6 +348,9 @@ def derive_open_legs(
     if earnings_lookup is None:
         # Defensive default: cache miss-only sentinel. Never trigger network.
         earnings_lookup = lambda _ticker: None  # noqa: E731 — small inline default
+    if option_marks is None:
+        # Defensive default: no live marks → every leg's % CAPT is unknown.
+        option_marks = {}
     legs: list[dict] = []
     for position in positions:
         ticker = position["ticker"]
@@ -270,6 +367,15 @@ def derive_open_legs(
             moneyness = compute_moneyness(option_type, strike, current_price)
             moneyness_state = moneyness["state"] if moneyness else None
             decision_tag = compute_decision_tag(dte, moneyness_state)
+            # Match this leg against the live option-chain mid index. A key
+            # absent from the index → current_mid=None → % CAPT "unknown".
+            mark_key = (
+                ticker,
+                option_type,
+                round(strike, 4),
+                str(trade["expiration"])[:10],
+            )
+            current_mid = option_marks.get(mark_key)
             legs.append(
                 {
                     "id": trade["id"],
@@ -280,7 +386,12 @@ def derive_open_legs(
                     "dte": dte,
                     "moneyness": moneyness,
                     "position_id": position_id,
-                    "profit_target_status": build_profit_target_status(),
+                    "profit_target_status": build_profit_target_status(
+                        premium=trade.get("premium"),
+                        current_mid=current_mid,
+                        dte=dte,
+                        profit_review_pct=profit_review_pct,
+                    ),
                     "assignment_risk": compute_assignment_risk(dte, moneyness_state),
                     "suggested_action": compute_suggested_action(decision_tag),
                     "earnings_in_window": compute_earnings_in_window(

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -5,6 +5,7 @@ from datetime import date, timedelta
 import pytest
 
 from app.services.dashboard_legs import (
+    build_option_mark_index,
     build_profit_target_status,
     compute_assignment_risk,
     compute_decision_tag,
@@ -349,9 +350,161 @@ class TestComputeSuggestedAction:
 
 
 class TestProfitTargetStatusBuilder:
-    def test_state_is_universally_unknown_in_v05(self):
-        result = build_profit_target_status()
+    """Pure math for the dashboard ``% CAPT`` profit-target signal (#240)."""
+
+    def test_locked_acceptance_screenshot_example(self):
+        # LOCKED acceptance test — the F 15C leg from the issue #240 screenshot.
+        # premium 0.3834 credit, current mid 0.155 → ~59.57% of credit captured,
+        # past the default 50% target.
+        result = build_profit_target_status(premium=0.3834, current_mid=0.155)
+        assert result["captured_pct"] == pytest.approx(0.5957, abs=1e-4)
+        assert result["state"] == "captured_50"
+
+    def test_in_progress_below_target(self):
+        # 1.00 credit decayed to 0.70 → 30% captured, under the 50% target.
+        result = build_profit_target_status(premium=1.00, current_mid=0.70)
+        assert result["captured_pct"] == pytest.approx(0.30)
+        assert result["state"] == "in_progress"
+
+    def test_captured_50_at_exact_boundary(self):
+        # Exactly the 50% threshold counts as captured (>= compare).
+        result = build_profit_target_status(premium=1.00, current_mid=0.50)
+        assert result["captured_pct"] == pytest.approx(0.50)
+        assert result["state"] == "captured_50"
+
+    def test_underwater_when_mid_above_premium(self):
+        # 1.00 credit, mid rose to 1.30 → -30% captured (a paper loss).
+        result = build_profit_target_status(premium=1.00, current_mid=1.30)
+        assert result["captured_pct"] == pytest.approx(-0.30)
+        assert result["state"] == "underwater"
+
+    def test_in_progress_when_mid_equals_premium(self):
+        # mid == premium → exactly 0% captured → in_progress, not underwater.
+        result = build_profit_target_status(premium=1.00, current_mid=1.00)
+        assert result["captured_pct"] == pytest.approx(0.0)
+        assert result["state"] == "in_progress"
+
+    @pytest.mark.parametrize(
+        "premium,current_mid",
+        [
+            (1.00, None),  # no live mark
+            (None, 0.50),  # no premium recorded
+            (0.0, 0.50),  # zero credit — no division
+            (-1.00, 0.50),  # debit / non-credit leg
+        ],
+    )
+    def test_degrades_to_unknown_on_bad_inputs(self, premium, current_mid):
+        result = build_profit_target_status(
+            premium=premium, current_mid=current_mid
+        )
         assert result == {"captured_pct": None, "state": "unknown"}
+
+    def test_expired_leg_is_unknown(self):
+        # Once expired (dte < 0) there is no live management decision.
+        result = build_profit_target_status(
+            premium=1.00, current_mid=0.10, dte=-3
+        )
+        assert result == {"captured_pct": None, "state": "unknown"}
+
+    def test_profit_review_pct_threshold_is_honored(self):
+        # ~60% captured, but the user's threshold is 75% → still in_progress.
+        result = build_profit_target_status(
+            premium=1.00, current_mid=0.40, profit_review_pct=75.0
+        )
+        assert result["captured_pct"] == pytest.approx(0.60)
+        assert result["state"] == "in_progress"
+
+
+class TestBuildOptionMarkIndex:
+    """Flatten raw Schwab option chains into the flat mid-price index (#240)."""
+
+    def _chain(self) -> dict:
+        return {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "240.0": [{"strikePrice": 240.0, "mark": 3.10}],
+                }
+            },
+            "putExpDateMap": {
+                "2026-05-08:3": {
+                    # strikePrice given as a bare integer-style string.
+                    "175": [{"strikePrice": "175", "bid": 1.40, "ask": 1.60}],
+                }
+            },
+        }
+
+    def test_builds_keys_and_mids(self):
+        index = build_option_mark_index({"AAPL": self._chain()})
+        # Call leg uses the explicit `mark`.
+        assert index[("AAPL", "call", 240.0, "2026-06-26")] == pytest.approx(3.10)
+        # Put leg with no `mark` falls back to (bid + ask) / 2.
+        assert index[("AAPL", "put", 175.0, "2026-05-08")] == pytest.approx(1.50)
+
+    def test_strike_normalization(self):
+        # "15" and "15.0" must both normalize to the float 15.0.
+        chain = {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "15": [{"strikePrice": "15", "mark": 0.50}],
+                }
+            }
+        }
+        index = build_option_mark_index({"F": chain})
+        assert ("F", "call", 15.0, "2026-06-26") in index
+
+    def test_exp_key_prefix_is_split(self):
+        # The exp_key carries a ":DTE" suffix that must be stripped.
+        index = build_option_mark_index({"AAPL": self._chain()})
+        keys = {key[3] for key in index}
+        assert keys == {"2026-06-26", "2026-05-08"}
+
+    def test_mark_preferred_over_bid_ask(self):
+        chain = {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "100.0": [
+                        {"strikePrice": 100.0, "mark": 2.00, "bid": 1.0, "ask": 1.2}
+                    ],
+                }
+            }
+        }
+        index = build_option_mark_index({"AAPL": chain})
+        # mark wins even when bid/ask are present.
+        assert index[("AAPL", "call", 100.0, "2026-06-26")] == pytest.approx(2.00)
+
+    def test_contract_with_no_usable_mid_is_skipped(self):
+        chain = {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "100.0": [{"strikePrice": 100.0, "bid": 0.0, "ask": 0.0}],
+                }
+            }
+        }
+        index = build_option_mark_index({"AAPL": chain})
+        assert index == {}
+
+    def test_malformed_chains_do_not_raise(self):
+        malformed = {
+            "AAPL": {
+                "callExpDateMap": {
+                    "2026-06-26:38": {
+                        "100.0": [],  # empty contract list
+                        "105.0": ["not-a-dict"],  # non-dict contract
+                        "110.0": [{"bid": 1.0, "ask": 1.2}],  # missing strikePrice
+                    },
+                    "bad-node": "not-a-strikes-map",
+                },
+                "putExpDateMap": "not-a-map",
+            },
+            "TSLA": "not-a-chain",
+            "MSFT": {},  # no maps at all
+        }
+        # Must not raise; everything malformed is simply skipped.
+        index = build_option_mark_index(malformed)
+        assert index == {}
+
+    def test_none_input_returns_empty(self):
+        assert build_option_mark_index(None) == {}
 
 
 class TestComputeEarningsInWindow:
@@ -414,6 +567,8 @@ class TestDeriveOpenLegsV05Signals:
                         "trade_type": "sell_put",
                         "strike": 175.0,
                         "expiration": "2026-05-08",
+                        "premium": 2.25,
+                        "quantity": 1,
                         "closed_at": None,
                     }
                 ],
@@ -425,6 +580,7 @@ class TestDeriveOpenLegsV05Signals:
             today=date(2026, 5, 5),
         )
         leg = legs[0]
+        # No option_marks supplied → % CAPT degrades to unknown.
         assert leg["profit_target_status"] == {
             "captured_pct": None,
             "state": "unknown",
@@ -435,6 +591,67 @@ class TestDeriveOpenLegsV05Signals:
         assert leg["suggested_action"] == "roll"
         # Earnings lookup defaults to cache-miss → False.
         assert leg["earnings_in_window"] is False
+
+    def test_profit_target_status_uses_matching_option_mark(self):
+        positions = [
+            self._position(
+                "AAPL",
+                "p-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_put",
+                        "strike": 175.0,
+                        "expiration": "2026-05-08",
+                        "premium": 1.00,
+                        "quantity": 1,
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        # A live mark of 0.40 → 60% of the 1.00 credit captured.
+        option_marks = {("AAPL", "put", 175.0, "2026-05-08"): 0.40}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 174.50},
+            today=date(2026, 5, 5),
+            option_marks=option_marks,
+        )
+        status = legs[0]["profit_target_status"]
+        assert status["captured_pct"] == pytest.approx(0.60)
+        assert status["state"] == "captured_50"
+
+    def test_profit_target_status_unknown_when_mark_key_absent(self):
+        positions = [
+            self._position(
+                "AAPL",
+                "p-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_put",
+                        "strike": 175.0,
+                        "expiration": "2026-05-08",
+                        "premium": 1.00,
+                        "quantity": 1,
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        # Index has a mark, but for a different strike — no match for this leg.
+        option_marks = {("AAPL", "put", 180.0, "2026-05-08"): 0.40}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 174.50},
+            today=date(2026, 5, 5),
+            option_marks=option_marks,
+        )
+        assert legs[0]["profit_target_status"] == {
+            "captured_pct": None,
+            "state": "unknown",
+        }
 
     def test_earnings_lookup_must_not_be_called_with_network(self):
         # Custom lookup proves derive_open_legs uses cache-only semantics
@@ -455,6 +672,8 @@ class TestDeriveOpenLegsV05Signals:
                         "trade_type": "sell_put",
                         "strike": 175.0,
                         "expiration": "2026-05-08",
+                        "premium": 2.25,
+                        "quantity": 1,
                         "closed_at": None,
                     }
                 ],

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -131,6 +131,34 @@ def test_dashboard_populated(client, monkeypatch):
         "app.services.dashboard.SchwabClient.get_quote", fake_get_quote
     )
 
+    # Mock Schwab option chains so the % CAPT (profit-target) signal resolves.
+    # The AAPL short put 175 was opened for a 2.25 credit (the _seed_trade
+    # default); a current mid of 0.90 → 60% of the credit captured.
+    chain_responses = {
+        "AAPL": {
+            "putExpDateMap": {
+                "2026-05-08:3": {
+                    "175.0": [{"strikePrice": 175.0, "mark": 0.90}],
+                }
+            },
+        },
+        "TSLA": {
+            "callExpDateMap": {
+                "2026-05-15:10": {
+                    "240.0": [{"strikePrice": 240.0, "mark": 1.10}],
+                }
+            },
+        },
+    }
+
+    def fake_get_option_chain(self, ticker, *args, **kwargs):
+        return chain_responses[ticker]
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        fake_get_option_chain,
+    )
+
     # Pin "today" so DTE math is deterministic.
     today = datetime(2026, 5, 5, tzinfo=timezone.utc).date()
     monkeypatch.setattr(
@@ -206,6 +234,12 @@ def test_dashboard_populated(client, monkeypatch):
     )
     assert aapl_upcoming["decision_tag"] == "roll-or-assign"
     assert aapl_upcoming["dte"] == 3
+
+    # % CAPT is now a real value — AAPL short put 175 opened for 2.25, current
+    # mid 0.90 → (2.25 - 0.90) / 2.25 = 0.60 captured, past the 50% target.
+    aapl_leg = next(leg for leg in data["open_legs"] if leg["ticker"] == "AAPL")
+    assert aapl_leg["profit_target_status"]["state"] == "captured_50"
+    assert aapl_leg["profit_target_status"]["captured_pct"] == pytest.approx(0.60)
 
     # Recent activity contains both the trade and the session.
     kinds = {event["kind"] for event in data["recent_activity"]}
@@ -330,6 +364,94 @@ def test_dashboard_unexpected_quote_exception_does_not_500(client, monkeypatch):
     # And the failure is surfaced on data_meta so the UI can flag it.
     assert "schwab" in data["data_meta"]["sources_unavailable"]
     assert data["data_meta"]["is_stale"] is True
+
+
+def test_dashboard_option_chain_failure_degrades_gracefully(client, monkeypatch):
+    """A failed option-chain fetch flags `schwab` and degrades % CAPT to unknown.
+
+    Quotes still succeed, so moneyness resolves; only the profit-target signal
+    degrades. The dashboard must still return 200.
+    """
+    from app.services.schwab_client import SchwabClientError
+
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 174.0},
+    )
+
+    def fake_get_option_chain(self, ticker, *args, **kwargs):
+        raise SchwabClientError("simulated chain outage")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        fake_get_option_chain,
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # The chain failure is folded into the partial-outage flags.
+    assert "schwab" in data["data_meta"]["sources_unavailable"]
+    assert data["data_meta"]["is_stale"] is True
+
+    # The leg renders, but % CAPT degrades to unknown (no live mark).
+    assert len(data["open_legs"]) == 1
+    assert data["open_legs"][0]["profit_target_status"] == {
+        "captured_pct": None,
+        "state": "unknown",
+    }
+
+
+def test_dashboard_unexpected_chain_exception_does_not_500(client, monkeypatch):
+    """A non-Schwab exception escaping a per-ticker chain call must not 500.
+
+    Defense-in-depth: the chain-fetch worker catches broad Exception so a
+    malformed payload or escaped timeout cannot propagate out of
+    ThreadPoolExecutor.map and surface as a 500.
+    """
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 174.0},
+    )
+
+    def fake_get_option_chain(self, ticker, *args, **kwargs):
+        raise RuntimeError("synthetic unexpected chain failure")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        fake_get_option_chain,
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    # Surfaced as a partial outage; the dashboard still rendered.
+    assert "schwab" in data["data_meta"]["sources_unavailable"]
+    assert data["open_legs"][0]["profit_target_status"]["state"] == "unknown"
 
 
 def test_dashboard_stale_cache(client, monkeypatch):
@@ -494,6 +616,18 @@ def test_dashboard_per_leg_signals_present(client, monkeypatch):
     monkeypatch.setattr(
         "app.services.dashboard.SchwabClient.get_quote",
         lambda self, ticker: {"lastPrice": 174.0},
+    )
+    # Chain has no matching strike for the seeded leg → % CAPT stays unknown,
+    # deterministically (independent of any locally configured Schwab token).
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        lambda self, ticker, *a, **kw: {
+            "putExpDateMap": {
+                "2099-12-31:99999": {
+                    "999.0": [{"strikePrice": 999.0, "mark": 1.00}],
+                }
+            }
+        },
     )
 
     pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)


### PR DESCRIPTION
## Summary

Backend slice of #240. The dashboard's "Open option legs" table has a `% CAPT` (profit-target) column that always rendered `—`, backed by `build_profit_target_status()` — a no-arg stub that hard-returned `{"captured_pct": None, "state": "unknown"}`. A stale comment claimed the 50%-profit signal "requires live option-chain data (deferred to V0.7)." That comment was wrong: every input already exists in production (`Trade.premium`, `SchwabClient.get_option_chain()`). This wires up a real per-leg `% CAPT`.

`captured_pct = (premium − current_mid) / premium`, classified against `rules.management.profit_review_pct` (default 50) into `captured_50` / `in_progress` / `underwater`. Missing/non-credit inputs and expired legs degrade to `state: "unknown"` — today's safe behavior, never a wrong number.

## What changed

**`backend/app/services/dashboard_legs.py`** (stays pure / side-effect-free)
- `build_profit_target_status(premium, current_mid, dte=9999, profit_review_pct=50.0)` — rewritten from a no-arg stub into a pure math function. `quantity` is deliberately not a parameter (the per-share ratio is quantity-invariant).
- New pure helper `build_option_mark_index(chains_by_ticker)` — flattens raw Schwab `callExpDateMap`/`putExpDateMap` into a flat `{(ticker, type, round(strike,4), exp_date): mid}` index. `mid = mark or (bid+ask)/2`; tolerant of malformed nodes.
- `derive_open_legs()` — adds `option_marks` + `profit_review_pct` params (defensive `None → {}` default), builds the leg lookup key, and passes `premium` + `current_mid` + `dte` + `profit_review_pct` into the builder.
- Dropped the stale "deferred to V0.7" comment; updated the `derive_open_legs` docstring.

**`backend/app/services/dashboard.py`** (owns all network I/O)
- New `_fetch_option_chains_parallel(tickers, schwab_configured)` — thread-pool fan-out modeled on `_fetch_quotes_parallel`, capped at `QUOTE_FANOUT_WORKERS`. Per-ticker failure caught (known `SchwabClientError`/`SchwabAuthError` **and** broad `Exception`, defense-in-depth) → ticker omitted + `schwab_failed=True`. Workers log only; no `str(e)` ever reaches a response (CLAUDE.md).
- `build_dashboard_payload()` — collects distinct open-leg tickers, fetches chains, builds the index, threads it into `derive_open_legs`. `load_rules_config(db)` is hoisted above and reused by the action engine. Chain-fetch failure folds into `schwab_failed` so `sources_unavailable`/`is_stale` surface it.

No response-schema change — `DashboardProfitTargetStatus` already had the right shape.

## Accepted tradeoff — no caching this slice

`_fetch_option_chains_parallel` issues N extra blocking `get_option_chain` calls per dashboard load (N = distinct open-leg tickers). The dashboard **already** fans out N blocking `get_quote` calls the same way via `_fetch_quotes_parallel`, so this is consistent. An in-process TTL cache is a deferred V1.2 follow-up — noted in a code comment on the new function.

## Test coverage

`backend/tests/test_dashboard_legs.py`
- Rewrote `TestProfitTargetStatusBuilder` — includes the **locked acceptance test** from the issue #240 screenshot (`premium=0.3834, current_mid=0.155` → `captured_pct≈0.5957`, `state=="captured_50"`), boundary/underwater/in-progress cases, all degradation paths (`None`/`0`/negative premium, expired leg), and a `profit_review_pct` threshold-honoring case.
- New `TestBuildOptionMarkIndex` — key/mid construction, strike normalization, exp-key prefix split, `mark` vs `(bid+ask)/2` fallback, malformed-chain tolerance.
- Extended `TestDeriveOpenLegsV05Signals` — matching mark → real `captured_pct`; non-matching key → `unknown`; `premium`/`quantity` added to fixtures.

`backend/tests/test_integration_dashboard.py`
- `test_dashboard_populated` — monkeypatches `get_option_chain`, asserts a leg with a real non-`unknown` `% CAPT`.
- New `test_dashboard_option_chain_failure_degrades_gracefully` — chain raises `SchwabClientError` → 200, legs `unknown`, `sources_unavailable` has `"schwab"`.
- New `test_dashboard_unexpected_chain_exception_does_not_500` — non-Schwab exception → still 200.

`cd backend && python -m pytest` — **1054 passed, 9 skipped** (pre-existing), no regressions.

The `frontend/e2e/dashboard-open-legs-card.spec.js` `% CAPT` test was reviewed: it mocks `/api/dashboard` with a fixture that explicitly sets `state: 'unknown'`, so it tests the `unknown` rendering path — not a stale "always `—`" assertion. Left unchanged (frontend JSX is out of scope; the column already renders `captured_pct`).

## Scope

This PR **references but does not close #240**. It ships the backend `% CAPT` signal. #240 stays open for its design-gated remainder — the styled `ACTION` verdict column and the NextActions cards for profit-target hits (both `needs-design`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)