### PR TITLE
Rule-monitor verdict layer + action cards: ManagementTriggers §R6 on the dashboard (closes #240)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -571,9 +571,22 @@ DASHBOARD_ACTION_ID = Literal[
     "expiration.short_dte",
     "position.cc_candidate",
     "journal.no_open_legs",
+    # New in V1.0.4 (#240) — the §R6 rule-monitor action cards.
+    "leg.profit_take_review",
+    "leg.dte_review",
 ]
 DASHBOARD_ACTION_PRIORITY = Literal["P0", "P1", "P2"]
 DASHBOARD_ACTION_CTA_KIND = Literal["link", "inline"]
+# New in V1.0.4 (#240) — the per-leg §R6 rule-monitor verdict layer.
+DASHBOARD_VERDICT = Literal[
+    "hold", "profit_take_review", "dte_review", "expiration", "assignment"
+]
+DASHBOARD_RULE_STATUS = Literal["triggered", "not_yet", "no"]
+DASHBOARD_RULE_ID = Literal[
+    "profit_review", "dte_review", "expiration_warning", "assignment_risk"
+]
+# Card valence — `priority` ranks urgency, `tone` carries valence (§4.3 Q6).
+DASHBOARD_ACTION_TONE = Literal["opportunity", "warning"]
 
 
 class DashboardSchwabStatus(BaseModel):
@@ -700,6 +713,24 @@ class DashboardProfitTargetStatus(BaseModel):
     state: DASHBOARD_PROFIT_TARGET_STATE
 
 
+class DashboardRuleEvaluation(BaseModel):
+    """One §R6 management rule evaluated against an open leg (issue #240).
+
+    Emitted fired and not-fired alike — the inspect panel renders every rule,
+    including the ones that did not fire, so the table reads as a monitor and
+    not just an alert list. ``reasoning`` is present only on the single
+    governing (highest-precedence triggered) rule.
+    """
+
+    rule_id: DASHBOARD_RULE_ID
+    metric_label: str
+    value_display: str
+    rule_display: str
+    status: DASHBOARD_RULE_STATUS
+    is_governing: bool = False
+    reasoning: Optional[str] = None
+
+
 class DashboardOpenLeg(BaseModel):
     id: str
     ticker: str
@@ -714,6 +745,12 @@ class DashboardOpenLeg(BaseModel):
     assignment_risk: DASHBOARD_ASSIGNMENT_RISK
     suggested_action: DASHBOARD_SUGGESTED_ACTION
     earnings_in_window: bool = False
+    # New in V1.0.4 (#240) — the §R6 rule-monitor verdict layer. All four
+    # fields default so older payloads / tests that omit them still validate.
+    verdict: DASHBOARD_VERDICT = "hold"
+    verdict_label: str = "Hold"
+    reasoning: str = "No management rule has triggered for this leg yet."
+    triggered_rules: list[DashboardRuleEvaluation] = []
 
 
 class DashboardUpcomingExpiration(DashboardOpenLeg):
@@ -755,6 +792,12 @@ class DashboardNextAction(BaseModel):
     subject: DashboardNextActionSubject = DashboardNextActionSubject()
     reason: str
     cta: DashboardNextActionCta
+    # New in V1.0.4 (#240). ``tone`` defaults to "warning" so every existing
+    # card (expiration.*, data.*, position.*, journal.*) is schema-valid and
+    # visually unchanged. ``triggered_rules`` is the §R6 evaluation payload
+    # carried by the two leg.* cards (empty for every other card type).
+    tone: DASHBOARD_ACTION_TONE = "warning"
+    triggered_rules: list[DashboardRuleEvaluation] = []
 
 
 class DashboardActivity(BaseModel):

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 from typing import Iterable
 from urllib.parse import quote
 
+from app.services.rule_monitor import card_reason_for
 from app.services.rules_config import DEFAULT_RULES_CONFIG, RulesConfig
 
 # Cap from spec §2.2: anything beyond 8 cards is noise; the user should
@@ -110,6 +111,12 @@ def _sub_bucket_for(action: dict) -> int:
         return 0
     if action_id.startswith("expiration."):
         return 1
+    if action_id == "leg.profit_take_review":
+        # P1, after expiration.* — a deadline outranks an opportunity (§4.2).
+        return 2
+    if action_id == "leg.dte_review":
+        # P2: below cc_candidate(0), above the no-legs scanner(9).
+        return 1
     if action_id == "position.cc_candidate":
         # P2 tiebreaker: CC candidates outrank the scanner.
         return 0
@@ -130,6 +137,9 @@ def _tie_breaker_for(action: dict) -> tuple:
     if action_id == "expiration.itm_short_dte":
         return (action.get("_dte", 0), subject_ticker)
     if action_id == "expiration.short_dte":
+        return (action.get("_dte", 0), subject_ticker)
+    if action_id in ("leg.profit_take_review", "leg.dte_review"):
+        # The §R6 leg cards sort by DTE ascending, then ticker A→Z.
         return (action.get("_dte", 0), subject_ticker)
     if action_id == "position.cc_candidate":
         return (0, subject_ticker)
@@ -412,6 +422,109 @@ def _short_dte_aggregate_actions(
     return cards
 
 
+def _leg_profit_take_review_actions(
+    open_legs: Iterable[dict], profit_review_pct: float
+) -> list[dict]:
+    """Build ``leg.profit_take_review`` cards — one per leg whose *governing*
+    verdict is ``profit_take_review`` (issue #240, spec §4).
+
+    Reads ``leg["verdict"]`` / ``leg["triggered_rules"]`` already computed by
+    :mod:`app.services.rule_monitor` — the engine does NOT re-evaluate. Because
+    ``verdict`` is already the §R6 governing rule, filtering on it gives
+    one-leg-one-card by construction: a leg whose governing verdict is
+    ``expiration``/``assignment`` is skipped, so it cannot double-emit
+    alongside the existing ``expiration.*`` cards (spec §4.2).
+    """
+    cards: list[dict] = []
+    for leg in open_legs:
+        if leg.get("verdict") != "profit_take_review":
+            continue
+        dte = leg.get("dte")
+        ticker = leg["ticker"]
+        strike = leg["strike"]
+        option_letter = "P" if leg.get("type") == "put" else "C"
+        triggered_rules = leg.get("triggered_rules") or []
+        cards.append(
+            {
+                "id": f"leg.profit_take_review.{leg['id']}",
+                "action_id": "leg.profit_take_review",
+                "priority": "P1",
+                # `opportunity` tone — a profit-take is a win, not a warning;
+                # NextActionCard renders it emerald with a ✓ glyph (§4.3 Q6).
+                "tone": "opportunity",
+                "title": "Profit-take review",
+                "subject": {
+                    "ticker": ticker,
+                    "amount": f"{strike:g}{option_letter}",
+                },
+                "reason": card_reason_for(
+                    triggered_rules,
+                    profit_review_pct=profit_review_pct,
+                    dte_review_days=21,
+                ),
+                "cta": {
+                    "label": "Inspect rule",
+                    "href": f"/dashboard#leg-{quote(str(leg['id']), safe='')}",
+                    "kind": "link",
+                },
+                "triggered_rules": triggered_rules,
+                # Sort metadata consumed by `_tie_breaker_for`.
+                "_dte": int(dte) if dte is not None else 0,
+            }
+        )
+    cards.sort(key=lambda c: (c["_dte"], c["subject"]["ticker"], c["id"]))
+    return cards
+
+
+def _leg_dte_review_actions(
+    open_legs: Iterable[dict], dte_review_days: int
+) -> list[dict]:
+    """Build ``leg.dte_review`` cards — one per leg whose *governing* verdict
+    is ``dte_review`` (issue #240, spec §4).
+
+    Like :func:`_leg_profit_take_review_actions`, filters on the precomputed
+    ``verdict`` so a leg already governed by a higher-precedence rule
+    (``expiration``/``assignment``/``profit_take_review``) is skipped — one
+    leg, one card. ``priority`` is ``P2`` and the card carries no ``tone``
+    key, so it defaults to ``"warning"`` (slate treatment).
+    """
+    cards: list[dict] = []
+    for leg in open_legs:
+        if leg.get("verdict") != "dte_review":
+            continue
+        dte = leg.get("dte")
+        ticker = leg["ticker"]
+        strike = leg["strike"]
+        option_letter = "P" if leg.get("type") == "put" else "C"
+        triggered_rules = leg.get("triggered_rules") or []
+        cards.append(
+            {
+                "id": f"leg.dte_review.{leg['id']}",
+                "action_id": "leg.dte_review",
+                "priority": "P2",
+                "title": f"{dte_review_days}-day review",
+                "subject": {
+                    "ticker": ticker,
+                    "amount": f"{strike:g}{option_letter}",
+                },
+                "reason": card_reason_for(
+                    triggered_rules,
+                    profit_review_pct=50.0,
+                    dte_review_days=dte_review_days,
+                ),
+                "cta": {
+                    "label": "Inspect rule",
+                    "href": f"/dashboard#leg-{quote(str(leg['id']), safe='')}",
+                    "kind": "link",
+                },
+                "triggered_rules": triggered_rules,
+                "_dte": int(dte) if dte is not None else 0,
+            }
+        )
+    cards.sort(key=lambda c: (c["_dte"], c["subject"]["ticker"], c["id"]))
+    return cards
+
+
 def _cc_candidate_actions(
     positions: Iterable[dict],
     open_legs: Iterable[dict],
@@ -554,6 +667,16 @@ def compute_next_actions(
 
     candidates.extend(_itm_short_dte_actions(open_legs, short_dte_max))
     candidates.extend(_short_dte_aggregate_actions(open_legs, short_dte_max))
+    # §R6 rule-monitor leg cards (issue #240). These read each leg's
+    # precomputed `verdict` — filtering on the governing rule means a leg
+    # already covered by an expiration.* card is skipped, so one leg yields
+    # exactly one card across all four families.
+    candidates.extend(
+        _leg_profit_take_review_actions(open_legs, rules.management.profit_review_pct)
+    )
+    candidates.extend(
+        _leg_dte_review_actions(open_legs, rules.management.dte_review_days)
+    )
     candidates.extend(_cc_candidate_actions(positions, open_legs))
 
     no_legs_card = _no_open_legs_action(kpis)

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -423,7 +423,10 @@ def _short_dte_aggregate_actions(
 
 
 def _leg_profit_take_review_actions(
-    open_legs: Iterable[dict], profit_review_pct: float
+    open_legs: Iterable[dict],
+    profit_review_pct: float,
+    dte_review_days: int,
+    expiration_warning_days: int,
 ) -> list[dict]:
     """Build ``leg.profit_take_review`` cards — one per leg whose *governing*
     verdict is ``profit_take_review`` (issue #240, spec §4).
@@ -460,7 +463,8 @@ def _leg_profit_take_review_actions(
                 "reason": card_reason_for(
                     triggered_rules,
                     profit_review_pct=profit_review_pct,
-                    dte_review_days=21,
+                    dte_review_days=dte_review_days,
+                    expiration_warning_days=expiration_warning_days,
                 ),
                 "cta": {
                     "label": "Inspect rule",
@@ -672,7 +676,12 @@ def compute_next_actions(
     # already covered by an expiration.* card is skipped, so one leg yields
     # exactly one card across all four families.
     candidates.extend(
-        _leg_profit_take_review_actions(open_legs, rules.management.profit_review_pct)
+        _leg_profit_take_review_actions(
+            open_legs,
+            rules.management.profit_review_pct,
+            rules.management.dte_review_days,
+            rules.management.expiration_warning_days,
+        )
     )
     candidates.extend(
         _leg_dte_review_actions(open_legs, rules.management.dte_review_days)

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -336,6 +336,9 @@ _NEXT_ACTION_TABLE_LABEL: dict[str, str] = {
     "expiration.short_dte": "Manage",
     "position.cc_candidate": "Cover",
     "journal.no_open_legs": "Run scanner",
+    # New in V1.0.4 (#240) — the §R6 rule-monitor leg cards.
+    "leg.profit_take_review": "Review",
+    "leg.dte_review": "Review",
 }
 
 
@@ -368,7 +371,11 @@ def _attach_next_suggested_actions(
             # Subject id is the position uuid.
             if subject_id and subject_id not in label_by_position:
                 label_by_position[subject_id] = label
-        elif action_id == "expiration.itm_short_dte":
+        elif action_id in {
+            "expiration.itm_short_dte",
+            "leg.profit_take_review",
+            "leg.dte_review",
+        }:
             # Subject id is the leg/trade uuid — resolve via the legs map.
             position_id = position_id_by_leg.get(subject_id)
             if position_id and position_id not in label_by_position:
@@ -683,6 +690,8 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         earnings_lookup=get_cached_next_earnings_date,
         option_marks=option_marks,
         profit_review_pct=rules.management.profit_review_pct,
+        dte_review_days=rules.management.dte_review_days,
+        expiration_warning_days=rules.management.expiration_warning_days,
     )
     upcoming = filter_upcoming(open_legs, horizon_days=14)
 

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Iterable, Literal
 
+from app.services.rule_monitor import evaluate_leg_rules
 from app.utils.parsing import to_float
 
 # A "leg-opening" trade type implies the leg is currently open *unless* the
@@ -320,6 +321,8 @@ def derive_open_legs(
     earnings_lookup=None,
     option_marks: dict | None = None,
     profit_review_pct: float = 50.0,
+    dte_review_days: int = 21,
+    expiration_warning_days: int = 7,
 ) -> list[dict]:
     """Flatten open option legs across the given positions.
 
@@ -328,7 +331,9 @@ def derive_open_legs(
     DTE, moneyness, and the per-leg signal fields:
     ``profit_target_status`` (the ``% CAPT`` signal — a real ``captured_pct``
     when a live mark is available, else ``state="unknown"``),
-    ``assignment_risk``, ``suggested_action``, and ``earnings_in_window``.
+    ``assignment_risk``, ``suggested_action``, ``earnings_in_window``, and the
+    §R6 rule-monitor verdict layer (issue #240): ``verdict``,
+    ``verdict_label``, ``reasoning``, and ``triggered_rules``.
 
     ``earnings_lookup`` is an optional callable used to populate
     ``earnings_in_window``. It MUST be cache-hit-only — defaults to a
@@ -338,8 +343,9 @@ def derive_open_legs(
     ``option_marks`` is the flat ``{(ticker, type, strike, exp): mid}`` index
     produced by :func:`build_option_mark_index`. It is optional — a missing
     index (or a leg absent from it) degrades that leg's ``profit_target_status``
-    to ``state="unknown"``. ``profit_review_pct`` is the user's profit-target
-    threshold (``rules.management.profit_review_pct``).
+    to ``state="unknown"``. ``profit_review_pct``, ``dte_review_days``, and
+    ``expiration_warning_days`` are the user's ManagementTriggers §R6
+    thresholds (``rules.management.*``).
 
     Returns a list ordered by (dte ASC, ticker ASC) — callers that need
     other orderings should re-sort.
@@ -376,6 +382,26 @@ def derive_open_legs(
                 str(trade["expiration"])[:10],
             )
             current_mid = option_marks.get(mark_key)
+            profit_target_status = build_profit_target_status(
+                premium=trade.get("premium"),
+                current_mid=current_mid,
+                dte=dte,
+                profit_review_pct=profit_review_pct,
+            )
+            assignment_risk = compute_assignment_risk(dte, moneyness_state)
+            # §R6 rule-monitor verdict layer (issue #240). Pure — derives the
+            # verdict from values already on this leg; no I/O, no DB.
+            verdict, verdict_label, reasoning, triggered_rules = evaluate_leg_rules(
+                dte=dte,
+                moneyness_state=moneyness_state,
+                profit_target_status=profit_target_status,
+                premium=trade.get("premium"),
+                current_mid=current_mid,
+                profit_review_pct=profit_review_pct,
+                dte_review_days=dte_review_days,
+                expiration_warning_days=expiration_warning_days,
+                assignment_risk=assignment_risk,
+            )
             legs.append(
                 {
                     "id": trade["id"],
@@ -386,17 +412,16 @@ def derive_open_legs(
                     "dte": dte,
                     "moneyness": moneyness,
                     "position_id": position_id,
-                    "profit_target_status": build_profit_target_status(
-                        premium=trade.get("premium"),
-                        current_mid=current_mid,
-                        dte=dte,
-                        profit_review_pct=profit_review_pct,
-                    ),
-                    "assignment_risk": compute_assignment_risk(dte, moneyness_state),
+                    "profit_target_status": profit_target_status,
+                    "assignment_risk": assignment_risk,
                     "suggested_action": compute_suggested_action(decision_tag),
                     "earnings_in_window": compute_earnings_in_window(
                         ticker, dte, earnings_lookup, today=today
                     ),
+                    "verdict": verdict,
+                    "verdict_label": verdict_label,
+                    "reasoning": reasoning,
+                    "triggered_rules": triggered_rules,
                 }
             )
     legs.sort(key=lambda x: (x["dte"], x["ticker"]))

--- a/backend/app/services/rule_monitor.py
+++ b/backend/app/services/rule_monitor.py
@@ -62,17 +62,6 @@ def _captured_dollars(captured_pct: float | None, premium: float | None) -> floa
     return round(captured_pct * premium, 2)
 
 
-def _moneyness_label(moneyness_state: str | None) -> str:
-    """Human label for the assignment-risk metric Value column."""
-    if moneyness_state == "ITM":
-        return "ITM"
-    if moneyness_state == "ATM":
-        return "ATM"
-    if moneyness_state == "OTM":
-        return "OTM"
-    return "—"
-
-
 def _reasoning_for(
     governing: str | None,
     *,
@@ -221,10 +210,7 @@ def evaluate_leg_rules(
     expired = dte < 0
 
     # --- assignment (7d ITM) — never a countdown: triggered or no. ----------
-    if in_warning_window and is_itm:
-        assignment_status = "triggered"
-    else:
-        assignment_status = "no"
+    assignment_status = "triggered" if in_warning_window and is_itm else "no"
 
     # --- expiration (7d OTM) — carries the not-yet countdown for non-ITM. ---
     if in_warning_window and not is_itm:
@@ -293,7 +279,6 @@ def evaluate_leg_rules(
     captured_value = (
         f"{round(captured_pct * 100)}%" if captured_pct is not None else "—"
     )
-    moneyness_value = _moneyness_label(moneyness_state)
 
     rows: list[dict] = []
     for key in RULE_PRECEDENCE:
@@ -301,7 +286,10 @@ def evaluate_leg_rules(
         is_governing = key == governing
         if key == "assignment":
             metric_label = "Assignment risk"
-            value_display = moneyness_value
+            # Show the risk level (High / Watch / Low) — not moneyness — so the
+            # row value agrees with its "Review at ≥ High" rule. `moneyness` is
+            # already surfaced by the dedicated moneyness column.
+            value_display = assignment_risk.capitalize()
             rule_display = "Review at ≥ High"
         elif key == "expiration":
             metric_label = "Days to expiration"
@@ -330,13 +318,24 @@ def evaluate_leg_rules(
     return verdict, verdict_label, reasoning, rows
 
 
-def card_reason_for(triggered_rules: list[dict], *, profit_review_pct: float, dte_review_days: int) -> str:
+def card_reason_for(
+    triggered_rules: list[dict],
+    *,
+    profit_review_pct: float,
+    dte_review_days: int,
+    expiration_warning_days: int = 7,
+) -> str:
     """Build the short-form card ``reason`` from a leg's ``triggered_rules``.
 
     Reads the governing rule off the already-evaluated ``triggered_rules``
     array so the card and the inspect table share one reasoning source and
     never drift. Returns an empty string when no rule governs (the engine
     only emits a card when a rule fired, so this is defensive).
+
+    The threshold parameters (``profit_review_pct`` / ``dte_review_days`` /
+    ``expiration_warning_days``) must be the user's *actual* configured
+    ``rules.management`` values so the reason text agrees with the rule
+    evaluation — never hardcode them at the call site.
     """
     governing_row = next(
         (r for r in triggered_rules if r.get("is_governing")), None
@@ -368,7 +367,7 @@ def card_reason_for(triggered_rules: list[dict], *, profit_review_pct: float, dt
         premium=None,
         profit_review_pct=profit_review_pct,
         dte_review_days=dte_review_days,
-        expiration_warning_days=7,
+        expiration_warning_days=expiration_warning_days,
         also_fired=[],
         short=True,
     )

--- a/backend/app/services/rule_monitor.py
+++ b/backend/app/services/rule_monitor.py
@@ -1,0 +1,381 @@
+"""Per-leg §R6 rule-monitor — the verdict layer (issue #240).
+
+This module owns the ManagementTriggers §R6 rule evaluation that sits *on
+top of* the already-shipped ``% CAPT`` profit-target signal (PR #241). It is
+pure: every input is a plain value, every output is a plain dict. There is no
+DB access, no I/O, and nothing here raises — so the dashboard route's
+generic-500 wrapper is untouched.
+
+The keystone export is :func:`evaluate_leg_rules`. It evaluates all four §R6
+rules against an open leg (fired and not-fired alike), resolves precedence to
+a single governing rule, and returns a ``(verdict, verdict_label, reasoning,
+triggered_rules)`` tuple. ``dashboard_legs.py`` calls it once per leg; the
+result feeds three render sites — the ``ACTION`` verdict column, the inspect
+panel, and the two new NextActions cards — so all three agree by construction.
+
+Advice-framing discipline (spec §11): every ``reasoning`` string attributes
+the verdict to *the user's ruleset* — "Your 50% profit-take rule triggered" —
+never to the app. The app reports what the user's own rules said.
+"""
+
+from __future__ import annotations
+
+# Highest priority first. The governing rule owns the verdict, the verdict
+# label, the reasoning sentence, and the single emitted card. Spec §1.
+RULE_PRECEDENCE: tuple[str, ...] = (
+    "assignment",      # expiration_warning_days window AND leg is ITM
+    "expiration",      # expiration_warning_days window, OTM
+    "profit_review",   # profit_review_pct threshold crossed
+    "dte_review",      # dte_review_days window
+)
+
+# Precedence/verdict key -> the leg ``verdict`` string the frontend ACTION
+# column keys its visual treatment off. These are the verdict *buckets*.
+_RULE_ID_TO_VERDICT: dict[str, str] = {
+    "assignment": "assignment",
+    "expiration": "expiration",
+    "profit_review": "profit_take_review",
+    "dte_review": "dte_review",
+}
+
+# Precedence/verdict key -> the spec §6.2 ``rule_id`` enum carried on the
+# RuleEvaluation dict. ``assignment`` and ``expiration`` are two verdict
+# buckets from the one §R6 ``expiration_warning`` rule, so the precedence key
+# and the ``rule_id`` differ — this map keeps the mapping explicit.
+_RULE_ID_FOR_BUCKET: dict[str, str] = {
+    "assignment": "assignment_risk",
+    "expiration": "expiration_warning",
+    "profit_review": "profit_review",
+    "dte_review": "dte_review",
+}
+
+
+def _format_dollars(amount: float) -> str:
+    """Render a dollar amount with comma grouping (e.g. ``$22.84``)."""
+    return f"${amount:,.2f}"
+
+
+def _captured_dollars(captured_pct: float | None, premium: float | None) -> float | None:
+    """Dollar value of the captured premium fraction, or ``None`` when unknown."""
+    if captured_pct is None or premium is None:
+        return None
+    return round(captured_pct * premium, 2)
+
+
+def _moneyness_label(moneyness_state: str | None) -> str:
+    """Human label for the assignment-risk metric Value column."""
+    if moneyness_state == "ITM":
+        return "ITM"
+    if moneyness_state == "ATM":
+        return "ATM"
+    if moneyness_state == "OTM":
+        return "OTM"
+    return "—"
+
+
+def _reasoning_for(
+    governing: str | None,
+    *,
+    dte: int,
+    captured_pct: float | None,
+    premium: float | None,
+    profit_review_pct: float,
+    dte_review_days: int,
+    expiration_warning_days: int,
+    also_fired: list[str],
+    short: bool = False,
+) -> str:
+    """Build the §3.4 plain-language reasoning sentence.
+
+    ``short=True`` returns the compact card ``reason`` form; ``short=False``
+    returns the full inspect-panel sentence. Both share this one dispatch so
+    the card and the table can never drift. ``also_fired`` is the list of
+    non-governing precedence keys that also triggered — appended as a clause
+    when present (spec §3.5).
+
+    Every sentence attributes the verdict to the user's ruleset (spec §11).
+    """
+    pct = f"{profit_review_pct:g}"
+
+    if governing is None:
+        return "No management rule has triggered for this leg yet."
+
+    if governing == "profit_review":
+        captured = round((captured_pct or 0.0) * 100)
+        if short:
+            sentence = (
+                f"Your {pct}% profit-take rule triggered — "
+                f"{captured}% of max premium captured."
+            )
+        else:
+            dollars = _captured_dollars(captured_pct, premium)
+            if dollars is not None and premium is not None:
+                amount_clause = (
+                    f" ({_format_dollars(dollars)} of {_format_dollars(premium)})"
+                )
+            else:
+                amount_clause = ""
+            sentence = (
+                f"Your {pct}% profit-take rule triggered. This leg has captured "
+                f"{captured}% of its max premium{amount_clause} — past the "
+                f"{pct}% review threshold you set."
+            )
+    elif governing == "dte_review":
+        if short:
+            sentence = (
+                f"{dte} days to expiration — your review window. "
+                "Decide: hold, roll, or close."
+            )
+        else:
+            sentence = (
+                f"This leg is inside your {dte_review_days}-day review window "
+                f"({dte} days to expiration). Your rule says: decide — "
+                "hold, roll, or close."
+            )
+    elif governing == "expiration":
+        sentence = (
+            f"Your expiration rule triggered — {dte} days to expiration, "
+            f"inside your {expiration_warning_days}-day warning window."
+        )
+    else:  # assignment
+        sentence = (
+            f"Your expiration rule triggered and this leg is ITM — "
+            f"{dte} days to expiration with assignment risk."
+        )
+
+    if also_fired:
+        clauses = []
+        for key in also_fired:
+            if key == "dte_review":
+                clauses.append(f"inside your {dte_review_days}-day review window")
+            elif key == "profit_review":
+                clauses.append(f"past your {pct}% profit-take threshold")
+            elif key == "expiration":
+                clauses.append(
+                    f"inside your {expiration_warning_days}-day warning window"
+                )
+        if clauses:
+            joined = "; ".join(clauses)
+            # Trim the trailing period before appending the parenthetical.
+            stem = sentence[:-1] if sentence.endswith(".") else sentence
+            sentence = f"{stem} (this leg is also {joined})."
+
+    return sentence
+
+
+def _verdict_label(governing: str | None, profit_review_pct: float, dte_review_days: int) -> str:
+    """Render the fully-formed verdict label string for the ACTION column.
+
+    Server-rendered so the frontend does no threshold parsing — the label
+    says exactly what the user's rule said (spec §2.2). The user's configured
+    thresholds are interpolated, so a 65% ``profit_review_pct`` reads
+    ``Review · 65%``.
+    """
+    if governing == "profit_review":
+        return f"Review · {profit_review_pct:g}%"
+    if governing == "dte_review":
+        return f"Review · {dte_review_days:g}d"
+    if governing == "expiration":
+        return "Close · exp"
+    if governing == "assignment":
+        return "Close · ITM"
+    return "Hold"
+
+
+def evaluate_leg_rules(
+    *,
+    dte: int,
+    moneyness_state: str | None,
+    profit_target_status: dict,
+    premium: float | None,
+    current_mid: float | None,
+    profit_review_pct: float = 50.0,
+    dte_review_days: int = 21,
+    expiration_warning_days: int = 7,
+    assignment_risk: str = "low",
+) -> tuple[str, str, str, list[dict]]:
+    """Evaluate the four §R6 management rules against one open leg.
+
+    Returns ``(verdict, verdict_label, reasoning, triggered_rules)``:
+
+    - ``verdict`` — the governing rule's verdict bucket (``profit_take_review``
+      / ``dte_review`` / ``expiration`` / ``assignment``), or ``"hold"`` when
+      nothing fired.
+    - ``verdict_label`` — the fully-rendered ACTION-column label string
+      (``"Review · 50%"`` / ``"Hold"`` / …). Server-rendered; no frontend
+      threshold parsing.
+    - ``reasoning`` — the §3.4 plain-language sentence for the governing rule;
+      the "nothing triggered" sentence when ``verdict == "hold"``.
+    - ``triggered_rules`` — one RuleEvaluation dict per §R6 rule, fired and
+      not-fired alike, in fixed :data:`RULE_PRECEDENCE` order.
+
+    Graceful degradation (spec §2.5): when ``current_mid`` is ``None`` the
+    ``captured_pct`` is ``None``, the ``profit_review`` row is
+    ``status="no"`` / ``value_display="—"``, and ``profit_review`` can never
+    be the governing rule — the verdict falls back to the DTE/moneyness rules.
+    """
+    captured_pct = (profit_target_status or {}).get("captured_pct")
+    is_itm = moneyness_state == "ITM"
+    in_warning_window = 0 <= dte <= expiration_warning_days
+    in_dte_window = 0 <= dte <= dte_review_days
+    expired = dte < 0
+
+    # --- assignment (7d ITM) — never a countdown: triggered or no. ----------
+    if in_warning_window and is_itm:
+        assignment_status = "triggered"
+    else:
+        assignment_status = "no"
+
+    # --- expiration (7d OTM) — carries the not-yet countdown for non-ITM. ---
+    if in_warning_window and not is_itm:
+        expiration_status = "triggered"
+    elif expired:
+        expiration_status = "no"
+    elif dte > expiration_warning_days:
+        expiration_status = "not_yet"
+    else:
+        # In the warning window but ITM — the assignment rule owns this leg;
+        # the expiration row reports "no" so it is not double-flagged.
+        expiration_status = "no"
+
+    # --- profit_review — unevaluable without a live mid. --------------------
+    threshold_fraction = profit_review_pct / 100
+    if captured_pct is None:
+        profit_status = "no"
+    elif captured_pct >= threshold_fraction:
+        profit_status = "triggered"
+    else:
+        profit_status = "not_yet"
+
+    # --- dte_review (21d window) — carries a not-yet countdown. -------------
+    if in_dte_window:
+        dte_review_status = "triggered"
+    elif expired:
+        dte_review_status = "no"
+    else:
+        dte_review_status = "not_yet"
+
+    status_by_bucket: dict[str, str] = {
+        "assignment": assignment_status,
+        "expiration": expiration_status,
+        "profit_review": profit_status,
+        "dte_review": dte_review_status,
+    }
+
+    # Governing rule = first triggered rule in precedence order.
+    governing: str | None = None
+    for key in RULE_PRECEDENCE:
+        if status_by_bucket[key] == "triggered":
+            governing = key
+            break
+
+    verdict = _RULE_ID_TO_VERDICT.get(governing, "hold") if governing else "hold"
+    verdict_label = _verdict_label(governing, profit_review_pct, dte_review_days)
+
+    also_fired = [
+        key
+        for key in RULE_PRECEDENCE
+        if key != governing and status_by_bucket[key] == "triggered"
+    ]
+    reasoning = _reasoning_for(
+        governing,
+        dte=dte,
+        captured_pct=captured_pct,
+        premium=premium,
+        profit_review_pct=profit_review_pct,
+        dte_review_days=dte_review_days,
+        expiration_warning_days=expiration_warning_days,
+        also_fired=also_fired,
+    )
+
+    # --- Build the four RuleEvaluation dicts, in RULE_PRECEDENCE order. -----
+    dte_value = f"{dte} d"
+    captured_value = (
+        f"{round(captured_pct * 100)}%" if captured_pct is not None else "—"
+    )
+    moneyness_value = _moneyness_label(moneyness_state)
+
+    rows: list[dict] = []
+    for key in RULE_PRECEDENCE:
+        status = status_by_bucket[key]
+        is_governing = key == governing
+        if key == "assignment":
+            metric_label = "Assignment risk"
+            value_display = moneyness_value
+            rule_display = "Review at ≥ High"
+        elif key == "expiration":
+            metric_label = "Days to expiration"
+            value_display = dte_value
+            rule_display = f"Warn at ≤ {expiration_warning_days} d"
+        elif key == "profit_review":
+            metric_label = "Premium captured"
+            value_display = captured_value
+            rule_display = f"Review at ≥ {profit_review_pct:g}%"
+        else:  # dte_review
+            metric_label = "Days to expiration"
+            value_display = dte_value
+            rule_display = f"Review at ≤ {dte_review_days} d"
+        rows.append(
+            {
+                "rule_id": _RULE_ID_FOR_BUCKET[key],
+                "metric_label": metric_label,
+                "value_display": value_display,
+                "rule_display": rule_display,
+                "status": status,
+                "is_governing": is_governing,
+                "reasoning": reasoning if is_governing else None,
+            }
+        )
+
+    return verdict, verdict_label, reasoning, rows
+
+
+def card_reason_for(triggered_rules: list[dict], *, profit_review_pct: float, dte_review_days: int) -> str:
+    """Build the short-form card ``reason`` from a leg's ``triggered_rules``.
+
+    Reads the governing rule off the already-evaluated ``triggered_rules``
+    array so the card and the inspect table share one reasoning source and
+    never drift. Returns an empty string when no rule governs (the engine
+    only emits a card when a rule fired, so this is defensive).
+    """
+    governing_row = next(
+        (r for r in triggered_rules if r.get("is_governing")), None
+    )
+    if governing_row is None:
+        return ""
+    rule_id = governing_row.get("rule_id")
+    bucket = next(
+        (k for k, v in _RULE_ID_FOR_BUCKET.items() if v == rule_id), None
+    )
+    captured_pct: float | None = None
+    if governing_row.get("value_display", "").endswith("%"):
+        try:
+            captured_pct = int(governing_row["value_display"][:-1]) / 100
+        except ValueError:
+            captured_pct = None
+    dte = 0
+    for row in triggered_rules:
+        if row.get("metric_label") == "Days to expiration":
+            try:
+                dte = int(str(row.get("value_display", "0")).split()[0])
+            except (ValueError, IndexError):
+                dte = 0
+            break
+    return _reasoning_for(
+        bucket,
+        dte=dte,
+        captured_pct=captured_pct,
+        premium=None,
+        profit_review_pct=profit_review_pct,
+        dte_review_days=dte_review_days,
+        expiration_warning_days=7,
+        also_fired=[],
+        short=True,
+    )
+
+
+__all__ = [
+    "RULE_PRECEDENCE",
+    "evaluate_leg_rules",
+    "card_reason_for",
+]

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -742,3 +742,266 @@ class TestActionShape:
             assert action["priority"] in {"P0", "P1", "P2"}
 
 
+# ---------------------------------------------------------------------------
+# §R6 rule-monitor leg cards (issue #240)
+# ---------------------------------------------------------------------------
+
+
+def _verdict_leg(
+    leg_id: str,
+    *,
+    verdict: str,
+    ticker: str = "F",
+    type_: str = "call",
+    strike: float = 15.0,
+    dte: int = 38,
+    moneyness_state: str | None = "OTM",
+    position_id: str = "p-1",
+) -> dict:
+    """Build a leg dict carrying the §R6 verdict layer (issue #240).
+
+    ``triggered_rules`` is a minimal but realistic payload — one governing
+    rule plus the other three rows — so card builders that read it (for the
+    short reason) have a real source to parse.
+    """
+    leg = _leg(
+        leg_id,
+        ticker=ticker,
+        type_=type_,
+        strike=strike,
+        dte=dte,
+        moneyness_state=moneyness_state,
+        position_id=position_id,
+    )
+    governing_rule_id = {
+        "profit_take_review": "profit_review",
+        "dte_review": "dte_review",
+        "expiration": "expiration_warning",
+        "assignment": "assignment_risk",
+    }.get(verdict)
+    triggered_rules = [
+        {
+            "rule_id": "assignment_risk",
+            "metric_label": "Assignment risk",
+            "value_display": "OTM",
+            "rule_display": "Review at ≥ High",
+            "status": "no",
+            "is_governing": False,
+            "reasoning": None,
+        },
+        {
+            "rule_id": "expiration_warning",
+            "metric_label": "Days to expiration",
+            "value_display": f"{dte} d",
+            "rule_display": "Warn at ≤ 7 d",
+            "status": "not_yet",
+            "is_governing": False,
+            "reasoning": None,
+        },
+        {
+            "rule_id": "profit_review",
+            "metric_label": "Premium captured",
+            "value_display": "60%",
+            "rule_display": "Review at ≥ 50%",
+            "status": "triggered" if verdict == "profit_take_review" else "not_yet",
+            "is_governing": verdict == "profit_take_review",
+            "reasoning": None,
+        },
+        {
+            "rule_id": "dte_review",
+            "metric_label": "Days to expiration",
+            "value_display": f"{dte} d",
+            "rule_display": "Review at ≤ 21 d",
+            "status": "triggered" if verdict == "dte_review" else "not_yet",
+            "is_governing": verdict == "dte_review",
+            "reasoning": None,
+        },
+    ]
+    for row in triggered_rules:
+        if row["rule_id"] == governing_rule_id:
+            row["is_governing"] = True
+            row["status"] = "triggered"
+            row["reasoning"] = "Your rule triggered."
+    leg["verdict"] = verdict
+    leg["verdict_label"] = "Review · 50%"
+    leg["reasoning"] = "Your rule triggered."
+    leg["triggered_rules"] = triggered_rules
+    return leg
+
+
+class TestProfitTakeReviewCard:
+    def test_emits_when_verdict_is_profit_take_review(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="profit_take_review")],
+        )
+        cards = [a for a in actions if a["action_id"] == "leg.profit_take_review"]
+        assert len(cards) == 1
+        card = cards[0]
+        assert card["priority"] == "P1"
+        assert card["tone"] == "opportunity"
+        assert card["id"] == "leg.profit_take_review.l-1"
+        assert card["triggered_rules"]
+
+    def test_card_cta_deep_links_to_leg_hash(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="profit_take_review")],
+        )
+        card = next(a for a in actions if a["action_id"] == "leg.profit_take_review")
+        assert card["cta"]["href"] == "/dashboard#leg-l-1"
+
+    def test_not_emitted_for_hold_verdict(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="hold")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "leg.profit_take_review" not in ids
+
+
+class TestDteReviewCard:
+    def test_emits_when_verdict_is_dte_review(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="dte_review", dte=18)],
+        )
+        cards = [a for a in actions if a["action_id"] == "leg.dte_review"]
+        assert len(cards) == 1
+        card = cards[0]
+        assert card["priority"] == "P2"
+        # No tone key → schema default "warning" applies.
+        assert card.get("tone", "warning") == "warning"
+        assert card["id"] == "leg.dte_review.l-1"
+
+    def test_not_emitted_for_profit_take_verdict(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="profit_take_review")],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "leg.dte_review" not in ids
+
+
+class TestRuleMonitorCardPrecedence:
+    def test_itm_short_dte_leg_emits_only_expiration_card(self):
+        # A 5-DTE ITM leg: verdict is "assignment" (the §R6 governing rule).
+        # The legacy expiration.itm_short_dte builder still fires on its own
+        # DTE/moneyness gating; the two new builders skip it.
+        leg = _verdict_leg(
+            "l-1", verdict="assignment", dte=5, moneyness_state="ITM"
+        )
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[leg],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "expiration.itm_short_dte" in ids
+        assert "leg.profit_take_review" not in ids
+        assert "leg.dte_review" not in ids
+
+    def test_profit_take_leg_inside_dte_window_emits_only_profit_card(self):
+        # 18-DTE leg, 60% captured: profit-take governs (verdict drives it),
+        # so no leg.dte_review card despite the 21d window also matching.
+        leg = _verdict_leg(
+            "l-1", verdict="profit_take_review", dte=18, moneyness_state="OTM"
+        )
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[leg],
+        )
+        ids = {a["action_id"] for a in actions}
+        assert "leg.profit_take_review" in ids
+        assert "leg.dte_review" not in ids
+
+
+class TestExpirationCardsUnaffected:
+    """Regression guard — the existing expiration.* cards are byte-identical
+    after the new §R6 builders land (spec §10 cross-cutting AC).
+    """
+
+    def test_mixed_leg_set_expiration_cards_unchanged(self):
+        legs = [
+            # ITM short-DTE → expiration.itm_short_dte
+            _verdict_leg(
+                "l-itm", verdict="assignment", dte=4, moneyness_state="ITM",
+                ticker="SOFI", position_id="p-sofi",
+            ),
+            # OTM short-DTE → expiration.short_dte (aggregate)
+            _verdict_leg(
+                "l-otm", verdict="expiration", dte=6, moneyness_state="OTM",
+                ticker="MSFT", position_id="p-msft",
+            ),
+            # Profit-take leg → leg.profit_take_review only
+            _verdict_leg(
+                "l-pt", verdict="profit_take_review", dte=38, moneyness_state="OTM",
+                ticker="F", position_id="p-f",
+            ),
+        ]
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=len(legs)),
+            positions=[],
+            open_legs=legs,
+        )
+        itm = [a for a in actions if a["action_id"] == "expiration.itm_short_dte"]
+        short = [a for a in actions if a["action_id"] == "expiration.short_dte"]
+        assert len(itm) == 1
+        assert itm[0]["id"] == "expiration.itm_short_dte.l-itm"
+        assert len(short) == 1
+        assert short[0]["id"] == "expiration.short_dte.msft"
+
+
+class TestRuleMonitorCardSort:
+    def test_expiration_card_sorts_before_profit_take_within_p1(self):
+        legs = [
+            _verdict_leg(
+                "l-pt", verdict="profit_take_review", dte=10, moneyness_state="OTM",
+                ticker="F", position_id="p-f",
+            ),
+            _verdict_leg(
+                "l-itm", verdict="assignment", dte=3, moneyness_state="ITM",
+                ticker="SOFI", position_id="p-sofi",
+            ),
+        ]
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=len(legs)),
+            positions=[],
+            open_legs=legs,
+        )
+        order = [a["action_id"] for a in actions]
+        assert order.index("expiration.itm_short_dte") < order.index(
+            "leg.profit_take_review"
+        )
+
+    def test_dte_review_card_sorts_in_p2(self):
+        legs = [
+            _verdict_leg(
+                "l-dte", verdict="dte_review", dte=18, moneyness_state="OTM",
+                ticker="AAPL", position_id="p-aapl",
+            ),
+        ]
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=len(legs)),
+            positions=[],
+            open_legs=legs,
+        )
+        dte_card = next(a for a in actions if a["action_id"] == "leg.dte_review")
+        assert dte_card["priority"] == "P2"
+

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -20,7 +20,11 @@ from app.services.action_engine import (
     MAX_ACTIONS,
     compute_next_actions,
 )
-from app.services.rules_config import RiskRules, RulesConfig
+from app.services.rules_config import (
+    ManagementTriggers,
+    RiskRules,
+    RulesConfig,
+)
 
 
 def _rules(loss_review_threshold_pct: float) -> RulesConfig:
@@ -1004,4 +1008,46 @@ class TestRuleMonitorCardSort:
         )
         dte_card = next(a for a in actions if a["action_id"] == "leg.dte_review")
         assert dte_card["priority"] == "P2"
+
+
+class TestProfitTakeCardThreadsManagementThresholds:
+    """The profit-take card reason must be built from the user's *actual*
+    configured ``rules.management`` thresholds — never a hardcoded literal
+    (CodeRabbit fix: ``dte_review_days``/``expiration_warning_days``).
+    """
+
+    def test_custom_dte_review_days_flows_into_profit_take_card_reason(
+        self, monkeypatch
+    ):
+        # Spy on card_reason_for to capture the kwargs the profit-take builder
+        # threads through — proves the configured value reaches the reason
+        # builder rather than a stale literal 21.
+        captured: dict = {}
+        from app.services import action_engine as _ae
+
+        real_card_reason_for = _ae.card_reason_for
+
+        def _spy(triggered_rules, **kwargs):
+            captured.update(kwargs)
+            return real_card_reason_for(triggered_rules, **kwargs)
+
+        monkeypatch.setattr(_ae, "card_reason_for", _spy)
+
+        rules = RulesConfig(
+            management=ManagementTriggers(
+                dte_review_days=30, expiration_warning_days=10
+            )
+        )
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="profit_take_review")],
+            rules=rules,
+        )
+        card = next(a for a in actions if a["action_id"] == "leg.profit_take_review")
+        assert card["reason"]  # a reason was built
+        # The builder passed the configured thresholds, not hardcoded 21 / 7.
+        assert captured["dte_review_days"] == 30
+        assert captured["expiration_warning_days"] == 10
 

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -686,3 +686,101 @@ class TestDeriveOpenLegsV05Signals:
             earnings_lookup=lookup,
         )
         assert calls == ["AAPL"]
+
+
+class TestDeriveOpenLegsRuleMonitor:
+    """The §R6 rule-monitor verdict layer attached to each leg (issue #240)."""
+
+    def _position(self, ticker: str, position_id: str, trades: list[dict]) -> dict:
+        return {"id": position_id, "ticker": ticker, "trades": trades}
+
+    def _trade(self, **overrides) -> dict:
+        trade = {
+            "id": "t1",
+            "trade_type": "sell_put",
+            "strike": 175.0,
+            "expiration": "2026-06-12",
+            "premium": 1.00,
+            "quantity": 1,
+            "closed_at": None,
+        }
+        trade.update(overrides)
+        return trade
+
+    def test_every_leg_carries_verdict_layer_fields(self):
+        positions = [
+            self._position("AAPL", "p-1", [self._trade(expiration="2026-07-31")])
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 200.0},
+            today=date(2026, 5, 5),
+        )
+        leg = legs[0]
+        assert "verdict" in leg
+        assert "verdict_label" in leg
+        assert "reasoning" in leg
+        assert "triggered_rules" in leg
+        assert len(leg["triggered_rules"]) == 4
+
+    def test_quiet_leg_verdict_is_hold(self):
+        # 87 DTE, OTM, no mark → nothing fires.
+        positions = [
+            self._position("AAPL", "p-1", [self._trade(expiration="2026-07-31")])
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 200.0},
+            today=date(2026, 5, 5),
+        )
+        assert legs[0]["verdict"] == "hold"
+        assert legs[0]["verdict_label"] == "Hold"
+
+    def test_profit_take_verdict_with_live_mark(self):
+        # Premium 1.00, mark 0.40 → 60% captured → profit-take verdict.
+        positions = [
+            self._position("AAPL", "p-1", [self._trade(expiration="2026-07-31")])
+        ]
+        option_marks = {("AAPL", "put", 175.0, "2026-07-31"): 0.40}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 200.0},
+            today=date(2026, 5, 5),
+            option_marks=option_marks,
+        )
+        assert legs[0]["verdict"] == "profit_take_review"
+        assert legs[0]["verdict_label"] == "Review · 50%"
+
+    def test_dte_review_window_threshold_honored(self):
+        # 25-DTE leg with dte_review_days=30 → fires; with default 21 → quiet.
+        positions = [
+            self._position("AAPL", "p-1", [self._trade(expiration="2026-05-30")])
+        ]
+        fired = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 200.0},
+            today=date(2026, 5, 5),
+            dte_review_days=30,
+        )
+        assert fired[0]["verdict"] == "dte_review"
+        assert fired[0]["verdict_label"] == "Review · 30d"
+
+        quiet = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 200.0},
+            today=date(2026, 5, 5),
+        )
+        assert quiet[0]["verdict"] == "hold"
+
+    def test_expiration_warning_threshold_honored(self):
+        # 10-DTE OTM leg: fires only when expiration_warning_days >= 10.
+        positions = [
+            self._position("AAPL", "p-1", [self._trade(expiration="2026-05-15")])
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 200.0},
+            today=date(2026, 5, 5),
+            expiration_warning_days=10,
+        )
+        assert legs[0]["verdict"] == "expiration"

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -685,3 +685,81 @@ def test_dashboard_position_rows_have_v05_signals(client, monkeypatch):
     # #151 — broker_cost_basis is surfaced so the Positions card can render
     # the dual-line ("broker / adjusted") cost-basis cell.
     assert row["broker_cost_basis"] == 17000.0
+
+
+def test_dashboard_rule_monitor_verdict_layer_present(client, monkeypatch):
+    """Every open leg carries the §R6 verdict layer fields (issue #240)."""
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 200.0},
+    )
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        lambda self, ticker, *a, **kw: {
+            "putExpDateMap": {
+                "2099-12-31:99999": {
+                    "999.0": [{"strikePrice": 999.0, "mark": 1.00}],
+                }
+            }
+        },
+    )
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(client, pid, trade_type="sell_put", strike=175.0, expiration="2099-12-31")
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["open_legs"], "expected at least one open leg"
+    leg = data["open_legs"][0]
+    assert leg["verdict"] in {
+        "hold", "profit_take_review", "dte_review", "expiration", "assignment"
+    }
+    assert isinstance(leg["verdict_label"], str)
+    assert isinstance(leg["reasoning"], str)
+    assert isinstance(leg["triggered_rules"], list)
+    assert len(leg["triggered_rules"]) == 4
+
+
+def test_dashboard_profit_take_card_matches_leg_verdict(client, monkeypatch):
+    """A leg past the profit-take threshold yields the verdict AND the card."""
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 250.0},
+    )
+    # Live option mark of 0.40 against a premium of 1.00 → 60% captured.
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        lambda self, ticker, *a, **kw: {
+            "putExpDateMap": {
+                "2099-12-31:99999": {
+                    "175.0": [{"strikePrice": 175.0, "mark": 0.40}],
+                }
+            }
+        },
+    )
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2099-12-31",
+        premium=1.00,
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    leg = data["open_legs"][0]
+    assert leg["verdict"] == "profit_take_review"
+    assert leg["verdict_label"] == "Review · 50%"
+
+    cards = [
+        a for a in data["next_actions"]
+        if a["action_id"] == "leg.profit_take_review"
+    ]
+    assert len(cards) == 1
+    assert cards[0]["tone"] == "opportunity"
+    assert cards[0]["priority"] == "P1"

--- a/backend/tests/test_rule_monitor.py
+++ b/backend/tests/test_rule_monitor.py
@@ -300,6 +300,49 @@ class TestTriState:
 
 
 # ---------------------------------------------------------------------------
+# Assignment-risk inspect row — shows the risk level, not moneyness
+# ---------------------------------------------------------------------------
+
+
+class TestAssignmentRiskRowValue:
+    """The "Assignment risk" row value must read as a risk level
+    (High / Watch / Low) so it agrees with its "Review at ≥ High" rule —
+    not the ITM/ATM/OTM moneyness label (CodeRabbit fix).
+    """
+
+    def test_high_risk_row_shows_high_not_moneyness(self):
+        _, _, _, rules = _evaluate(
+            dte=5,
+            moneyness_state="ITM",
+            assignment_risk="high",
+            profit_target_status=_profit_status(0.20),
+        )
+        assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
+        assert assignment_row["value_display"] == "High"
+        assert assignment_row["value_display"] not in {"ITM", "ATM", "OTM"}
+
+    def test_watch_risk_row_shows_watch(self):
+        _, _, _, rules = _evaluate(
+            dte=12,
+            moneyness_state="ITM",
+            assignment_risk="watch",
+            profit_target_status=_profit_status(0.20),
+        )
+        assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
+        assert assignment_row["value_display"] == "Watch"
+
+    def test_low_risk_row_shows_low(self):
+        _, _, _, rules = _evaluate(
+            dte=38,
+            moneyness_state="OTM",
+            assignment_risk="low",
+            profit_target_status=_profit_status(0.20),
+        )
+        assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
+        assert assignment_row["value_display"] == "Low"
+
+
+# ---------------------------------------------------------------------------
 # Degraded path — no live mid
 # ---------------------------------------------------------------------------
 
@@ -413,3 +456,34 @@ class TestCardReason:
             dte=40, profit_target_status=_profit_status(0.18)
         )
         assert card_reason_for(rules, profit_review_pct=50.0, dte_review_days=21) == ""
+
+    def test_custom_dte_review_days_in_short_reason(self):
+        # A custom 30-day review window must surface in the dte_review card
+        # reason — the caller threads rules.management.dte_review_days, never
+        # a hardcoded literal.
+        _, _, _, rules = _evaluate(
+            dte=25,
+            dte_review_days=30,
+            profit_target_status=_profit_status(0.20),
+        )
+        reason = card_reason_for(
+            rules, profit_review_pct=50.0, dte_review_days=30
+        )
+        assert "25 days to expiration" in reason
+
+    def test_expiration_warning_days_is_a_threadable_parameter(self):
+        # card_reason_for accepts expiration_warning_days so the caller can
+        # pass the user's configured window instead of a hardcoded 7.
+        _, _, _, rules = _evaluate(
+            dte=6,
+            moneyness_state="OTM",
+            expiration_warning_days=10,
+            profit_target_status=_profit_status(0.20),
+        )
+        reason = card_reason_for(
+            rules,
+            profit_review_pct=50.0,
+            dte_review_days=21,
+            expiration_warning_days=10,
+        )
+        assert reason  # builds without error using the configured window

--- a/backend/tests/test_rule_monitor.py
+++ b/backend/tests/test_rule_monitor.py
@@ -1,0 +1,415 @@
+"""Unit tests for the §R6 rule-monitor (issue #240).
+
+``evaluate_leg_rules`` is a pure function — every input is a plain value,
+every output is a plain dict. These tests exercise:
+- each rule fires positive + negative across its threshold boundary;
+- precedence — the single governing rule when several fire;
+- the tri-state ``triggered`` / ``not_yet`` / ``no`` status;
+- the graceful-degradation path when no live mid is available;
+- the advice-framing discipline on every reasoning string (spec §11).
+
+No DB, no HTTP.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.rule_monitor import (
+    RULE_PRECEDENCE,
+    card_reason_for,
+    evaluate_leg_rules,
+)
+
+
+def _profit_status(captured_pct):
+    """Build a profit_target_status dict with the given captured fraction."""
+    if captured_pct is None:
+        return {"captured_pct": None, "state": "unknown"}
+    return {"captured_pct": captured_pct, "state": "in_progress"}
+
+
+def _evaluate(**overrides):
+    """Evaluate a leg with sensible quiet defaults overridden as needed."""
+    kwargs = {
+        "dte": 40,
+        "moneyness_state": "OTM",
+        "profit_target_status": _profit_status(0.18),
+        "premium": 38.34,
+        "current_mid": 12.00,
+        "profit_review_pct": 50.0,
+        "dte_review_days": 21,
+        "expiration_warning_days": 7,
+        "assignment_risk": "low",
+    }
+    kwargs.update(overrides)
+    return evaluate_leg_rules(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Payload shape
+# ---------------------------------------------------------------------------
+
+
+class TestTriggeredRulesShape:
+    def test_always_four_rows_in_precedence_order(self):
+        _, _, _, rules = _evaluate()
+        assert len(rules) == 4
+        assert [r["rule_id"] for r in rules] == [
+            "assignment_risk",
+            "expiration_warning",
+            "profit_review",
+            "dte_review",
+        ]
+
+    def test_precedence_constant_has_four_keys(self):
+        assert RULE_PRECEDENCE == (
+            "assignment",
+            "expiration",
+            "profit_review",
+            "dte_review",
+        )
+
+    def test_every_row_has_required_keys(self):
+        _, _, _, rules = _evaluate()
+        for row in rules:
+            assert set(row) == {
+                "rule_id",
+                "metric_label",
+                "value_display",
+                "rule_display",
+                "status",
+                "is_governing",
+                "reasoning",
+            }
+
+
+# ---------------------------------------------------------------------------
+# Quiet leg — nothing fires
+# ---------------------------------------------------------------------------
+
+
+class TestQuietLeg:
+    def test_no_rule_fires_yields_hold(self):
+        verdict, label, reasoning, rules = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.18)
+        )
+        assert verdict == "hold"
+        assert label == "Hold"
+        assert reasoning == "No management rule has triggered for this leg yet."
+        assert all(not r["is_governing"] for r in rules)
+
+    def test_quiet_leg_rows_are_not_triggered(self):
+        _, _, _, rules = _evaluate(dte=40, profit_target_status=_profit_status(0.18))
+        statuses = {r["rule_id"]: r["status"] for r in rules}
+        assert statuses["profit_review"] == "not_yet"
+        assert statuses["dte_review"] == "not_yet"
+        assert statuses["expiration_warning"] == "not_yet"
+        assert statuses["assignment_risk"] == "no"
+
+
+# ---------------------------------------------------------------------------
+# Profit-take rule
+# ---------------------------------------------------------------------------
+
+
+class TestProfitTakeRule:
+    def test_fires_above_threshold(self):
+        verdict, label, _, _ = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.60)
+        )
+        assert verdict == "profit_take_review"
+        assert label == "Review · 50%"
+
+    def test_fires_exactly_at_threshold(self):
+        verdict, _, _, rules = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.50)
+        )
+        assert verdict == "profit_take_review"
+        profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
+        assert profit_row["status"] == "triggered"
+
+    def test_just_below_threshold_not_yet(self):
+        verdict, _, _, rules = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.49)
+        )
+        assert verdict == "hold"
+        profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
+        assert profit_row["status"] == "not_yet"
+
+    def test_custom_threshold_interpolated_in_label(self):
+        verdict, label, _, rules = _evaluate(
+            dte=40,
+            profit_target_status=_profit_status(0.67),
+            profit_review_pct=65.0,
+        )
+        assert verdict == "profit_take_review"
+        assert label == "Review · 65%"
+        profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
+        assert profit_row["rule_display"] == "Review at ≥ 65%"
+
+
+# ---------------------------------------------------------------------------
+# DTE-review rule
+# ---------------------------------------------------------------------------
+
+
+class TestDteReviewRule:
+    def test_fires_inside_window(self):
+        verdict, label, _, _ = _evaluate(
+            dte=20, profit_target_status=_profit_status(0.10)
+        )
+        assert verdict == "dte_review"
+        assert label == "Review · 21d"
+
+    def test_fires_exactly_at_window_boundary(self):
+        verdict, _, _, _ = _evaluate(
+            dte=21, profit_target_status=_profit_status(0.10)
+        )
+        assert verdict == "dte_review"
+
+    def test_one_day_past_window_not_yet(self):
+        verdict, _, _, rules = _evaluate(
+            dte=22, profit_target_status=_profit_status(0.10)
+        )
+        assert verdict == "hold"
+        dte_row = next(r for r in rules if r["rule_id"] == "dte_review")
+        assert dte_row["status"] == "not_yet"
+
+    def test_custom_dte_window_honored(self):
+        verdict, label, _, _ = _evaluate(
+            dte=25,
+            profit_target_status=_profit_status(0.10),
+            dte_review_days=30,
+        )
+        assert verdict == "dte_review"
+        assert label == "Review · 30d"
+
+
+# ---------------------------------------------------------------------------
+# Expiration / assignment rules
+# ---------------------------------------------------------------------------
+
+
+class TestExpirationRule:
+    def test_expiration_fires_otm_inside_warning_window(self):
+        verdict, label, _, _ = _evaluate(
+            dte=5, moneyness_state="OTM", profit_target_status=_profit_status(0.10)
+        )
+        assert verdict == "expiration"
+        assert label == "Close · exp"
+
+    def test_assignment_fires_itm_inside_warning_window(self):
+        verdict, label, _, _ = _evaluate(
+            dte=5, moneyness_state="ITM", profit_target_status=_profit_status(0.10)
+        )
+        assert verdict == "assignment"
+        assert label == "Close · ITM"
+
+    def test_expiration_boundary_at_warning_window(self):
+        verdict, _, _, _ = _evaluate(
+            dte=7, moneyness_state="OTM", profit_target_status=_profit_status(0.10)
+        )
+        assert verdict == "expiration"
+
+    def test_assignment_row_never_not_yet(self):
+        # An OTM leg approaching expiry is an expiration case, never an
+        # armed assignment countdown (spec §3.3).
+        _, _, _, rules = _evaluate(
+            dte=40, moneyness_state="OTM", profit_target_status=_profit_status(0.10)
+        )
+        assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
+        assert assignment_row["status"] == "no"
+
+    def test_expired_leg_yields_hold(self):
+        verdict, _, _, rules = _evaluate(
+            dte=-3, moneyness_state="OTM", profit_target_status=_profit_status(None)
+        )
+        assert verdict == "hold"
+        exp_row = next(r for r in rules if r["rule_id"] == "expiration_warning")
+        dte_row = next(r for r in rules if r["rule_id"] == "dte_review")
+        assert exp_row["status"] == "no"
+        assert dte_row["status"] == "no"
+
+
+# ---------------------------------------------------------------------------
+# Precedence
+# ---------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    def test_profit_take_outranks_dte_review(self):
+        # Inside the 21d window AND past 50% capture.
+        verdict, _, reasoning, rules = _evaluate(
+            dte=14, profit_target_status=_profit_status(0.67)
+        )
+        assert verdict == "profit_take_review"
+        profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
+        dte_row = next(r for r in rules if r["rule_id"] == "dte_review")
+        assert profit_row["status"] == "triggered"
+        assert profit_row["is_governing"] is True
+        assert dte_row["status"] == "triggered"
+        assert dte_row["is_governing"] is False
+        # The reasoning leads with the governing rule and appends the other.
+        assert "profit-take rule triggered" in reasoning
+        assert "21-day review window" in reasoning
+
+    def test_assignment_outranks_everything(self):
+        # 5-DTE ITM leg also past 50% capture: assignment governs.
+        verdict, label, _, rules = _evaluate(
+            dte=5, moneyness_state="ITM", profit_target_status=_profit_status(0.60)
+        )
+        assert verdict == "assignment"
+        assert label == "Close · ITM"
+        assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
+        assert assignment_row["is_governing"] is True
+
+    def test_only_governing_rule_carries_reasoning(self):
+        _, _, _, rules = _evaluate(
+            dte=14, profit_target_status=_profit_status(0.67)
+        )
+        governing = [r for r in rules if r["is_governing"]]
+        assert len(governing) == 1
+        for row in rules:
+            if row["is_governing"]:
+                assert row["reasoning"] is not None
+            else:
+                assert row["reasoning"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tri-state status
+# ---------------------------------------------------------------------------
+
+
+class TestTriState:
+    def test_far_dte_leg_is_not_yet(self):
+        _, _, _, rules = _evaluate(
+            dte=38, profit_target_status=_profit_status(0.20)
+        )
+        dte_row = next(r for r in rules if r["rule_id"] == "dte_review")
+        assert dte_row["status"] == "not_yet"
+        assert dte_row["value_display"] == "38 d"
+
+    def test_otm_leg_assignment_row_is_no(self):
+        _, _, _, rules = _evaluate(
+            dte=38, moneyness_state="OTM", profit_target_status=_profit_status(0.20)
+        )
+        assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
+        assert assignment_row["status"] == "no"
+
+
+# ---------------------------------------------------------------------------
+# Degraded path — no live mid
+# ---------------------------------------------------------------------------
+
+
+class TestDegradedNoMid:
+    def test_no_mid_profit_row_is_no_with_dash(self):
+        _, _, _, rules = _evaluate(
+            dte=12,
+            current_mid=None,
+            profit_target_status=_profit_status(None),
+        )
+        profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
+        assert profit_row["status"] == "no"
+        assert profit_row["value_display"] == "—"
+
+    def test_verdict_falls_back_to_dte_rules_without_mid(self):
+        # 12-DTE leg, no mid: profit-take unevaluable, DTE-review still fires.
+        verdict, _, _, _ = _evaluate(
+            dte=12,
+            current_mid=None,
+            profit_target_status=_profit_status(None),
+        )
+        assert verdict == "dte_review"
+
+    def test_profit_take_never_governs_without_mid(self):
+        verdict, _, _, _ = _evaluate(
+            dte=40,
+            current_mid=None,
+            profit_target_status=_profit_status(None),
+        )
+        assert verdict != "profit_take_review"
+
+
+# ---------------------------------------------------------------------------
+# Advice framing — spec §11
+# ---------------------------------------------------------------------------
+
+
+class TestAdviceFraming:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"dte": 40, "profit_target_status": _profit_status(0.60)},  # profit-take
+            {"dte": 18, "profit_target_status": _profit_status(0.20)},  # dte-review
+            {
+                "dte": 5,
+                "moneyness_state": "OTM",
+                "profit_target_status": _profit_status(0.20),
+            },  # expiration
+            {
+                "dte": 5,
+                "moneyness_state": "ITM",
+                "profit_target_status": _profit_status(0.20),
+            },  # assignment
+        ],
+    )
+    def test_reasoning_attributes_to_user_ruleset(self, kwargs):
+        _, _, reasoning, _ = _evaluate(**kwargs)
+        assert "Your" in reasoning or "your" in reasoning
+        assert "rule" in reasoning.lower()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"dte": 40, "profit_target_status": _profit_status(0.60)},
+            {"dte": 18, "profit_target_status": _profit_status(0.20)},
+            {"dte": 5, "moneyness_state": "ITM", "profit_target_status": _profit_status(0.20)},
+        ],
+    )
+    def test_reasoning_avoids_app_first_person(self, kwargs):
+        _, _, reasoning, _ = _evaluate(**kwargs)
+        lowered = reasoning.lower()
+        assert "we recommend" not in lowered
+        # "our" as a standalone app-first-person word — not the "our" inside
+        # the user-attributed "your".
+        words = lowered.replace(".", " ").replace(",", " ").replace("(", " ").split()
+        assert "our" not in words
+
+    def test_profit_take_reasoning_names_dollar_amounts(self):
+        _, _, reasoning, _ = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.60), premium=38.34
+        )
+        assert "$" in reasoning
+        # 60% of $38.34 = $23.00 (rounded).
+        assert "$38.34" in reasoning
+
+
+# ---------------------------------------------------------------------------
+# card_reason_for — the short-form card reason
+# ---------------------------------------------------------------------------
+
+
+class TestCardReason:
+    def test_profit_take_short_reason(self):
+        _, _, _, rules = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.60)
+        )
+        reason = card_reason_for(rules, profit_review_pct=50.0, dte_review_days=21)
+        assert "profit-take rule triggered" in reason
+        assert "60%" in reason
+
+    def test_dte_review_short_reason(self):
+        _, _, _, rules = _evaluate(
+            dte=18, profit_target_status=_profit_status(0.20)
+        )
+        reason = card_reason_for(rules, profit_review_pct=50.0, dte_review_days=21)
+        assert "18 days to expiration" in reason
+
+    def test_no_governing_rule_yields_empty_reason(self):
+        _, _, _, rules = _evaluate(
+            dte=40, profit_target_status=_profit_status(0.18)
+        )
+        assert card_reason_for(rules, profit_review_pct=50.0, dte_review_days=21) == ""

--- a/frontend/components/dashboard/DashboardPage.jsx
+++ b/frontend/components/dashboard/DashboardPage.jsx
@@ -1,6 +1,6 @@
+import { useState } from 'react';
 import Header from '../layout/Header';
 import { useDashboard } from '../../hooks/useDashboard';
-import { formatDate } from '../../utils/formatters';
 import StatusStrip from './StatusStrip';
 import DataReadinessBanner from './DataReadinessBanner';
 import NextActionsSection from './NextActionsSection';
@@ -29,8 +29,22 @@ function isAllEmpty(data) {
   return !schwab && !fred && positions === 0;
 }
 
+// Parse the `#leg-{id}` deep-link hash (set by a rule-monitor card CTA — spec
+// §4.4 Q7) into the bare leg id, or null. The dashboard route is rendered
+// `ssr: false`, so reading `window` on mount is safe.
+function parseLegHash() {
+  if (typeof window === 'undefined') return null;
+  const hash = window.location.hash || '';
+  const match = hash.match(/^#leg-(.+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
 export default function DashboardPage() {
   const { data, loading, error, refetch } = useDashboard();
+  // Captured once at first render — the `#leg-{id}` target seeds the
+  // OpenLegsCard expanded set and scroll. The dashboard route is rendered
+  // `ssr: false`, so reading `window` in the lazy initializer is safe.
+  const [hashLegId] = useState(parseLegHash);
 
   return (
     <div data-testid="dashboard-page" className="h-screen flex flex-col bg-slate-100 dark:bg-slate-900">
@@ -90,7 +104,11 @@ export default function DashboardPage() {
                     />
                   </div>
                   <div className="lg:col-span-5">
-                    <OpenLegsCard legs={data?.open_legs} loading={loading} />
+                    <OpenLegsCard
+                      legs={data?.open_legs}
+                      loading={loading}
+                      initialExpandedLegId={hashLegId}
+                    />
                   </div>
                 </div>
 

--- a/frontend/components/dashboard/DashboardPage.jsx
+++ b/frontend/components/dashboard/DashboardPage.jsx
@@ -36,7 +36,15 @@ function parseLegHash() {
   if (typeof window === 'undefined') return null;
   const hash = window.location.hash || '';
   const match = hash.match(/^#leg-(.+)$/);
-  return match ? decodeURIComponent(match[1]) : null;
+  if (!match) return null;
+  // A malformed escape sequence (e.g. `#leg-%FF`) makes decodeURIComponent
+  // throw. This runs in a lazy useState initializer, so an unguarded throw
+  // would crash the dashboard at render — fall back to null instead.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
 }
 
 export default function DashboardPage() {

--- a/frontend/components/dashboard/NextActionCard.jsx
+++ b/frontend/components/dashboard/NextActionCard.jsx
@@ -12,6 +12,13 @@ import Link from 'next/link';
  * ``<button>`` when ``action.cta.kind === "inline"`` (e.g.
  * ``data.cache_very_stale`` calls ``refreshStaleCache()`` in place). The
  * trailing ``→`` is ``aria-hidden`` decoration.
+ *
+ * V1.0.4 (issue #240): an optional ``action.tone`` (``"opportunity" |
+ * "warning"``, default ``"warning"``) drives the *valence* of the card.
+ * ``priority`` keeps doing exactly one job — urgency/ranking + the ``[P1]``
+ * badge — while ``tone === "opportunity"`` overrides the border/bg/glyph to
+ * emerald + ``✓`` so a profit-take win does not render as a warning. Every
+ * existing card omits ``tone`` and is byte-identical.
  */
 
 const PRIORITY_VISUALS = {
@@ -35,6 +42,20 @@ const PRIORITY_VISUALS = {
     bgClass: 'bg-white dark:bg-slate-800',
     glyph: 'ℹ',
     glyphClass: 'text-slate-500 dark:text-slate-400',
+  },
+};
+
+// Tone overrides — `priority` ranks urgency; `tone` carries valence (§4.3
+// Q6). Only `opportunity` is a non-default tone: it repaints the border,
+// background, and glyph emerald so a profit-take win is not miscolored as a
+// warning. `badgeClass` is intentionally NOT overridden — the `[P1]` badge
+// stays priority-driven. No new token: emerald is already in the palette.
+const TONE_VISUALS = {
+  opportunity: {
+    borderClass: 'border-emerald-300 dark:border-emerald-700',
+    bgClass: 'bg-emerald-50 dark:bg-emerald-900/20',
+    glyph: '✓',
+    glyphClass: 'text-emerald-600 dark:text-emerald-300',
   },
 };
 
@@ -83,7 +104,12 @@ function CardBody({ action, visuals }) {
 }
 
 export default function NextActionCard({ action, onInlineCta }) {
-  const visuals = PRIORITY_VISUALS[action.priority] || PRIORITY_VISUALS.P2;
+  const priorityVisuals = PRIORITY_VISUALS[action.priority] || PRIORITY_VISUALS.P2;
+  // tone defaults to "warning" — every existing card is byte-identical.
+  const toneOverride = TONE_VISUALS[action.tone];
+  const visuals = toneOverride
+    ? { ...priorityVisuals, ...toneOverride }
+    : priorityVisuals;
   const baseClasses = `block text-left p-4 border rounded-xl transition-colors hover:shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${visuals.bgClass} ${visuals.borderClass}`;
   // Use the unique ``action.id`` (e.g. ``position.cc_candidate.aapl``) so a
    // family that emits multiple cards (e.g. 3 ITM legs) does not collide on

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -1,29 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Card from '../common/Card';
 import EmptyState from '../common/EmptyState';
 import { formatPercent } from '../../utils/formatters';
 
 /**
- * OpenLegsCard — triage-grade table of every open short option leg.
+ * OpenLegsCard — triage-grade table of every open short option leg, and the
+ * per-leg §R6 rule monitor (issue #240).
  *
- * V0.5 upgrade (issue #150 / spec §2.5 + §14.5):
- *   - %CAPTURED column — from `legs[].profit_target_status.captured_pct`.
- *     Renders `—` whenever `state === "unknown"` (universal V0.5 case
- *     because live option-chain data is deferred).
- *   - RISK column — from `legs[].assignment_risk` ("high" / "watch" / "low").
- *     "High" carries the ⛔ glyph for color-blind safety; all values are
- *     text-labeled so screen readers and grayscale users get the signal.
- *   - ACTION column — from `legs[].suggested_action` ("roll" / "hold" /
- *     "manage"). V0.5 never emits "close" because the underlying signal
- *     requires live option-chain data (see #146).
- *   - Earnings glyph (⚠) — rendered next to the expiration when
- *     `legs[].earnings_in_window === true`. Aria-labeled "Earnings before
- *     expiration" for screen readers.
+ * V1.0.4 upgrade (issue #240 / spec §2–§3):
+ *   - ACTION column reads `leg.verdict` (rule-driven) instead of the old
+ *     DTE/moneyness `suggested_action`. The label string is server-rendered
+ *     into `leg.verdict_label` ("Review · 50%" / "Hold" / …) so the frontend
+ *     does no threshold parsing. Emerald = opportunity (profit-take), amber =
+ *     scheduled review, red = deadline/assignment, slate = Hold.
+ *   - Each row is a `<button>` toggle (was a `<Link>` to /journal). Clicking
+ *     expands an inline InspectPanel — the rule-evaluation audit table. The
+ *     journal navigation relocated into the panel's "Open in Journal" CTA.
+ *   - A leading chevron cell shows the expand state; Ticker shrank 2→1 cols
+ *     to make room (spec §5.1 Q8).
+ *   - The card seeds its expanded set from `initialExpandedLegId` (the
+ *     `#leg-{id}` deep-link from a card CTA — spec §4.4 Q7).
  *
- * Responsive (spec §2.5):
- *   - Desktop (lg+): all columns visible.
- *   - Mobile (< lg): %CAPTURED and RISK hidden; ACTION rendered only when
- *     the value is "roll" or "manage" (the urgent cases).
+ * V0.5 columns (issue #150) — %CAPTURED, RISK, earnings ⚠ glyph — unchanged.
+ *
+ * Responsive (spec §2.5 / §5.1):
+ *   - Desktop (lg+): all columns visible — 1/1/1/2/1/2/1/1/2 = 12.
+ *   - Mobile (< lg): %CAPTURED and RISK hidden; ACTION rendered only when the
+ *     verdict is non-`hold`.
  */
 
 function dteBadgeClass(dte) {
@@ -97,37 +103,201 @@ function RiskCell({ risk }) {
   );
 }
 
-const ACTION_VISUALS = {
-  roll: { label: 'Roll', className: 'text-red-700 dark:text-red-300 font-medium' },
-  manage: { label: 'Manage', className: 'text-yellow-700 dark:text-yellow-300 font-medium' },
-  hold: { label: 'Hold', className: 'text-slate-600 dark:text-slate-300' },
-  // V0.5 never emits "close" per spec §14.5, but include for forward-compat.
-  close: { label: 'Close target ✓', className: 'text-green-700 dark:text-green-300 font-medium' },
+// Verdict map (spec §2.3) — keyed by `leg.verdict`. The label string itself
+// is server-rendered into `leg.verdict_label` (so a user-set 65% threshold
+// shows "Review · 65%"); this map only carries the per-verdict color + glyph.
+// Emerald = opportunity, amber = scheduled review, red = deadline/assignment.
+const VERDICT_VISUALS = {
+  hold: {
+    className: 'text-slate-600 dark:text-slate-300',
+    glyph: '',
+  },
+  profit_take_review: {
+    className: 'text-emerald-700 dark:text-emerald-300 font-medium',
+    glyph: '',
+  },
+  dte_review: {
+    className: 'text-amber-700 dark:text-amber-300 font-medium',
+    glyph: '',
+  },
+  expiration: {
+    className: 'text-red-700 dark:text-red-300 font-medium',
+    glyph: '',
+  },
+  assignment: {
+    className: 'text-red-700 dark:text-red-300 font-medium',
+    glyph: '⛔',
+  },
 };
 
-function ActionCell({ action, mobileOnlyUrgent }) {
-  const visuals = ACTION_VISUALS[action] || ACTION_VISUALS.hold;
-  const isUrgent = action === 'roll' || action === 'manage';
-  // On mobile we hide non-urgent actions per spec §2.5. `lg:inline` re-shows at desktop.
-  const visibilityClass =
-    mobileOnlyUrgent && !isUrgent ? 'hidden lg:inline' : 'inline';
-  return <span className={`${visibilityClass} ${visuals.className}`}>{visuals.label}</span>;
+function ActionCell({ leg }) {
+  const verdict = leg.verdict || 'hold';
+  const visuals = VERDICT_VISUALS[verdict] || VERDICT_VISUALS.hold;
+  const label = leg.verdict_label || 'Hold';
+  // Mobile: hide a `hold` verdict (parity with the old non-urgent rule);
+  // any non-hold verdict stays visible on mobile.
+  const visibilityClass = verdict === 'hold' ? 'hidden lg:inline' : 'inline';
+  return (
+    <span
+      data-verdict={verdict}
+      className={`${visibilityClass} ${visuals.className}`}
+    >
+      {visuals.glyph && (
+        <span aria-hidden="true" className="mr-0.5">
+          {visuals.glyph}
+        </span>
+      )}
+      {label}
+    </span>
+  );
 }
 
-function LegRow({ leg }) {
+// Tri-state status dot + label for the inspect table's "Triggered?" cell.
+const STATUS_DISPLAY = {
+  triggered: { dot: '●', label: 'Yes' },
+  not_yet: { dot: '○', label: 'Not yet' },
+  no: { dot: '○', label: 'No' },
+};
+
+function RuleStatusCell({ leg, rule }) {
+  const display = STATUS_DISPLAY[rule.status] || STATUS_DISPLAY.no;
+  const fired = rule.status === 'triggered';
+  // The governing fired row takes the verdict color; a lower-precedence fired
+  // row is neutral slate; non-firing rows inherit the greyed row class.
+  let cellClass = '';
+  if (fired && rule.is_governing) {
+    const visuals = VERDICT_VISUALS[leg.verdict] || VERDICT_VISUALS.hold;
+    cellClass = `font-medium ${visuals.className}`;
+  } else if (fired) {
+    cellClass = 'font-medium text-slate-600 dark:text-slate-300';
+  }
   return (
-    <Link
-      href={`/journal?position=${encodeURIComponent(leg.position_id)}`}
+    <td
+      data-testid={`dashboard-leg-inspect-status-${leg.id}-${rule.rule_id}`}
+      className={`py-1.5 ${cellClass}`}
+    >
+      <span aria-hidden="true">{display.dot}</span> {display.label}
+    </td>
+  );
+}
+
+/**
+ * InspectPanel — the expanded per-leg rule-evaluation audit (spec §3.3–§3.4).
+ *
+ * Renders as a full-width row inside the 12-col grid. Shows every §R6 rule —
+ * fired and not-fired alike — so the table reads as a monitor, not an alert
+ * list. The reasoning sentence and the CTAs sit below the table.
+ */
+function InspectPanel({ leg }) {
+  const optionLetter = leg.type === 'put' ? 'P' : 'C';
+  const verdict = leg.verdict || 'hold';
+  // A "closing" verdict gets a "Buy to close" CTA; a quiet/review leg does not.
+  const showCloseCta =
+    verdict === 'profit_take_review' ||
+    verdict === 'expiration' ||
+    verdict === 'assignment';
+  const positionHref = `/journal?position=${encodeURIComponent(leg.position_id)}`;
+  return (
+    <div
+      id={`dashboard-leg-inspect-${leg.id}`}
+      data-testid={`dashboard-leg-inspect-${leg.id}`}
+      className="col-span-12 bg-slate-50 dark:bg-slate-900/40 border border-slate-200 dark:border-slate-700 rounded-lg mt-1 mb-2 p-4"
+    >
+      <div className="text-sm font-medium text-slate-700 dark:text-slate-200 mb-1">
+        {leg.ticker} ${leg.strike} {optionLetter} · exp {leg.expiration} ·{' '}
+        {leg.dte} DTE
+      </div>
+      <div className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+        Rule evaluation — checked against your Management Triggers
+      </div>
+      <table
+        data-testid={`dashboard-leg-inspect-table-${leg.id}`}
+        className="w-full text-sm border-collapse"
+      >
+        <thead>
+          <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+            <th className="text-left font-medium py-1.5">Metric</th>
+            <th className="text-left font-medium py-1.5">Value</th>
+            <th className="text-left font-medium py-1.5">Your rule</th>
+            <th className="text-left font-medium py-1.5">Triggered?</th>
+          </tr>
+        </thead>
+        <tbody>
+          {(leg.triggered_rules || []).map((rule) => {
+            const fired = rule.status === 'triggered';
+            const rowClass = fired
+              ? 'border-b border-slate-100 dark:border-slate-800 last:border-b-0'
+              : 'border-b border-slate-100 dark:border-slate-800 last:border-b-0 text-slate-400 dark:text-slate-500';
+            return (
+              <tr
+                key={rule.rule_id}
+                data-testid={`dashboard-leg-inspect-rule-${leg.id}-${rule.rule_id}`}
+                className={rowClass}
+              >
+                <td className="py-1.5">{rule.metric_label}</td>
+                <td className="py-1.5 tabular-nums">{rule.value_display}</td>
+                <td className="py-1.5">{rule.rule_display}</td>
+                <RuleStatusCell leg={leg} rule={rule} />
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <p
+        data-testid={`dashboard-leg-inspect-reasoning-${leg.id}`}
+        className="text-sm text-slate-600 dark:text-slate-300 mt-3"
+      >
+        {leg.reasoning || 'No management rule has triggered for this leg yet.'}
+      </p>
+      <div className="flex items-center gap-3 mt-3">
+        {showCloseCta && (
+          <Link
+            href={`${positionHref}&action=close-leg`}
+            data-testid={`dashboard-leg-inspect-cta-close-${leg.id}`}
+            className="inline-flex items-center px-3 py-1.5 rounded-lg border border-slate-300 dark:border-slate-600 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700"
+          >
+            Buy to close
+          </Link>
+        )}
+        <Link
+          href={positionHref}
+          data-testid={`dashboard-leg-inspect-cta-journal-${leg.id}`}
+          className="text-sm font-medium text-blue-600 dark:text-blue-400 hover:underline"
+        >
+          Open in Journal
+          <span aria-hidden="true"> →</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function LegRow({ leg, isExpanded, onToggle, rowRef }) {
+  return (
+    <button
+      type="button"
+      ref={rowRef}
+      onClick={() => onToggle(leg.id)}
+      aria-expanded={isExpanded}
+      aria-controls={`dashboard-leg-inspect-${leg.id}`}
       data-testid="dashboard-leg-row"
-      className="grid grid-cols-12 gap-2 items-center py-2 border-b border-slate-100 dark:border-slate-700 last:border-b-0 hover:bg-slate-50 dark:hover:bg-slate-700/50 px-2 -mx-2 rounded text-sm"
+      data-toggle-testid="dashboard-leg-row-toggle"
+      data-leg-id={leg.id}
+      className="w-full text-left grid grid-cols-12 gap-2 items-center py-2 border-b border-slate-100 dark:border-slate-700 last:border-b-0 hover:bg-slate-50 dark:hover:bg-slate-700/50 px-2 -mx-2 rounded text-sm cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
     >
       {/*
-        Mobile (< lg): 12-col grid uses 2/2/3/2/3 for the 5 visible cells
-        (ticker, strike, exp, dte, moneyness); %captured & risk are hidden;
-        action wraps to a full-width row below when urgent.
-        Desktop (lg+): 12-col grid uses 2/1/2/1/2/1/1/2 to fit 8 cells.
+        Mobile (< lg): chevron(1) + ticker(1) + strike(2) + exp(3) + dte(2) +
+        moneyness(3) = 12; %captured & risk hidden; action wraps full-width.
+        Desktop (lg+): 1/1/1/2/1/2/1/1/2 = 12.
       */}
-      <span className="col-span-2 lg:col-span-2 font-semibold text-slate-900 dark:text-white">
+      <span
+        data-testid="dashboard-leg-row-chevron"
+        aria-hidden="true"
+        className="col-span-1 text-slate-400"
+      >
+        {isExpanded ? '▾' : '▸'}
+      </span>
+      <span className="col-span-1 lg:col-span-1 font-semibold text-slate-900 dark:text-white">
         {leg.ticker}
       </span>
       <span className="col-span-2 lg:col-span-1 tabular-nums text-slate-700 dark:text-slate-200">
@@ -171,16 +341,17 @@ function LegRow({ leg }) {
         data-testid="dashboard-leg-row-action"
         className="col-span-12 lg:col-span-2 mt-1 lg:mt-0"
       >
-        <ActionCell action={leg.suggested_action} mobileOnlyUrgent />
+        <ActionCell leg={leg} />
       </span>
-    </Link>
+    </button>
   );
 }
 
 function HeaderRow() {
   return (
     <div className="grid grid-cols-12 gap-2 items-center px-2 -mx-2 pb-2 mb-1 text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
-      <span className="col-span-2 lg:col-span-2">Ticker</span>
+      <span className="col-span-1" aria-hidden="true" />
+      <span className="col-span-1 lg:col-span-1">Ticker</span>
       <span className="col-span-2 lg:col-span-1">Strike</span>
       <span className="col-span-3 lg:col-span-2">Exp</span>
       <span className="col-span-2 lg:col-span-1">DTE</span>
@@ -192,7 +363,42 @@ function HeaderRow() {
   );
 }
 
-export default function OpenLegsCard({ legs, loading }) {
+export default function OpenLegsCard({ legs, loading, initialExpandedLegId }) {
+  // A Set of expanded leg ids — multi-open (spec §3.2 Q2). Seeded with the
+  // `#leg-{id}` deep-link target, if any, on mount (spec §4.4 Q7).
+  const [expanded, setExpanded] = useState(() => {
+    const seed = new Set();
+    if (initialExpandedLegId) seed.add(initialExpandedLegId);
+    return seed;
+  });
+  const [deepLinkRow, setDeepLinkRow] = useState(null);
+
+  // Scroll the deep-linked row into view once it mounts, honoring
+  // prefers-reduced-motion (mirrors issue-182 §12.3).
+  useEffect(() => {
+    if (!initialExpandedLegId || !deepLinkRow) return;
+    const motionOK =
+      typeof window !== 'undefined' &&
+      window.matchMedia &&
+      !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    deepLinkRow.scrollIntoView({
+      behavior: motionOK ? 'smooth' : 'auto',
+      block: 'center',
+    });
+  }, [initialExpandedLegId, deepLinkRow]);
+
+  function toggle(legId) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(legId)) {
+        next.delete(legId);
+      } else {
+        next.add(legId);
+      }
+      return next;
+    });
+  }
+
   if (loading) {
     return (
       <Card title="Open option legs" dataTestid="dashboard-legs-card">
@@ -224,9 +430,26 @@ export default function OpenLegsCard({ legs, loading }) {
       {legs?.length ? (
         <div>
           <HeaderRow />
-          {legs.map((leg) => (
-            <LegRow key={leg.id} leg={leg} />
-          ))}
+          <div className="grid grid-cols-12 gap-x-2">
+            {legs.map((leg) => {
+              const isExpanded = expanded.has(leg.id);
+              return (
+                <div key={leg.id} className="col-span-12 grid grid-cols-12 gap-2">
+                  <div className="col-span-12">
+                    <LegRow
+                      leg={leg}
+                      isExpanded={isExpanded}
+                      onToggle={toggle}
+                      rowRef={
+                        leg.id === initialExpandedLegId ? setDeepLinkRow : null
+                      }
+                    />
+                  </div>
+                  {isExpanded && <InspectPanel leg={leg} />}
+                </div>
+              );
+            })}
+          </div>
           <div className="text-xs text-slate-500 dark:text-slate-400 pt-3">
             Showing {legs.length} of {legs.length} open legs
           </div>

--- a/frontend/e2e/dashboard-open-legs-card.spec.js
+++ b/frontend/e2e/dashboard-open-legs-card.spec.js
@@ -6,13 +6,20 @@ import { test, expect } from '@playwright/test';
  * Covers AC:
  *   - %CAPTURED column renders `—` when state === "unknown" (universal V0.5)
  *   - RISK column reflects `legs[].assignment_risk` (high/watch/low)
- *   - ACTION column reflects `legs[].suggested_action` (roll/hold/manage —
- *     never "close" in V0.5 per spec §14.5)
+ *   - ACTION column reflects the rule-driven `legs[].verdict` (issue #240 —
+ *     was `suggested_action`; the column now reads the §R6 verdict layer).
  *   - Earnings ⚠ glyph in expiration cell when `earnings_in_window === true`,
  *     with `aria-label="Earnings before expiration"`.
  *   - Mobile breakpoint hides %CAPTURED and RISK columns.
  *   - Test IDs preserved: dashboard-leg-row.
  *   - New test IDs: dashboard-leg-row-captured, -risk, -action.
+ *
+ * Issue #240 migration note: the leg row was a `<Link>` to /journal; it is
+ * now a `<button>` expand toggle (journal navigation relocated into the
+ * InspectPanel CTA). The ACTION column reads `leg.verdict` /
+ * `leg.verdict_label` instead of `suggested_action`. The fixtures below carry
+ * a minimal verdict layer so the row renders. Verdict-specific assertions
+ * live in `dashboard-rule-monitor.spec.js`.
  */
 
 const BASE_PAYLOAD = {
@@ -62,7 +69,38 @@ const BASE_PAYLOAD = {
   },
 };
 
+const VERDICT_LABEL = {
+  hold: 'Hold',
+  profit_take_review: 'Review · 50%',
+  dte_review: 'Review · 21d',
+  expiration: 'Close · exp',
+  assignment: 'Close · ITM',
+};
+
+// A minimal four-row triggered_rules payload — enough for the InspectPanel
+// to render. Verdict-evaluation correctness is covered by the backend unit
+// tests and `dashboard-rule-monitor.spec.js`.
+function makeTriggeredRules(verdict) {
+  const ids = ['assignment_risk', 'expiration_warning', 'profit_review', 'dte_review'];
+  const governingId = {
+    assignment: 'assignment_risk',
+    expiration: 'expiration_warning',
+    profit_take_review: 'profit_review',
+    dte_review: 'dte_review',
+  }[verdict];
+  return ids.map((rule_id) => ({
+    rule_id,
+    metric_label: rule_id === 'profit_review' ? 'Premium captured' : 'Days to expiration',
+    value_display: '—',
+    rule_display: 'Review at ≥ 50%',
+    status: rule_id === governingId ? 'triggered' : 'no',
+    is_governing: rule_id === governingId,
+    reasoning: rule_id === governingId ? 'Your rule triggered.' : null,
+  }));
+}
+
 function makeLeg(overrides = {}) {
+  const verdict = overrides.verdict || 'hold';
   return {
     id: 'leg-1',
     ticker: 'AAPL',
@@ -76,6 +114,13 @@ function makeLeg(overrides = {}) {
     assignment_risk: 'high',
     suggested_action: 'roll',
     earnings_in_window: false,
+    verdict,
+    verdict_label: VERDICT_LABEL[verdict],
+    reasoning:
+      verdict === 'hold'
+        ? 'No management rule has triggered for this leg yet.'
+        : 'Your rule triggered.',
+    triggered_rules: makeTriggeredRules(verdict),
     ...overrides,
   };
 }
@@ -141,34 +186,34 @@ test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
     await expect(riskCells.nth(1)).toContainText('Low');
   });
 
-  test('ACTION column reflects suggested_action — roll / hold / manage', async ({ page }) => {
-    const rollLeg = makeLeg({ id: 'leg-roll', suggested_action: 'roll' });
+  test('ACTION column reflects the rule-driven verdict (issue #240)', async ({ page }) => {
+    const closeLeg = makeLeg({ id: 'leg-close', verdict: 'expiration' });
     const holdLeg = makeLeg({
       id: 'leg-hold',
       ticker: 'TSLA',
-      suggested_action: 'hold',
+      verdict: 'hold',
       assignment_risk: 'low',
       dte: 21,
     });
-    const manageLeg = makeLeg({
-      id: 'leg-manage',
+    const reviewLeg = makeLeg({
+      id: 'leg-review',
       ticker: 'NVDA',
-      suggested_action: 'manage',
+      verdict: 'dte_review',
       assignment_risk: 'watch',
-      dte: 5,
+      dte: 18,
       moneyness: { state: 'OTM', distance_pct: 0.02, distance_dollars: 5 },
     });
     await mockDashboard(page, {
       ...BASE_PAYLOAD,
-      open_legs: [rollLeg, manageLeg, holdLeg],
+      open_legs: [closeLeg, reviewLeg, holdLeg],
     });
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
     const actions = page.getByTestId('dashboard-leg-row-action');
-    await expect(actions.nth(0)).toContainText('Roll');
-    await expect(actions.nth(1)).toContainText('Manage');
+    await expect(actions.nth(0)).toContainText('Close · exp');
+    await expect(actions.nth(1)).toContainText('Review · 21d');
     await expect(actions.nth(2)).toContainText('Hold');
   });
 
@@ -195,7 +240,7 @@ test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
   });
 
   test('mobile breakpoint (<lg) hides %CAPTURED and RISK columns', async ({ page }) => {
-    const leg = makeLeg({ assignment_risk: 'high', suggested_action: 'roll' });
+    const leg = makeLeg({ assignment_risk: 'high', verdict: 'expiration' });
     await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
     await page.setViewportSize({ width: 600, height: 900 });
     await page.goto('/dashboard');
@@ -209,47 +254,52 @@ test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
     await expect(page.getByTestId('dashboard-leg-row').first()).toBeVisible();
   });
 
-  test('mobile ACTION column visible for urgent actions (roll/manage), hidden for hold', async ({ page }) => {
-    const rollLeg = makeLeg({ id: 'leg-roll', suggested_action: 'roll' });
+  test('mobile ACTION column visible for a non-hold verdict, hidden for hold', async ({ page }) => {
+    const closeLeg = makeLeg({ id: 'leg-close', verdict: 'expiration' });
     const holdLeg = makeLeg({
       id: 'leg-hold',
       ticker: 'TSLA',
-      suggested_action: 'hold',
+      verdict: 'hold',
       assignment_risk: 'low',
       dte: 21,
     });
-    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [rollLeg, holdLeg] });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [closeLeg, holdLeg] });
     await page.setViewportSize({ width: 600, height: 900 });
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
-    // The roll action's label is visible (it's the urgent case).
+    // A non-hold verdict label is visible on mobile.
     const actionCells = page.getByTestId('dashboard-leg-row-action');
-    await expect(actionCells.nth(0).getByText('Roll', { exact: true })).toBeVisible();
-    // The hold label is hidden on mobile (it carries `hidden lg:inline`)
+    await expect(actionCells.nth(0).getByText('Close · exp', { exact: true })).toBeVisible();
+    // The hold verdict is hidden on mobile (it carries `hidden lg:inline`).
     await expect(actionCells.nth(1).getByText('Hold', { exact: true })).not.toBeVisible();
   });
 
-  test('mobile ACTION column visible for manage (urgent, same as roll)', async ({ page }) => {
-    const manageLeg = makeLeg({ id: 'leg-manage', suggested_action: 'manage', assignment_risk: 'watch' });
-    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [manageLeg] });
+  test('mobile ACTION column visible for a review verdict', async ({ page }) => {
+    const reviewLeg = makeLeg({ id: 'leg-review', verdict: 'profit_take_review', assignment_risk: 'watch' });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [reviewLeg] });
     await page.setViewportSize({ width: 600, height: 900 });
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByTestId('dashboard-leg-row-action').getByText('Manage', { exact: true })).toBeVisible();
+    await expect(
+      page.getByTestId('dashboard-leg-row-action').getByText('Review · 50%', { exact: true })
+    ).toBeVisible();
   });
 
-  test('close action never renders in V0.5 payload (spec §14.5)', async ({ page }) => {
-    const legs = [
-      makeLeg({ id: 'leg-roll', suggested_action: 'roll' }),
-      makeLeg({ id: 'leg-manage', ticker: 'TSLA', suggested_action: 'manage', assignment_risk: 'watch' }),
-      makeLeg({ id: 'leg-hold', ticker: 'AAPL', suggested_action: 'hold', assignment_risk: 'low', dte: 30 }),
-    ];
-    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: legs });
+  test('leg row is an expand toggle, not a journal link (issue #240)', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review' });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText('Close target ✓')).toHaveCount(0);
+    const row = page.getByTestId('dashboard-leg-row').first();
+    // The row is a <button> with aria-expanded — not an <a href>.
+    await expect(row).toHaveAttribute('aria-expanded', 'false');
+    await row.click();
+    await expect(row).toHaveAttribute('aria-expanded', 'true');
+    // Clicking expands in place — the page stays on /dashboard.
+    await expect(page).toHaveURL(/\/dashboard$/);
   });
 });

--- a/frontend/e2e/dashboard-rule-monitor.spec.js
+++ b/frontend/e2e/dashboard-rule-monitor.spec.js
@@ -1,0 +1,504 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #240 — per-leg rule monitor + action cards.
+ *
+ * Covers AC:
+ *   - ACTION column renders the rule-driven verdict (Hold / Review · 50% /
+ *     Review · 21d / Close · exp / Close · ITM) with the spec §2.3 treatment.
+ *   - Leg row is a `<button>` toggle; clicking expands an inline InspectPanel
+ *     with the Metric/Value/Rule/Triggered? audit table + reasoning + CTAs.
+ *   - Multi-open expansion — two panels can be open at once.
+ *   - Quiet leg (verdict=hold) is still inspectable; no Buy-to-close CTA.
+ *   - leg.profit_take_review card renders emerald + ✓ + [P1];
+ *     leg.dte_review card renders slate + [P2].
+ *   - `#leg-{id}` deep link auto-expands the targeted row on mount.
+ *   - Degraded path — no live mid → % Capt `—`, DTE-based fallback verdict.
+ *
+ * Mirrors `dashboard-open-legs-card.spec.js` — same `mockDashboard()` +
+ * `makeLeg()` fixture pattern.
+ */
+
+const BASE_PAYLOAD = {
+  generated_at: '2026-05-18T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 1 },
+  },
+  kpis: {
+    open_positions: 1,
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 1, holding: 0 },
+    notional_value: 17542,
+    notional_change_pct: 0,
+    open_legs: 4,
+    open_legs_breakdown: { puts: 2, calls: 2 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+    largest_risk: null,
+    premium_collected_total: 0,
+    premium_collected_trades: 0,
+    premium_collected_ytd: 0,
+    realized_pl: 0,
+    realized_pl_pct: null,
+    largest_loser: null,
+  },
+  positions: [
+    {
+      id: 'pos-ford',
+      ticker: 'F',
+      shares: 100,
+      strategy: 'wheel',
+      adjusted_cost_basis: 1500.0,
+      current_price: 15.5,
+      notional: 1550.0,
+      unrealized_pl: 0,
+      open_legs_count: 1,
+      wheel_status: 'Wheel',
+      next_suggested_action: 'Review',
+      pl_pct: 0,
+      broker_cost_basis: 1500.0,
+    },
+  ],
+  upcoming_expirations: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-05-18T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+  next_actions: [],
+};
+
+// Build the four-row triggered_rules payload, governed by `verdict`.
+function makeTriggeredRules({ verdict, dte, capturedPct, moneyness }) {
+  const dteValue = `${dte} d`;
+  const captured =
+    capturedPct == null ? '—' : `${Math.round(capturedPct * 100)}%`;
+  const moneynessValue = moneyness ? moneyness.state : '—';
+  const rows = [
+    {
+      rule_id: 'assignment_risk',
+      metric_label: 'Assignment risk',
+      value_display: moneynessValue,
+      rule_display: 'Review at ≥ High',
+      status: verdict === 'assignment' ? 'triggered' : 'no',
+      is_governing: verdict === 'assignment',
+      reasoning: null,
+    },
+    {
+      rule_id: 'expiration_warning',
+      metric_label: 'Days to expiration',
+      value_display: dteValue,
+      rule_display: 'Warn at ≤ 7 d',
+      status:
+        verdict === 'expiration'
+          ? 'triggered'
+          : dte > 7
+            ? 'not_yet'
+            : 'no',
+      is_governing: verdict === 'expiration',
+      reasoning: null,
+    },
+    {
+      rule_id: 'profit_review',
+      metric_label: 'Premium captured',
+      value_display: captured,
+      rule_display: 'Review at ≥ 50%',
+      status:
+        capturedPct == null
+          ? 'no'
+          : verdict === 'profit_take_review'
+            ? 'triggered'
+            : 'not_yet',
+      is_governing: verdict === 'profit_take_review',
+      reasoning: null,
+    },
+    {
+      rule_id: 'dte_review',
+      metric_label: 'Days to expiration',
+      value_display: dteValue,
+      rule_display: 'Review at ≤ 21 d',
+      status:
+        verdict === 'dte_review'
+          ? 'triggered'
+          : dte > 21
+            ? 'not_yet'
+            : 'triggered',
+      is_governing: verdict === 'dte_review',
+      reasoning: null,
+    },
+  ];
+  const reasoning = {
+    hold: 'No management rule has triggered for this leg yet.',
+    profit_take_review: 'Your 50% profit-take rule triggered. This leg has captured 60% of its max premium.',
+    dte_review: 'This leg is inside your 21-day review window. Your rule says: decide — hold, roll, or close.',
+    expiration: 'Your expiration rule triggered — 5 days to expiration.',
+    assignment: 'Your expiration rule triggered and this leg is ITM — 5 days to expiration with assignment risk.',
+  }[verdict];
+  rows.forEach((r) => {
+    if (r.is_governing) r.reasoning = reasoning;
+  });
+  return { rows, reasoning };
+}
+
+const VERDICT_LABEL = {
+  hold: 'Hold',
+  profit_take_review: 'Review · 50%',
+  dte_review: 'Review · 21d',
+  expiration: 'Close · exp',
+  assignment: 'Close · ITM',
+};
+
+function makeLeg(overrides = {}) {
+  const verdict = overrides.verdict || 'hold';
+  const dte = overrides.dte ?? 38;
+  const capturedPct =
+    overrides.capturedPct !== undefined ? overrides.capturedPct : 0.18;
+  const moneyness =
+    overrides.moneyness !== undefined
+      ? overrides.moneyness
+      : { state: 'OTM', distance_pct: 0.033, distance_dollars: 0.5 };
+  const { rows, reasoning } = makeTriggeredRules({
+    verdict,
+    dte,
+    capturedPct,
+    moneyness,
+  });
+  return {
+    id: overrides.id || 'leg-ford-15c',
+    ticker: overrides.ticker || 'F',
+    type: overrides.type || 'call',
+    strike: overrides.strike ?? 15.0,
+    expiration: overrides.expiration || '2026-06-26',
+    dte,
+    moneyness,
+    position_id: overrides.position_id || 'pos-ford',
+    profit_target_status:
+      capturedPct == null
+        ? { captured_pct: null, state: 'unknown' }
+        : {
+            captured_pct: capturedPct,
+            state: verdict === 'profit_take_review' ? 'captured_50' : 'in_progress',
+          },
+    assignment_risk: overrides.assignment_risk || 'low',
+    suggested_action: 'hold',
+    earnings_in_window: false,
+    verdict,
+    verdict_label: VERDICT_LABEL[verdict],
+    reasoning,
+    triggered_rules: rows,
+  };
+}
+
+function makeCard(overrides = {}) {
+  const actionId = overrides.action_id || 'leg.profit_take_review';
+  return {
+    id: overrides.id || `${actionId}.leg-ford-15c`,
+    action_id: actionId,
+    priority: overrides.priority || 'P1',
+    tone: overrides.tone,
+    title: overrides.title || 'Profit-take review',
+    subject: overrides.subject || { ticker: 'F', amount: '15C' },
+    reason: overrides.reason || 'Your 50% profit-take rule triggered — 60% of max premium captured.',
+    cta: {
+      label: 'Inspect rule',
+      href: overrides.href || '/dashboard#leg-leg-ford-15c',
+      kind: 'link',
+    },
+    triggered_rules: overrides.triggered_rules || [],
+  };
+}
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('OpenLegsCard rule monitor — ACTION verdict column', () => {
+  test('profit-take verdict renders "Review · 50%" emerald', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const action = page.getByTestId('dashboard-leg-row-action').first();
+    await expect(action).toContainText('Review · 50%');
+    const verdictEl = action.locator('[data-verdict="profit_take_review"]');
+    await expect(verdictEl).toHaveClass(/emerald/);
+  });
+
+  test('dte-review verdict renders "Review · 21d" amber', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'dte_review', dte: 20, capturedPct: 0.31 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const action = page.getByTestId('dashboard-leg-row-action').first();
+    await expect(action).toContainText('Review · 21d');
+    await expect(action.locator('[data-verdict="dte_review"]')).toHaveClass(/amber/);
+  });
+
+  test('assignment verdict renders "Close · ITM" red with ⛔', async ({ page }) => {
+    const leg = makeLeg({
+      verdict: 'assignment',
+      dte: 5,
+      capturedPct: 0.44,
+      moneyness: { state: 'ITM', distance_pct: 0.04, distance_dollars: 0.62 },
+      assignment_risk: 'high',
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const action = page.getByTestId('dashboard-leg-row-action').first();
+    await expect(action).toContainText('Close · ITM');
+    await expect(action).toContainText('⛔');
+    await expect(action.locator('[data-verdict="assignment"]')).toHaveClass(/red/);
+  });
+
+  test('expiration verdict renders "Close · exp" red', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'expiration', dte: 5, capturedPct: 0.2 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const action = page.getByTestId('dashboard-leg-row-action').first();
+    await expect(action).toContainText('Close · exp');
+    await expect(action.locator('[data-verdict="expiration"]')).toHaveClass(/red/);
+  });
+
+  test('quiet leg renders neutral "Hold" verdict', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'hold', dte: 73, capturedPct: 0.18 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const action = page.getByTestId('dashboard-leg-row-action').first();
+    await expect(action.locator('[data-verdict="hold"]')).toHaveText('Hold');
+  });
+
+  test('%CAPT and ACTION agree at threshold (state captured_50 → Review · 50%)', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-leg-row-captured').first()).toContainText('60%');
+    await expect(page.getByTestId('dashboard-leg-row-action').first()).toContainText('Review · 50%');
+  });
+});
+
+test.describe('OpenLegsCard rule monitor — InspectPanel', () => {
+  test('clicking a leg row expands the inspect panel', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-leg-row').first();
+    await expect(row).toHaveAttribute('aria-expanded', 'false');
+    await row.click();
+    await expect(row).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-ford-15c')).toBeVisible();
+  });
+
+  test('inspect table renders four rule rows with tri-state status', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    const id = 'leg-ford-15c';
+    await expect(page.getByTestId(`dashboard-leg-inspect-table-${id}`)).toBeVisible();
+    // Governing profit_review row shows ● Yes.
+    const profitStatus = page.getByTestId(`dashboard-leg-inspect-status-${id}-profit_review`);
+    await expect(profitStatus).toContainText('Yes');
+    // Assignment row is non-firing — ○ No.
+    const assignStatus = page.getByTestId(`dashboard-leg-inspect-status-${id}-assignment_risk`);
+    await expect(assignStatus).toContainText('No');
+    // The dte_review row trends toward the window — Not yet.
+    const dteStatus = page.getByTestId(`dashboard-leg-inspect-status-${id}-dte_review`);
+    await expect(dteStatus).toContainText('Not yet');
+  });
+
+  test('inspect panel reasoning is attributed to the user ruleset', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    const reasoning = page.getByTestId('dashboard-leg-inspect-reasoning-leg-ford-15c');
+    await expect(reasoning).toContainText('Your');
+    await expect(reasoning).toContainText('rule triggered');
+  });
+
+  test('Buy-to-close CTA shown for a closing verdict', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    const closeCta = page.getByTestId('dashboard-leg-inspect-cta-close-leg-ford-15c');
+    await expect(closeCta).toBeVisible();
+    await expect(closeCta).toHaveAttribute(
+      'href',
+      '/journal?position=pos-ford&action=close-leg'
+    );
+    await expect(
+      page.getByTestId('dashboard-leg-inspect-cta-journal-leg-ford-15c')
+    ).toBeVisible();
+  });
+
+  test('quiet leg is inspectable but has no Buy-to-close CTA', async ({ page }) => {
+    const leg = makeLeg({ verdict: 'hold', dte: 73, capturedPct: 0.18 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-ford-15c')).toBeVisible();
+    await expect(
+      page.getByTestId('dashboard-leg-inspect-reasoning-leg-ford-15c')
+    ).toContainText('No management rule has triggered');
+    await expect(
+      page.getByTestId('dashboard-leg-inspect-cta-close-leg-ford-15c')
+    ).toHaveCount(0);
+  });
+
+  test('multiple rows can be expanded at once (multi-open)', async ({ page }) => {
+    const legA = makeLeg({ id: 'leg-a', ticker: 'F', verdict: 'profit_take_review', capturedPct: 0.6 });
+    const legB = makeLeg({
+      id: 'leg-b',
+      ticker: 'AAPL',
+      strike: 190,
+      type: 'put',
+      verdict: 'dte_review',
+      dte: 20,
+      capturedPct: 0.31,
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [legA, legB] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const rows = page.getByTestId('dashboard-leg-row');
+    await rows.nth(0).click();
+    await rows.nth(1).click();
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-a')).toBeVisible();
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-b')).toBeVisible();
+  });
+});
+
+test.describe('OpenLegsCard rule monitor — degraded path', () => {
+  test('no live mid → % Capt shows — and verdict falls back to DTE rule', async ({ page }) => {
+    const leg = makeLeg({
+      id: 'leg-nvda',
+      ticker: 'NVDA',
+      type: 'put',
+      strike: 120,
+      verdict: 'dte_review',
+      dte: 12,
+      capturedPct: null,
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-leg-row-captured').first()).toContainText('—');
+    await expect(page.getByTestId('dashboard-leg-row-action').first()).toContainText('Review · 21d');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    const profitStatus = page.getByTestId('dashboard-leg-inspect-status-leg-nvda-profit_review');
+    await expect(profitStatus).toContainText('No');
+  });
+});
+
+test.describe('NextActionCard — rule-monitor cards', () => {
+  test('leg.profit_take_review card renders emerald, ✓, [P1]', async ({ page }) => {
+    const card = makeCard({ action_id: 'leg.profit_take_review', tone: 'opportunity', priority: 'P1' });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      open_legs: [makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 })],
+      next_actions: [card],
+    });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const cardEl = page.getByTestId('next-actions-card-leg.profit_take_review.leg-ford-15c');
+    await expect(cardEl).toBeVisible();
+    await expect(cardEl).toHaveClass(/emerald/);
+    await expect(cardEl).toContainText('✓');
+    await expect(cardEl).toContainText('[P1]');
+  });
+
+  test('leg.dte_review card renders slate, [P2]', async ({ page }) => {
+    const card = makeCard({
+      action_id: 'leg.dte_review',
+      id: 'leg.dte_review.leg-aapl',
+      priority: 'P2',
+      title: '21-day review',
+      tone: undefined,
+      subject: { ticker: 'AAPL', amount: '190P' },
+      reason: '20 days to expiration — your review window. Decide: hold, roll, or close.',
+      href: '/dashboard#leg-leg-aapl',
+    });
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      open_legs: [makeLeg({ id: 'leg-aapl', verdict: 'dte_review', dte: 20, capturedPct: 0.31 })],
+      next_actions: [card],
+    });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const cardEl = page.getByTestId('next-actions-card-leg.dte_review.leg-aapl');
+    await expect(cardEl).toBeVisible();
+    await expect(cardEl).toContainText('[P2]');
+    await expect(cardEl).not.toHaveClass(/emerald/);
+  });
+});
+
+test.describe('OpenLegsCard rule monitor — hash deep link', () => {
+  test('#leg-{id} auto-expands the targeted row on mount', async ({ page }) => {
+    const legA = makeLeg({ id: 'leg-a', ticker: 'F', verdict: 'hold', dte: 73 });
+    const legB = makeLeg({
+      id: 'leg-b',
+      ticker: 'AAPL',
+      strike: 190,
+      type: 'put',
+      verdict: 'profit_take_review',
+      capturedPct: 0.6,
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [legA, legB] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard#leg-leg-b');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-b')).toBeVisible();
+    // The non-targeted row stays collapsed.
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-a')).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/dashboard-rule-monitor.spec.js
+++ b/frontend/e2e/dashboard-rule-monitor.spec.js
@@ -501,4 +501,28 @@ test.describe('OpenLegsCard rule monitor — hash deep link', () => {
     // The non-targeted row stays collapsed.
     await expect(page.getByTestId('dashboard-leg-inspect-leg-a')).toHaveCount(0);
   });
+
+  test('malformed #leg-%FF hash does not crash the dashboard', async ({ page }) => {
+    // `decodeURIComponent('%FF')` throws — parseLegHash runs in a lazy
+    // useState initializer, so an unguarded throw would crash the dashboard
+    // at render. The guard returns null instead; the page must still mount.
+    const leg = makeLeg({ id: 'leg-a', ticker: 'F', verdict: 'hold', dte: 73 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+
+    const pageErrors = [];
+    page.on('pageerror', (err) => pageErrors.push(err));
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard#leg-%FF');
+    await page.waitForLoadState('networkidle');
+
+    // The dashboard shell rendered — no render crash.
+    await expect(page.getByTestId('dashboard-page')).toBeVisible();
+    // The leg row still rendered; the bad hash matched no leg, so nothing
+    // is auto-expanded.
+    await expect(page.getByTestId('dashboard-leg-row').first()).toBeVisible();
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-a')).toHaveCount(0);
+    // No uncaught URIError reached the page.
+    expect(pageErrors).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Completes issue #240 — the per-leg **§R6 rule-monitor verdict layer** that sits on top of the `% CAPT` signal shipped by PR #241. Every open option leg is now evaluated against the four ManagementTriggers §R6 rules; the result feeds three render sites from **one evaluation**: the `ACTION` verdict column, the expandable inspect panel, and two new NextActions cards.

This is the second half of #240 — `Closes #240`.

## Backend

- **New `backend/app/services/rule_monitor.py`** — pure §R6 evaluation module. `evaluate_leg_rules()` evaluates all four rules (fired and not-fired alike), resolves the precedence stack to a single governing rule, and returns `(verdict, verdict_label, reasoning, triggered_rules)`. Side-effect-free — no DB, no I/O, raises nothing.
- **`dashboard_legs.py`** — `derive_open_legs()` gains `dte_review_days` / `expiration_warning_days` params (defaulted); every leg dict gains `verdict`, `verdict_label`, `reasoning`, `triggered_rules`.
- **`action_engine.py`** — two **additive** card builders: `leg.profit_take_review` (P1, `tone: "opportunity"`) and `leg.dte_review` (P2). No existing builder was modified — `compute_next_actions` gained two `extend` calls and the two sort maps gained entries for the new `action_id`s only.
- **`dashboard.py`** — threads the two thresholds through; resolves the new cards in the per-position next-action label.
- **`schemas.py`** — `DashboardRuleEvaluation`; verdict layer on `DashboardOpenLeg`; `tone` + `triggered_rules` on `DashboardNextAction`. All additions are defaulted — every existing card / payload stays schema-valid and byte-identical.

### Precedence (one leg → one card, by construction)

`7d ITM assignment > 7d expiration > profit-take 50% > 21d DTE review`. Precedence is resolved once in `rule_monitor`; each card builder filters on the precomputed `verdict`, so a leg already governed by `expiration`/`assignment` is skipped by the new builders and cannot double-emit alongside the existing `expiration.*` cards.

## Frontend

- **`OpenLegsCard.jsx`** — rule-driven `ACTION` verdict column (server-rendered `verdict_label`, no frontend threshold parsing); the leg row is now a `<button>` expand toggle with a leading chevron; new `InspectPanel` sub-component renders the `Metric / Value / Your rule / Triggered?` audit table with tri-state `Yes`/`Not yet`/`No`, the reasoning sentence, and the `Buy to close` / `Open in Journal` CTAs. Multi-open expansion; `#leg-{id}` hash deep-link seam.
- **`NextActionCard.jsx`** — additive `tone` field (default `"warning"`); `"opportunity"` repaints the card emerald with a `✓` glyph while keeping the `[P1]` badge. Every existing card is unchanged.
- **`DashboardPage.jsx`** — parses the `#leg-{id}` hash and seeds `OpenLegsCard`.

## Verdict vocabulary (user-confirmed)

`Hold` / `Review · 50%` / `Review · 21d` / `Close · exp` / `Close · ITM` — `Close · ITM` is a distinct verdict from `Close · exp`. The threshold suffix interpolates the user's configured `ManagementTriggers` value (a 65% `profit_review_pct` renders `Review · 65%`).

## Advice-framing audit (spec §11 — every verdict attributed to the user's ruleset)

| Phrase the UI uses | Phrase it avoids |
|---|---|
| "Your 50% profit-take rule triggered" | "We recommend closing this leg" |
| "Checked against your Management Triggers" | "Our analysis flagged" |
| "Your rule" / "Review at ≥ 50%" | "Our threshold" / "Sell at 50%" |
| "past the 50% review threshold you set" | "past our recommended exit" |
| "No management rule has triggered for this leg yet" | "This leg is fine" |

Codified as a parametrized backend assertion (`test_rule_monitor.py::TestAdviceFraming`).

## Regression callout

`action_engine.py` is shared with the live `expiration.*` / `position.*` / `data.*` cards. **No existing builder function was modified** — `compute_next_actions` gained only additive `extend` calls; the sort maps gained entries for the new `action_id`s only. `test_action_engine.py::TestExpirationCardsUnaffected` is the explicit regression guard.

## Journal-route verification (spec Q5)

`JournalPage.jsx` reads only the `position` query param via `useSearchParams()` — it does **not** read `action`. The `Buy to close` CTA links to `/journal?position={id}&action=close-leg`; the unrecognized `action` param is harmlessly ignored and the link still lands on the correct position page (the spec's documented acceptable fallback for Q5 recommendation (a)). No journal-side close-flow logic was added — out of scope per the plan.

## Test coverage

**Backend (`cd backend && python -m pytest`) — 1110 passed, 9 skipped:**
- `test_rule_monitor.py` (new, 37 tests) — every rule's fired/not-fired boundary; precedence; tri-state `triggered`/`not_yet`/`no`; the degraded no-mid path; the advice-framing audit; `triggered_rules` length-4 + order.
- `test_action_engine.py` (extended) — both new cards emit on the right verdict; no double-emit; existing `expiration.*` cards unaffected; deterministic sort.
- `test_dashboard_legs.py` (extended) — the verdict layer attaches to every leg; threshold params honored.
- `test_integration_dashboard.py` (extended) — full payload validates with the new fields; a live-mark leg past the threshold yields the verdict AND the matching card.

**Frontend (`cd frontend && npx playwright test`) — 26 + 39 passed:**
- `dashboard-rule-monitor.spec.js` (new) — verdict column treatments, inspect panel, multi-open, degraded path, the two cards, hash deep-link.
- `dashboard-open-legs-card.spec.js` (updated) — row-as-button migration.
- Broader dashboard specs (`dashboard`, `next-actions`, `expirations`, `positions-triage`) — no regressions.

`npm run lint` clean (one pre-existing unrelated `UserMenu.jsx` warning) · `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)