### PR TITLE
Dedicated buy-to-close leg detail screen + fix broken Inspect-rule CTA (closes #244)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.config import settings as app_settings
 from app.logging_config import setup_logging
 from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
-from app.routers import assets, dashboard, data, health, journal, options, positions, regression, sessions, settings
+from app.routers import assets, dashboard, data, health, journal, legs, options, positions, regression, sessions, settings
 from app.services.backup import create_backup
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher, DataFetchError, InvalidTickerError, DataAlignmentError
@@ -165,6 +165,7 @@ app.include_router(options.router, dependencies=[Depends(get_current_user)])
 app.include_router(journal.router, dependencies=[Depends(get_current_user)])
 app.include_router(dashboard.router, dependencies=[Depends(get_current_user)])
 app.include_router(positions.router, dependencies=[Depends(get_current_user)])
+app.include_router(legs.router, dependencies=[Depends(get_current_user)])
 
 
 # --- Exception handlers ---

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -976,3 +976,60 @@ class RecoveryPlanResponse(BaseModel):
     recommendation: Optional[RecoveryRecommendation] = None
     assumptions: list[RecoveryAssumptionRow] = Field(default_factory=list)
     disclaimer: Optional[str] = None
+
+
+# --- Buy-to-close leg detail (V1.0.6, issue #244) ---
+
+# The two delivered states the BTC endpoint returns a 200 body for. The
+# 'not-found' state is delivered as an HTTP 404 with no body.
+BTC_DETAIL_STATE = Literal["populated", "no-rule-triggered"]
+
+
+class BtcLeg(BaseModel):
+    """The open option leg the buy-to-close review is scoped to."""
+
+    id: str
+    position_id: str
+    ticker: str
+    strike: float
+    option_type: Literal["C", "P"]
+    contracts: int
+    expiration: str
+    dte: int
+    moneyness: str  # 'OTM' | 'ITM' | 'ATM' | 'Unknown'
+    position_label: str
+
+
+class BtcEconomics(BaseModel):
+    """Buy-to-close economics for the leg.
+
+    ``credit_received`` is always real (static, from the opening trade row).
+    The pricing-dependent fields are ``None`` when no live option mark is
+    available — the frontend renders the em-dash + "Pricing unavailable"
+    treatment in that case (spec §5.3 Q4).
+    """
+
+    credit_received: float
+    current_option_mid: Optional[float] = None
+    cost_to_close: Optional[float] = None
+    captured_pct: Optional[float] = None
+    est_pl_if_closed: Optional[float] = None
+    pricing_as_of: Optional[str] = None
+    pricing_source: Literal["live", "stub", "unavailable"]
+
+
+class BtcDetailResponse(BaseModel):
+    """Top-level response for ``GET /api/positions/{id}/legs/{legId}/btc``.
+
+    Composes the leg identity, the §R6 rule-monitor verdict + audit (reused
+    verbatim from :func:`app.services.rule_monitor.evaluate_leg_rules` via
+    ``derive_open_legs``), and the buy-to-close economics block. A 404 with
+    ``{"detail": "Leg not found"}`` is returned for an unknown / closed leg.
+    """
+
+    state: BTC_DETAIL_STATE
+    leg: BtcLeg
+    verdict: DASHBOARD_VERDICT
+    economics: BtcEconomics
+    triggered_rules: list[DashboardRuleEvaluation] = Field(default_factory=list)
+    disclaimer: Optional[str] = None

--- a/backend/app/routers/legs.py
+++ b/backend/app/routers/legs.py
@@ -1,0 +1,71 @@
+"""Legs router — the per-leg buy-to-close detail endpoint (issue #244).
+
+Single route: ``GET /api/positions/{position_id}/legs/{leg_id}/btc``. Feeds
+the dedicated buy-to-close (BTC) leg detail screen — the per-leg analog of
+the per-position recovery screen.
+
+Branch shape:
+
+- 404 — ``Leg not found`` — unknown / closed leg, or a leg that belongs to a
+  different position.
+- 200 — :class:`BtcDetailResponse`. ``state == "no-rule-triggered"`` when the
+  leg's §R6 verdict is ``hold``; ``state == "populated"`` when a rule fired.
+- 500 — generic ``Failed to load buy-to-close detail. Please try again.`` on
+  Schwab / option-chain failure. Never leaks ``str(e)`` (CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import get_db
+from app.models.schemas import BtcDetailResponse
+from app.services.btc_detail import build_btc_detail
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/positions", tags=["legs"])
+
+# Generic 500 detail per CLAUDE.md — never leak ``str(e)``.
+GENERIC_BTC_500_DETAIL = "Failed to load buy-to-close detail. Please try again."
+
+
+@router.get(
+    "/{position_id}/legs/{leg_id}/btc",
+    response_model=BtcDetailResponse,
+)
+def get_btc_detail(
+    position_id: str,
+    leg_id: str,
+    db: DBSession = Depends(get_db),
+):
+    """Return the buy-to-close detail payload for one open option leg.
+
+    Composes the leg identity, the §R6 rule-monitor verdict + audit (reused
+    verbatim from the dashboard's ``derive_open_legs`` path), and the
+    buy-to-close economics block. 404 for an unknown / closed leg.
+    """
+    try:
+        detail = build_btc_detail(db, position_id, leg_id)
+    except Exception as exc:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.error(
+            "Buy-to-close detail build failed for position %s leg %s: %s",
+            position_id,
+            leg_id,
+            exc,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": GENERIC_BTC_500_DETAIL},
+        )
+
+    if detail is None:
+        return JSONResponse(
+            status_code=404, content={"detail": "Leg not found"}
+        )
+
+    return detail

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -468,7 +468,10 @@ def _leg_profit_take_review_actions(
                 ),
                 "cta": {
                     "label": "Inspect rule",
-                    "href": f"/dashboard#leg-{quote(str(leg['id']), safe='')}",
+                    "href": (
+                        f"/positions/{quote(str(leg['position_id']), safe='')}"
+                        f"/legs/{quote(str(leg['id']), safe='')}/btc"
+                    ),
                     "kind": "link",
                 },
                 "triggered_rules": triggered_rules,
@@ -518,7 +521,10 @@ def _leg_dte_review_actions(
                 ),
                 "cta": {
                     "label": "Inspect rule",
-                    "href": f"/dashboard#leg-{quote(str(leg['id']), safe='')}",
+                    "href": (
+                        f"/positions/{quote(str(leg['position_id']), safe='')}"
+                        f"/legs/{quote(str(leg['id']), safe='')}/btc"
+                    ),
                     "kind": "link",
                 },
                 "triggered_rules": triggered_rules,

--- a/backend/app/services/btc_detail.py
+++ b/backend/app/services/btc_detail.py
@@ -180,7 +180,7 @@ def build_btc_detail(
     )
 
     leg = next(
-        (l for l in open_legs if str(l["id"]) == str(leg_id)), None
+        (lg for lg in open_legs if str(lg["id"]) == str(leg_id)), None
     )
     if leg is None:
         # Unknown leg, closed leg, or a leg that belongs to a different

--- a/backend/app/services/btc_detail.py
+++ b/backend/app/services/btc_detail.py
@@ -1,0 +1,204 @@
+"""Buy-to-close leg detail service (issue #244).
+
+Composes the per-leg buy-to-close (BTC) detail payload for the new
+``GET /api/positions/{position_id}/legs/{leg_id}/btc`` endpoint. The screen
+is the per-leg analog of the per-position recovery screen.
+
+Reuse over re-implementation (plan §4.3):
+
+- The §R6 rule audit is **not** re-evaluated here. This service reuses the
+  whole :func:`app.services.dashboard_legs.derive_open_legs` path — the
+  exact function the dashboard service calls — which itself calls
+  :func:`app.services.rule_monitor.evaluate_leg_rules` per leg. The
+  ``triggered_rules`` / ``verdict`` this endpoint returns are therefore
+  byte-identical to what the dashboard renders for the same leg: no drift
+  is possible by construction.
+- The only genuinely new computation is the BTC economics block
+  (:func:`_build_economics`) — and even there ``captured_pct`` is *lifted*
+  from the leg's ``profit_target_status`` rather than recomputed, so it
+  agrees with the dashboard ``% CAPT`` column.
+
+The single Schwab fetch (one quote + one option chain for the position's
+ticker) is fully guarded by the caller (the router) — this service raises on
+fetch failure and the router converts it to a generic 500 per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.services import journal
+from app.services.dashboard_legs import build_option_mark_index, derive_open_legs
+from app.services.rules_config import load_rules_config
+from app.services.schwab_client import SchwabClient
+
+logger = logging.getLogger(__name__)
+
+# Persistent disclaimer footer copy — BTC-specific, shipped in the payload so
+# the frontend renders it the same way the recovery screen renders its
+# disclaimer (spec §6 / §4.2).
+DISCLAIMER_TEXT: str = (
+    "This buy-to-close review reports what your own Management Triggers said "
+    "about this leg and the mechanical economics of closing it. It is not "
+    "trading advice. Option mid prices are estimates, may be stale, and "
+    "exclude commissions; the decision to buy to close is yours."
+)
+
+# Maps the position's derived strategy label to the human context phrase used
+# in the leg header sub-line. Unknown strategies fall back to "position".
+_STRATEGY_LABEL: dict[str, str] = {
+    "csp": "cash-secured put",
+    "cc": "covered call",
+    "wheel": "wheel",
+    "holding": "holding",
+}
+
+
+def _moneyness_label(leg: dict) -> str:
+    """Return the leg's moneyness state, or 'Unknown' when no live price."""
+    moneyness = leg.get("moneyness")
+    if isinstance(moneyness, dict) and moneyness.get("state"):
+        return str(moneyness["state"])
+    return "Unknown"
+
+
+def _position_label(position: dict) -> str:
+    """Compose ``"{ticker} {strategy phrase}"`` for the header sub-line."""
+    ticker = position.get("ticker", "")
+    strategy = str(position.get("strategy") or "").lower()
+    phrase = _STRATEGY_LABEL.get(strategy, "position")
+    return f"{ticker} {phrase}".strip()
+
+
+def _build_economics(leg: dict) -> dict[str, Any]:
+    """Compute the buy-to-close economics block for one leg.
+
+    All money figures are whole-position dollars (per-share value × contracts
+    × 100). ``credit_received`` is always real; the pricing-dependent fields
+    degrade to ``None`` when no live option mark is available (spec §5.3 Q4).
+
+    ``captured_pct`` is lifted straight off ``profit_target_status`` — the
+    identical value the dashboard ``% CAPT`` column shows — never recomputed.
+    """
+    contracts = int(leg.get("quantity") or 1)
+    premium = leg.get("premium")  # per-share opening credit
+    current_mid = leg.get("current_mid")  # per-share, None ⇒ no live mark
+
+    # The opening credit is static — always real, even with no live pricing.
+    credit_received = round(float(premium or 0.0) * contracts * 100, 2)
+
+    if current_mid is None:
+        return {
+            "credit_received": credit_received,
+            "current_option_mid": None,
+            "cost_to_close": None,
+            "captured_pct": None,
+            "est_pl_if_closed": None,
+            "pricing_as_of": None,
+            "pricing_source": "unavailable",
+        }
+
+    cost_to_close = round(float(current_mid) * contracts * 100, 2)
+    # Lift captured_pct from the already-computed % CAPT signal — agree by
+    # construction with the dashboard column (spec §10 note 2).
+    captured_pct = (leg.get("profit_target_status") or {}).get("captured_pct")
+    est_pl_if_closed = round(credit_received - cost_to_close, 2)
+    return {
+        "credit_received": credit_received,
+        "current_option_mid": round(float(current_mid), 4),
+        "cost_to_close": cost_to_close,
+        "captured_pct": captured_pct,
+        "est_pl_if_closed": est_pl_if_closed,
+        "pricing_as_of": datetime.now(timezone.utc).isoformat(),
+        "pricing_source": "live",
+    }
+
+
+def _reshape_leg(leg: dict, position: dict) -> dict[str, Any]:
+    """Reshape the internal ``derive_open_legs`` leg dict into the API ``leg``."""
+    return {
+        "id": str(leg["id"]),
+        "position_id": str(leg["position_id"]),
+        "ticker": leg["ticker"],
+        "strike": float(leg["strike"]),
+        "option_type": "P" if leg.get("type") == "put" else "C",
+        "contracts": int(leg.get("quantity") or 1),
+        "expiration": str(leg["expiration"])[:10],
+        "dte": int(leg["dte"]),
+        "moneyness": _moneyness_label(leg),
+        "position_label": _position_label(position),
+    }
+
+
+def build_btc_detail(
+    db: DBSession,
+    position_id: str,
+    leg_id: str,
+) -> dict[str, Any] | None:
+    """Build the buy-to-close detail payload for one open leg.
+
+    Returns the response dict on success, or ``None`` when the leg cannot be
+    resolved (unknown / closed leg, or a leg that belongs to a different
+    position) — the router converts ``None`` to a 404.
+
+    Raises on a Schwab quote / option-chain failure; the router wraps that in
+    a generic 500 (no ``str(e)`` leak, per CLAUDE.md).
+    """
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return None
+
+    rules = load_rules_config(db)
+    ticker = position["ticker"]
+
+    # Resolve the live price + option chain for THIS position's ticker only.
+    # A single quote + single chain — far cheaper than the dashboard fan-out.
+    client = SchwabClient()
+    quote = client.get_quote(ticker)
+    current_price_raw = quote.get("lastPrice") if isinstance(quote, dict) else None
+    if current_price_raw is None and isinstance(quote, dict):
+        current_price_raw = quote.get("mark")
+    current_price = (
+        float(current_price_raw) if current_price_raw is not None else None
+    )
+    chain = client.get_option_chain(ticker)
+    marks = build_option_mark_index(
+        {ticker: chain} if isinstance(chain, dict) else {}
+    )
+
+    open_legs = derive_open_legs(
+        [position],
+        {ticker: current_price},
+        option_marks=marks,
+        profit_review_pct=rules.management.profit_review_pct,
+        dte_review_days=rules.management.dte_review_days,
+        expiration_warning_days=rules.management.expiration_warning_days,
+    )
+
+    leg = next(
+        (l for l in open_legs if str(l["id"]) == str(leg_id)), None
+    )
+    if leg is None:
+        # Unknown leg, closed leg, or a leg that belongs to a different
+        # position — derive_open_legs only yields open legs of this position.
+        return None
+
+    economics = _build_economics(leg)
+    verdict = leg.get("verdict") or "hold"
+    state = "no-rule-triggered" if verdict == "hold" else "populated"
+
+    return {
+        "state": state,
+        "leg": _reshape_leg(leg, position),
+        "verdict": verdict,
+        "economics": economics,
+        "triggered_rules": leg.get("triggered_rules") or [],
+        "disclaimer": DISCLAIMER_TEXT,
+    }
+
+
+__all__ = ["build_btc_detail", "DISCLAIMER_TEXT"]

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -412,6 +412,12 @@ def derive_open_legs(
                     "dte": dte,
                     "moneyness": moneyness,
                     "position_id": position_id,
+                    "premium": trade.get("premium"),
+                    "quantity": int(trade.get("quantity") or 1),
+                    # Raw matched option mid (None when no live mark) — consumed
+                    # by the BTC detail endpoint (issue #244). The dashboard
+                    # ignores this key, so it cannot regress #240.
+                    "current_mid": current_mid,
                     "profit_target_status": profit_target_status,
                     "assignment_risk": assignment_risk,
                     "suggested_action": compute_suggested_action(decision_tag),

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -849,7 +849,9 @@ class TestProfitTakeReviewCard:
         assert card["id"] == "leg.profit_take_review.l-1"
         assert card["triggered_rules"]
 
-    def test_card_cta_deep_links_to_leg_hash(self):
+    def test_card_cta_links_to_btc_detail_route(self):
+        # Issue #244 — the CTA repoints from the dead `/dashboard#leg-{id}`
+        # hash to the dedicated per-leg buy-to-close detail route.
         actions = compute_next_actions(
             status=_status(),
             kpis=_kpis(open_legs=1),
@@ -857,7 +859,7 @@ class TestProfitTakeReviewCard:
             open_legs=[_verdict_leg("l-1", verdict="profit_take_review")],
         )
         card = next(a for a in actions if a["action_id"] == "leg.profit_take_review")
-        assert card["cta"]["href"] == "/dashboard#leg-l-1"
+        assert card["cta"]["href"] == "/positions/p-1/legs/l-1/btc"
 
     def test_not_emitted_for_hold_verdict(self):
         actions = compute_next_actions(

--- a/backend/tests/test_btc_detail_endpoint.py
+++ b/backend/tests/test_btc_detail_endpoint.py
@@ -19,9 +19,26 @@ Covers:
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from unittest.mock import patch
 
 from app.models.database import Position, Trade
+
+# ---------------------------------------------------------------------------
+# Time-relative expirations — keep DTE constant whatever day the suite runs.
+#
+# Hardcoded calendar dates rot: once "today" passes the expiration the DTE
+# flips negative, rule evaluation changes, and the assertions break. These
+# offsets are anchored to ``date.today()`` so the rule outcomes stay fixed.
+# ---------------------------------------------------------------------------
+
+# 38 days out — comfortably past the 21-day DTE-review threshold, so the
+# governing verdict in the "populated" tests stays the profit-take rule.
+_NEAR_DTE = 38
+_NEAR_EXPIRY = (date.today() + timedelta(days=_NEAR_DTE)).isoformat()
+# ~13 months out — a far-DTE leg used for the quiet-leg case (no rule fires).
+_FAR_DTE = 400
+_FAR_EXPIRY = (date.today() + timedelta(days=_FAR_DTE)).isoformat()
 
 
 # ---------------------------------------------------------------------------
@@ -72,11 +89,13 @@ def _seed_trade(
     trade_id: str = "leg-ford-15c",
     trade_type: str = "sell_call",
     strike: float = 15.0,
-    expiration: str = "2026-06-26",
+    expiration: str | None = None,
     premium: float = 0.3834,
     quantity: int = 1,
     closed_at: str | None = None,
 ) -> str:
+    if expiration is None:
+        expiration = _NEAR_EXPIRY
     db = _db(client)
     try:
         db.add(
@@ -99,12 +118,27 @@ def _seed_trade(
     return trade_id
 
 
-def _chain(strike: float, mid: float, *, option_type: str = "call") -> dict:
-    """Return a Schwab option-chain-shaped response with one contract."""
+def _chain(
+    strike: float,
+    mid: float,
+    *,
+    option_type: str = "call",
+    expiration: str | None = None,
+) -> dict:
+    """Return a Schwab option-chain-shaped response with one contract.
+
+    The exp-date-map key is ``"<expiration>:<dte>"``; ``build_option_mark_index``
+    keys the flat index on the date prefix only, so the chain's expiration must
+    match the seeded trade's expiration for the mark to be found. Defaults to
+    the same time-relative near expiry the trade helpers use.
+    """
+    if expiration is None:
+        expiration = _NEAR_EXPIRY
     map_key = "callExpDateMap" if option_type == "call" else "putExpDateMap"
+    dte = (date.fromisoformat(expiration) - date.today()).days
     return {
         map_key: {
-            "2026-06-26:38": {
+            f"{expiration}:{dte}": {
                 f"{strike}": [{"strikePrice": strike, "mark": mid}],
             }
         }
@@ -201,15 +235,11 @@ def test_btc_detail_no_rule_triggered_for_quiet_leg(client):
     # Far expiration, low capture → no rule fires.
     _seed_trade(
         client,
-        expiration="2027-06-26",
+        expiration=_FAR_EXPIRY,
         premium=1.00,
     )
     # Current mid still high → captured_pct low → profit rule does not fire.
-    chain = {
-        "callExpDateMap": {
-            "2027-06-26:400": {"15.0": [{"strikePrice": 15.0, "mark": 0.95}]}
-        }
-    }
+    chain = _chain(15.0, 0.95, expiration=_FAR_EXPIRY)
     with _patch_schwab(chain=chain):
         resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
     assert resp.status_code == 200

--- a/backend/tests/test_btc_detail_endpoint.py
+++ b/backend/tests/test_btc_detail_endpoint.py
@@ -1,0 +1,316 @@
+"""Integration tests for the buy-to-close detail endpoint (issue #244).
+
+``GET /api/positions/{position_id}/legs/{leg_id}/btc``.
+
+Uses the in-memory SQLite ``client`` fixture from ``conftest.py``. Patches
+``SchwabClient.get_quote`` / ``get_option_chain`` so no real Schwab calls are
+made.
+
+Covers:
+
+- 200 for a known open leg whose profit-take rule fired → ``populated``.
+- The rules audit + economics fields are correct.
+- ``captured_pct`` agrees with the % CAPT signal (lifted, not recomputed).
+- 404 for an unknown leg, a closed leg, and a position/leg mismatch.
+- ``no-rule-triggered`` 200 for a quiet leg (``verdict == "hold"``).
+- Pricing-unavailable degradation when no option mark matches the contract.
+- 500 hygiene — a quote failure yields the generic detail with no ``str(e)``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.models.database import Position, Trade
+
+
+# ---------------------------------------------------------------------------
+# Helpers — seed positions / trades directly via SQLAlchemy
+# ---------------------------------------------------------------------------
+
+
+def _db(client):
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    return next(override())
+
+
+def _seed_position(
+    client,
+    *,
+    pos_id: str = "pos-ford",
+    ticker: str = "F",
+    shares: int = 0,
+    strategy: str = "cc",
+    status: str = "open",
+) -> str:
+    db = _db(client)
+    try:
+        db.add(
+            Position(
+                id=pos_id,
+                ticker=ticker,
+                shares=shares,
+                broker_cost_basis=1500.0,
+                status=status,
+                strategy=strategy,
+                opened_at="2026-01-01",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+    return pos_id
+
+
+def _seed_trade(
+    client,
+    position_id: str = "pos-ford",
+    *,
+    trade_id: str = "leg-ford-15c",
+    trade_type: str = "sell_call",
+    strike: float = 15.0,
+    expiration: str = "2026-06-26",
+    premium: float = 0.3834,
+    quantity: int = 1,
+    closed_at: str | None = None,
+) -> str:
+    db = _db(client)
+    try:
+        db.add(
+            Trade(
+                id=trade_id,
+                position_id=position_id,
+                trade_type=trade_type,
+                strike=strike,
+                expiration=expiration,
+                premium=premium,
+                fees=0.0,
+                quantity=quantity,
+                opened_at="2026-04-01T10:00:00Z",
+                closed_at=closed_at,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+    return trade_id
+
+
+def _chain(strike: float, mid: float, *, option_type: str = "call") -> dict:
+    """Return a Schwab option-chain-shaped response with one contract."""
+    map_key = "callExpDateMap" if option_type == "call" else "putExpDateMap"
+    return {
+        map_key: {
+            "2026-06-26:38": {
+                f"{strike}": [{"strikePrice": strike, "mark": mid}],
+            }
+        }
+    }
+
+
+def _patch_schwab(quote_price=15.0, chain=None):
+    """Context manager patching the BTC service's Schwab client."""
+    return patch.multiple(
+        "app.services.btc_detail.SchwabClient",
+        get_quote=lambda self, ticker: {"lastPrice": quote_price},
+        get_option_chain=lambda self, ticker: (chain if chain is not None else {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 200 — populated (profit-take fired)
+# ---------------------------------------------------------------------------
+
+
+def test_btc_detail_200_populated_when_profit_take_fired(client):
+    """A leg deep in the money for the seller (% captured high) → populated."""
+    _seed_position(client)
+    _seed_trade(client)
+    # Premium 0.3834, current mid 0.1572 → captured ≈ 59% → profit-take fires.
+    chain = _chain(15.0, 0.1572)
+    with _patch_schwab(chain=chain):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["state"] == "populated"
+    assert payload["verdict"] == "profit_take_review"
+    assert payload["leg"]["ticker"] == "F"
+    assert payload["leg"]["strike"] == 15.0
+    assert payload["leg"]["option_type"] == "C"
+    assert payload["leg"]["position_label"] == "F covered call"
+    assert payload["disclaimer"]
+
+
+def test_btc_detail_rules_audit_has_all_four_rules(client):
+    _seed_position(client)
+    _seed_trade(client)
+    with _patch_schwab(chain=_chain(15.0, 0.1572)):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    payload = resp.json()
+    rule_ids = {r["rule_id"] for r in payload["triggered_rules"]}
+    assert rule_ids == {
+        "assignment_risk",
+        "expiration_warning",
+        "profit_review",
+        "dte_review",
+    }
+    governing = [r for r in payload["triggered_rules"] if r["is_governing"]]
+    assert len(governing) == 1
+    assert governing[0]["rule_id"] == "profit_review"
+    assert governing[0]["status"] == "triggered"
+    assert governing[0]["reasoning"]
+
+
+def test_btc_detail_economics_fields_are_correct(client):
+    _seed_position(client)
+    # 1 contract, $0.3834 premium → $38.34 credit; $0.1572 mid → $15.72 cost.
+    _seed_trade(client, premium=0.3834, quantity=1)
+    with _patch_schwab(chain=_chain(15.0, 0.1572)):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    econ = resp.json()["economics"]
+    assert econ["credit_received"] == 38.34
+    assert econ["cost_to_close"] == 15.72
+    assert econ["est_pl_if_closed"] == 22.62
+    assert econ["pricing_source"] == "live"
+    assert econ["pricing_as_of"] is not None
+
+
+def test_btc_detail_captured_pct_agrees_with_profit_signal(client):
+    """captured_pct is lifted from the % CAPT signal — agree by construction."""
+    _seed_position(client)
+    _seed_trade(client, premium=0.3834)
+    with _patch_schwab(chain=_chain(15.0, 0.1572)):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    econ = resp.json()["economics"]
+    # (0.3834 - 0.1572) / 0.3834 ≈ 0.5900.
+    assert econ["captured_pct"] is not None
+    assert abs(econ["captured_pct"] - 0.5900) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# 200 — no-rule-triggered (quiet leg)
+# ---------------------------------------------------------------------------
+
+
+def test_btc_detail_no_rule_triggered_for_quiet_leg(client):
+    """A far-DTE OTM leg with low capture → verdict hold → no-rule-triggered."""
+    _seed_position(client)
+    # Far expiration, low capture → no rule fires.
+    _seed_trade(
+        client,
+        expiration="2027-06-26",
+        premium=1.00,
+    )
+    # Current mid still high → captured_pct low → profit rule does not fire.
+    chain = {
+        "callExpDateMap": {
+            "2027-06-26:400": {"15.0": [{"strikePrice": 15.0, "mark": 0.95}]}
+        }
+    }
+    with _patch_schwab(chain=chain):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["state"] == "no-rule-triggered"
+    assert payload["verdict"] == "hold"
+    # Audit still renders — every rule present, none triggered.
+    assert len(payload["triggered_rules"]) == 4
+    assert all(r["status"] != "triggered" for r in payload["triggered_rules"])
+    # Economics still meaningful for an open leg.
+    assert payload["economics"]["credit_received"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Pricing-unavailable degradation
+# ---------------------------------------------------------------------------
+
+
+def test_btc_detail_pricing_unavailable_when_no_mark(client):
+    """No option mark for the contract → pricing fields degrade to null."""
+    _seed_position(client)
+    _seed_trade(client)
+    # Empty option chain → no mark matches the leg.
+    with _patch_schwab(chain={}):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 200
+    econ = resp.json()["economics"]
+    assert econ["current_option_mid"] is None
+    assert econ["cost_to_close"] is None
+    assert econ["captured_pct"] is None
+    assert econ["est_pl_if_closed"] is None
+    assert econ["pricing_source"] == "unavailable"
+    # credit_received is static — still real.
+    assert econ["credit_received"] == 38.34
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown / closed / mismatched leg
+# ---------------------------------------------------------------------------
+
+
+def test_btc_detail_404_for_unknown_position(client):
+    with _patch_schwab():
+        resp = client.get("/api/positions/nope/legs/whatever/btc")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Leg not found"}
+
+
+def test_btc_detail_404_for_unknown_leg(client):
+    _seed_position(client)
+    _seed_trade(client)
+    with _patch_schwab(chain=_chain(15.0, 0.1572)):
+        resp = client.get("/api/positions/pos-ford/legs/no-such-leg/btc")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Leg not found"}
+
+
+def test_btc_detail_404_for_closed_leg(client):
+    _seed_position(client)
+    _seed_trade(client, closed_at="2026-05-01T00:00:00Z")
+    with _patch_schwab(chain=_chain(15.0, 0.1572)):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Leg not found"}
+
+
+def test_btc_detail_404_for_position_leg_mismatch(client):
+    """A leg id that belongs to a different position → 404, no cross-leak."""
+    _seed_position(client, pos_id="pos-ford", ticker="F")
+    _seed_position(client, pos_id="pos-aapl", ticker="AAPL")
+    _seed_trade(client, position_id="pos-ford", trade_id="leg-ford-15c")
+    with _patch_schwab(chain=_chain(15.0, 0.1572)):
+        # Ask for the Ford leg under the AAPL position URL.
+        resp = client.get("/api/positions/pos-aapl/legs/leg-ford-15c/btc")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Leg not found"}
+
+
+# ---------------------------------------------------------------------------
+# 500 hygiene — no str(e) leak (CLAUDE.md)
+# ---------------------------------------------------------------------------
+
+
+def test_btc_detail_500_uses_generic_detail_on_quote_failure(client):
+    _seed_position(client)
+    _seed_trade(client)
+    secret = "boom-internal-traceback-detail"
+
+    def _raise(self, ticker):
+        raise RuntimeError(secret)
+
+    with patch.object(
+        __import__(
+            "app.services.btc_detail", fromlist=["SchwabClient"]
+        ).SchwabClient,
+        "get_quote",
+        _raise,
+    ):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["detail"] == "Failed to load buy-to-close detail. Please try again."
+    # The raw exception text must never reach the client.
+    assert secret not in resp.text

--- a/backend/tests/test_btc_detail_service.py
+++ b/backend/tests/test_btc_detail_service.py
@@ -1,0 +1,137 @@
+"""Unit tests for the buy-to-close detail service (issue #244).
+
+Covers the only genuinely-new backend logic in ``btc_detail.py``:
+
+- ``_build_economics`` — per-share scaling, signed P/L, null propagation
+  when no live option mark is available.
+- ``_position_label`` / ``_moneyness_label`` helpers.
+
+The rule audit itself is reused from ``rule_monitor`` via ``derive_open_legs``
+and is covered by ``test_rule_monitor.py`` / ``test_dashboard_legs.py`` — it
+is not re-tested here. The full endpoint flow is covered by
+``test_btc_detail_endpoint.py``.
+"""
+
+from __future__ import annotations
+
+from app.services.btc_detail import (
+    _build_economics,
+    _moneyness_label,
+    _position_label,
+)
+
+
+class TestBuildEconomics:
+    def test_per_share_premium_scales_to_whole_position_credit(self):
+        # A 1-contract $0.3834 per-share premium → $38.34 credit (×1×100).
+        leg = {
+            "premium": 0.3834,
+            "quantity": 1,
+            "current_mid": 0.1572,
+            "profit_target_status": {"captured_pct": 0.59},
+        }
+        econ = _build_economics(leg)
+        assert econ["credit_received"] == 38.34
+        assert econ["cost_to_close"] == 15.72
+        assert econ["pricing_source"] == "live"
+
+    def test_credit_scales_by_contract_count(self):
+        leg = {
+            "premium": 2.25,
+            "quantity": 3,
+            "current_mid": 0.90,
+            "profit_target_status": {"captured_pct": 0.60},
+        }
+        econ = _build_economics(leg)
+        assert econ["credit_received"] == 675.0  # 2.25 × 3 × 100
+        assert econ["cost_to_close"] == 270.0  # 0.90 × 3 × 100
+
+    def test_est_pl_is_signed_credit_minus_cost(self):
+        leg = {
+            "premium": 2.25,
+            "quantity": 1,
+            "current_mid": 0.90,
+            "profit_target_status": {"captured_pct": 0.60},
+        }
+        econ = _build_economics(leg)
+        # 225 credit - 90 cost = +135 gain.
+        assert econ["est_pl_if_closed"] == 135.0
+
+    def test_est_pl_is_negative_when_cost_exceeds_credit(self):
+        leg = {
+            "premium": 1.00,
+            "quantity": 1,
+            "current_mid": 2.50,
+            "profit_target_status": {"captured_pct": -1.5},
+        }
+        econ = _build_economics(leg)
+        # 100 credit - 250 cost = -150 loss.
+        assert econ["est_pl_if_closed"] == -150.0
+
+    def test_captured_pct_is_lifted_not_recomputed(self):
+        # The economics block lifts captured_pct verbatim from the % CAPT
+        # signal so it agrees with the dashboard column by construction.
+        leg = {
+            "premium": 2.25,
+            "quantity": 1,
+            "current_mid": 0.90,
+            "profit_target_status": {"captured_pct": 0.6042},
+        }
+        econ = _build_economics(leg)
+        assert econ["captured_pct"] == 0.6042
+
+    def test_no_mid_propagates_null_pricing_fields(self):
+        # No live mark → cost/captured/est_pl/as_of all None, source unavailable.
+        leg = {
+            "premium": 2.25,
+            "quantity": 1,
+            "current_mid": None,
+            "profit_target_status": {"captured_pct": None, "state": "unknown"},
+        }
+        econ = _build_economics(leg)
+        assert econ["current_option_mid"] is None
+        assert econ["cost_to_close"] is None
+        assert econ["captured_pct"] is None
+        assert econ["est_pl_if_closed"] is None
+        assert econ["pricing_as_of"] is None
+        assert econ["pricing_source"] == "unavailable"
+        # credit_received is static — always real even with no live pricing.
+        assert econ["credit_received"] == 225.0
+
+    def test_pricing_as_of_is_set_when_mid_available(self):
+        leg = {
+            "premium": 2.25,
+            "quantity": 1,
+            "current_mid": 0.90,
+            "profit_target_status": {"captured_pct": 0.60},
+        }
+        econ = _build_economics(leg)
+        assert econ["pricing_as_of"] is not None
+        assert "T" in econ["pricing_as_of"]  # ISO timestamp
+
+
+class TestPositionLabel:
+    def test_covered_call_label(self):
+        assert _position_label({"ticker": "F", "strategy": "cc"}) == "F covered call"
+
+    def test_cash_secured_put_label(self):
+        assert (
+            _position_label({"ticker": "SOFI", "strategy": "csp"})
+            == "SOFI cash-secured put"
+        )
+
+    def test_wheel_label(self):
+        assert _position_label({"ticker": "F", "strategy": "wheel"}) == "F wheel"
+
+    def test_unknown_strategy_falls_back_to_position(self):
+        assert _position_label({"ticker": "F", "strategy": "mystery"}) == "F position"
+
+
+class TestMoneynessLabel:
+    def test_reports_state_when_present(self):
+        assert _moneyness_label({"moneyness": {"state": "ITM"}}) == "ITM"
+        assert _moneyness_label({"moneyness": {"state": "OTM"}}) == "OTM"
+
+    def test_unknown_when_no_moneyness(self):
+        assert _moneyness_label({"moneyness": None}) == "Unknown"
+        assert _moneyness_label({}) == "Unknown"

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -207,6 +207,42 @@ class TestDeriveOpenLegs:
         assert legs[0]["dte"] == 3
         assert legs[0]["moneyness"]["state"] == "ITM"
 
+    def test_exposes_raw_current_mid_passthrough(self):
+        # Issue #244 — the leg dict carries the raw matched option mid so the
+        # BTC detail endpoint can compute cost-to-close. `None` when no mark.
+        positions = [
+            self._position(
+                "AAPL",
+                "pos-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_put",
+                        "strike": 175.0,
+                        "expiration": "2026-05-08",
+                        "premium": 2.25,
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        marks = {("AAPL", "put", 175.0, "2026-05-08"): 0.90}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 174.50},
+            today=date(2026, 5, 5),
+            option_marks=marks,
+        )
+        assert legs[0]["current_mid"] == 0.90
+        assert legs[0]["quantity"] == 1
+        # No mark for this contract → current_mid is None.
+        no_mark = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 174.50},
+            today=date(2026, 5, 5),
+        )
+        assert no_mark[0]["current_mid"] is None
+
     def test_sorts_by_dte_then_ticker(self):
         positions = [
             self._position(

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -341,4 +341,14 @@ export async function getRecoveryPlan(id) {
   return data;
 }
 
+// --- Buy-to-close leg detail (V1.0.6, issue #244) ---
+
+export async function getBtcDetail(positionId, legId) {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}` +
+      `/legs/${encodeURIComponent(legId)}/btc`,
+  );
+  return data;
+}
+
 export default api;

--- a/frontend/app/positions/[id]/legs/[legId]/btc/page.jsx
+++ b/frontend/app/positions/[id]/legs/[legId]/btc/page.jsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { use } from 'react';
+import dynamic from 'next/dynamic';
+import LoadingSkeleton from '@/components/layout/LoadingSkeleton';
+
+// Route shell for /positions/[id]/legs/[legId]/btc — the dedicated per-leg
+// buy-to-close detail screen (issue #244). Reached from the rule-monitor
+// "Inspect rule →" card CTA. Structural twin of recovery/page.jsx.
+const BtcDetailPage = dynamic(
+  () => import('@/components/btc/BtcDetailPage'),
+  {
+    loading: () => (
+      <div className="h-screen flex items-center justify-center bg-slate-100 dark:bg-slate-900">
+        <LoadingSkeleton />
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+export default function PositionLegBtc({ params }) {
+  // Next 16: route params are delivered as a Promise; `use()` unwraps it.
+  const { id, legId } = use(params);
+  return <BtcDetailPage positionId={id} legId={legId} />;
+}

--- a/frontend/components/btc/BtcDetailPage.jsx
+++ b/frontend/components/btc/BtcDetailPage.jsx
@@ -1,0 +1,118 @@
+// Top-level page for /positions/[id]/legs/[legId]/btc.
+//
+// State machine (mirrors RecoveryPlanPage, with one extra leaf):
+//   - loading             → skeleton
+//   - error               → red retry banner
+//   - not-found           → EmptyState (HTTP 404 — unknown / closed leg)
+//   - no-rule-triggered   → BtcDetailView (verdict 'hold' — no Buy-to-close CTA)
+//   - populated           → BtcDetailView (a rule fired)
+//
+// Spec: frontend/design-specs/issue-244-btc-detail-screen.md §1, §7.
+
+import Link from 'next/link';
+import Header from '../layout/Header';
+import { useBtcDetail } from '../../hooks/useBtcDetail';
+import BtcDetailView from './BtcDetailView';
+
+function EmptyState({ testId, title, body }) {
+  return (
+    <div
+      data-testid={testId}
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 text-center"
+    >
+      <h2 className="text-base font-semibold text-slate-900 dark:text-white">
+        {title}
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-2 max-w-prose mx-auto">
+        {body}
+      </p>
+      <Link
+        href="/dashboard"
+        className="inline-block mt-4 text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+      >
+        ← Back to dashboard
+      </Link>
+    </div>
+  );
+}
+
+export default function BtcDetailPage({ positionId, legId }) {
+  const { data, loading, error, refetch } = useBtcDetail(positionId, legId);
+
+  const state = data?.state || null;
+  const isNoRule = state === 'no-rule-triggered';
+  // The page root testid distinguishes the no-rule variant from populated.
+  const pageTestId = isNoRule ? 'btc-detail-no-rule' : 'btc-detail-page';
+
+  return (
+    <div className="h-screen flex flex-col bg-slate-100 dark:bg-slate-900">
+      <Header sessions={[]} onLoadSession={() => {}} />
+      <main
+        data-testid={
+          !error && data && (state === 'populated' || isNoRule)
+            ? pageTestId
+            : undefined
+        }
+        className="flex-1 overflow-y-auto p-6 space-y-4"
+      >
+        <Link
+          href="/dashboard"
+          className="inline-block text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+          data-testid="btc-detail-back-to-dashboard"
+        >
+          ← Back to dashboard
+        </Link>
+
+        {loading && !data && (
+          <div data-testid="btc-detail-loading" className="space-y-4">
+            <div className="space-y-2">
+              <div className="h-6 w-72 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+              <div className="h-3 w-96 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+            </div>
+            <div className="h-24 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              {[0, 1, 2, 3].map((i) => (
+                <div
+                  key={i}
+                  className="h-24 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse"
+                />
+              ))}
+            </div>
+            <div className="h-40 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+          </div>
+        )}
+
+        {error && (
+          <div
+            data-testid="btc-detail-error"
+            className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 text-sm text-red-700 dark:text-red-300 flex items-center justify-between gap-4"
+          >
+            <span>
+              Couldn&apos;t load the buy-to-close detail for this leg. Check
+              your connection and try again.
+            </span>
+            <button
+              type="button"
+              onClick={refetch}
+              className="px-3 py-1.5 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 shrink-0"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!error && data && state === 'not-found' && (
+          <EmptyState
+            testId="btc-detail-not-found"
+            title="Leg not found"
+            body="This option leg doesn't exist, or it has been closed. Buy-to-close review is only available for open option legs."
+          />
+        )}
+
+        {!error && data && (state === 'populated' || isNoRule) && (
+          <BtcDetailView data={data} />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/btc/BtcDetailView.jsx
+++ b/frontend/components/btc/BtcDetailView.jsx
@@ -1,0 +1,435 @@
+// Composition surface for the populated / no-rule-triggered BTC detail state.
+//
+// Renders: leg header → recommended-action block ("banner") → buy-to-close
+// economics panel → rule-audit panel → persistent disclaimer footer.
+//
+// The screen is the per-leg analog of the recovery screen. All four
+// sub-components are kept local here, mirroring how RecoveryPlanPage keeps
+// PositionHeader / EmptyState local.
+//
+// Spec: frontend/design-specs/issue-244-btc-detail-screen.md §5–§9.
+
+import Link from 'next/link';
+
+// --- Verdict color tokens (spec §9 — no new tokens) ------------------------
+
+const VERDICT_TONE = {
+  hold: {
+    pill: 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600',
+    block: 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800',
+    accent: 'text-slate-700 dark:text-slate-200',
+    dot: 'text-slate-500 dark:text-slate-400',
+  },
+  profit_take_review: {
+    pill: 'bg-emerald-50 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 border-emerald-300 dark:border-emerald-700',
+    block: 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/20',
+    accent: 'text-emerald-800 dark:text-emerald-200',
+    dot: 'text-emerald-700 dark:text-emerald-300',
+  },
+  dte_review: {
+    pill: 'bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 border-amber-300 dark:border-amber-700',
+    block: 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20',
+    accent: 'text-amber-800 dark:text-amber-200',
+    dot: 'text-amber-700 dark:text-amber-300',
+  },
+  expiration: {
+    pill: 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-300 dark:border-red-700',
+    block: 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20',
+    accent: 'text-red-800 dark:text-red-200',
+    dot: 'text-red-700 dark:text-red-300',
+  },
+  assignment: {
+    pill: 'bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-300 border-red-300 dark:border-red-700',
+    block: 'border-red-300 dark:border-red-700 bg-red-50 dark:bg-red-900/20',
+    accent: 'text-red-800 dark:text-red-200',
+    dot: 'text-red-700 dark:text-red-300',
+  },
+};
+
+// The pill phrase per verdict — names the governing rule, attributed to the
+// user's ruleset (spec §5.1 / §7.5). `⛔` glyph only on the assignment verdict.
+const VERDICT_PILL_TEXT = {
+  hold: 'No management rule has triggered for this leg yet',
+  profit_take_review: 'Your profit-take rule triggered',
+  dte_review: 'Your DTE review window reached',
+  expiration: 'Your expiration warning triggered',
+  assignment: 'Your expiration warning triggered — this leg is in the money',
+};
+
+// Closing verdicts surface the `Buy to close` CTA; dte_review and hold do not.
+const CLOSING_VERDICTS = new Set(['profit_take_review', 'expiration', 'assignment']);
+
+function tone(verdict) {
+  return VERDICT_TONE[verdict] || VERDICT_TONE.hold;
+}
+
+function formatDollar(value) {
+  if (value === null || value === undefined) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  return `${sign}$${abs.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatSignedDollar(value) {
+  if (value === null || value === undefined) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '+';
+  return `${sign}$${abs.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatPct(value) {
+  if (value === null || value === undefined) return '—';
+  return `${Math.round(value * 100)}%`;
+}
+
+// --- LegHeader -------------------------------------------------------------
+
+function LegHeader({ leg, verdict }) {
+  const t = tone(verdict);
+  const pillText = VERDICT_PILL_TEXT[verdict] || VERDICT_PILL_TEXT.hold;
+  return (
+    <div data-testid="btc-detail-leg-header">
+      <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
+        Buy-to-close review: {leg.ticker} ${leg.strike} {leg.option_type}
+      </h1>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+        <Link
+          href={`/journal?position=${encodeURIComponent(leg.position_id)}`}
+          className="text-blue-700 dark:text-blue-300 hover:underline"
+        >
+          {leg.position_label}
+        </Link>
+        {' · '}
+        {leg.contracts} contract{leg.contracts === 1 ? '' : 's'} · exp{' '}
+        {leg.expiration} · {leg.dte} DTE
+      </p>
+      <span
+        data-testid="btc-detail-rule-pill"
+        data-verdict={verdict}
+        className={`inline-flex items-center gap-1 mt-2 px-2 py-0.5 rounded-full text-xs font-medium border ${t.pill}`}
+      >
+        {verdict === 'assignment' && (
+          <span aria-hidden="true">⛔</span>
+        )}
+        {pillText}
+      </span>
+    </div>
+  );
+}
+
+// --- RecommendedActionBlock ------------------------------------------------
+
+function RecommendedActionBlock({ data }) {
+  const { verdict, leg, economics, triggered_rules: rules = [] } = data;
+  const t = tone(verdict);
+  const isHold = verdict === 'hold';
+  const showCloseCta = CLOSING_VERDICTS.has(verdict);
+
+  // First sentence: the governing rule's server-authored reasoning. Never
+  // re-author it — it is already advice-framed. Then append the BTC outcome.
+  const governing = rules.find((r) => r.is_governing) || null;
+  let reasoning;
+  if (isHold) {
+    reasoning =
+      'No management rule has triggered for this leg yet. Buying to close ' +
+      'is still available as a manual action, but none of your Management ' +
+      'Triggers are calling for it right now.';
+  } else {
+    const head =
+      governing?.reasoning ||
+      'Your management rule triggered for this leg.';
+    let tail;
+    if (economics.pricing_source !== 'live') {
+      tail =
+        " Live option pricing isn't connected, so cost-to-close and P/L " +
+        "can't be shown right now.";
+    } else if (
+      verdict === 'profit_take_review' &&
+      economics.est_pl_if_closed !== null &&
+      economics.est_pl_if_closed !== undefined
+    ) {
+      tail = ` Buying to close now banks an estimated ${formatSignedDollar(
+        economics.est_pl_if_closed,
+      )} gain on this leg.`;
+    } else if (
+      economics.cost_to_close !== null &&
+      economics.cost_to_close !== undefined
+    ) {
+      tail = ` Closing now costs ${formatDollar(
+        economics.cost_to_close,
+      )} against the ${formatDollar(
+        economics.credit_received,
+      )} credit you received.`;
+    } else {
+      tail = '';
+    }
+    reasoning = `${head}${tail}`;
+  }
+
+  return (
+    <div
+      data-testid="btc-detail-recommended-action"
+      data-verdict={verdict}
+      className={`rounded-xl border p-4 ${t.block}`}
+    >
+      <p
+        data-testid="btc-detail-recommended-reasoning"
+        className="text-sm text-slate-700 dark:text-slate-200"
+      >
+        {reasoning}
+      </p>
+      <div className="mt-3 flex items-center gap-4">
+        {showCloseCta && (
+          <Link
+            href={
+              `/journal?position=${encodeURIComponent(leg.position_id)}` +
+              `&leg=${encodeURIComponent(leg.id)}&action=close-leg`
+            }
+            data-testid="btc-detail-cta-close"
+            className="inline-flex items-center px-4 py-2 rounded-lg bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+          >
+            Buy to close
+          </Link>
+        )}
+        <Link
+          href={`/journal?position=${encodeURIComponent(leg.position_id)}`}
+          data-testid="btc-detail-cta-journal"
+          className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+        >
+          Open in Journal
+          <span aria-hidden="true"> →</span>
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// --- BtcEconomicsPanel -----------------------------------------------------
+
+function EconomicsTile({ testId, label, value, valueClass }) {
+  return (
+    <div data-testid={testId}>
+      <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+      <div
+        className={`text-2xl font-semibold tabular-nums mt-1 ${
+          valueClass || 'text-slate-900 dark:text-white'
+        }`}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function BtcEconomicsPanel({ economics, verdict }) {
+  const pricingLive = economics.pricing_source === 'live';
+  const captured = economics.captured_pct;
+  // The % captured tile reads emerald when the leg cleared the user's
+  // profit-take threshold (verdict tells us, no threshold parsing needed).
+  const pctClass =
+    verdict === 'profit_take_review' && captured !== null && captured !== undefined
+      ? 'text-emerald-700 dark:text-emerald-300'
+      : pricingLive
+        ? 'text-slate-900 dark:text-white'
+        : 'text-slate-400 dark:text-slate-500';
+  const estPl = economics.est_pl_if_closed;
+  let estPlClass = 'text-slate-400 dark:text-slate-500';
+  if (estPl !== null && estPl !== undefined) {
+    estPlClass =
+      estPl < 0
+        ? 'text-red-700 dark:text-red-300'
+        : 'text-emerald-700 dark:text-emerald-300';
+  }
+  const stubClass = pricingLive
+    ? 'text-slate-900 dark:text-white'
+    : 'text-slate-400 dark:text-slate-500';
+
+  let caption;
+  if (pricingLive) {
+    const asOf = economics.pricing_as_of
+      ? new Date(economics.pricing_as_of).toLocaleString()
+      : 'now';
+    caption = `Option mid as of ${asOf} · est. P/L excludes commissions.`;
+  } else {
+    caption =
+      "Live option pricing isn't connected — cost-to-close and P/L can't " +
+      'be shown. The rule audit below still applies.';
+  }
+
+  return (
+    <div
+      data-testid="btc-detail-economics"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+    >
+      <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
+        <h3 className="text-base font-semibold text-slate-900 dark:text-white">
+          Buy-to-close economics
+        </h3>
+        {!pricingLive && (
+          <span
+            data-testid="btc-detail-economics-stub-badge"
+            className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400"
+          >
+            Pricing unavailable
+          </span>
+        )}
+      </div>
+      <div className="p-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <EconomicsTile
+            testId="btc-detail-economics-tile-cost-to-close"
+            label="Cost to close"
+            value={formatDollar(economics.cost_to_close)}
+            valueClass={stubClass}
+          />
+          <EconomicsTile
+            testId="btc-detail-economics-tile-credit"
+            label="Credit received"
+            value={formatDollar(economics.credit_received)}
+          />
+          <EconomicsTile
+            testId="btc-detail-economics-tile-pct-captured"
+            label="% premium captured"
+            value={formatPct(economics.captured_pct)}
+            valueClass={pctClass}
+          />
+          <EconomicsTile
+            testId="btc-detail-economics-tile-est-pl"
+            label="Est. P/L if closed"
+            value={formatSignedDollar(economics.est_pl_if_closed)}
+            valueClass={estPlClass}
+          />
+        </div>
+        <p
+          data-testid="btc-detail-economics-caption"
+          className="text-xs text-slate-500 dark:text-slate-400 mt-3"
+        >
+          {caption}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// --- RuleAuditPanel --------------------------------------------------------
+
+const STATUS_DISPLAY = {
+  triggered: { dot: '●', label: 'Yes' },
+  not_yet: { dot: '○', label: 'Not yet' },
+  no: { dot: '○', label: 'No' },
+};
+
+function RuleAuditPanel({ rules, verdict }) {
+  const t = tone(verdict);
+  const governing = rules.find((r) => r.is_governing) || null;
+  const reasoning =
+    governing?.reasoning || 'No management rule has triggered for this leg yet.';
+
+  return (
+    <div
+      data-testid="btc-detail-rule-audit"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+    >
+      <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+        <h3 className="text-base font-semibold text-slate-900 dark:text-white">
+          Rule audit — checked against your Management Triggers
+        </h3>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">
+          Every management rule you&apos;ve configured, evaluated for this leg.
+        </p>
+      </div>
+      <div className="p-4">
+        <table
+          data-testid="btc-detail-rule-audit-table"
+          className="w-full text-sm"
+        >
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+              <th className="text-left font-medium pb-2">Metric</th>
+              <th className="text-left font-medium pb-2">Value</th>
+              <th className="text-left font-medium pb-2">Your rule</th>
+              <th className="text-left font-medium pb-2">Triggered?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rules.map((rule) => {
+              const display = STATUS_DISPLAY[rule.status] || STATUS_DISPLAY.no;
+              const fired = rule.status === 'triggered';
+              const rowClass = fired
+                ? 'text-slate-700 dark:text-slate-200 border-b border-slate-100 dark:border-slate-700/50 last:border-b-0'
+                : 'text-slate-400 dark:text-slate-500 border-b border-slate-100 dark:border-slate-700/50 last:border-b-0';
+              // The governing fired row takes the verdict color; a
+              // lower-precedence fired row is neutral slate.
+              let statusClass = '';
+              if (fired && rule.is_governing) {
+                statusClass = `font-medium ${t.dot}`;
+              } else if (fired) {
+                statusClass = 'text-slate-500 dark:text-slate-400';
+              }
+              return (
+                <tr
+                  key={rule.rule_id}
+                  data-testid={`btc-detail-rule-audit-row-${rule.rule_id}`}
+                  className={rowClass}
+                >
+                  <td className={`py-2 ${fired && rule.is_governing ? 'font-medium' : ''}`}>
+                    {rule.metric_label}
+                  </td>
+                  <td className="py-2 tabular-nums">{rule.value_display}</td>
+                  <td className="py-2">{rule.rule_display}</td>
+                  <td
+                    data-testid={`btc-detail-rule-audit-status-${rule.rule_id}`}
+                    className={`py-2 ${statusClass}`}
+                  >
+                    <span aria-hidden="true">{display.dot}</span> {display.label}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+        <p
+          data-testid="btc-detail-rule-audit-reasoning"
+          className="text-sm text-slate-600 dark:text-slate-300 mt-3"
+        >
+          {reasoning}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// --- BtcDetailView ---------------------------------------------------------
+
+export default function BtcDetailView({ data }) {
+  if (!data || !data.leg) return null;
+  const { leg, verdict, economics, triggered_rules: rules = [], disclaimer } =
+    data;
+
+  return (
+    <div className="space-y-4">
+      <LegHeader leg={leg} verdict={verdict} />
+      <RecommendedActionBlock data={data} />
+      <BtcEconomicsPanel economics={economics} verdict={verdict} />
+      <RuleAuditPanel rules={rules} verdict={verdict} />
+
+      <footer
+        data-testid="btc-detail-disclaimer"
+        className="mt-4 p-4 rounded-lg bg-slate-100 dark:bg-slate-800/40 border border-slate-200 dark:border-slate-700"
+        aria-label="Buy-to-close disclaimer"
+      >
+        <p className="text-xs text-slate-500 dark:text-slate-400 max-w-prose mx-auto text-center">
+          {disclaimer}
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/DashboardPage.jsx
+++ b/frontend/components/dashboard/DashboardPage.jsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Header from '../layout/Header';
 import { useDashboard } from '../../hooks/useDashboard';
 import StatusStrip from './StatusStrip';
@@ -29,30 +28,8 @@ function isAllEmpty(data) {
   return !schwab && !fred && positions === 0;
 }
 
-// Parse the `#leg-{id}` deep-link hash (set by a rule-monitor card CTA — spec
-// §4.4 Q7) into the bare leg id, or null. The dashboard route is rendered
-// `ssr: false`, so reading `window` on mount is safe.
-function parseLegHash() {
-  if (typeof window === 'undefined') return null;
-  const hash = window.location.hash || '';
-  const match = hash.match(/^#leg-(.+)$/);
-  if (!match) return null;
-  // A malformed escape sequence (e.g. `#leg-%FF`) makes decodeURIComponent
-  // throw. This runs in a lazy useState initializer, so an unguarded throw
-  // would crash the dashboard at render — fall back to null instead.
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return null;
-  }
-}
-
 export default function DashboardPage() {
   const { data, loading, error, refetch } = useDashboard();
-  // Captured once at first render — the `#leg-{id}` target seeds the
-  // OpenLegsCard expanded set and scroll. The dashboard route is rendered
-  // `ssr: false`, so reading `window` in the lazy initializer is safe.
-  const [hashLegId] = useState(parseLegHash);
 
   return (
     <div data-testid="dashboard-page" className="h-screen flex flex-col bg-slate-100 dark:bg-slate-900">
@@ -115,7 +92,6 @@ export default function DashboardPage() {
                     <OpenLegsCard
                       legs={data?.open_legs}
                       loading={loading}
-                      initialExpandedLegId={hashLegId}
                     />
                   </div>
                 </div>

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import Card from '../common/Card';
 import EmptyState from '../common/EmptyState';
@@ -21,8 +21,11 @@ import { formatPercent } from '../../utils/formatters';
  *     journal navigation relocated into the panel's "Open in Journal" CTA.
  *   - A leading chevron cell shows the expand state; Ticker shrank 2→1 cols
  *     to make room (spec §5.1 Q8).
- *   - The card seeds its expanded set from `initialExpandedLegId` (the
- *     `#leg-{id}` deep-link from a card CTA — spec §4.4 Q7).
+ *
+ * V1.0.6 (issue #244): the dead `#leg-{id}` hash deep-link was removed. The
+ * rule-monitor card "Inspect rule →" CTA now navigates to the dedicated
+ * per-leg buy-to-close detail screen. The inline expandable inspect row
+ * (toggled by clicking the leg row) is unchanged.
  *
  * V0.5 columns (issue #150) — %CAPTURED, RISK, earnings ⚠ glyph — unchanged.
  *
@@ -272,11 +275,10 @@ function InspectPanel({ leg }) {
   );
 }
 
-function LegRow({ leg, isExpanded, onToggle, rowRef }) {
+function LegRow({ leg, isExpanded, onToggle }) {
   return (
     <button
       type="button"
-      ref={rowRef}
       onClick={() => onToggle(leg.id)}
       aria-expanded={isExpanded}
       aria-controls={`dashboard-leg-inspect-${leg.id}`}
@@ -363,29 +365,9 @@ function HeaderRow() {
   );
 }
 
-export default function OpenLegsCard({ legs, loading, initialExpandedLegId }) {
-  // A Set of expanded leg ids — multi-open (spec §3.2 Q2). Seeded with the
-  // `#leg-{id}` deep-link target, if any, on mount (spec §4.4 Q7).
-  const [expanded, setExpanded] = useState(() => {
-    const seed = new Set();
-    if (initialExpandedLegId) seed.add(initialExpandedLegId);
-    return seed;
-  });
-  const [deepLinkRow, setDeepLinkRow] = useState(null);
-
-  // Scroll the deep-linked row into view once it mounts, honoring
-  // prefers-reduced-motion (mirrors issue-182 §12.3).
-  useEffect(() => {
-    if (!initialExpandedLegId || !deepLinkRow) return;
-    const motionOK =
-      typeof window !== 'undefined' &&
-      window.matchMedia &&
-      !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    deepLinkRow.scrollIntoView({
-      behavior: motionOK ? 'smooth' : 'auto',
-      block: 'center',
-    });
-  }, [initialExpandedLegId, deepLinkRow]);
+export default function OpenLegsCard({ legs, loading }) {
+  // A Set of expanded leg ids — multi-open (spec §3.2 Q2).
+  const [expanded, setExpanded] = useState(() => new Set());
 
   function toggle(legId) {
     setExpanded((prev) => {
@@ -440,9 +422,6 @@ export default function OpenLegsCard({ legs, loading, initialExpandedLegId }) {
                       leg={leg}
                       isExpanded={isExpanded}
                       onToggle={toggle}
-                      rowRef={
-                        leg.id === initialExpandedLegId ? setDeepLinkRow : null
-                      }
                     />
                   </div>
                   {isExpanded && <InspectPanel leg={leg} />}

--- a/frontend/components/journal/JournalPage.jsx
+++ b/frontend/components/journal/JournalPage.jsx
@@ -16,7 +16,14 @@ export default function JournalPage() {
   const [deleteBusy, setDeleteBusy] = useState(false);
   const searchParams = useSearchParams();
   const positionParam = searchParams?.get('position') ?? null;
+  const legParam = searchParams?.get('leg') ?? null;
+  const actionParam = searchParams?.get('action') ?? null;
   const consumedDeepLinkRef = useRef(false);
+  // Buy-to-close pre-fill (issue #244): once-per-mount, an `action=close-leg`
+  // deep-link with a `leg` param seeds the trade form with an inverse-close
+  // trade. Held in state so the prefill object is stable across re-renders.
+  const [closeLegPrefill, setCloseLegPrefill] = useState(null);
+  const consumedPrefillRef = useRef(false);
 
   // Pull stable refs out of the journal hook for the deep-link effect's
   // dependency list — keeps `react-hooks/exhaustive-deps` honest without
@@ -38,6 +45,36 @@ export default function JournalPage() {
     consumedDeepLinkRef.current = true;
     selectPosition(positionParam);
   }, [positionParam, journalLoading, selectPosition]);
+
+  // Buy-to-close pre-fill consumer (issue #244): when arriving via the BTC
+  // detail screen's "Buy to close" CTA — /journal?position=…&leg=…&action=
+  // close-leg — find the open opening leg in the selected position and build
+  // an inverse-close pre-fill object for the trade form. Consumed once per
+  // mount. Degrades gracefully: a missing / closed / unknown `leg` simply
+  // produces no pre-fill — the journal opens normally on the position.
+  const selectedPosition = journal.selectedPosition;
+  useEffect(() => {
+    if (actionParam !== 'close-leg' || !legParam) return;
+    if (consumedPrefillRef.current) return;
+    if (!selectedPosition || selectedPosition.id !== positionParam) return;
+    consumedPrefillRef.current = true;
+    const leg = (selectedPosition.trades || []).find(
+      (t) => t.id === legParam,
+    );
+    if (!leg) return;
+    const isOpeningLeg =
+      (leg.trade_type === 'sell_put' || leg.trade_type === 'sell_call') &&
+      !leg.closed_at;
+    if (!isOpeningLeg) return;
+    setCloseLegPrefill({
+      // Inverse-close trade type — buying back the short leg.
+      trade_type:
+        leg.trade_type === 'sell_put' ? 'buy_put_close' : 'buy_call_close',
+      strike: leg.strike != null ? String(leg.strike) : '',
+      expiration: leg.expiration ? String(leg.expiration).slice(0, 10) : '',
+      quantity: leg.quantity != null ? String(leg.quantity) : '1',
+    });
+  }, [actionParam, legParam, positionParam, selectedPosition]);
 
   const handleCreatePosition = async (data) => {
     try {
@@ -106,6 +143,7 @@ export default function JournalPage() {
             position={journal.selectedPosition}
             onAddTrade={journal.addTrade}
             onDeleteTrade={journal.removeTrade}
+            closeLegPrefill={closeLegPrefill}
           />
         )}
 

--- a/frontend/components/journal/TradeEntryForm.jsx
+++ b/frontend/components/journal/TradeEntryForm.jsx
@@ -19,7 +19,16 @@ const CLOSE_REASONS = [
   { value: 'called_away', label: 'Called Away' },
 ];
 
-export default function TradeEntryForm({ positionId, onSubmit, onCancel }) {
+export default function TradeEntryForm({
+  positionId,
+  initialValues,
+  onSubmit,
+  onCancel,
+}) {
+  // `initialValues` (issue #244) lets a caller pre-fill the form — e.g. the
+  // buy-to-close deep-link from the BTC detail screen seeds the inverse-close
+  // trade type, strike, expiration, and quantity. Defaults below win for any
+  // field `initialValues` does not provide.
   const [form, setForm] = useState({
     trade_type: 'sell_put',
     strike: '',
@@ -28,6 +37,7 @@ export default function TradeEntryForm({ positionId, onSubmit, onCancel }) {
     fees: '0',
     quantity: '1',
     close_reason: '',
+    ...initialValues,
   });
 
   const handleChange = (e) => {
@@ -58,17 +68,17 @@ export default function TradeEntryForm({ positionId, onSubmit, onCancel }) {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         <div>
           <label className={labelClass}>Type</label>
-          <select name="trade_type" value={form.trade_type} onChange={handleChange} className={inputClass}>
+          <select data-testid="trade-entry-type" name="trade_type" value={form.trade_type} onChange={handleChange} className={inputClass}>
             {TRADE_TYPES.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
           </select>
         </div>
         <div>
           <label className={labelClass}>Strike</label>
-          <input name="strike" type="number" step="0.01" value={form.strike} onChange={handleChange} required placeholder="145.00" className={inputClass} />
+          <input data-testid="trade-entry-strike" name="strike" type="number" step="0.01" value={form.strike} onChange={handleChange} required placeholder="145.00" className={inputClass} />
         </div>
         <div>
           <label className={labelClass}>Expiration</label>
-          <input name="expiration" type="date" value={form.expiration} onChange={handleChange} required className={inputClass} />
+          <input data-testid="trade-entry-expiration" name="expiration" type="date" value={form.expiration} onChange={handleChange} required className={inputClass} />
         </div>
         <div>
           <label className={labelClass}>Premium</label>

--- a/frontend/components/journal/TradeHistory.jsx
+++ b/frontend/components/journal/TradeHistory.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import TradeEntryForm from './TradeEntryForm';
 import ConfirmDialog from '../common/ConfirmDialog';
 
@@ -27,10 +27,26 @@ function formatCurrency(value) {
   return `$${Number(value).toFixed(2)}`;
 }
 
-export default function TradeHistory({ position, onAddTrade, onDeleteTrade }) {
+export default function TradeHistory({
+  position,
+  onAddTrade,
+  onDeleteTrade,
+  closeLegPrefill,
+}) {
   const [showForm, setShowForm] = useState(false);
   const [pendingDeleteTradeId, setPendingDeleteTradeId] = useState(null);
   const [deleteBusy, setDeleteBusy] = useState(false);
+  // `closeLegPrefill` (issue #244) — when the journal page resolves a
+  // buy-to-close deep-link, it passes a pre-fill object. Auto-open the trade
+  // form seeded with it, once, when it first becomes available.
+  const appliedPrefillRef = useRef(false);
+
+  useEffect(() => {
+    if (closeLegPrefill && !appliedPrefillRef.current) {
+      appliedPrefillRef.current = true;
+      setShowForm(true);
+    }
+  }, [closeLegPrefill]);
 
   const handleAddTrade = async (data) => {
     try {
@@ -79,7 +95,12 @@ export default function TradeHistory({ position, onAddTrade, onDeleteTrade }) {
 
       {showForm && (
         <div className="p-4 border-b border-slate-200 dark:border-slate-700">
-          <TradeEntryForm positionId={position.id} onSubmit={handleAddTrade} onCancel={() => setShowForm(false)} />
+          <TradeEntryForm
+            positionId={position.id}
+            initialValues={closeLegPrefill || undefined}
+            onSubmit={handleAddTrade}
+            onCancel={() => setShowForm(false)}
+          />
         </div>
       )}
 

--- a/frontend/components/journal/TradeHistory.jsx
+++ b/frontend/components/journal/TradeHistory.jsx
@@ -40,18 +40,37 @@ export default function TradeHistory({
   // buy-to-close deep-link, it passes a pre-fill object. Auto-open the trade
   // form seeded with it, once, when it first becomes available.
   const appliedPrefillRef = useRef(false);
+  // Tracks whether the currently-visible form is the auto-opened, prefilled
+  // instance. The prefill seeds *only* that first form — a later manual
+  // "Add Trade" must open a blank form, not reuse the stale buy-to-close leg.
+  const [formIsPrefilled, setFormIsPrefilled] = useState(false);
 
   useEffect(() => {
     if (closeLegPrefill && !appliedPrefillRef.current) {
       appliedPrefillRef.current = true;
+      setFormIsPrefilled(true);
       setShowForm(true);
     }
   }, [closeLegPrefill]);
 
+  const toggleForm = () => {
+    setShowForm((prev) => {
+      const next = !prev;
+      // Any manual open/close drops the prefill — it belongs to the auto-open.
+      if (formIsPrefilled) setFormIsPrefilled(false);
+      return next;
+    });
+  };
+
+  const closeForm = () => {
+    setShowForm(false);
+    if (formIsPrefilled) setFormIsPrefilled(false);
+  };
+
   const handleAddTrade = async (data) => {
     try {
       await onAddTrade(data);
-      setShowForm(false);
+      closeForm();
     } catch {
       // Form stays open for retry; error toast handled by parent
     }
@@ -86,7 +105,7 @@ export default function TradeHistory({
         </div>
         <button
           data-testid="add-trade-btn"
-          onClick={() => setShowForm(!showForm)}
+          onClick={toggleForm}
           className="px-3 py-1.5 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700"
         >
           {showForm ? 'Cancel' : 'Add Trade'}
@@ -97,9 +116,9 @@ export default function TradeHistory({
         <div className="p-4 border-b border-slate-200 dark:border-slate-700">
           <TradeEntryForm
             positionId={position.id}
-            initialValues={closeLegPrefill || undefined}
+            initialValues={formIsPrefilled ? closeLegPrefill : undefined}
             onSubmit={handleAddTrade}
-            onCancel={() => setShowForm(false)}
+            onCancel={closeForm}
           />
         </div>
       )}

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -1,0 +1,510 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #244 — dedicated buy-to-close (BTC) leg detail screen.
+ *
+ * Covers the issue's AC:
+ *   - The new route /positions/[id]/legs/[legId]/btc renders for a valid leg
+ *     and shows the rule audit + BTC economics + recommended action.
+ *   - A 404 renders the leg-not-found EmptyState (distinct from a network
+ *     error state).
+ *   - The screen is reachable via the "Inspect rule →" card CTA from both the
+ *     profit-take and the DTE-review action cards on the dashboard.
+ *   - States: loading skeleton, error + retry, no-rule-triggered, and the
+ *     pricing-unavailable degraded variant.
+ *   - Journal pre-fill: clicking "Buy to close" lands on the journal with
+ *     ?action=close-leg and pre-fills the inverse-close trade form. Degrades
+ *     gracefully when the leg param does not resolve.
+ *
+ * Every test mocks the BTC endpoint (and, for the CTA tests, the dashboard
+ * endpoint) at the route level — no live backend or Schwab quote required.
+ */
+
+const POSITION_ID = 'pos-ford';
+const LEG_ID = 'leg-ford-15c';
+const BTC_ROUTE = `/positions/${POSITION_ID}/legs/${LEG_ID}/btc`;
+
+const DISCLAIMER =
+  'This buy-to-close review reports what your own Management Triggers said about this leg.';
+
+// --- Fixture builders -------------------------------------------------------
+
+function triggeredRules(verdict) {
+  const govern = (id) => verdict === id;
+  return [
+    {
+      rule_id: 'assignment_risk',
+      metric_label: 'Assignment risk',
+      value_display: verdict === 'assignment' ? 'High' : 'Low',
+      rule_display: 'Review at ≥ High',
+      status: verdict === 'assignment' ? 'triggered' : 'no',
+      is_governing: govern('assignment'),
+      reasoning: govern('assignment')
+        ? 'Your expiration rule triggered and this leg is ITM.'
+        : null,
+    },
+    {
+      rule_id: 'expiration_warning',
+      metric_label: 'Days to expiration',
+      value_display: '38 d',
+      rule_display: 'Warn at ≤ 7 d',
+      status: verdict === 'expiration' ? 'triggered' : 'not_yet',
+      is_governing: govern('expiration'),
+      reasoning: govern('expiration')
+        ? 'Your expiration rule triggered — 4 days to expiration.'
+        : null,
+    },
+    {
+      rule_id: 'profit_review',
+      metric_label: 'Premium captured',
+      value_display: '59%',
+      rule_display: 'Review at ≥ 50%',
+      status: verdict === 'profit_take_review' ? 'triggered' : 'not_yet',
+      is_governing: govern('profit_take_review'),
+      reasoning: govern('profit_take_review')
+        ? 'Your 50% profit-take rule triggered. This leg has captured 59% of its max premium — past the 50% review threshold you set.'
+        : null,
+    },
+    {
+      rule_id: 'dte_review',
+      metric_label: 'Days to expiration',
+      value_display: '38 d',
+      rule_display: 'Review at ≤ 21 d',
+      status: verdict === 'dte_review' ? 'triggered' : 'not_yet',
+      is_governing: govern('dte_review'),
+      reasoning: govern('dte_review')
+        ? 'This leg is inside your 21-day review window. Your rule says: decide — hold, roll, or close.'
+        : null,
+    },
+  ];
+}
+
+function populatedPayload(overrides = {}) {
+  const verdict = overrides.verdict || 'profit_take_review';
+  return {
+    state: 'populated',
+    leg: {
+      id: LEG_ID,
+      position_id: POSITION_ID,
+      ticker: 'F',
+      strike: 15.0,
+      option_type: 'C',
+      contracts: 1,
+      expiration: '2026-06-26',
+      dte: 38,
+      moneyness: 'OTM',
+      position_label: 'F covered call',
+      ...overrides.leg,
+    },
+    verdict,
+    economics: {
+      credit_received: 38.34,
+      current_option_mid: 15.72,
+      cost_to_close: 15.72,
+      captured_pct: 0.59,
+      est_pl_if_closed: 22.62,
+      pricing_as_of: '2026-05-19T14:32:00+00:00',
+      pricing_source: 'live',
+      ...overrides.economics,
+    },
+    triggered_rules: overrides.triggered_rules || triggeredRules(verdict),
+    disclaimer: DISCLAIMER,
+  };
+}
+
+function noRulePayload() {
+  const payload = populatedPayload({ verdict: 'hold' });
+  payload.state = 'no-rule-triggered';
+  return payload;
+}
+
+function pricingUnavailablePayload() {
+  return populatedPayload({
+    verdict: 'dte_review',
+    economics: {
+      credit_received: 61.0,
+      current_option_mid: null,
+      cost_to_close: null,
+      captured_pct: null,
+      est_pl_if_closed: null,
+      pricing_as_of: null,
+      pricing_source: 'unavailable',
+    },
+  });
+}
+
+// --- Route mocks ------------------------------------------------------------
+
+function mockBtcDetail(page, payload, status = 200, legId = LEG_ID) {
+  return page.route(
+    `**/api/positions/${POSITION_ID}/legs/${legId}/btc`,
+    (route) =>
+      route.fulfill({
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(payload),
+      }),
+  );
+}
+
+async function openBtcDetail(page, route = BTC_ROUTE) {
+  await page.goto(route);
+  await page.waitForLoadState('networkidle');
+}
+
+// --- Dashboard fixtures for the CTA-navigation tests ------------------------
+
+const DASHBOARD_BASE = {
+  generated_at: '2026-05-19T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 1 },
+  },
+  kpis: {
+    open_positions: 1,
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 1, holding: 0 },
+    notional_value: 1550,
+    notional_change_pct: 0,
+    open_legs: 1,
+    open_legs_breakdown: { puts: 0, calls: 1 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+    largest_risk: null,
+    premium_collected_total: 0,
+    premium_collected_trades: 0,
+    premium_collected_ytd: 0,
+    realized_pl: 0,
+    realized_pl_pct: null,
+    largest_loser: null,
+  },
+  positions: [],
+  upcoming_expirations: [],
+  open_legs: [],
+  recent_activity: [],
+  data_meta: { is_stale: false, fetched_at: '2026-05-19T13:42:00+00:00', sources_unavailable: [] },
+  next_actions: [],
+};
+
+function dashboardCard(actionId) {
+  const isDte = actionId === 'leg.dte_review';
+  return {
+    id: `${actionId}.${LEG_ID}`,
+    action_id: actionId,
+    priority: isDte ? 'P2' : 'P1',
+    tone: isDte ? undefined : 'opportunity',
+    title: isDte ? '21-day review' : 'Profit-take review',
+    subject: { ticker: 'F', amount: '15C' },
+    reason: 'Your management rule triggered for this leg.',
+    cta: { label: 'Inspect rule', href: BTC_ROUTE, kind: 'link' },
+    triggered_rules: [],
+  };
+}
+
+function mockDashboard(page, card) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ...DASHBOARD_BASE, next_actions: [card] }),
+    }),
+  );
+}
+
+// --- Tests: route renders + states -----------------------------------------
+
+test.describe('BTC detail screen — route + states', () => {
+  test('renders the populated page for a valid leg', async ({ page }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-detail-page')).toBeVisible();
+    await expect(page.getByTestId('btc-detail-leg-header')).toContainText(
+      'Buy-to-close review: F $15 C',
+    );
+    // The triggered rule pill names the user's rule, attributed.
+    const pill = page.getByTestId('btc-detail-rule-pill');
+    await expect(pill).toHaveAttribute('data-verdict', 'profit_take_review');
+    await expect(pill).toContainText('profit-take rule');
+  });
+
+  test('renders the three content blocks: recommendation, economics, audit', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    // (c) recommended action summary
+    await expect(
+      page.getByTestId('btc-detail-recommended-reasoning'),
+    ).toContainText('profit-take rule triggered');
+    // (b) BTC economics tiles
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-cost-to-close'),
+    ).toContainText('$15.72');
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-credit'),
+    ).toContainText('$38.34');
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-pct-captured'),
+    ).toContainText('59%');
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-est-pl'),
+    ).toContainText('+$22.62');
+    // (a) rule audit — Metric/Value/Rule/Triggered? rows for ALL rules
+    await expect(page.getByTestId('btc-detail-rule-audit-table')).toBeVisible();
+    for (const id of [
+      'profit_review',
+      'dte_review',
+      'expiration_warning',
+      'assignment_risk',
+    ]) {
+      await expect(
+        page.getByTestId(`btc-detail-rule-audit-row-${id}`),
+      ).toBeVisible();
+    }
+    // The governing rule's status cell reads "Yes".
+    await expect(
+      page.getByTestId('btc-detail-rule-audit-status-profit_review'),
+    ).toContainText('Yes');
+  });
+
+  test('advice-framing — audit + pill attribute to the user, not the app', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-detail-rule-audit')).toContainText(
+      'checked against your Management Triggers',
+    );
+    await expect(page.getByTestId('btc-detail-rule-pill')).toContainText(
+      'Your',
+    );
+  });
+
+  test('404 renders the leg-not-found EmptyState (not the error banner)', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, { detail: 'Leg not found' }, 404);
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-detail-not-found')).toBeVisible();
+    await expect(page.getByTestId('btc-detail-not-found')).toContainText(
+      'Leg not found',
+    );
+    // It must NOT be treated as a generic error.
+    await expect(page.getByTestId('btc-detail-error')).toHaveCount(0);
+    await expect(page.getByTestId('btc-detail-page')).toHaveCount(0);
+  });
+
+  test('a server error renders the retry banner', async ({ page }) => {
+    await mockBtcDetail(
+      page,
+      { detail: 'Failed to load buy-to-close detail. Please try again.' },
+      500,
+    );
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-detail-error')).toBeVisible();
+    await expect(
+      page.getByTestId('btc-detail-error').getByRole('button', { name: 'Retry' }),
+    ).toBeVisible();
+  });
+
+  test('no-rule-triggered: economics + audit render, Buy-to-close CTA omitted', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, noRulePayload());
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-detail-no-rule')).toBeVisible();
+    // Economics and audit still render fully.
+    await expect(page.getByTestId('btc-detail-economics')).toBeVisible();
+    await expect(page.getByTestId('btc-detail-rule-audit')).toBeVisible();
+    // No closing verdict fired → no Buy-to-close CTA; journal link still shows.
+    await expect(page.getByTestId('btc-detail-cta-close')).toHaveCount(0);
+    await expect(page.getByTestId('btc-detail-cta-journal')).toBeVisible();
+  });
+
+  test('pricing-unavailable: em-dash tiles + "Pricing unavailable" badge', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, pricingUnavailablePayload());
+    await openBtcDetail(page);
+
+    await expect(
+      page.getByTestId('btc-detail-economics-stub-badge'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-cost-to-close'),
+    ).toContainText('—');
+    // Credit received still shows its real static value.
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-credit'),
+    ).toContainText('$61.00');
+  });
+});
+
+// --- Tests: CTA navigation from the dashboard action cards ------------------
+
+test.describe('BTC detail screen — reachable from dashboard card CTA', () => {
+  test('"Inspect rule →" on a profit-take card navigates to the BTC route', async ({
+    page,
+  }) => {
+    await mockDashboard(page, dashboardCard('leg.profit_take_review'));
+    await mockBtcDetail(page, populatedPayload());
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The whole card is the CTA `<Link>` — its href is the BTC route.
+    const cardEl = page.getByTestId(
+      `next-actions-card-leg.profit_take_review.${LEG_ID}`,
+    );
+    await expect(cardEl).toBeVisible();
+    await expect(cardEl).toContainText('Inspect rule');
+    await expect(cardEl).toHaveAttribute('href', BTC_ROUTE);
+    await cardEl.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(new RegExp(`${BTC_ROUTE}$`));
+    await expect(page.getByTestId('btc-detail-page')).toBeVisible();
+    await expect(page.getByTestId('btc-detail-leg-header')).toContainText('F');
+  });
+
+  test('"Inspect rule →" on a DTE-review card also navigates to the BTC route', async ({
+    page,
+  }) => {
+    await mockDashboard(page, dashboardCard('leg.dte_review'));
+    await mockBtcDetail(page, populatedPayload({ verdict: 'dte_review' }));
+
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const cardEl = page.getByTestId(
+      `next-actions-card-leg.dte_review.${LEG_ID}`,
+    );
+    await expect(cardEl).toBeVisible();
+    await expect(cardEl).toHaveAttribute('href', BTC_ROUTE);
+    await cardEl.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(new RegExp(`${BTC_ROUTE}$`));
+    await expect(page.getByTestId('btc-detail-page')).toBeVisible();
+  });
+});
+
+// --- Tests: journal pre-fill via the "Buy to close" CTA ---------------------
+
+const JOURNAL_POSITION = {
+  id: POSITION_ID,
+  ticker: 'F',
+  shares: 100,
+  strategy: 'cc',
+  status: 'open',
+  broker_cost_basis: 1500,
+  adjusted_cost_basis: 1461.66,
+  min_compliant_cc_strike: 15,
+  total_premiums: 38.34,
+  trades: [
+    {
+      id: LEG_ID,
+      position_id: POSITION_ID,
+      trade_type: 'sell_call',
+      strike: 15.0,
+      expiration: '2026-06-26',
+      premium: 0.3834,
+      fees: 0,
+      quantity: 1,
+      opened_at: '2026-04-01T10:00:00Z',
+      closed_at: null,
+      close_reason: null,
+    },
+  ],
+};
+
+async function mockJournalPositions(page, positions) {
+  // The list endpoint (used by the positions table).
+  await page.route('**/api/journal/positions', (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ positions }),
+    });
+  });
+  // The single-position endpoint (used by selectPosition → TradeHistory).
+  await page.route('**/api/journal/positions/*', (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    const url = route.request().url();
+    const found = positions.find((p) => url.endsWith(`/${p.id}`));
+    if (!found) {
+      return route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ detail: 'Position not found' }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(found),
+    });
+  });
+}
+
+test.describe('BTC detail — journal close-leg pre-fill (issue #244)', () => {
+  test('"Buy to close" CTA points at the close-leg journal deep-link', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    const cta = page.getByTestId('btc-detail-cta-close');
+    await expect(cta).toBeVisible();
+    await expect(cta).toHaveAttribute(
+      'href',
+      `/journal?position=${POSITION_ID}&leg=${LEG_ID}&action=close-leg`,
+    );
+  });
+
+  test('arriving at the close-leg deep-link pre-fills the inverse-close form', async ({
+    page,
+  }) => {
+    await mockJournalPositions(page, [JOURNAL_POSITION]);
+    await page.goto(
+      `/journal?position=${POSITION_ID}&leg=${LEG_ID}&action=close-leg`,
+    );
+    await page.waitForLoadState('networkidle');
+
+    // The trade form auto-opens, pre-filled with the inverse-close trade.
+    const form = page.getByTestId('trade-entry-form');
+    await expect(form).toBeVisible();
+    // sell_call → buy_call_close.
+    await expect(page.getByTestId('trade-entry-type')).toHaveValue(
+      'buy_call_close',
+    );
+    await expect(page.getByTestId('trade-entry-strike')).toHaveValue('15');
+    await expect(page.getByTestId('trade-entry-expiration')).toHaveValue(
+      '2026-06-26',
+    );
+  });
+
+  test('degrades gracefully when the leg param does not resolve', async ({
+    page,
+  }) => {
+    await mockJournalPositions(page, [JOURNAL_POSITION]);
+    await page.goto(
+      `/journal?position=${POSITION_ID}&leg=no-such-leg&action=close-leg`,
+    );
+    await page.waitForLoadState('networkidle');
+
+    // The journal opens on the position; no form auto-opens, no error.
+    await expect(page.getByTestId('trade-history')).toBeVisible();
+    await expect(page.getByTestId('trade-entry-form')).toHaveCount(0);
+  });
+});

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -494,6 +494,33 @@ test.describe('BTC detail — journal close-leg pre-fill (issue #244)', () => {
     );
   });
 
+  test('close-leg pre-fill applies only to the auto-opened form, not a later manual one', async ({
+    page,
+  }) => {
+    await mockJournalPositions(page, [JOURNAL_POSITION]);
+    await page.goto(
+      `/journal?position=${POSITION_ID}&leg=${LEG_ID}&action=close-leg`,
+    );
+    await page.waitForLoadState('networkidle');
+
+    // The auto-opened form is pre-filled with the inverse-close leg.
+    await expect(page.getByTestId('trade-entry-form')).toBeVisible();
+    await expect(page.getByTestId('trade-entry-type')).toHaveValue(
+      'buy_call_close',
+    );
+
+    // Dismiss it, then manually re-open via the "Add Trade" button.
+    await page.getByTestId('add-trade-btn').click();
+    await expect(page.getByTestId('trade-entry-form')).toHaveCount(0);
+    await page.getByTestId('add-trade-btn').click();
+
+    // The manually-opened form must be blank — no stale buy-to-close values.
+    await expect(page.getByTestId('trade-entry-form')).toBeVisible();
+    await expect(page.getByTestId('trade-entry-type')).toHaveValue('sell_put');
+    await expect(page.getByTestId('trade-entry-strike')).toHaveValue('');
+    await expect(page.getByTestId('trade-entry-expiration')).toHaveValue('');
+  });
+
   test('degrades gracefully when the leg param does not resolve', async ({
     page,
   }) => {

--- a/frontend/e2e/dashboard-rule-monitor.spec.js
+++ b/frontend/e2e/dashboard-rule-monitor.spec.js
@@ -12,7 +12,8 @@ import { test, expect } from '@playwright/test';
  *   - Quiet leg (verdict=hold) is still inspectable; no Buy-to-close CTA.
  *   - leg.profit_take_review card renders emerald + ✓ + [P1];
  *     leg.dte_review card renders slate + [P2].
- *   - `#leg-{id}` deep link auto-expands the targeted row on mount.
+ *   - Dead `#leg-{id}` deep link removed (issue #244) — a `#leg-` hash no
+ *     longer auto-expands any row.
  *   - Degraded path — no live mid → % Capt `—`, DTE-based fallback verdict.
  *
  * Mirrors `dashboard-open-legs-card.spec.js` — same `mockDashboard()` +
@@ -204,7 +205,9 @@ function makeCard(overrides = {}) {
     reason: overrides.reason || 'Your 50% profit-take rule triggered — 60% of max premium captured.',
     cta: {
       label: 'Inspect rule',
-      href: overrides.href || '/dashboard#leg-leg-ford-15c',
+      href:
+        overrides.href ||
+        '/positions/pos-ford/legs/leg-ford-15c/btc',
       kind: 'link',
     },
     triggered_rules: overrides.triggered_rules || [],
@@ -463,7 +466,7 @@ test.describe('NextActionCard — rule-monitor cards', () => {
       tone: undefined,
       subject: { ticker: 'AAPL', amount: '190P' },
       reason: '20 days to expiration — your review window. Decide: hold, roll, or close.',
-      href: '/dashboard#leg-leg-aapl',
+      href: '/positions/pos-aapl/legs/leg-aapl/btc',
     });
     await mockDashboard(page, {
       ...BASE_PAYLOAD,
@@ -481,8 +484,13 @@ test.describe('NextActionCard — rule-monitor cards', () => {
   });
 });
 
-test.describe('OpenLegsCard rule monitor — hash deep link', () => {
-  test('#leg-{id} auto-expands the targeted row on mount', async ({ page }) => {
+test.describe('OpenLegsCard — dead #leg hash deep link removed (issue #244)', () => {
+  test('navigating to /dashboard#leg-{id} does NOT auto-expand any row', async ({
+    page,
+  }) => {
+    // Issue #244 removed the dead `#leg-{id}` deep-link. The card CTA now
+    // navigates to the dedicated BTC detail screen instead. Landing on the
+    // dashboard with a `#leg-` hash must leave every inspect panel collapsed.
     const legA = makeLeg({ id: 'leg-a', ticker: 'F', verdict: 'hold', dte: 73 });
     const legB = makeLeg({
       id: 'leg-b',
@@ -497,15 +505,15 @@ test.describe('OpenLegsCard rule monitor — hash deep link', () => {
     await page.goto('/dashboard#leg-leg-b');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByTestId('dashboard-leg-inspect-leg-b')).toBeVisible();
-    // The non-targeted row stays collapsed.
+    // Both rows render — and NEITHER inspect panel is auto-expanded.
+    await expect(page.getByTestId('dashboard-leg-row').first()).toBeVisible();
     await expect(page.getByTestId('dashboard-leg-inspect-leg-a')).toHaveCount(0);
+    await expect(page.getByTestId('dashboard-leg-inspect-leg-b')).toHaveCount(0);
   });
 
-  test('malformed #leg-%FF hash does not crash the dashboard', async ({ page }) => {
-    // `decodeURIComponent('%FF')` throws — parseLegHash runs in a lazy
-    // useState initializer, so an unguarded throw would crash the dashboard
-    // at render. The guard returns null instead; the page must still mount.
+  test('a #leg hash never crashes the dashboard', async ({ page }) => {
+    // The hash-reading code (and its decodeURIComponent throw path) is gone.
+    // Any `#leg-` hash — even a malformed one — is now inert.
     const leg = makeLeg({ id: 'leg-a', ticker: 'F', verdict: 'hold', dte: 73 });
     await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
 
@@ -516,13 +524,9 @@ test.describe('OpenLegsCard rule monitor — hash deep link', () => {
     await page.goto('/dashboard#leg-%FF');
     await page.waitForLoadState('networkidle');
 
-    // The dashboard shell rendered — no render crash.
     await expect(page.getByTestId('dashboard-page')).toBeVisible();
-    // The leg row still rendered; the bad hash matched no leg, so nothing
-    // is auto-expanded.
     await expect(page.getByTestId('dashboard-leg-row').first()).toBeVisible();
     await expect(page.getByTestId('dashboard-leg-inspect-leg-a')).toHaveCount(0);
-    // No uncaught URIError reached the page.
     expect(pageErrors).toHaveLength(0);
   });
 });

--- a/frontend/hooks/useBtcDetail.js
+++ b/frontend/hooks/useBtcDetail.js
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getBtcDetail } from '../api/client';
+
+/**
+ * useBtcDetail — fetch the buy-to-close detail payload for a single leg.
+ *
+ * Mirrors `useRecoveryPlan` (`{ data, loading, error, refetch }`), with one
+ * deliberate difference: a 404 is a *known state* for this screen, not an
+ * error. The endpoint 404s for an unknown / closed leg, which drives the
+ * `not-found` EmptyState — so the hook converts a 404 into a synthetic
+ * `{ state: 'not-found' }` payload rather than surfacing the error banner.
+ *
+ * Pattern: V1.0.6 / issue #244.
+ */
+export function useBtcDetail(positionId, legId) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refetch = useCallback(async () => {
+    if (!positionId || !legId) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+    // Drop the prior leg's detail before the new fetch resolves.
+    setData(null);
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await getBtcDetail(positionId, legId);
+      setData(payload);
+    } catch (e) {
+      if (e?.response?.status === 404) {
+        // A 404 is a known state — render the not-found EmptyState, not the
+        // error banner. The leg is unknown, closed, or on another position.
+        setData({ state: 'not-found' });
+      } else {
+        setError(
+          e?.response?.data?.detail ||
+            'Failed to load buy-to-close detail',
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [positionId, legId]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, loading, error, refetch };
+}


### PR DESCRIPTION
Closes #244

## What this does

Builds a dedicated per-leg **buy-to-close (BTC) detail screen** and fixes the dead `/dashboard#leg-{id}` rule-monitor card CTA shipped in #240. The screen answers one question — *should I buy to close this option leg, and why?* — and is the per-leg analog of the per-position recovery screen.

This is a single full-stack PR (the plan described a 2-PR split; consolidated per the task instructions).

## Backend

- **New endpoint** `GET /api/positions/{position_id}/legs/{leg_id}/btc` in a new leg-scoped router (`legs.py` + `btc_detail.py` service). It does **not** re-implement rule evaluation — it reuses `derive_open_legs()`, the exact function the dashboard calls, which itself calls the `rule_monitor` engine. The rule audit on this screen and the dashboard ACTION column therefore agree by construction.
- The only new computation is the **BTC economics block** (cost-to-close, original credit, est. P/L). `captured_pct` is *lifted* from the existing `% CAPT` signal, not recomputed, so it agrees with the dashboard `% CAPT` column.
- **404** for an unknown / closed / position-mismatched leg; **generic 500** on a Schwab failure — no `str(e)` leak (CLAUDE.md).
- Labeled stub: when no live option mark matches the contract, the pricing-dependent fields degrade to `null` and `pricing_source` is `"unavailable"`.
- Repoints **both** rule-monitor card CTA hrefs in `action_engine.py` from `/dashboard#leg-{id}` to `/positions/{position_id}/legs/{leg_id}/btc`.
- Adds an additive `current_mid` / `premium` / `quantity` passthrough to the `derive_open_legs` leg dict (the dashboard ignores it — cannot regress #240).

## Frontend

- **New route** `/positions/[id]/legs/[legId]/btc` — structural twin of the recovery route. `BtcDetailPage` runs a `loading → error → not-found → no-rule-triggered → populated` state machine; `BtcDetailView` composes the leg header, recommended-action block, always-open BTC economics panel, and always-open rule-audit panel. A **404 is a distinct `not-found` state**, not a network error.
- Removes the **dead `#leg-{id}` hash code**: `parseLegHash` + `hashLegId` from `DashboardPage.jsx`, and the deep-link seeding / scroll wiring from `OpenLegsCard.jsx`. The inline expandable inspect row is untouched.
- **Journal pre-fill**: `JournalPage` reads `action=close-leg` + `leg` and pre-fills an inverse-close trade entry (`buy_put_close` / `buy_call_close`, strike, expiration, quantity). Degrades gracefully when the leg param is missing or does not resolve.

## Advice-framing audit

The screen reports what the user's own ruleset said — never app advice. The rule-audit header reads "checked against your Management Triggers", the column is "Your rule", the verdict pill is "Your … rule triggered". The server-authored governing `reasoning` string is never re-authored; the client only appends the plain-dollars BTC outcome sentence.

## Test coverage

Backend (pytest):
- `test_btc_detail_endpoint.py` — 200 populated (profit-take fired), the four-rule audit, economics fields, `captured_pct` agreement, no-rule-triggered, pricing-unavailable degradation, 404 for unknown / closed / mismatched leg, and 500-hygiene (no `str(e)` leak).
- `test_btc_detail_service.py` — economics math: per-share scaling, contract-count scaling, signed P/L, null propagation, lifted `captured_pct`, position/moneyness labels.
- `test_dashboard_legs.py` — `current_mid` passthrough assertion.
- `test_action_engine.py` — CTA href updated to the new route.

Frontend (Playwright, `btc-detail.spec.js`):
- Route renders for a valid leg; all three content blocks; advice-framing wording.
- 404 → not-found EmptyState (distinct from the error banner); 500 → retry banner.
- no-rule-triggered variant; pricing-unavailable badge + em-dash tiles.
- CTA navigation from **both** the profit-take and DTE-review dashboard cards.
- Journal pre-fill: `Buy to close` href, the auto-opened pre-filled inverse-close form, and graceful degradation on an unresolvable leg.
- `dashboard-rule-monitor.spec.js` updated — a `#leg-` hash no longer auto-expands any row.

Full backend suite: 1141 passed, 9 skipped. Frontend `lint` + `build` clean; the BTC, rule-monitor, open-legs, journal and recovery e2e specs all green.

## Notes / deviations from the plan

- The plan proposed a 2-PR split; consolidated into one full-stack PR per the task instructions.
- The inline inspect panel's `Buy to close` link (`OpenLegsCard.jsx`) was already emitting `action=close-leg` and is left untouched (out of scope per spec §13). The new journal pre-fill tolerates that older link shape — a missing `leg` param degrades gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)