### PR TITLE
Align rule-monitor card vocabulary with the buy-to-close destination (closes #249)

### DIFF
--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -455,7 +455,7 @@ def _leg_profit_take_review_actions(
                 # `opportunity` tone — a profit-take is a win, not a warning;
                 # NextActionCard renders it emerald with a ✓ glyph (§4.3 Q6).
                 "tone": "opportunity",
-                "title": "Profit-take review",
+                "title": "Buy-to-close review",
                 "subject": {
                     "ticker": ticker,
                     "amount": f"{strike:g}{option_letter}",
@@ -467,7 +467,7 @@ def _leg_profit_take_review_actions(
                     expiration_warning_days=expiration_warning_days,
                 ),
                 "cta": {
-                    "label": "Inspect rule",
+                    "label": "Review buy-to-close",
                     "href": (
                         f"/positions/{quote(str(leg['position_id']), safe='')}"
                         f"/legs/{quote(str(leg['id']), safe='')}/btc"
@@ -520,7 +520,7 @@ def _leg_dte_review_actions(
                     dte_review_days=dte_review_days,
                 ),
                 "cta": {
-                    "label": "Inspect rule",
+                    "label": "Review buy-to-close",
                     "href": (
                         f"/positions/{quote(str(leg['position_id']), safe='')}"
                         f"/legs/{quote(str(leg['id']), safe='')}/btc"

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -871,6 +871,22 @@ class TestProfitTakeReviewCard:
         ids = {a["action_id"] for a in actions}
         assert "leg.profit_take_review" not in ids
 
+    def test_card_title_and_cta_use_buy_to_close_vocabulary(self):
+        """Issue #249 — the card title and CTA label name the destination
+        screen, not the rule audit sub-section. Locks the vocabulary contract:
+        card title, CTA, and the destination page <h1> all use the same
+        ``Buy-to-close review`` language.
+        """
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="profit_take_review")],
+        )
+        card = next(a for a in actions if a["action_id"] == "leg.profit_take_review")
+        assert card["title"] == "Buy-to-close review"
+        assert card["cta"]["label"] == "Review buy-to-close"
+
 
 class TestDteReviewCard:
     def test_emits_when_verdict_is_dte_review(self):
@@ -897,6 +913,23 @@ class TestDteReviewCard:
         )
         ids = {a["action_id"] for a in actions}
         assert "leg.dte_review" not in ids
+
+    def test_cta_label_uses_buy_to_close_vocabulary(self):
+        """Issue #249 — DTE-review CTA also names the destination. The card
+        title (``{N}-day review``) is intentionally retained — it describes
+        the trigger window, not the destination (design spec §2).
+        """
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_verdict_leg("l-1", verdict="dte_review", dte=18)],
+        )
+        card = next(a for a in actions if a["action_id"] == "leg.dte_review")
+        assert card["cta"]["label"] == "Review buy-to-close"
+        # Title intentionally NOT renamed — it names the trigger window
+        # (``dte_review_days`` default = 21), not the destination screen.
+        assert card["title"] == "21-day review"
 
 
 class TestRuleMonitorCardPrecedence:

--- a/frontend/app/positions/[id]/legs/[legId]/btc/page.jsx
+++ b/frontend/app/positions/[id]/legs/[legId]/btc/page.jsx
@@ -6,7 +6,7 @@ import LoadingSkeleton from '@/components/layout/LoadingSkeleton';
 
 // Route shell for /positions/[id]/legs/[legId]/btc — the dedicated per-leg
 // buy-to-close detail screen (issue #244). Reached from the rule-monitor
-// "Inspect rule →" card CTA. Structural twin of recovery/page.jsx.
+// "Review buy-to-close →" card CTA. Structural twin of recovery/page.jsx.
 const BtcDetailPage = dynamic(
   () => import('@/components/btc/BtcDetailPage'),
   {

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -23,7 +23,7 @@ import { formatCurrency, formatPercent } from '../../utils/formatters';
  *     to make room (spec §5.1 Q8).
  *
  * V1.0.6 (issue #244): the dead `#leg-{id}` hash deep-link was removed. The
- * rule-monitor card "Inspect rule →" CTA now navigates to the dedicated
+ * rule-monitor card "Review buy-to-close →" CTA now navigates to the dedicated
  * per-leg buy-to-close detail screen. The inline expandable inspect row
  * (toggled by clicking the leg row) is unchanged.
  *

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -8,7 +8,7 @@ import { test, expect } from '@playwright/test';
  *     and shows the rule audit + BTC economics + recommended action.
  *   - A 404 renders the leg-not-found EmptyState (distinct from a network
  *     error state).
- *   - The screen is reachable via the "Inspect rule →" card CTA from both the
+ *   - The screen is reachable via the "Review buy-to-close →" card CTA from both the
  *     profit-take and the DTE-review action cards on the dashboard.
  *   - States: loading skeleton, error + retry, no-rule-triggered, and the
  *     pricing-unavailable degraded variant.
@@ -194,10 +194,10 @@ function dashboardCard(actionId) {
     action_id: actionId,
     priority: isDte ? 'P2' : 'P1',
     tone: isDte ? undefined : 'opportunity',
-    title: isDte ? '21-day review' : 'Profit-take review',
+    title: isDte ? '21-day review' : 'Buy-to-close review',
     subject: { ticker: 'F', amount: '15C' },
     reason: 'Your management rule triggered for this leg.',
-    cta: { label: 'Inspect rule', href: BTC_ROUTE, kind: 'link' },
+    cta: { label: 'Review buy-to-close', href: BTC_ROUTE, kind: 'link' },
     triggered_rules: [],
   };
 }
@@ -350,7 +350,7 @@ test.describe('BTC detail screen — route + states', () => {
 // --- Tests: CTA navigation from the dashboard action cards ------------------
 
 test.describe('BTC detail screen — reachable from dashboard card CTA', () => {
-  test('"Inspect rule →" on a profit-take card navigates to the BTC route', async ({
+  test('"Review buy-to-close →" on a profit-take card navigates to the BTC route', async ({
     page,
   }) => {
     await mockDashboard(page, dashboardCard('leg.profit_take_review'));
@@ -365,7 +365,7 @@ test.describe('BTC detail screen — reachable from dashboard card CTA', () => {
       `next-actions-card-leg.profit_take_review.${LEG_ID}`,
     );
     await expect(cardEl).toBeVisible();
-    await expect(cardEl).toContainText('Inspect rule');
+    await expect(cardEl).toContainText('Review buy-to-close');
     await expect(cardEl).toHaveAttribute('href', BTC_ROUTE);
     await cardEl.click();
     await page.waitForLoadState('networkidle');
@@ -375,7 +375,7 @@ test.describe('BTC detail screen — reachable from dashboard card CTA', () => {
     await expect(page.getByTestId('btc-detail-leg-header')).toContainText('F');
   });
 
-  test('"Inspect rule →" on a DTE-review card also navigates to the BTC route', async ({
+  test('"Review buy-to-close →" on a DTE-review card also navigates to the BTC route', async ({
     page,
   }) => {
     await mockDashboard(page, dashboardCard('leg.dte_review'));

--- a/frontend/e2e/dashboard-rule-monitor.spec.js
+++ b/frontend/e2e/dashboard-rule-monitor.spec.js
@@ -200,11 +200,11 @@ function makeCard(overrides = {}) {
     action_id: actionId,
     priority: overrides.priority || 'P1',
     tone: overrides.tone,
-    title: overrides.title || 'Profit-take review',
+    title: overrides.title || 'Buy-to-close review',
     subject: overrides.subject || { ticker: 'F', amount: '15C' },
     reason: overrides.reason || 'Your 50% profit-take rule triggered — 60% of max premium captured.',
     cta: {
-      label: 'Inspect rule',
+      label: 'Review buy-to-close',
       href:
         overrides.href ||
         '/positions/pos-ford/legs/leg-ford-15c/btc',


### PR DESCRIPTION
Closes #249.

## Summary

Pure copy-only realignment of three connected surfaces in the
rule-monitor -> buy-to-close flow. Before this PR the user saw three
different names for the same flow:

- Dashboard action card title `Profit-take review`
- Card CTA `Inspect rule` (names the rule-audit sub-section on the
  destination, not the destination itself)
- Destination page heading `Buy-to-close review`

The destination `<h1>` is the authoritative vocabulary anchor (it is
what the user reads when they arrive and decide). This PR conforms
the two upstream surfaces to it.

## Before / after

| Card | Field | Before | After |
| --- | --- | --- | --- |
| `leg.profit_take_review` | title | `Profit-take review` | `Buy-to-close review` |
| `leg.profit_take_review` | cta.label | `Inspect rule` | `Review buy-to-close` |
| `leg.dte_review` | title | `{N}-day review` | *(unchanged -- names the trigger window, not the destination; design spec §2)* |
| `leg.dte_review` | cta.label | `Inspect rule` | `Review buy-to-close` |

Backend payload is the source of truth (`backend/app/services/action_engine.py`).
`NextActionCard.jsx` is fully data-driven, so no JSX literals change.
`rulesFieldCatalog.js` `'Profit-take review'` is intentionally
preserved -- it names the configurable rule itself in Settings, a
different concept (renaming would break the user's mental model).

## Files changed

- `backend/app/services/action_engine.py` -- 3 string literals (L458 title + L470/L523 labels)
- `backend/tests/test_action_engine.py` -- 2 new tests lock the vocabulary contract
- `frontend/e2e/dashboard-rule-monitor.spec.js` -- fixture defaults (L203/L207)
- `frontend/e2e/btc-detail.spec.js` -- fixture + two test-name strings + one toContainText + header comment
- `frontend/components/dashboard/OpenLegsCard.jsx` -- JSDoc L26
- `frontend/app/positions/[id]/legs/[legId]/btc/page.jsx` -- file header L9
- `frontend/design-specs/issue-249-terminology-alignment.md` + `...-plan.md` -- design artifacts

## AC mapping

| AC | Where satisfied |
| --- | --- |
| The card CTA names the destination and signals it is an actionable review. | `TestProfitTakeReviewCard.test_card_title_and_cta_use_buy_to_close_vocabulary` + `TestDteReviewCard.test_cta_label_uses_buy_to_close_vocabulary` |
| Card title, CTA, and destination page title use consistent vocabulary; no surface still uses `Inspect rule`. | Both new backend tests + final grep sweep (zero hits in production code) |
| Designer sign-off on final copy (SDLC Phase 1.5). | `frontend/design-specs/issue-249-terminology-alignment.md` -- approved, wording locked |
| Playwright assertions asserting old CTA text are updated. | `frontend/e2e/dashboard-rule-monitor.spec.js` fixture + `frontend/e2e/btc-detail.spec.js` fixture + assertions + renamed test names |
| Smoke test verifies CTA navigates to the buy-to-close review page. | Existing `test_card_cta_links_to_btc_detail_route` (backend) + the two updated `"Review buy-to-close ->" ... navigates to the BTC route` Playwright tests |

## Verification

- Backend: `pytest` -- **1141 passed, 9 skipped**. The two new tests in `TestProfitTakeReviewCard` and `TestDteReviewCard` both pass.
- Frontend Playwright (`dashboard-rule-monitor.spec.js` + `btc-detail.spec.js`): **30 passed**.
- Frontend lint: clean for changed files (one pre-existing warning in `UserMenu.jsx`).
- Frontend build: green.
- Grep sweep -- production-code occurrences of `Inspect rule` or `Profit-take review` (excluding `rulesFieldCatalog.js` and the frozen design-specs/plans): zero.

## References

- Design spec: `frontend/design-specs/issue-249-terminology-alignment.md`
- Implementation plan: `frontend/design-specs/issue-249-terminology-alignment-plan.md`
- Depends on PR #245 (merged) for the BTC detail route the CTA now points at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)