### PR TITLE
Combined covered-call P&L (stock + option legs) + if-assigned projection (closes #247)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.config import settings as app_settings
 from app.logging_config import setup_logging
 from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
-from app.routers import assets, dashboard, data, health, journal, legs, options, positions, regression, sessions, settings
+from app.routers import assets, covered_call, dashboard, data, health, journal, legs, options, positions, regression, sessions, settings
 from app.services.backup import create_backup
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher, DataFetchError, InvalidTickerError, DataAlignmentError
@@ -166,6 +166,7 @@ app.include_router(journal.router, dependencies=[Depends(get_current_user)])
 app.include_router(dashboard.router, dependencies=[Depends(get_current_user)])
 app.include_router(positions.router, dependencies=[Depends(get_current_user)])
 app.include_router(legs.router, dependencies=[Depends(get_current_user)])
+app.include_router(covered_call.router, dependencies=[Depends(get_current_user)])
 
 
 # --- Exception handlers ---

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1036,3 +1036,109 @@ class BtcDetailResponse(BaseModel):
     economics: BtcEconomics
     triggered_rules: list[DashboardRuleEvaluation] = Field(default_factory=list)
     disclaimer: Optional[str] = None
+
+
+# --- Combined covered-call P&L + if-assigned (V1.0.6, issue #247) ---
+
+# The four states the covered-call endpoint can resolve a position into. The
+# "covered_call" bucket carries real today/if-assigned blocks; the three
+# not_applicable_* buckets carry empty blocks and drive the screen's
+# EmptyState rendering (spec §7).
+COVERED_CALL_APPLICABILITY = Literal[
+    "covered_call",
+    "not_applicable_no_shares",
+    "not_applicable_no_short_call",
+    "not_applicable_closed",
+]
+
+
+class CoveredCallPositionSummary(BaseModel):
+    """Position-identity block on the covered-call response (spec §5.2).
+
+    ``broker_cost_basis`` here is **per-share** — the screen divides the
+    stored total by ``shares`` so the downstream consumers can multiply by
+    share count again without surprises. ``current_price`` is ``None`` in
+    the no-live-quote degraded path; the timestamp goes ``None`` in lockstep.
+    """
+
+    id: str
+    ticker: str
+    shares: int
+    broker_cost_basis: float
+    current_price: Optional[float] = None
+    current_price_stale: bool = False
+    current_price_as_of: Optional[str] = None
+
+
+class CoveredCallToday(BaseModel):
+    """The "today — unrealized" block (spec §3.2 left card).
+
+    Each field degrades to ``None`` per spec §5.5: ``stock_pnl`` when
+    ``current_price`` is missing, ``options_pnl`` when any open leg's
+    ``pnl_dollars`` is missing, ``combined_pnl`` when either side is missing.
+    """
+
+    stock_pnl: Optional[float] = None
+    options_pnl: Optional[float] = None
+    combined_pnl: Optional[float] = None
+
+
+class CoveredCallIfAssignedLeg(BaseModel):
+    """One open-short-call leg's if-assigned projection (spec §5.2 / §7).
+
+    ``shares_called`` is capped at the position's available shares by
+    :func:`app.services.covered_call._allocate_shares_called` —
+    earliest-expiring-first (Q6) when multiple legs exist. ``premium_kept``
+    is independent of ``shares_called``: the credit booked at open stays
+    with the seller whether or not THIS leg's shares end up called.
+    ``if_assigned_pnl`` is ``None`` when premium is missing or the leg has
+    already expired (those legs are excluded from the array).
+    """
+
+    leg_id: str
+    strike: float
+    premium: float
+    qty: int
+    shares_called: int
+    share_pnl: float
+    premium_kept: float
+    if_assigned_pnl: Optional[float] = None
+
+
+class CoveredCallLegBreakdown(BaseModel):
+    """One row of the per-leg breakdown table (spec §3.3).
+
+    Mirrors the dashboard's `DashboardOpenLeg` fields the breakdown table
+    reuses — ``coverage`` and ``pnl_dollars`` from #246 — plus the per-leg
+    ``if_assigned_pnl`` (``None`` for a non-short-call leg, an expired leg,
+    or a leg with no booked premium).
+    """
+
+    leg_id: str
+    ticker: str
+    strike: float
+    type: Literal["call", "put"]
+    dte: int
+    coverage: Optional[Literal["covered", "naked"]] = None
+    pnl_dollars: Optional[float] = None
+    if_assigned_pnl: Optional[float] = None
+
+
+class CoveredCallView(BaseModel):
+    """Top-level response for ``GET /api/positions/{id}/covered-call``.
+
+    Composes the position summary, the today block, the if-assigned per-leg
+    projections, the per-leg breakdown rows, and the applicability flag the
+    frontend keys its state machine off. The disclaimer sentence (spec §3.6)
+    is shipped in the payload so the frontend renders the house framing
+    rule verbatim.
+    """
+
+    position: CoveredCallPositionSummary
+    combined_today: CoveredCallToday
+    if_assigned: list[CoveredCallIfAssignedLeg] = Field(default_factory=list)
+    per_leg_breakdown: list[CoveredCallLegBreakdown] = Field(
+        default_factory=list
+    )
+    applicability: COVERED_CALL_APPLICABILITY
+    disclaimer: Optional[str] = None

--- a/backend/app/routers/covered_call.py
+++ b/backend/app/routers/covered_call.py
@@ -1,0 +1,73 @@
+"""Covered-call router — the per-position combined-P&L endpoint (issue #247).
+
+Single route: ``GET /api/positions/{position_id}/covered-call``. Feeds the
+dedicated combined-P&L + if-assigned screen — the per-position analog of
+the per-leg buy-to-close screen (#244, ``routers/legs.py``).
+
+Branch shape:
+
+- 404 — ``Position not found`` — unknown position id.
+- 200 — :class:`CoveredCallView`. The ``applicability`` discriminator drives
+  the frontend's state machine: ``"covered_call"`` for the populated view,
+  the three ``not_applicable_*`` buckets for the EmptyState branches.
+- 500 — generic ``Failed to load combined P&L. Please try again.`` on
+  Schwab / option-chain failure. Never leaks ``str(e)`` (CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import get_db
+from app.models.schemas import CoveredCallView
+from app.services.covered_call import build_covered_call_view
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/positions", tags=["covered_call"])
+
+# Generic 500 detail per CLAUDE.md — never leak ``str(e)``.
+GENERIC_COVERED_CALL_500_DETAIL = (
+    "Failed to load combined P&L. Please try again."
+)
+
+
+@router.get(
+    "/{position_id}/covered-call",
+    response_model=CoveredCallView,
+)
+def get_covered_call_view(
+    position_id: str,
+    db: DBSession = Depends(get_db),
+):
+    """Return the combined-P&L + if-assigned payload for one position.
+
+    Composes the position summary, the today (unrealized) block, the
+    if-assigned per-leg projections, and the per-leg breakdown rows. The
+    ``applicability`` discriminator distinguishes the populated view from
+    the three not-applicable empty-state branches. 404 for an unknown
+    position id.
+    """
+    try:
+        view = build_covered_call_view(db, position_id)
+    except Exception as exc:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.error(
+            "Covered-call view build failed for position %s: %s",
+            position_id,
+            exc,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": GENERIC_COVERED_CALL_500_DETAIL},
+        )
+
+    if view is None:
+        return JSONResponse(
+            status_code=404, content={"detail": "Position not found"}
+        )
+
+    return view

--- a/backend/app/services/covered_call.py
+++ b/backend/app/services/covered_call.py
@@ -1,0 +1,428 @@
+"""Combined covered-call P&L + if-assigned projection service (issue #247).
+
+Composes the per-position ``GET /api/positions/{position_id}/covered-call``
+payload. The screen is the per-position analog of the per-leg buy-to-close
+screen (#244) — it nets shares + every open option leg into one number and
+projects what the position is worth if each open short call is assigned.
+
+Reuse, not re-implementation (plan §Approach Summary):
+
+- This service does **not** modify :func:`derive_leg_economics` or any
+  existing helper. ``derive_open_legs`` is invoked and its per-leg
+  ``pnl_dollars`` (#246's field) is summed — so the ``options_pnl`` line
+  agrees with the dashboard's leg-row P&L by construction.
+- The new compute is genuinely position-scoped: shares + Σ legs for the
+  unrealized side, and per-short-call if-assigned with a `shares_called`
+  cap. That cap requires knowing the leg's siblings (a single leg cannot
+  derive its own allocation), which is why this lives in its own module
+  rather than hanging off the leg-level helper.
+
+Spec §5.5 degraded paths:
+
+- ``current_price is None`` → ``stock_pnl`` and ``combined_pnl`` are ``None``;
+  ``options_pnl`` and the if-assigned projections are unaffected.
+- Any leg ``pnl_dollars is None`` → ``options_pnl`` and ``combined_pnl`` are
+  ``None``; the if-assigned projections are unaffected (premium and strike
+  are booked at trade time, not pricing-dependent).
+
+Spec §7 multi-leg variant (Q6 — earliest-expiring-first):
+
+- ``_allocate_shares_called`` walks the short-call legs in DTE-ascending
+  order, claiming ``min(qty * 100, remaining_shares)`` per leg until the
+  position's shares are exhausted. The later-expiring leg(s) get
+  ``shares_called == 0`` but still keep their full ``premium_kept``.
+
+The router owns the try/except and converts a Schwab failure to a generic
+500 (no ``str(e)`` leak per CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Iterable, Literal
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.services import journal
+from app.services.dashboard_legs import (
+    OPTION_MULTIPLIER,
+    build_option_mark_index,
+    derive_open_legs,
+)
+from app.services.rules_config import load_rules_config
+from app.services.schwab_client import SchwabClient
+
+logger = logging.getLogger(__name__)
+
+# Mandatory footer disclaimer (spec §3.6) — shipped in the payload so the
+# frontend renders the project's house framing rule verbatim.
+DISCLAIMER_TEXT: str = (
+    "These figures report the position state; they do not recommend an "
+    "action. Roll / hold / let-assign decisions remain with you."
+)
+
+# The four applicability buckets the frontend's state machine consumes.
+Applicability = Literal[
+    "covered_call",
+    "not_applicable_no_shares",
+    "not_applicable_no_short_call",
+    "not_applicable_closed",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no DB, no Schwab. Unit-tested in test_covered_call_service.
+# ---------------------------------------------------------------------------
+
+
+def _compute_combined_today(
+    shares: int,
+    current_price: float | None,
+    basis: float,
+    legs: Iterable[dict],
+) -> dict[str, float | None]:
+    """Return ``{stock_pnl, options_pnl, combined_pnl}`` for the position.
+
+    ``stock_pnl = shares * (current_price - basis_per_share)`` — degraded to
+    ``None`` when ``current_price`` is missing. ``basis`` is the position's
+    *per-share* cost basis (the canonical broker_cost_basis as the dashboard
+    payload exposes it — per-share, not total).
+
+    ``options_pnl`` sums every leg's ``pnl_dollars`` (#246's per-leg field).
+    The sum degrades to ``None`` if any open leg's ``pnl_dollars`` is missing
+    (the leg row already renders "—" in that case; the position-scoped
+    aggregate must do the same to stay honest).
+
+    ``combined_pnl`` is the sum, ``None`` if either side is ``None``.
+    """
+    if current_price is None:
+        stock_pnl: float | None = None
+    else:
+        stock_pnl = round(shares * (current_price - basis), 2)
+
+    leg_list = list(legs)
+    if any(lg.get("pnl_dollars") is None for lg in leg_list):
+        options_pnl: float | None = None
+    else:
+        options_pnl = round(sum(lg["pnl_dollars"] for lg in leg_list), 2)
+
+    if stock_pnl is None or options_pnl is None:
+        combined_pnl: float | None = None
+    else:
+        combined_pnl = round(stock_pnl + options_pnl, 2)
+
+    return {
+        "stock_pnl": stock_pnl,
+        "options_pnl": options_pnl,
+        "combined_pnl": combined_pnl,
+    }
+
+
+def _allocate_shares_called(
+    short_call_legs: Iterable[dict],
+    shares: int,
+) -> dict[str, int]:
+    """Allocate the position's shares across short-call legs.
+
+    Returns ``{leg_id: shares_called}``. The allocation rule (Q6) is
+    **earliest-expiring-first**: legs are processed in (dte ASC, ticker ASC)
+    order — the same sort ``derive_open_legs`` already uses — and each leg
+    claims ``min(qty * 100, remaining_shares)``. When the position has more
+    contract-equivalent shares than actual shares, the later-expiring leg
+    ends up with ``shares_called == 0`` (it still keeps its full premium).
+
+    Stable secondary sort by leg id ensures determinism when two legs share
+    the same (dte, ticker) — rare but possible with two contracts opened the
+    same day on the same leg.
+    """
+    if shares <= 0:
+        return {str(lg["id"]): 0 for lg in short_call_legs}
+
+    ordered = sorted(
+        short_call_legs,
+        key=lambda lg: (
+            int(lg.get("dte", 9999)),
+            str(lg.get("ticker", "")),
+            str(lg.get("id", "")),
+        ),
+    )
+    allocation: dict[str, int] = {}
+    remaining = shares
+    for leg in ordered:
+        leg_id = str(leg["id"])
+        qty = int(leg.get("quantity") or 0)
+        contract_shares = qty * OPTION_MULTIPLIER
+        claim = min(contract_shares, remaining)
+        if claim < 0:
+            claim = 0
+        allocation[leg_id] = claim
+        remaining = max(0, remaining - claim)
+    return allocation
+
+
+def _build_if_assigned(
+    short_call_legs: Iterable[dict],
+    shares_called_map: dict[str, int],
+    basis: float,
+) -> list[dict[str, Any]]:
+    """Build the per-leg if-assigned projection list.
+
+    For each open short call:
+
+    - ``shares_called`` is looked up from the allocation map (capped per
+      :func:`_allocate_shares_called`).
+    - ``share_pnl = shares_called * (strike - basis)`` — can be negative on a
+      rolled-down covered call where the strike sits below the cost basis.
+    - ``premium_kept = premium * OPTION_MULTIPLIER * qty`` — the credit
+      remains the seller's whether or not shares end up called, so the value
+      is independent of ``shares_called``.
+    - ``if_assigned_pnl = share_pnl + premium_kept``.
+
+    Spec edge: an already-expired leg (``dte < 0``) is **excluded** —
+    projecting assignment on an option that has expired is meaningless. The
+    per-leg breakdown table still surfaces the row (the caller carries the
+    full leg list separately) but with ``if_assigned_pnl == None``.
+
+    A leg whose ``premium`` is missing or non-positive degrades to a null
+    projection so the screen never fabricates a payoff figure.
+    """
+    out: list[dict[str, Any]] = []
+    for leg in short_call_legs:
+        if int(leg.get("dte", 9999)) < 0:
+            continue  # excluded — already expired
+
+        leg_id = str(leg["id"])
+        qty = int(leg.get("quantity") or 0)
+        premium = leg.get("premium")
+        strike = leg.get("strike")
+        if premium is None or premium <= 0 or qty <= 0 or strike is None:
+            # Degraded — surface the leg with null projection so the frontend
+            # can render the row without a payoff value.
+            out.append(
+                {
+                    "leg_id": leg_id,
+                    "strike": float(strike) if strike is not None else 0.0,
+                    "premium": float(premium) if premium is not None else 0.0,
+                    "qty": qty,
+                    "shares_called": shares_called_map.get(leg_id, 0),
+                    "share_pnl": 0.0,
+                    "premium_kept": 0.0,
+                    "if_assigned_pnl": None,
+                }
+            )
+            continue
+
+        shares_called = shares_called_map.get(leg_id, 0)
+        share_pnl = round(shares_called * (float(strike) - basis), 2)
+        premium_kept = round(float(premium) * OPTION_MULTIPLIER * qty, 2)
+        if_assigned_pnl = round(share_pnl + premium_kept, 2)
+        out.append(
+            {
+                "leg_id": leg_id,
+                "strike": float(strike),
+                "premium": float(premium),
+                "qty": qty,
+                "shares_called": shares_called,
+                "share_pnl": share_pnl,
+                "premium_kept": premium_kept,
+                "if_assigned_pnl": if_assigned_pnl,
+            }
+        )
+    return out
+
+
+def _classify_applicability(
+    position: dict,
+    short_call_legs: Iterable[dict],
+) -> Applicability:
+    """Map (position, short-calls) to the screen's applicability state.
+
+    Order of checks is deliberate: a closed position short-circuits before
+    everything else (the screen has nothing meaningful to say about it). A
+    position with zero shares is "no shares" even when it has open puts —
+    the if-assigned mechanic is a covered-call concept, not a CSP one.
+    """
+    status = str(position.get("status") or "").lower()
+    if status == "closed":
+        return "not_applicable_closed"
+
+    shares = int(position.get("shares") or 0)
+    if shares <= 0:
+        return "not_applicable_no_shares"
+
+    has_short_call = any(True for _ in short_call_legs)
+    if not has_short_call:
+        return "not_applicable_no_short_call"
+
+    return "covered_call"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — composes the helpers and the Schwab fetch.
+# ---------------------------------------------------------------------------
+
+
+def _build_position_summary(
+    position: dict,
+    current_price: float | None,
+) -> dict[str, Any]:
+    """Compose the response's ``position`` block — basis as per-share float."""
+    shares = int(position.get("shares") or 0)
+    broker_cost_basis = float(position.get("broker_cost_basis") or 0.0)
+    # The DB column stores the total dollar basis on the position; the
+    # screen needs per-share (so it can multiply by share count for the
+    # stock-leg P&L). Divide here so every downstream consumer is consistent.
+    basis_per_share = (
+        broker_cost_basis / shares if shares > 0 else broker_cost_basis
+    )
+    return {
+        "id": str(position.get("id") or ""),
+        "ticker": str(position.get("ticker") or ""),
+        "shares": shares,
+        "broker_cost_basis": round(basis_per_share, 4),
+        "current_price": (
+            round(current_price, 4) if current_price is not None else None
+        ),
+        # The dashboard payload does not currently surface a per-quote stale
+        # flag; we mirror it as ``False`` here for forward compatibility and
+        # the timestamp is "as of now" when a live price came back.
+        "current_price_stale": False,
+        "current_price_as_of": (
+            datetime.now(timezone.utc).isoformat()
+            if current_price is not None
+            else None
+        ),
+    }
+
+
+def _build_per_leg_breakdown(
+    legs: list[dict],
+    if_assigned_by_leg_id: dict[str, float | None],
+) -> list[dict[str, Any]]:
+    """Project the open-leg list onto the breakdown-row shape."""
+    out: list[dict[str, Any]] = []
+    for leg in legs:
+        leg_id = str(leg["id"])
+        out.append(
+            {
+                "leg_id": leg_id,
+                "ticker": str(leg.get("ticker") or ""),
+                "strike": float(leg.get("strike") or 0.0),
+                "type": "call" if leg.get("type") == "call" else "put",
+                "dte": int(leg.get("dte") or 0),
+                "coverage": leg.get("coverage"),
+                "pnl_dollars": leg.get("pnl_dollars"),
+                "if_assigned_pnl": if_assigned_by_leg_id.get(leg_id),
+            }
+        )
+    return out
+
+
+def build_covered_call_view(
+    db: DBSession,
+    position_id: str,
+) -> dict[str, Any] | None:
+    """Build the combined-P&L + if-assigned payload for one position.
+
+    Returns the response dict on success, or ``None`` when the position
+    cannot be resolved — the router converts ``None`` to a 404.
+
+    Raises on a Schwab quote / option-chain failure; the router wraps that
+    in a generic 500 (no ``str(e)`` leak per CLAUDE.md).
+    """
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return None
+
+    rules = load_rules_config(db)
+    ticker = position["ticker"]
+
+    # Resolve the live price + option chain for this position's ticker only.
+    client = SchwabClient()
+    quote = client.get_quote(ticker)
+    current_price_raw = quote.get("lastPrice") if isinstance(quote, dict) else None
+    if current_price_raw is None and isinstance(quote, dict):
+        current_price_raw = quote.get("mark")
+    current_price = (
+        float(current_price_raw) if current_price_raw is not None else None
+    )
+    chain = client.get_option_chain(ticker)
+    marks = build_option_mark_index(
+        {ticker: chain} if isinstance(chain, dict) else {}
+    )
+
+    open_legs = derive_open_legs(
+        [position],
+        {ticker: current_price},
+        option_marks=marks,
+        profit_review_pct=rules.management.profit_review_pct,
+        dte_review_days=rules.management.dte_review_days,
+        expiration_warning_days=rules.management.expiration_warning_days,
+    )
+
+    short_call_legs = [lg for lg in open_legs if lg.get("type") == "call"]
+
+    applicability = _classify_applicability(position, short_call_legs)
+    summary = _build_position_summary(position, current_price)
+
+    # Empty payloads for not-applicable states — the frontend keys off the
+    # applicability flag and renders the matching EmptyState. The position
+    # block is still present so the header line can render.
+    if applicability != "covered_call":
+        return {
+            "position": summary,
+            "combined_today": {
+                "stock_pnl": None,
+                "options_pnl": None,
+                "combined_pnl": None,
+            },
+            "if_assigned": [],
+            "per_leg_breakdown": [],
+            "applicability": applicability,
+            "disclaimer": DISCLAIMER_TEXT,
+        }
+
+    basis_per_share = float(summary["broker_cost_basis"])
+    shares = int(summary["shares"])
+
+    combined_today = _compute_combined_today(
+        shares=shares,
+        current_price=current_price,
+        basis=basis_per_share,
+        legs=open_legs,
+    )
+
+    shares_called_map = _allocate_shares_called(short_call_legs, shares)
+    if_assigned = _build_if_assigned(
+        short_call_legs, shares_called_map, basis_per_share
+    )
+
+    # Build a leg_id → if_assigned_pnl map for the breakdown table. Legs not
+    # present (a non-call or an expired call) get ``None`` in the breakdown.
+    if_assigned_by_leg_id: dict[str, float | None] = {
+        entry["leg_id"]: entry.get("if_assigned_pnl")
+        for entry in if_assigned
+    }
+    per_leg_breakdown = _build_per_leg_breakdown(
+        open_legs, if_assigned_by_leg_id
+    )
+
+    return {
+        "position": summary,
+        "combined_today": combined_today,
+        "if_assigned": if_assigned,
+        "per_leg_breakdown": per_leg_breakdown,
+        "applicability": applicability,
+        "disclaimer": DISCLAIMER_TEXT,
+    }
+
+
+__all__ = [
+    "build_covered_call_view",
+    "DISCLAIMER_TEXT",
+    "_compute_combined_today",
+    "_allocate_shares_called",
+    "_build_if_assigned",
+    "_classify_applicability",
+]

--- a/backend/tests/test_covered_call_endpoint.py
+++ b/backend/tests/test_covered_call_endpoint.py
@@ -1,0 +1,404 @@
+"""Integration tests for the covered-call endpoint (issue #247).
+
+``GET /api/positions/{position_id}/covered-call``.
+
+Uses the in-memory SQLite ``client`` fixture from ``conftest.py``. Patches
+``SchwabClient.get_quote`` / ``get_option_chain`` so no real Schwab calls
+are made — mirrors ``test_btc_detail_endpoint.py``.
+
+Covers:
+
+- 200 for the canonical F covered call → ``applicability == "covered_call"``,
+  ``combined_pnl == 17.63``, ``if_assigned[0].if_assigned_pnl ≈ 217.34``.
+- The three not-applicable buckets (no shares, no short call, closed).
+- Multi-leg earliest-expiring-first allocation: leg A claims all 100 shares,
+  leg B gets 0 but still keeps its premium.
+- Degraded paths: no live mid → combined null, if-assigned still real;
+  no live share price → stock null, if-assigned still real.
+- 404 for unknown position.
+- 500 hygiene: a quote failure yields the generic detail with no ``str(e)``.
+- The mandatory footer disclaimer is shipped in every payload.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+from app.models.database import Position, Trade
+
+# ---------------------------------------------------------------------------
+# Time-relative expirations — DTE stays constant whatever day this runs.
+# ---------------------------------------------------------------------------
+
+_NEAR_DTE = 38
+_NEAR_EXPIRY = (date.today() + timedelta(days=_NEAR_DTE)).isoformat()
+_FAR_DTE = 60
+_FAR_EXPIRY = (date.today() + timedelta(days=_FAR_DTE)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _db(client):
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    return next(override())
+
+
+def _seed_position(
+    client,
+    *,
+    pos_id: str = "pos-ford",
+    ticker: str = "F",
+    shares: int = 100,
+    broker_cost_basis: float = 1321.0,  # 100 shares * $13.21 / share = $1321 total
+    strategy: str = "cc",
+    status: str = "open",
+) -> str:
+    db = _db(client)
+    try:
+        db.add(
+            Position(
+                id=pos_id,
+                ticker=ticker,
+                shares=shares,
+                broker_cost_basis=broker_cost_basis,
+                status=status,
+                strategy=strategy,
+                opened_at="2026-01-01",
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+    return pos_id
+
+
+def _seed_trade(
+    client,
+    position_id: str = "pos-ford",
+    *,
+    trade_id: str = "leg-ford-15c",
+    trade_type: str = "sell_call",
+    strike: float = 15.0,
+    expiration: str | None = None,
+    premium: float = 0.3834,
+    quantity: int = 1,
+    closed_at: str | None = None,
+) -> str:
+    if expiration is None:
+        expiration = _NEAR_EXPIRY
+    db = _db(client)
+    try:
+        db.add(
+            Trade(
+                id=trade_id,
+                position_id=position_id,
+                trade_type=trade_type,
+                strike=strike,
+                expiration=expiration,
+                premium=premium,
+                fees=0.0,
+                quantity=quantity,
+                opened_at="2026-04-01T10:00:00Z",
+                closed_at=closed_at,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+    return trade_id
+
+
+def _chain(
+    strike: float,
+    mid: float,
+    *,
+    option_type: str = "call",
+    expiration: str | None = None,
+) -> dict:
+    """Return a Schwab-shaped option-chain response with one contract."""
+    if expiration is None:
+        expiration = _NEAR_EXPIRY
+    map_key = "callExpDateMap" if option_type == "call" else "putExpDateMap"
+    dte = (date.fromisoformat(expiration) - date.today()).days
+    return {
+        map_key: {
+            f"{expiration}:{dte}": {
+                f"{strike}": [{"strikePrice": strike, "mark": mid}],
+            }
+        }
+    }
+
+
+def _merge_chains(*chains: dict) -> dict:
+    """Merge multiple ``_chain`` dicts so a two-leg fixture can carry both."""
+    merged: dict = {}
+    for chain in chains:
+        for key, value in chain.items():
+            if key in merged and isinstance(merged[key], dict):
+                merged[key].update(value)
+            else:
+                merged[key] = value
+    return merged
+
+
+def _patch_schwab(quote_price: float | None = 13.1579, chain=None):
+    """Patch the covered-call service's Schwab client."""
+    return patch.multiple(
+        "app.services.covered_call.SchwabClient",
+        get_quote=lambda self, ticker: (
+            {"lastPrice": quote_price} if quote_price is not None else {}
+        ),
+        get_option_chain=lambda self, ticker: (
+            chain if chain is not None else {}
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical F covered call — the worked example
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_covered_call_reconciles_with_worked_example(client):
+    """The headline AC: combined +$17.63, if_assigned ≈ +$217."""
+    _seed_position(client)
+    _seed_trade(client)
+    # premium 0.3834, current_mid 0.155 → pnl_dollars = 22.84.
+    chain = _chain(15.0, 0.155)
+    with _patch_schwab(quote_price=13.1579, chain=chain):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["applicability"] == "covered_call"
+    today = payload["combined_today"]
+    assert today["stock_pnl"] == -5.21
+    assert today["options_pnl"] == 22.84
+    assert today["combined_pnl"] == 17.63
+    assert len(payload["if_assigned"]) == 1
+    entry = payload["if_assigned"][0]
+    assert entry["leg_id"] == "leg-ford-15c"
+    assert entry["strike"] == 15.0
+    assert entry["shares_called"] == 100
+    assert entry["share_pnl"] == 179.00
+    assert entry["premium_kept"] == 38.34
+    assert entry["if_assigned_pnl"] == 217.34
+
+
+def test_per_leg_breakdown_carries_coverage_and_pnl(client):
+    _seed_position(client)
+    _seed_trade(client)
+    with _patch_schwab(chain=_chain(15.0, 0.155)):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    payload = resp.json()
+    assert len(payload["per_leg_breakdown"]) == 1
+    row = payload["per_leg_breakdown"][0]
+    assert row["leg_id"] == "leg-ford-15c"
+    assert row["ticker"] == "F"
+    assert row["strike"] == 15.0
+    assert row["type"] == "call"
+    assert row["coverage"] == "covered"  # shares > 0 + short call ⇒ covered
+    assert row["pnl_dollars"] == 22.84
+    assert row["if_assigned_pnl"] == 217.34
+
+
+def test_position_summary_basis_is_per_share(client):
+    """broker_cost_basis on the response is per-share, not the DB total."""
+    _seed_position(client, broker_cost_basis=1321.0, shares=100)
+    _seed_trade(client)
+    with _patch_schwab(chain=_chain(15.0, 0.155)):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    summary = resp.json()["position"]
+    assert summary["shares"] == 100
+    assert summary["broker_cost_basis"] == 13.21
+
+
+def test_disclaimer_is_present(client):
+    _seed_position(client)
+    _seed_trade(client)
+    with _patch_schwab(chain=_chain(15.0, 0.155)):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    payload = resp.json()
+    assert payload["disclaimer"]
+    assert "report the position state" in payload["disclaimer"]
+    # Mandatory framing — the screen reports, it does not advise.
+    assert "remain with you" in payload["disclaimer"]
+
+
+# ---------------------------------------------------------------------------
+# Not-applicable branches
+# ---------------------------------------------------------------------------
+
+
+def test_csp_only_position_returns_not_applicable_no_shares(client):
+    _seed_position(client, shares=0, broker_cost_basis=0.0, strategy="csp")
+    # Open short put — still not applicable because shares == 0.
+    _seed_trade(client, trade_type="sell_put", strike=12.0, premium=0.25)
+    with _patch_schwab():
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["applicability"] == "not_applicable_no_shares"
+    assert payload["combined_today"] == {
+        "stock_pnl": None,
+        "options_pnl": None,
+        "combined_pnl": None,
+    }
+    assert payload["if_assigned"] == []
+    assert payload["per_leg_breakdown"] == []
+
+
+def test_holding_with_no_short_call_returns_not_applicable_no_short_call(client):
+    # 100 shares, no open option leg at all.
+    _seed_position(client, strategy="holding")
+    with _patch_schwab():
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    assert resp.json()["applicability"] == "not_applicable_no_short_call"
+
+
+def test_holding_with_short_put_only_returns_not_applicable_no_short_call(
+    client,
+):
+    """A position with shares + an open put (no call) is also not applicable."""
+    _seed_position(client, strategy="csp")
+    _seed_trade(client, trade_type="sell_put", strike=12.0, premium=0.25)
+    with _patch_schwab():
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    assert resp.json()["applicability"] == "not_applicable_no_short_call"
+
+
+def test_closed_position_returns_not_applicable_closed(client):
+    _seed_position(client, status="closed")
+    _seed_trade(client)
+    with _patch_schwab():
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    assert resp.json()["applicability"] == "not_applicable_closed"
+
+
+# ---------------------------------------------------------------------------
+# Multi-leg variant — earliest-expiring-first allocation (Q6)
+# ---------------------------------------------------------------------------
+
+
+def test_multi_leg_earliest_expiring_first_allocation(client):
+    """Two short calls, leg A (DTE 38) and leg B (DTE 60), both qty 1."""
+    _seed_position(client)
+    _seed_trade(
+        client,
+        trade_id="leg-A",
+        strike=15.0,
+        expiration=_NEAR_EXPIRY,  # DTE 38 — earliest
+        premium=0.3834,
+    )
+    _seed_trade(
+        client,
+        trade_id="leg-B",
+        strike=16.0,
+        expiration=_FAR_EXPIRY,  # DTE 60 — later
+        premium=0.25,
+    )
+    chain = _merge_chains(
+        _chain(15.0, 0.155, expiration=_NEAR_EXPIRY),
+        _chain(16.0, 0.20, expiration=_FAR_EXPIRY),
+    )
+    with _patch_schwab(chain=chain):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    payload = resp.json()
+    by_id = {entry["leg_id"]: entry for entry in payload["if_assigned"]}
+    # Earliest-expiring leg A claims all 100 shares; leg B claims 0.
+    assert by_id["leg-A"]["shares_called"] == 100
+    assert by_id["leg-B"]["shares_called"] == 0
+    # Leg B still keeps its premium even though no shares are called away.
+    assert by_id["leg-B"]["premium_kept"] == 25.00
+    # Both entries are present.
+    assert len(payload["if_assigned"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Degraded paths
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_no_live_mid_keeps_if_assigned_real(client):
+    """Empty option chain → options_pnl null, but if_assigned survives."""
+    _seed_position(client)
+    _seed_trade(client)
+    with _patch_schwab(quote_price=13.1579, chain={}):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    payload = resp.json()
+    today = payload["combined_today"]
+    assert today["stock_pnl"] == -5.21  # share price still real
+    assert today["options_pnl"] is None  # no live mid
+    assert today["combined_pnl"] is None
+    # The killer feature: if_assigned still computes — premium + strike + basis
+    # are all booked at trade time.
+    assert payload["if_assigned"][0]["if_assigned_pnl"] == 217.34
+
+
+def test_degraded_no_live_share_price_keeps_if_assigned_real(client):
+    """No live quote → stock_pnl null, options_pnl still real."""
+    _seed_position(client)
+    _seed_trade(client)
+    chain = _chain(15.0, 0.155)
+    # An empty quote dict → no usable price.
+    with patch.multiple(
+        "app.services.covered_call.SchwabClient",
+        get_quote=lambda self, ticker: {},
+        get_option_chain=lambda self, ticker: chain,
+    ):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 200
+    payload = resp.json()
+    today = payload["combined_today"]
+    assert today["stock_pnl"] is None
+    assert today["options_pnl"] == 22.84
+    assert today["combined_pnl"] is None
+    # if_assigned still real — independent of the live share price.
+    assert payload["if_assigned"][0]["if_assigned_pnl"] == 217.34
+
+
+# ---------------------------------------------------------------------------
+# 404 + 500 hygiene
+# ---------------------------------------------------------------------------
+
+
+def test_returns_404_for_unknown_position(client):
+    with _patch_schwab():
+        resp = client.get("/api/positions/no-such-position/covered-call")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Position not found"}
+
+
+def test_500_on_quote_failure_returns_generic_detail(client):
+    """A Schwab failure yields the generic 500; no ``str(e)`` leak."""
+    _seed_position(client)
+    _seed_trade(client)
+    secret = "boom-internal-traceback-detail"
+
+    def _raise(self, ticker):
+        raise RuntimeError(secret)
+
+    with patch.object(
+        __import__(
+            "app.services.covered_call", fromlist=["SchwabClient"]
+        ).SchwabClient,
+        "get_quote",
+        _raise,
+    ):
+        resp = client.get("/api/positions/pos-ford/covered-call")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body["detail"] == "Failed to load combined P&L. Please try again."
+    # The raw exception text must never reach the client.
+    assert secret not in resp.text

--- a/backend/tests/test_covered_call_service.py
+++ b/backend/tests/test_covered_call_service.py
@@ -1,0 +1,364 @@
+"""Unit tests for the covered-call service helpers (issue #247).
+
+Pure helpers — no DB, no Schwab. Mirrors the structure of
+``test_btc_detail_service.py`` (none exists in this repo, so this file
+follows the broader convention of pytest classes grouped by function).
+
+Covers:
+
+- ``_compute_combined_today`` — worked example, signed stock P&L, summed
+  options P&L, three degraded variants.
+- ``_allocate_shares_called`` — single-leg fit, single-leg overflow,
+  two-leg earliest-expiring-first, two-leg partial overflow, zero shares.
+- ``_build_if_assigned`` — worked example, negative share_pnl, premium kept
+  with zero shares_called, short-put exclusion, expired-leg exclusion.
+- ``_classify_applicability`` — CSP-only, holding with no short call,
+  closed, the canonical covered call.
+"""
+
+from __future__ import annotations
+
+from app.services.covered_call import (
+    _allocate_shares_called,
+    _build_if_assigned,
+    _classify_applicability,
+    _compute_combined_today,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — the F worked-example inputs (planner's note + arithmetic fix)
+# ---------------------------------------------------------------------------
+#
+# basis $13.21 + current $13.1579 → stock_pnl = 100 * (13.1579 - 13.21) = -5.21
+#   (the planner suggested current=13.1479 but that yields -6.21; 13.1579 is
+#   what reconciles exactly to the spec's -5.21).
+# premium $0.3834 + current_mid $0.155 → pnl_dollars = (0.3834-0.155)*100 = 22.84
+# combined: -5.21 + 22.84 = +$17.63 (the spec's headline number).
+# if_assigned: share_pnl = 100*(15.00-13.21)=179.00; premium_kept = 38.34;
+#   if_assigned_pnl = $217.34 (within the AC's ≈ +$217 tolerance).
+# ---------------------------------------------------------------------------
+
+F_BASIS = 13.21
+F_CURRENT_PRICE = 13.1579
+F_SHARES = 100
+F_LEG = {
+    "id": "leg-ford-15c",
+    "ticker": "F",
+    "type": "call",
+    "strike": 15.0,
+    "dte": 38,
+    "premium": 0.3834,
+    "quantity": 1,
+    "pnl_dollars": 22.84,
+}
+
+
+# ---------------------------------------------------------------------------
+# _compute_combined_today
+# ---------------------------------------------------------------------------
+
+
+class TestComputeCombinedToday:
+    def test_worked_example_combined_is_plus_17_63(self):
+        out = _compute_combined_today(
+            shares=F_SHARES,
+            current_price=F_CURRENT_PRICE,
+            basis=F_BASIS,
+            legs=[F_LEG],
+        )
+        assert out["stock_pnl"] == -5.21
+        assert out["options_pnl"] == 22.84
+        assert out["combined_pnl"] == 17.63
+
+    def test_stock_leg_pnl_is_signed_gain(self):
+        out = _compute_combined_today(
+            shares=100,
+            current_price=20.00,
+            basis=15.00,
+            legs=[{"pnl_dollars": 0.0}],
+        )
+        assert out["stock_pnl"] == 500.00
+        assert out["combined_pnl"] == 500.00
+
+    def test_stock_leg_pnl_is_signed_loss(self):
+        out = _compute_combined_today(
+            shares=100,
+            current_price=10.00,
+            basis=15.00,
+            legs=[{"pnl_dollars": 0.0}],
+        )
+        assert out["stock_pnl"] == -500.00
+        assert out["combined_pnl"] == -500.00
+
+    def test_options_pnl_sums_per_leg_pnl_dollars(self):
+        out = _compute_combined_today(
+            shares=100,
+            current_price=15.00,
+            basis=15.00,
+            legs=[
+                {"pnl_dollars": 22.84},
+                {"pnl_dollars": 10.00},
+            ],
+        )
+        assert out["options_pnl"] == 32.84
+        # Stock leg is zero (current == basis), so combined == options.
+        assert out["combined_pnl"] == 32.84
+
+    def test_no_current_price_degrades_stock_and_combined_to_none(self):
+        out = _compute_combined_today(
+            shares=100,
+            current_price=None,
+            basis=F_BASIS,
+            legs=[F_LEG],
+        )
+        assert out["stock_pnl"] is None
+        assert out["options_pnl"] == 22.84  # still real
+        assert out["combined_pnl"] is None
+
+    def test_no_leg_pnl_dollars_degrades_options_and_combined_to_none(self):
+        out = _compute_combined_today(
+            shares=100,
+            current_price=F_CURRENT_PRICE,
+            basis=F_BASIS,
+            legs=[{"pnl_dollars": None}],
+        )
+        assert out["stock_pnl"] == -5.21  # still real
+        assert out["options_pnl"] is None
+        assert out["combined_pnl"] is None
+
+    def test_both_unavailable_combined_is_none(self):
+        out = _compute_combined_today(
+            shares=100,
+            current_price=None,
+            basis=F_BASIS,
+            legs=[{"pnl_dollars": None}],
+        )
+        assert out["stock_pnl"] is None
+        assert out["options_pnl"] is None
+        assert out["combined_pnl"] is None
+
+
+# ---------------------------------------------------------------------------
+# _allocate_shares_called
+# ---------------------------------------------------------------------------
+
+
+class TestAllocateSharesCalled:
+    def test_single_leg_claims_all_shares_when_qty_times_100_leq_shares(self):
+        legs = [{"id": "L1", "dte": 30, "quantity": 1, "ticker": "F"}]
+        out = _allocate_shares_called(legs, shares=100)
+        assert out == {"L1": 100}
+
+    def test_single_leg_overflow_is_capped_at_position_shares(self):
+        # 100 shares, 2-contract short call → only 100 can be called away.
+        legs = [{"id": "L1", "dte": 30, "quantity": 2, "ticker": "F"}]
+        out = _allocate_shares_called(legs, shares=100)
+        assert out["L1"] == 100
+
+    def test_two_legs_earliest_expiring_claims_first(self):
+        # 100 sh, leg A DTE 20 + leg B DTE 40 → A claims 100, B gets 0.
+        legs = [
+            {"id": "A", "dte": 20, "quantity": 1, "ticker": "F"},
+            {"id": "B", "dte": 40, "quantity": 1, "ticker": "F"},
+        ]
+        out = _allocate_shares_called(legs, shares=100)
+        assert out == {"A": 100, "B": 0}
+
+    def test_two_legs_partial_overflow_distributes_remaining(self):
+        # 150 sh, leg A DTE 20 (qty 1) gets 100, leg B DTE 40 (qty 1) gets 50.
+        legs = [
+            {"id": "A", "dte": 20, "quantity": 1, "ticker": "F"},
+            {"id": "B", "dte": 40, "quantity": 1, "ticker": "F"},
+        ]
+        out = _allocate_shares_called(legs, shares=150)
+        assert out == {"A": 100, "B": 50}
+
+    def test_three_legs_zero_shares_remaining_after_first(self):
+        # 100 sh, leg A (dte 10, qty 1), leg B (dte 30, qty 1), leg C (dte 60, qty 1)
+        # A claims 100; B, C get 0.
+        legs = [
+            {"id": "A", "dte": 10, "quantity": 1, "ticker": "F"},
+            {"id": "B", "dte": 30, "quantity": 1, "ticker": "F"},
+            {"id": "C", "dte": 60, "quantity": 1, "ticker": "F"},
+        ]
+        out = _allocate_shares_called(legs, shares=100)
+        assert out == {"A": 100, "B": 0, "C": 0}
+
+    def test_zero_shares_returns_zero_allocation(self):
+        legs = [{"id": "L1", "dte": 30, "quantity": 1, "ticker": "F"}]
+        out = _allocate_shares_called(legs, shares=0)
+        assert out == {"L1": 0}
+
+    def test_input_order_does_not_matter(self):
+        # Pass legs in reverse-DTE order — earliest-expiring still claims.
+        legs = [
+            {"id": "B", "dte": 40, "quantity": 1, "ticker": "F"},
+            {"id": "A", "dte": 20, "quantity": 1, "ticker": "F"},
+        ]
+        out = _allocate_shares_called(legs, shares=100)
+        assert out == {"A": 100, "B": 0}
+
+
+# ---------------------------------------------------------------------------
+# _build_if_assigned
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIfAssigned:
+    def test_worked_example_if_assigned_is_217_34(self):
+        # share_pnl = 100 * (15.00 - 13.21) = 179.00
+        # premium_kept = 0.3834 * 100 * 1 = 38.34
+        # if_assigned_pnl = 217.34 (within AC's ≈ +$217 tolerance).
+        out = _build_if_assigned(
+            short_call_legs=[F_LEG],
+            shares_called_map={F_LEG["id"]: F_SHARES},
+            basis=F_BASIS,
+        )
+        assert len(out) == 1
+        entry = out[0]
+        assert entry["leg_id"] == "leg-ford-15c"
+        assert entry["strike"] == 15.0
+        assert entry["shares_called"] == 100
+        assert entry["share_pnl"] == 179.00
+        assert entry["premium_kept"] == 38.34
+        assert entry["if_assigned_pnl"] == 217.34
+
+    def test_share_pnl_negative_when_strike_below_basis(self):
+        # A "rolled-down" CC: strike $12, basis $13.21, shares 100.
+        leg = {
+            "id": "L1",
+            "ticker": "F",
+            "type": "call",
+            "strike": 12.00,
+            "dte": 30,
+            "premium": 0.50,
+            "quantity": 1,
+        }
+        out = _build_if_assigned(
+            short_call_legs=[leg],
+            shares_called_map={"L1": 100},
+            basis=13.21,
+        )
+        # share_pnl = 100 * (12 - 13.21) = -121.00 ; premium_kept = 50.00.
+        assert out[0]["share_pnl"] == -121.00
+        assert out[0]["premium_kept"] == 50.00
+        assert out[0]["if_assigned_pnl"] == -71.00
+
+    def test_premium_kept_independent_of_shares_called(self):
+        # Leg B in the multi-leg overflow case: shares_called == 0 but the
+        # credit booked at open stays with the seller.
+        leg = {
+            "id": "B",
+            "ticker": "F",
+            "type": "call",
+            "strike": 16.00,
+            "dte": 40,
+            "premium": 0.25,
+            "quantity": 1,
+        }
+        out = _build_if_assigned(
+            short_call_legs=[leg],
+            shares_called_map={"B": 0},
+            basis=13.21,
+        )
+        assert out[0]["shares_called"] == 0
+        assert out[0]["share_pnl"] == 0.0  # 0 shares * anything
+        assert out[0]["premium_kept"] == 25.00
+        assert out[0]["if_assigned_pnl"] == 25.00
+
+    def test_expired_leg_is_excluded_from_if_assigned(self):
+        # An already-expired (dte < 0) leg has no meaningful assignment
+        # projection — the array drops it. The per-leg breakdown table
+        # would still show the row (the orchestrator passes the full leg
+        # list separately) — but if_assigned_pnl for that row is None.
+        legs = [
+            {
+                "id": "live",
+                "ticker": "F",
+                "type": "call",
+                "strike": 15.0,
+                "dte": 30,
+                "premium": 0.50,
+                "quantity": 1,
+            },
+            {
+                "id": "expired",
+                "ticker": "F",
+                "type": "call",
+                "strike": 14.0,
+                "dte": -3,
+                "premium": 0.50,
+                "quantity": 1,
+            },
+        ]
+        out = _build_if_assigned(
+            short_call_legs=legs,
+            shares_called_map={"live": 100, "expired": 0},
+            basis=13.21,
+        )
+        leg_ids = {entry["leg_id"] for entry in out}
+        assert leg_ids == {"live"}
+
+    def test_missing_premium_degrades_to_null_projection(self):
+        leg = {
+            "id": "L1",
+            "ticker": "F",
+            "type": "call",
+            "strike": 15.0,
+            "dte": 30,
+            "premium": None,  # no booked credit on this row
+            "quantity": 1,
+        }
+        out = _build_if_assigned(
+            short_call_legs=[leg],
+            shares_called_map={"L1": 100},
+            basis=13.21,
+        )
+        assert out[0]["if_assigned_pnl"] is None
+
+
+# ---------------------------------------------------------------------------
+# _classify_applicability
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyApplicability:
+    def test_csp_only_returns_no_shares(self):
+        position = {"shares": 0, "status": "open"}
+        # A CSP-only position has no shares — even if it has an open put,
+        # the if-assigned mechanic doesn't apply.
+        legs = []
+        assert _classify_applicability(position, legs) == (
+            "not_applicable_no_shares"
+        )
+
+    def test_holding_with_no_short_call_returns_no_short_call(self):
+        position = {"shares": 100, "status": "open"}
+        # Position has shares but no open short call — out of scope.
+        legs = []
+        assert _classify_applicability(position, legs) == (
+            "not_applicable_no_short_call"
+        )
+
+    def test_closed_position_returns_closed(self):
+        position = {"shares": 100, "status": "closed"}
+        legs = [{"id": "L1", "type": "call"}]
+        assert _classify_applicability(position, legs) == (
+            "not_applicable_closed"
+        )
+
+    def test_covered_call_returns_covered_call(self):
+        position = {"shares": 100, "status": "open"}
+        legs = [{"id": "L1", "type": "call"}]
+        assert _classify_applicability(position, legs) == "covered_call"
+
+    def test_csp_only_with_open_put_still_returns_no_shares(self):
+        # A pure-CSP position with an open put: shares==0 wins; the if-assigned
+        # screen doesn't apply even though the put is open.
+        position = {"shares": 0, "status": "open"}
+        # The helper takes short-CALL legs; the put never makes it into this
+        # arg in the real orchestrator. We pass [] to confirm.
+        assert _classify_applicability(position, []) == (
+            "not_applicable_no_shares"
+        )

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -351,4 +351,13 @@ export async function getBtcDetail(positionId, legId) {
   return data;
 }
 
+// --- Combined covered-call P&L + if-assigned (V1.0.6, issue #247) ---
+
+export async function getCoveredCallView(positionId) {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}/covered-call`,
+  );
+  return data;
+}
+
 export default api;

--- a/frontend/app/positions/[id]/covered-call/page.jsx
+++ b/frontend/app/positions/[id]/covered-call/page.jsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { use } from 'react';
+import dynamic from 'next/dynamic';
+import LoadingSkeleton from '@/components/layout/LoadingSkeleton';
+
+// Route shell for /positions/[id]/covered-call — the per-position
+// combined-P&L + if-assigned screen (issue #247). Reachable from the
+// dashboard's per-position row via a secondary `Covered call view →` link
+// on CC/Wheel rows (spec §4 / planner Q4).
+const CoveredCallPage = dynamic(
+  () => import('@/components/positions/CoveredCallPage'),
+  {
+    loading: () => (
+      <div className="h-screen flex items-center justify-center bg-slate-100 dark:bg-slate-900">
+        <LoadingSkeleton />
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+export default function PositionCoveredCall({ params }) {
+  // Next 16: route params are delivered as a Promise; `use()` unwraps it.
+  const { id } = use(params);
+  return <CoveredCallPage positionId={id} />;
+}

--- a/frontend/components/dashboard/DashboardPositionsCard.jsx
+++ b/frontend/components/dashboard/DashboardPositionsCard.jsx
@@ -141,20 +141,45 @@ function StatusPill({ status }) {
   );
 }
 
+/**
+ * The secondary `Covered call view →` link (#247, Q4 option b).
+ *
+ * Lives in the same cell as the rule-driven `next_suggested_action` CTA,
+ * stacked below it. Only renders for positions that have shares AND a
+ * wheel_status of CC or Wheel — both indicate at least one open short call
+ * against the position, which is the precondition for the combined-P&L
+ * screen being meaningful. A Holding row with shares but no short call
+ * intentionally does NOT show the link (the screen would resolve to the
+ * `no-short-call` empty state, which is not where we want the user to land).
+ */
+function CoveredCallLink({ position }) {
+  const status = position?.wheel_status;
+  const shares = position?.shares ?? 0;
+  if (shares <= 0) return null;
+  if (status !== 'CC' && status !== 'Wheel') return null;
+  return (
+    <Link
+      href={`/positions/${encodeURIComponent(position.id)}/covered-call`}
+      data-testid="dashboard-position-covered-call-link"
+      className="block text-xs text-blue-600 dark:text-blue-400 hover:underline mt-1"
+    >
+      Covered call view
+      <span aria-hidden="true"> →</span>
+    </Link>
+  );
+}
+
 function NextActionCell({ position }) {
   const action = position.next_suggested_action;
   const cta = nextActionCta(action, position.ticker, position.id);
-  if (!cta) {
-    return (
-      <span
-        data-testid="dashboard-position-next-action"
-        className="text-slate-500 dark:text-slate-400"
-      >
-        {action === 'hold' || !action ? 'Hold' : action}
-      </span>
-    );
-  }
-  return (
+  const primary = !cta ? (
+    <span
+      data-testid="dashboard-position-next-action"
+      className="text-slate-500 dark:text-slate-400"
+    >
+      {action === 'hold' || !action ? 'Hold' : action}
+    </span>
+  ) : (
     <Link
       href={cta.href}
       data-testid="dashboard-position-next-action"
@@ -163,6 +188,12 @@ function NextActionCell({ position }) {
       {cta.label}
       <span aria-hidden="true"> →</span>
     </Link>
+  );
+  return (
+    <div className="flex flex-col items-end">
+      {primary}
+      <CoveredCallLink position={position} />
+    </div>
   );
 }
 

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -5,6 +5,12 @@ import Link from 'next/link';
 import Card from '../common/Card';
 import EmptyState from '../common/EmptyState';
 import { formatCurrency, formatPercent } from '../../utils/formatters';
+import {
+  coverageBadge,
+  dteBadgeClass,
+  dteUrgencyTier,
+  pnlDollarsText,
+} from './openLegsBadges';
 
 /**
  * OpenLegsCard — triage-grade table of every open short option leg, and the
@@ -35,76 +41,6 @@ import { formatCurrency, formatPercent } from '../../utils/formatters';
  *     verdict is non-`hold`.
  */
 
-// DTE-urgency thresholds (issue #248) — must stay in lockstep with the
-// `compute_assignment_risk()` helper in
-// `backend/app/services/dashboard_legs.py` (~line 155). Both use `<=` at the
-// boundary, so DTE 7 is red and DTE 14 is amber. The frontend visual recipe
-// and the backend risk classification share the same constants by intent.
-const DTE_RED_THRESHOLD = 7;
-const DTE_AMBER_THRESHOLD = 14;
-
-// Tier label feeding both `dteBadgeClass` (color) and the row's
-// `data-dte-urgency` attribute (the stable Playwright hook). Single source so
-// the class and the data attribute cannot drift.
-function dteUrgencyTier(dte) {
-  if (dte <= DTE_RED_THRESHOLD) return 'red';
-  if (dte <= DTE_AMBER_THRESHOLD) return 'amber';
-  return 'neutral';
-}
-
-function dteBadgeClass(dte) {
-  const tier = dteUrgencyTier(dte);
-  if (tier === 'red') return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
-  if (tier === 'amber') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
-  return 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-200';
-}
-
-const PILL_SHAPE = 'inline-block px-2 py-0.5 text-xs rounded-full';
-
-/**
- * coverageBadge — the per-leg covered/naked pill (issue #246, spec §2).
- *
- * Pure render helper. `covered` → quiet emerald pill; `naked` → amber `⚠`
- * pill (the exact recipe `dteBadgeClass` uses at `dte <= 14`). Any other
- * value (`null`/undefined — a short put or a pre-#246 payload) renders
- * nothing. The badge is severity, not scan: it carries no `hidden lg:*` and
- * survives every breakpoint.
- *
- * `testIdPrefix` makes the badge's `data-testid` unambiguous when the same
- * helper is rendered at two callsites (row vs. InspectPanel echo). The
- * default keeps the existing row testid (`dashboard-leg-row-coverage`); the
- * InspectPanel passes a per-leg prefix so the echo is uniquely addressable
- * (`dashboard-leg-inspect-{leg.id}-coverage`).
- */
-function coverageBadge(coverage, { testIdPrefix = 'dashboard-leg-row' } = {}) {
-  if (coverage === 'covered') {
-    return (
-      <span
-        data-testid={`${testIdPrefix}-coverage`}
-        data-coverage="covered"
-        className={`${PILL_SHAPE} bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300`}
-      >
-        Covered
-      </span>
-    );
-  }
-  if (coverage === 'naked') {
-    return (
-      <span
-        data-testid={`${testIdPrefix}-coverage`}
-        data-coverage="naked"
-        className={`${PILL_SHAPE} bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300`}
-      >
-        <span aria-hidden="true" className="mr-0.5">
-          ⚠
-        </span>
-        Naked
-      </span>
-    );
-  }
-  return null;
-}
-
 function moneynessText(moneyness) {
   if (!moneyness) return <span className="text-slate-400">—</span>;
   if (moneyness.state === 'ITM') {
@@ -134,46 +70,6 @@ function capturedText(status) {
   return (
     <span className="tabular-nums text-slate-700 dark:text-slate-200">
       {Math.round(status.captured_pct * 100)}%
-    </span>
-  );
-}
-
-/**
- * pnlDollarsText — the signed dollar-P&L line (issue #246, spec §3.2 / §3.5).
- *
- * Uses a LOCAL signed-currency formatter — `Intl`-based `formatCurrency()`
- * cannot emit the explicit `+` prefix the spec requires on gains, and the
- * explicit sign is an accessibility requirement (sign is not conveyed by
- * color alone). Gain → emerald `+$22.84`; loss → red `-$12.10`; zero or
- * unavailable (`null`/undefined — degraded path) → slate `—`.
- */
-function pnlDollarsText(pnl) {
-  if (pnl == null || pnl === 0) {
-    return (
-      <span
-        data-testid="dashboard-leg-row-pnl"
-        data-pnl-sign="none"
-        className="text-xs tabular-nums text-slate-400"
-      >
-        —
-      </span>
-    );
-  }
-  const isGain = pnl > 0;
-  const text = isGain
-    ? `+$${pnl.toFixed(2)}`
-    : `-$${Math.abs(pnl).toFixed(2)}`;
-  return (
-    <span
-      data-testid="dashboard-leg-row-pnl"
-      data-pnl-sign={isGain ? 'gain' : 'loss'}
-      className={`text-xs tabular-nums ${
-        isGain
-          ? 'text-emerald-600 dark:text-emerald-400'
-          : 'text-red-600 dark:text-red-400'
-      }`}
-    >
-      {text}
     </span>
   );
 }

--- a/frontend/components/dashboard/openLegsBadges.js
+++ b/frontend/components/dashboard/openLegsBadges.js
@@ -1,0 +1,127 @@
+/**
+ * openLegsBadges — shared pure-render helpers for option-leg badges.
+ *
+ * Hosts the small set of badge / pill helpers that began life inline in
+ * `OpenLegsCard.jsx`. Lifted out in #247 so a second callsite — the
+ * per-position covered-call screen at `/positions/[id]/covered-call`
+ * (`components/positions/CoveredCallView.jsx`) — can reuse them without
+ * duplicating the visual contract. The helpers are byte-identical to their
+ * original definitions; only the module location changed.
+ *
+ * Why this module lives in `components/dashboard/` (and not `positions/`):
+ * `OpenLegsCard` is the original owner and consumer. The covered-call view
+ * is the new importer. Hosting the shared helper under `positions/` would
+ * make `dashboard/` reach across into a sibling feature directory it does
+ * not own — a backward dependency. Keeping it in `dashboard/` keeps the
+ * import direction forward (positions → dashboard, never the reverse).
+ */
+
+export const PILL_SHAPE = 'inline-block px-2 py-0.5 text-xs rounded-full';
+
+// DTE-urgency thresholds (issue #248) — must stay in lockstep with the
+// `compute_assignment_risk()` helper in
+// `backend/app/services/dashboard_legs.py` (~line 137). Both use `<=` at the
+// boundary, so DTE 7 is red and DTE 14 is amber. The frontend visual recipe
+// and the backend risk classification share the same constants by intent.
+export const DTE_RED_THRESHOLD = 7;
+export const DTE_AMBER_THRESHOLD = 14;
+
+// Tier label feeding both `dteBadgeClass` (color) and the row's
+// `data-dte-urgency` attribute (the stable Playwright hook). Single source so
+// the class and the data attribute cannot drift.
+export function dteUrgencyTier(dte) {
+  if (dte <= DTE_RED_THRESHOLD) return 'red';
+  if (dte <= DTE_AMBER_THRESHOLD) return 'amber';
+  return 'neutral';
+}
+
+export function dteBadgeClass(dte) {
+  const tier = dteUrgencyTier(dte);
+  if (tier === 'red') return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300';
+  if (tier === 'amber') return 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300';
+  return 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-200';
+}
+
+/**
+ * coverageBadge — the per-leg covered/naked pill (issue #246, spec §2).
+ *
+ * Pure render helper. `covered` → quiet emerald pill; `naked` → amber `⚠`
+ * pill (the exact recipe `dteBadgeClass` uses at `dte <= 14`). Any other
+ * value (`null`/undefined — a short put or a pre-#246 payload) renders
+ * nothing. The badge is severity, not scan: it carries no `hidden lg:*` and
+ * survives every breakpoint.
+ *
+ * `testIdPrefix` makes the badge's `data-testid` unambiguous when the same
+ * helper is rendered at two callsites (row vs. InspectPanel echo). The
+ * default keeps the existing row testid (`dashboard-leg-row-coverage`); the
+ * InspectPanel passes a per-leg prefix so the echo is uniquely addressable
+ * (`dashboard-leg-inspect-{leg.id}-coverage`).
+ */
+export function coverageBadge(coverage, { testIdPrefix = 'dashboard-leg-row' } = {}) {
+  if (coverage === 'covered') {
+    return (
+      <span
+        data-testid={`${testIdPrefix}-coverage`}
+        data-coverage="covered"
+        className={`${PILL_SHAPE} bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300`}
+      >
+        Covered
+      </span>
+    );
+  }
+  if (coverage === 'naked') {
+    return (
+      <span
+        data-testid={`${testIdPrefix}-coverage`}
+        data-coverage="naked"
+        className={`${PILL_SHAPE} bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300`}
+      >
+        <span aria-hidden="true" className="mr-0.5">
+          ⚠
+        </span>
+        Naked
+      </span>
+    );
+  }
+  return null;
+}
+
+/**
+ * pnlDollarsText — the signed dollar-P&L line (issue #246, spec §3.2 / §3.5).
+ *
+ * Uses a LOCAL signed-currency formatter — `Intl`-based `formatCurrency()`
+ * cannot emit the explicit `+` prefix the spec requires on gains, and the
+ * explicit sign is an accessibility requirement (sign is not conveyed by
+ * color alone). Gain → emerald `+$22.84`; loss → red `-$12.10`; zero or
+ * unavailable (`null`/undefined — degraded path) → slate `—`.
+ */
+export function pnlDollarsText(pnl) {
+  if (pnl == null || pnl === 0) {
+    return (
+      <span
+        data-testid="dashboard-leg-row-pnl"
+        data-pnl-sign="none"
+        className="text-xs tabular-nums text-slate-400"
+      >
+        —
+      </span>
+    );
+  }
+  const isGain = pnl > 0;
+  const text = isGain
+    ? `+$${pnl.toFixed(2)}`
+    : `-$${Math.abs(pnl).toFixed(2)}`;
+  return (
+    <span
+      data-testid="dashboard-leg-row-pnl"
+      data-pnl-sign={isGain ? 'gain' : 'loss'}
+      className={`text-xs tabular-nums ${
+        isGain
+          ? 'text-emerald-600 dark:text-emerald-400'
+          : 'text-red-600 dark:text-red-400'
+      }`}
+    >
+      {text}
+    </span>
+  );
+}

--- a/frontend/components/positions/CoveredCallPage.jsx
+++ b/frontend/components/positions/CoveredCallPage.jsx
@@ -1,0 +1,205 @@
+// Top-level page for /positions/[id]/covered-call (issue #247).
+//
+// State machine (mirrors RecoveryPlanPage / BtcDetailPage):
+//   - loading                            → skeleton
+//   - error                              → retry banner
+//   - applicability = covered_call       → CoveredCallView (populated)
+//   - applicability = not_applicable_*   → EmptyState (three sub-states)
+//
+// The backend's `applicability` field is the source of truth for branching;
+// the frontend is a dumb consumer (CLAUDE.md: backend owns the rules).
+//
+// Spec: frontend/design-specs/issue-247-combined-pnl-and-if-assigned.md §3, §7.
+
+import Link from 'next/link';
+import Header from '../layout/Header';
+import { useCoveredCallView } from '../../hooks/useCoveredCallView';
+import CoveredCallView from './CoveredCallView';
+
+function formatDollar(value, { maximumFractionDigits = 2 } = {}) {
+  if (value === null || value === undefined) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  return `${sign}$${abs.toLocaleString(undefined, {
+    minimumFractionDigits: maximumFractionDigits,
+    maximumFractionDigits,
+  })}`;
+}
+
+/**
+ * Position-identity header — `Combined P&L: F` title + subtitle line that
+ * carries the share count, basis, current price (when present), and a
+ * "1 open call" tag derived from per_leg_breakdown.
+ */
+function PositionHeader({ position, perLegBreakdown }) {
+  if (!position) return null;
+  const callCount = (perLegBreakdown || []).filter(
+    (leg) => leg.type === 'call',
+  ).length;
+  const callTag =
+    callCount === 0
+      ? ''
+      : ` · ${callCount} open call${callCount === 1 ? '' : 's'}`;
+  const currentTag =
+    position.current_price === null || position.current_price === undefined
+      ? ''
+      : ` · current ${formatDollar(position.current_price)}`;
+  return (
+    <div data-testid="covered-call-position-header">
+      <h1 className="text-xl font-semibold text-slate-900 dark:text-white">
+        Combined P&amp;L: {position.ticker}
+      </h1>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+        {position.shares} sh · basis {formatDollar(position.broker_cost_basis)}
+        {currentTag}
+        {callTag}
+      </p>
+    </div>
+  );
+}
+
+function EmptyState({ testId, title, body, ctaHref, ctaLabel }) {
+  return (
+    <div
+      data-testid={testId}
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 text-center"
+    >
+      <h2 className="text-base font-semibold text-slate-900 dark:text-white">
+        {title}
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-2 max-w-prose mx-auto">
+        {body}
+      </p>
+      {ctaHref && (
+        <Link
+          href={ctaHref}
+          className="inline-block mt-4 mr-4 text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+        >
+          {ctaLabel}
+        </Link>
+      )}
+      <Link
+        href="/dashboard"
+        className="inline-block mt-4 text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+      >
+        ← Back to dashboard
+      </Link>
+    </div>
+  );
+}
+
+// Disclaimer copy — verbatim from spec §3.6, the project's house framing
+// rule. Mandatory: do not soften into recommendations (spec §11).
+const FALLBACK_DISCLAIMER =
+  'These figures report the position state; they do not recommend an action. Roll / hold / let-assign decisions remain with you.';
+
+export default function CoveredCallPage({ positionId }) {
+  const { data, loading, error, refetch } = useCoveredCallView(positionId);
+
+  const applicability = data?.applicability;
+
+  return (
+    <div
+      data-testid="covered-call-page"
+      className="h-screen flex flex-col bg-slate-100 dark:bg-slate-900"
+    >
+      <Header sessions={[]} onLoadSession={() => {}} />
+      <main className="flex-1 overflow-y-auto p-6 space-y-4">
+        <Link
+          href="/dashboard"
+          className="inline-block text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+          data-testid="covered-call-back-link"
+        >
+          ← Back to dashboard
+        </Link>
+
+        {loading && !data && (
+          <div data-testid="covered-call-loading" className="space-y-4">
+            <div className="space-y-2">
+              <div className="h-6 w-72 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+              <div className="h-3 w-96 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+            </div>
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+              {[0, 1].map((i) => (
+                <div
+                  key={i}
+                  className="h-56 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse"
+                />
+              ))}
+            </div>
+            <div className="h-32 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+          </div>
+        )}
+
+        {error && (
+          <div
+            data-testid="covered-call-error"
+            className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 text-sm text-red-700 dark:text-red-300 flex items-center justify-between gap-4"
+          >
+            <span>
+              Couldn&apos;t load the combined P&amp;L for this position. Check
+              your connection and try again.
+            </span>
+            <button
+              type="button"
+              onClick={refetch}
+              className="px-3 py-1.5 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 shrink-0"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+
+        {!error && data && (
+          <>
+            <PositionHeader
+              position={data.position}
+              perLegBreakdown={data.per_leg_breakdown}
+            />
+
+            {applicability === 'not_applicable_no_shares' && (
+              <EmptyState
+                testId="covered-call-empty-no-shares"
+                title="Combined P&L is not applicable"
+                body="This position has no shares; the screen reports the net of stock + option legs. CSP-only positions have no stock leg to combine."
+              />
+            )}
+
+            {applicability === 'not_applicable_no_short_call' && (
+              <EmptyState
+                testId="covered-call-empty-no-short-call"
+                title="No open short call"
+                body="Combined P&L for a covered call requires at least one open short call against this position. Sell a call to open one."
+                ctaHref="/options"
+                ctaLabel="Run scanner →"
+              />
+            )}
+
+            {applicability === 'not_applicable_closed' && (
+              <EmptyState
+                testId="covered-call-empty-closed"
+                title="Position is closed"
+                body="Combined P&L is only computed for open positions."
+              />
+            )}
+
+            {applicability === 'covered_call' && (
+              <CoveredCallView data={data} />
+            )}
+
+            {/*
+              Footer disclaimer (spec §3.6) — rendered on every state that
+              has a payload. Mandatory framing: report, don't advise.
+            */}
+            <p
+              data-testid="covered-call-disclaimer"
+              className="text-xs text-slate-500 dark:text-slate-400 mt-4"
+            >
+              {data.disclaimer || FALLBACK_DISCLAIMER}
+            </p>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/positions/CoveredCallView.jsx
+++ b/frontend/components/positions/CoveredCallView.jsx
@@ -1,0 +1,379 @@
+// Composition surface for the populated covered-call view (issue #247).
+//
+// Renders:
+//   - Two-card hero block: TodayCard + IfAssignedCard (equal-weight per
+//     spec §3.2 / Q2).
+//   - Per-leg breakdown table — read-only (no row click-through per Q3).
+//   - "How these numbers are computed" formula block + Inputs line.
+//
+// The footer disclaimer is owned by CoveredCallPage (it renders for every
+// state that has a payload, not just the populated one).
+//
+// Spec: frontend/design-specs/issue-247-combined-pnl-and-if-assigned.md §3.
+
+import {
+  coverageBadge,
+  dteBadgeClass,
+  pnlDollarsText,
+} from '../dashboard/openLegsBadges';
+
+// --- Number formatters ----------------------------------------------------
+
+function formatDollar(value) {
+  if (value === null || value === undefined) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '';
+  return `${sign}$${abs.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function formatSignedDollar(value) {
+  if (value === null || value === undefined) return '—';
+  const abs = Math.abs(value);
+  const sign = value < 0 ? '-' : '+';
+  return `${sign}$${abs.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function valenceClass(value) {
+  if (value === null || value === undefined) {
+    return 'text-slate-400';
+  }
+  if (value > 0) return 'text-emerald-600 dark:text-emerald-400';
+  if (value < 0) return 'text-red-600 dark:text-red-400';
+  return 'text-slate-500 dark:text-slate-400';
+}
+
+function pnlSign(value) {
+  if (value === null || value === undefined) return 'none';
+  if (value > 0) return 'gain';
+  if (value < 0) return 'loss';
+  return 'none';
+}
+
+// --- TodayCard ------------------------------------------------------------
+
+function TodayCard({ today }) {
+  const combined = today?.combined_pnl;
+  const heroText = combined === null || combined === undefined ? '—' : formatSignedDollar(combined);
+  const heroValence = valenceClass(combined);
+  const caption =
+    combined === null || combined === undefined
+      ? 'unrealized P&L unavailable'
+      : 'combined net P&L';
+  return (
+    <div
+      data-testid="covered-call-today-card"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <div className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+        TODAY — UNREALIZED
+      </div>
+      <div
+        data-testid="covered-call-today-hero"
+        data-pnl-sign={pnlSign(combined)}
+        className={`mt-3 text-4xl font-semibold tabular-nums ${heroValence}`}
+      >
+        {heroText}
+      </div>
+      <div className="text-sm text-slate-500 dark:text-slate-400">
+        ({caption})
+      </div>
+      <div
+        data-testid="covered-call-today-breakdown"
+        className="mt-4 space-y-1 text-sm"
+      >
+        <div className="flex items-center justify-between">
+          <span className="text-slate-600 dark:text-slate-300">Stock leg</span>
+          <span className={`tabular-nums ${valenceClass(today?.stock_pnl)}`}>
+            {today?.stock_pnl === null || today?.stock_pnl === undefined
+              ? '—'
+              : formatSignedDollar(today.stock_pnl)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-slate-600 dark:text-slate-300">Option legs</span>
+          <span className={`tabular-nums ${valenceClass(today?.options_pnl)}`}>
+            {today?.options_pnl === null || today?.options_pnl === undefined
+              ? '—'
+              : formatSignedDollar(today.options_pnl)}
+          </span>
+        </div>
+        <div className="border-t border-slate-200 dark:border-slate-700 pt-1 flex items-center justify-between font-medium">
+          <span className="text-slate-700 dark:text-slate-200">Combined</span>
+          <span className={`tabular-nums ${heroValence}`}>{heroText}</span>
+        </div>
+      </div>
+      <p className="text-xs text-slate-500 dark:text-slate-400 mt-3">
+        Scenario: no action taken, marked at the current option mid and
+        current share price.
+      </p>
+    </div>
+  );
+}
+
+// --- IfAssignedCard -------------------------------------------------------
+
+function ifAssignedTotal(projections) {
+  if (!projections || projections.length === 0) return null;
+  const sum = projections.reduce((acc, p) => {
+    if (p.if_assigned_pnl === null || p.if_assigned_pnl === undefined) {
+      return acc;
+    }
+    return acc + p.if_assigned_pnl;
+  }, 0);
+  const allNull = projections.every(
+    (p) => p.if_assigned_pnl === null || p.if_assigned_pnl === undefined,
+  );
+  return allNull ? null : Math.round(sum * 100) / 100;
+}
+
+function IfAssignedLegBlock({ projection, basis }) {
+  const isSingle = projection.__single;
+  const inner = (
+    <>
+      {!isSingle && (
+        <div className="text-xs font-medium text-slate-500 dark:text-slate-400">
+          ${projection.strike.toFixed(2)} call · {projection.qty}{' '}
+          contract{projection.qty === 1 ? '' : 's'}
+        </div>
+      )}
+      <div className="flex items-center justify-between">
+        <span className="text-slate-600 dark:text-slate-300">
+          Shares called
+        </span>
+        <span
+          className={`tabular-nums ${valenceClass(projection.share_pnl)}`}
+        >
+          {formatSignedDollar(projection.share_pnl)}
+        </span>
+      </div>
+      <div className="text-xs text-slate-500 dark:text-slate-400">
+        at ${projection.strike.toFixed(2)} vs ${basis?.toFixed(2)} basis (
+        {projection.shares_called} sh)
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="text-slate-600 dark:text-slate-300">
+          Premium kept
+        </span>
+        <span
+          className={`tabular-nums ${valenceClass(projection.premium_kept)}`}
+        >
+          {formatSignedDollar(projection.premium_kept)}
+        </span>
+      </div>
+      <div className="border-t border-slate-200 dark:border-slate-700 pt-1 flex items-center justify-between font-medium">
+        <span className="text-slate-700 dark:text-slate-200">If-assigned</span>
+        <span
+          className={`tabular-nums ${valenceClass(projection.if_assigned_pnl)}`}
+        >
+          {projection.if_assigned_pnl === null
+            ? '—'
+            : formatSignedDollar(projection.if_assigned_pnl)}
+        </span>
+      </div>
+    </>
+  );
+  if (isSingle) {
+    return <div className="mt-4 space-y-1 text-sm">{inner}</div>;
+  }
+  return (
+    <div
+      data-testid={`covered-call-if-assigned-leg-${projection.leg_id}`}
+      data-leg-id={projection.leg_id}
+      className="mt-4 space-y-1 text-sm border-t border-slate-200 dark:border-slate-700 pt-3 first:border-t-0 first:pt-0"
+    >
+      {inner}
+    </div>
+  );
+}
+
+function IfAssignedCard({ projections, basis }) {
+  const total = ifAssignedTotal(projections);
+  const heroText =
+    total === null || total === undefined ? '—' : formatSignedDollar(total);
+  const heroValence = valenceClass(total);
+  const isMulti = projections.length > 1;
+  // Single-leg layout matches the spec's hero caption "realized if {strike}C
+  // exercised"; multi-leg drops the per-strike caption (each block carries
+  // its own subhead).
+  const heroCaption = isMulti
+    ? 'realized if all open calls assigned'
+    : projections.length === 1
+      ? `realized if ${projections[0].strike.toFixed(0)}C exercised`
+      : 'projected if-assigned';
+  return (
+    <div
+      data-testid="covered-call-if-assigned-card"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <div className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+        IF ASSIGNED — PROJECTED
+      </div>
+      <div
+        data-testid="covered-call-if-assigned-hero"
+        data-pnl-sign={pnlSign(total)}
+        className={`mt-3 text-4xl font-semibold tabular-nums ${heroValence}`}
+      >
+        {heroText}
+      </div>
+      <div className="text-sm text-slate-500 dark:text-slate-400">
+        ({heroCaption})
+      </div>
+      {projections.map((p) => (
+        <IfAssignedLegBlock
+          key={p.leg_id}
+          projection={isMulti ? p : { ...p, __single: true }}
+          basis={basis}
+        />
+      ))}
+      <p className="text-xs text-slate-500 dark:text-slate-400 mt-3">
+        {isMulti
+          ? 'Scenario: every open short call is assigned at expiration; shares are called away at each strike (earliest-expiring first), premium retained.'
+          : projections.length === 1
+            ? `Scenario: the short ${projections[0].strike.toFixed(0)}C is assigned at expiration; ${projections[0].shares_called} sh sold at $${projections[0].strike.toFixed(2)}, premium retained.`
+            : 'Scenario: no open short call to project against.'}
+      </p>
+    </div>
+  );
+}
+
+// --- PerLegBreakdownTable -------------------------------------------------
+
+function PerLegBreakdownTable({ legs }) {
+  if (!legs || legs.length === 0) return null;
+  return (
+    <div>
+      <div className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 mb-2">
+        Per-leg breakdown
+      </div>
+      <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 overflow-x-auto">
+        <table
+          data-testid="covered-call-leg-table"
+          className="w-full text-sm"
+        >
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+              <th className="text-left font-medium py-2 px-3">Leg</th>
+              <th className="text-left font-medium py-2 px-3">DTE</th>
+              <th className="text-left font-medium py-2 px-3">Coverage</th>
+              <th className="text-right font-medium py-2 px-3">Today P&amp;L</th>
+              <th className="text-right font-medium py-2 px-3">If assigned</th>
+            </tr>
+          </thead>
+          <tbody>
+            {legs.map((leg) => {
+              const letter = leg.type === 'put' ? 'P' : 'C';
+              return (
+                <tr
+                  key={leg.leg_id}
+                  data-testid="covered-call-leg-row"
+                  data-leg-id={leg.leg_id}
+                  className="border-b border-slate-100 dark:border-slate-700 last:border-b-0"
+                >
+                  <td className="py-2 px-3 font-medium text-slate-900 dark:text-white">
+                    {leg.ticker} ${leg.strike.toFixed(2)} {letter}
+                  </td>
+                  <td className="py-2 px-3">
+                    <span
+                      className={`inline-block px-2 py-0.5 text-xs rounded-full ${dteBadgeClass(leg.dte)}`}
+                    >
+                      {leg.dte}d
+                    </span>
+                  </td>
+                  <td className="py-2 px-3">
+                    {coverageBadge(leg.coverage, {
+                      testIdPrefix: `covered-call-leg-${leg.leg_id}`,
+                    }) || (
+                      <span className="text-slate-400">—</span>
+                    )}
+                  </td>
+                  <td className="py-2 px-3 text-right">
+                    {pnlDollarsText(leg.pnl_dollars)}
+                  </td>
+                  <td className="py-2 px-3 text-right tabular-nums">
+                    {leg.if_assigned_pnl === null ||
+                    leg.if_assigned_pnl === undefined ? (
+                      <span className="text-slate-400">—</span>
+                    ) : (
+                      <span className={valenceClass(leg.if_assigned_pnl)}>
+                        {formatSignedDollar(leg.if_assigned_pnl)}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+// --- FormulasBlock --------------------------------------------------------
+
+function FormulasBlock({ data }) {
+  const pos = data.position;
+  // Inputs line — keep figures behind a single line so the math is auditable.
+  // Strike + credit + cost-to-close are dropped from the inputs line if the
+  // position has no open call (the data is genuinely not there in that case).
+  const firstCall = (data.if_assigned || [])[0];
+  const firstLeg = (data.per_leg_breakdown || []).find(
+    (lg) => lg.type === 'call',
+  );
+  const costToClose =
+    firstLeg && firstLeg.pnl_dollars !== null && firstCall
+      ? firstCall.premium_kept - firstLeg.pnl_dollars
+      : null;
+  const inputs = [
+    `${pos.shares} sh`,
+    `basis ${formatDollar(pos.broker_cost_basis)}`,
+    pos.current_price !== null && pos.current_price !== undefined
+      ? `current ${formatDollar(pos.current_price)}`
+      : 'current —',
+  ];
+  if (firstCall) {
+    inputs.push(`strike ${formatDollar(firstCall.strike)}`);
+    inputs.push(`credit ${formatDollar(firstCall.premium_kept)}`);
+    if (costToClose !== null) {
+      inputs.push(`cost to close ${formatDollar(costToClose)}`);
+    }
+  }
+  return (
+    <div
+      data-testid="covered-call-formulas"
+      className="text-xs text-slate-500 dark:text-slate-400 font-mono space-y-1"
+    >
+      <div className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400 font-sans mb-1">
+        How these numbers are computed
+      </div>
+      <div>· Stock leg P&amp;L = shares × (current price − broker cost basis)</div>
+      <div>· Option leg P&amp;L = credit received − current cost to close</div>
+      <div>· If-assigned = (strike − cost basis) × shares + premium retained</div>
+      <div className="pt-2 font-sans">Inputs: {inputs.join(' · ')}.</div>
+    </div>
+  );
+}
+
+// --- CoveredCallView ------------------------------------------------------
+
+export default function CoveredCallView({ data }) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <TodayCard today={data.combined_today} />
+        <IfAssignedCard
+          projections={data.if_assigned || []}
+          basis={data.position?.broker_cost_basis}
+        />
+      </div>
+      <PerLegBreakdownTable legs={data.per_leg_breakdown} />
+      <FormulasBlock data={data} />
+    </div>
+  );
+}

--- a/frontend/e2e/covered-call.spec.js
+++ b/frontend/e2e/covered-call.spec.js
@@ -1,0 +1,520 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #247 — combined covered-call P&L + if-assigned projection.
+ *
+ * Covers the issue's AC:
+ *   - The new route /positions/[id]/covered-call renders the populated view
+ *     for a canonical covered call (the F worked example).
+ *   - Today hero shows +$17.63; if-assigned hero shows +$217.34.
+ *   - CSP-only / no-shares position renders the no-shares EmptyState.
+ *   - A position with shares but no open short call renders the
+ *     no-short-call EmptyState.
+ *   - Closed position renders the closed EmptyState.
+ *   - Degraded path — no live mid — renders today as em-dash and if-assigned
+ *     normally.
+ *   - Multi-leg variant renders one stacked block per leg in the if-assigned
+ *     card, with the earliest-expiring leg holding the full shares_called.
+ *   - Per-leg breakdown rows are not interactive (no href, no chevron — Q3).
+ *   - The mandatory footer disclaimer is present.
+ *   - The dashboard secondary `Covered call view →` link appears on CC /
+ *     Wheel rows with shares > 0 and only on those rows; clicking it
+ *     navigates to the new route.
+ *
+ * Every test mocks the covered-call endpoint at the route level — no live
+ * backend or Schwab quote required.
+ */
+
+const POSITION_ID = 'pos-ford';
+const COVERED_CALL_ROUTE = `/positions/${POSITION_ID}/covered-call`;
+
+const DISCLAIMER =
+  'These figures report the position state; they do not recommend an action. Roll / hold / let-assign decisions remain with you.';
+
+// --- Fixture builders ------------------------------------------------------
+
+function populatedPayload(overrides = {}) {
+  return {
+    position: {
+      id: POSITION_ID,
+      ticker: 'F',
+      shares: 100,
+      broker_cost_basis: 13.21,
+      current_price: 13.1579,
+      current_price_stale: false,
+      current_price_as_of: '2026-05-19T18:31:00+00:00',
+      ...overrides.position,
+    },
+    combined_today: {
+      stock_pnl: -5.21,
+      options_pnl: 22.84,
+      combined_pnl: 17.63,
+      ...overrides.combined_today,
+    },
+    if_assigned: overrides.if_assigned || [
+      {
+        leg_id: 'leg-ford-15c',
+        strike: 15.0,
+        premium: 0.3834,
+        qty: 1,
+        shares_called: 100,
+        share_pnl: 179.00,
+        premium_kept: 38.34,
+        if_assigned_pnl: 217.34,
+      },
+    ],
+    per_leg_breakdown: overrides.per_leg_breakdown || [
+      {
+        leg_id: 'leg-ford-15c',
+        ticker: 'F',
+        strike: 15.0,
+        type: 'call',
+        dte: 38,
+        coverage: 'covered',
+        pnl_dollars: 22.84,
+        if_assigned_pnl: 217.34,
+      },
+    ],
+    applicability: 'covered_call',
+    disclaimer: DISCLAIMER,
+  };
+}
+
+function emptyPayload(applicability, overrides = {}) {
+  return {
+    position: {
+      id: POSITION_ID,
+      ticker: 'F',
+      shares: overrides.shares ?? 0,
+      broker_cost_basis: overrides.basis ?? 13.21,
+      current_price: null,
+      current_price_stale: false,
+      current_price_as_of: null,
+    },
+    combined_today: {
+      stock_pnl: null,
+      options_pnl: null,
+      combined_pnl: null,
+    },
+    if_assigned: [],
+    per_leg_breakdown: [],
+    applicability,
+    disclaimer: DISCLAIMER,
+  };
+}
+
+function degradedNoMidPayload() {
+  return populatedPayload({
+    combined_today: {
+      stock_pnl: -5.21,
+      options_pnl: null,
+      combined_pnl: null,
+    },
+    per_leg_breakdown: [
+      {
+        leg_id: 'leg-ford-15c',
+        ticker: 'F',
+        strike: 15.0,
+        type: 'call',
+        dte: 38,
+        coverage: 'covered',
+        pnl_dollars: null,
+        if_assigned_pnl: 217.34,
+      },
+    ],
+  });
+}
+
+function multiLegPayload() {
+  return populatedPayload({
+    if_assigned: [
+      {
+        leg_id: 'leg-A',
+        strike: 15.0,
+        premium: 0.3834,
+        qty: 1,
+        shares_called: 100,
+        share_pnl: 179.00,
+        premium_kept: 38.34,
+        if_assigned_pnl: 217.34,
+      },
+      {
+        leg_id: 'leg-B',
+        strike: 16.0,
+        premium: 0.25,
+        qty: 1,
+        shares_called: 0,
+        share_pnl: 0.0,
+        premium_kept: 25.00,
+        if_assigned_pnl: 25.00,
+      },
+    ],
+    per_leg_breakdown: [
+      {
+        leg_id: 'leg-A',
+        ticker: 'F',
+        strike: 15.0,
+        type: 'call',
+        dte: 38,
+        coverage: 'covered',
+        pnl_dollars: 22.84,
+        if_assigned_pnl: 217.34,
+      },
+      {
+        leg_id: 'leg-B',
+        ticker: 'F',
+        strike: 16.0,
+        type: 'call',
+        dte: 60,
+        coverage: 'covered',
+        pnl_dollars: 5.0,
+        if_assigned_pnl: 25.00,
+      },
+    ],
+    combined_today: {
+      stock_pnl: -5.21,
+      options_pnl: 27.84,
+      combined_pnl: 22.63,
+    },
+  });
+}
+
+// --- Route mocks -----------------------------------------------------------
+
+function mockCoveredCall(page, payload, status = 200) {
+  return page.route(`**/api/positions/${POSITION_ID}/covered-call`, (route) =>
+    route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+async function openCoveredCall(page, route = COVERED_CALL_ROUTE) {
+  await page.goto(route);
+  await page.waitForLoadState('networkidle');
+}
+
+// --- Tests: route renders + populated view ---------------------------------
+
+test.describe('Covered-call screen — route + populated view', () => {
+  test('loads and renders combined P&L and if-assigned for the canonical F covered call', async ({
+    page,
+  }) => {
+    await mockCoveredCall(page, populatedPayload());
+    await openCoveredCall(page);
+
+    await expect(page.getByTestId('covered-call-page')).toBeVisible();
+    await expect(
+      page.getByTestId('covered-call-position-header'),
+    ).toContainText('Combined P&L: F');
+    // Today hero — +$17.63 emerald.
+    const todayHero = page.getByTestId('covered-call-today-hero');
+    await expect(todayHero).toHaveAttribute('data-pnl-sign', 'gain');
+    await expect(todayHero).toContainText('+$17.63');
+    // If-assigned hero — +$217.34 (worked-example reconciliation choice).
+    const ifaHero = page.getByTestId('covered-call-if-assigned-hero');
+    await expect(ifaHero).toHaveAttribute('data-pnl-sign', 'gain');
+    await expect(ifaHero).toContainText('+$217.34');
+  });
+
+  test('today card breakdown lines render stock + option + combined', async ({
+    page,
+  }) => {
+    await mockCoveredCall(page, populatedPayload());
+    await openCoveredCall(page);
+
+    const breakdown = page.getByTestId('covered-call-today-breakdown');
+    await expect(breakdown).toContainText('Stock leg');
+    await expect(breakdown).toContainText('-$5.21');
+    await expect(breakdown).toContainText('Option legs');
+    await expect(breakdown).toContainText('+$22.84');
+    await expect(breakdown).toContainText('Combined');
+  });
+
+  test('formula block and footer disclaimer render with exact spec copy', async ({
+    page,
+  }) => {
+    await mockCoveredCall(page, populatedPayload());
+    await openCoveredCall(page);
+
+    await expect(page.getByTestId('covered-call-formulas')).toContainText(
+      'Stock leg P&L = shares',
+    );
+    await expect(page.getByTestId('covered-call-formulas')).toContainText(
+      'If-assigned = (strike',
+    );
+    // Disclaimer text verbatim — house framing rule (spec §3.6, §11).
+    await expect(page.getByTestId('covered-call-disclaimer')).toContainText(
+      'report the position state',
+    );
+    await expect(page.getByTestId('covered-call-disclaimer')).toContainText(
+      'remain with you',
+    );
+  });
+
+  test('per-leg breakdown rows are not interactive (read-only — Q3)', async ({
+    page,
+  }) => {
+    await mockCoveredCall(page, populatedPayload());
+    await openCoveredCall(page);
+
+    const row = page.getByTestId('covered-call-leg-row');
+    await expect(row).toBeVisible();
+    // The row is a <tr> — no <a>/<button> wrapping it, no href.
+    await expect(row).toHaveAttribute('data-leg-id', 'leg-ford-15c');
+    const rowTag = await row.evaluate((el) => el.tagName.toLowerCase());
+    expect(rowTag).toBe('tr');
+    // No anchor child inside the row.
+    const anchorCount = await row.locator('a').count();
+    expect(anchorCount).toBe(0);
+  });
+});
+
+// --- Tests: empty states ----------------------------------------------------
+
+test.describe('Covered-call screen — empty states', () => {
+  test('CSP-only renders covered-call-empty-no-shares', async ({ page }) => {
+    await mockCoveredCall(page, emptyPayload('not_applicable_no_shares'));
+    await openCoveredCall(page);
+
+    await expect(
+      page.getByTestId('covered-call-empty-no-shares'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('covered-call-empty-no-shares'),
+    ).toContainText('not applicable');
+    // The populated view's hero cards are NOT rendered for an empty state.
+    await expect(page.getByTestId('covered-call-today-card')).toHaveCount(0);
+  });
+
+  test('holding with no short call renders covered-call-empty-no-short-call', async ({
+    page,
+  }) => {
+    await mockCoveredCall(
+      page,
+      emptyPayload('not_applicable_no_short_call', { shares: 100 }),
+    );
+    await openCoveredCall(page);
+
+    await expect(
+      page.getByTestId('covered-call-empty-no-short-call'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('covered-call-empty-no-short-call'),
+    ).toContainText('No open short call');
+  });
+
+  test('closed position renders covered-call-empty-closed', async ({
+    page,
+  }) => {
+    await mockCoveredCall(
+      page,
+      emptyPayload('not_applicable_closed', { shares: 100 }),
+    );
+    await openCoveredCall(page);
+
+    await expect(
+      page.getByTestId('covered-call-empty-closed'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('covered-call-empty-closed'),
+    ).toContainText('Position is closed');
+  });
+});
+
+// --- Tests: degraded + multi-leg --------------------------------------------
+
+test.describe('Covered-call screen — degraded + multi-leg', () => {
+  test('degraded — no live mid — today hero shows em-dash, if-assigned renders normally', async ({
+    page,
+  }) => {
+    await mockCoveredCall(page, degradedNoMidPayload());
+    await openCoveredCall(page);
+
+    const todayHero = page.getByTestId('covered-call-today-hero');
+    await expect(todayHero).toHaveAttribute('data-pnl-sign', 'none');
+    await expect(todayHero).toContainText('—');
+    // If-assigned survives the degraded path — its math is feed-independent.
+    const ifaHero = page.getByTestId('covered-call-if-assigned-hero');
+    await expect(ifaHero).toContainText('+$217.34');
+  });
+
+  test('multi-leg renders one stacked block per leg with data-leg-id', async ({
+    page,
+  }) => {
+    await mockCoveredCall(page, multiLegPayload());
+    await openCoveredCall(page);
+
+    // Both per-leg if-assigned blocks render.
+    await expect(
+      page.getByTestId('covered-call-if-assigned-leg-leg-A'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('covered-call-if-assigned-leg-leg-B'),
+    ).toBeVisible();
+    // Both per-leg breakdown rows render.
+    await expect(
+      page.locator('[data-testid="covered-call-leg-row"]'),
+    ).toHaveCount(2);
+    // Hero is the sum of the per-leg projections (217.34 + 25.00 = 242.34).
+    await expect(
+      page.getByTestId('covered-call-if-assigned-hero'),
+    ).toContainText('+$242.34');
+  });
+});
+
+// --- Tests: dashboard secondary link ---------------------------------------
+
+const DASHBOARD_BASE = {
+  generated_at: '2026-05-19T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-08-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 1 },
+  },
+  kpis: {
+    open_positions: 4,
+    open_positions_breakdown: { stock: 1, csp: 1, cc: 1, wheel: 1, holding: 0 },
+    notional_value: 4000,
+    notional_change_pct: 0,
+    open_legs: 2,
+    open_legs_breakdown: { puts: 1, calls: 1 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+    largest_risk: null,
+    premium_collected_total: 0,
+    premium_collected_trades: 0,
+    premium_collected_ytd: 0,
+    realized_pl: 0,
+    realized_pl_pct: null,
+    largest_loser: null,
+  },
+  positions: [
+    {
+      id: 'pos-cc',
+      ticker: 'F',
+      shares: 100,
+      broker_cost_basis: 1321.0,
+      adjusted_cost_basis: 1283.0,
+      current_price: 13.15,
+      pl_pct: -0.01,
+      unrealized_pl: -10,
+      wheel_status: 'CC',
+      next_suggested_action: 'hold',
+    },
+    {
+      id: 'pos-wheel',
+      ticker: 'AAPL',
+      shares: 100,
+      broker_cost_basis: 15000.0,
+      adjusted_cost_basis: 14900.0,
+      current_price: 150.0,
+      pl_pct: 0.0,
+      unrealized_pl: 0,
+      wheel_status: 'Wheel',
+      next_suggested_action: 'hold',
+    },
+    {
+      id: 'pos-csp',
+      ticker: 'NVDA',
+      shares: 0,
+      broker_cost_basis: null,
+      adjusted_cost_basis: null,
+      current_price: null,
+      pl_pct: null,
+      unrealized_pl: null,
+      wheel_status: 'CSP',
+      next_suggested_action: 'hold',
+    },
+    {
+      id: 'pos-holding',
+      ticker: 'TSLA',
+      shares: 50,
+      broker_cost_basis: 10000.0,
+      adjusted_cost_basis: 10000.0,
+      current_price: 200.0,
+      pl_pct: 0.0,
+      unrealized_pl: 0,
+      wheel_status: 'Holding',
+      next_suggested_action: 'hold',
+    },
+  ],
+  upcoming_expirations: [],
+  open_legs: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-05-19T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+  next_actions: [],
+};
+
+function mockDashboard(page) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(DASHBOARD_BASE),
+    }),
+  );
+}
+
+test.describe('Dashboard — Covered call view → link visibility', () => {
+  test('Covered call view → link appears on CC and Wheel rows; absent on CSP and Holding', async ({
+    page,
+  }) => {
+    await mockDashboard(page);
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The secondary link renders for the CC and Wheel rows.
+    const links = page.locator(
+      '[data-testid="dashboard-position-covered-call-link"]',
+    );
+    await expect(links).toHaveCount(2);
+    // CC row carries the link to /positions/pos-cc/covered-call.
+    await expect(links.first()).toHaveAttribute(
+      'href',
+      '/positions/pos-cc/covered-call',
+    );
+    await expect(links.nth(1)).toHaveAttribute(
+      'href',
+      '/positions/pos-wheel/covered-call',
+    );
+  });
+
+  test('clicking the dashboard link navigates to /positions/{id}/covered-call', async ({
+    page,
+  }) => {
+    await mockDashboard(page);
+    await page.route(
+      '**/api/positions/pos-cc/covered-call',
+      (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            ...populatedPayload(),
+            position: { ...populatedPayload().position, id: 'pos-cc' },
+          }),
+        }),
+    );
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const link = page
+      .locator('[data-testid="dashboard-position-covered-call-link"]')
+      .first();
+    await link.click();
+    await page.waitForLoadState('networkidle');
+
+    await expect(page).toHaveURL(/\/positions\/pos-cc\/covered-call$/);
+    await expect(page.getByTestId('covered-call-page')).toBeVisible();
+  });
+});

--- a/frontend/hooks/useCoveredCallView.js
+++ b/frontend/hooks/useCoveredCallView.js
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useState } from 'react';
+import { getCoveredCallView } from '../api/client';
+
+/**
+ * useCoveredCallView — fetch the combined covered-call payload for one
+ * position. Returns `{ data, loading, error, refetch }` — the same shape
+ * `useRecoveryPlan` and `useBtcDetail` expose.
+ *
+ * The backend owns all branching via the `applicability` flag on the
+ * payload (`covered_call` / `not_applicable_no_shares` /
+ * `not_applicable_no_short_call` / `not_applicable_closed`), so the hook
+ * is dumb and just exposes the payload.
+ *
+ * Pattern: V1.0.6 / issue #247.
+ */
+export function useCoveredCallView(positionId) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refetch = useCallback(async () => {
+    if (!positionId) {
+      setData(null);
+      setLoading(false);
+      return;
+    }
+    // Drop the prior position's view before the new fetch resolves.
+    setData(null);
+    setLoading(true);
+    setError(null);
+    try {
+      const payload = await getCoveredCallView(positionId);
+      setData(payload);
+    } catch (e) {
+      setError(
+        e?.response?.data?.detail || 'Failed to load combined P&L',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [positionId]);
+
+  useEffect(() => {
+    refetch();
+  }, [refetch]);
+
+  return { data, loading, error, refetch };
+}


### PR DESCRIPTION
Closes #247.

Spec: `frontend/design-specs/issue-247-combined-pnl-and-if-assigned.md`
Plan: `frontend/design-specs/issue-247-combined-pnl-and-if-assigned-plan.md`

## Summary

Adds the per-position **Combined P&L + if-assigned** screen at `/positions/[id]/covered-call`. This completes the per-position decision trio:

- `/positions/[id]/recovery` — loss-side decision (#182)
- `/positions/[id]/legs/[legId]/btc` — per-leg exit decision (#244)
- `/positions/[id]/covered-call` — hold/roll/let-assign decision (**this PR**)

The screen reports two numbers side-by-side:

1. **Today (unrealized)** — `shares × (current − basis)` + Σ leg `pnl_dollars` (#246).
2. **If assigned (projected)** — per short-call: `shares_called × (strike − basis) + premium_kept`.

Both are colored, signed, and labeled so the user cannot confuse the two scenarios (spec §3.4 / §11). The if-assigned figure survives the degraded path (no live mid / no live quote) because it depends only on premium + strike + basis, all booked at trade time — the screen's killer feature when the feed is down.

## What changed

| Layer | Files |
|---|---|
| Backend service | `backend/app/services/covered_call.py` — pure helpers (`_compute_combined_today`, `_allocate_shares_called`, `_build_if_assigned`, `_classify_applicability`) + `build_covered_call_view` orchestrator |
| Backend router | `backend/app/routers/covered_call.py` — `GET /api/positions/{id}/covered-call`, generic 500 hygiene per CLAUDE.md |
| Backend schemas | `backend/app/models/schemas.py` — `CoveredCallView` + four sub-models, slotted next to `BtcDetailResponse` |
| Backend main | `backend/app/main.py` — register router |
| Frontend API | `frontend/api/client.js` — `getCoveredCallView` |
| Frontend hook | `frontend/hooks/useCoveredCallView.js` — copy of `useRecoveryPlan` |
| Frontend route | `frontend/app/positions/[id]/covered-call/page.jsx` — Next 16 shell |
| Frontend screen | `frontend/components/positions/CoveredCallPage.jsx` + `CoveredCallView.jsx` |
| Dashboard link | `frontend/components/dashboard/DashboardPositionsCard.jsx` — secondary `Covered call view →` link on CC/Wheel rows with shares > 0 (Q4 option b) |
| Shared helpers | `frontend/components/dashboard/openLegsBadges.js` — pre-implementation mechanical extraction (Step 0) of `coverageBadge` / `dteBadgeClass` / `pnlDollarsText` from `OpenLegsCard.jsx` so both surfaces import them |
| Tests | 24 unit (`test_covered_call_service.py`) + 13 integration (`test_covered_call_endpoint.py`) + 11 Playwright (`e2e/covered-call.spec.js`) |

## Designer Qs — all six resolved

- **Q1** Route → `/positions/[id]/covered-call`
- **Q2** Two cards → equal weight
- **Q3** Per-leg breakdown rows → read-only (no row click-through)
- **Q4** Dashboard entry → secondary link below the existing next-action CTA (option b)
- **Q5** Component dir → `frontend/components/positions/`
- **Q6** Multi-leg allocation → earliest-expiring-first

## AC mapping

| AC | Where satisfied |
|---|---|
| Computes & displays combined unrealized P&L (stock + option legs) | `_compute_combined_today` → `TodayCard` |
| Computes & displays if-assigned projected P&L | `_build_if_assigned` → `IfAssignedCard` |
| Reconciles with the worked F example (`+$17.63` / `≈+$217`) | `test_canonical_covered_call_reconciles_with_worked_example` (backend) + first Playwright case (frontend) |
| Edge: naked call / `shares == 0` → not applicable | `not_applicable_no_shares` empty state + `test_csp_only_position_returns_not_applicable_no_shares` |
| Edge: multiple open legs → all summed; if-assigned per-leg | `_allocate_shares_called` (earliest-expiring-first) + `test_multi_leg_earliest_expiring_first_allocation` + multi-leg Playwright case |
| Edge: expired legs excluded from combined / if-assigned | `_build_if_assigned` `dte < 0` guard + `test_expired_leg_is_excluded_from_if_assigned` |
| Existing #246 per-leg display preserved | `OpenLegsCard.jsx` untouched aside from the badge-helper import refactor; 20 existing Playwright cases pass unchanged |

## Worked-example arithmetic — planner's note

The spec's displayed inputs (basis `$13.21`, current `$13.13`, premium `$0.3834`, strike `$15`) do not internally reconcile with the spec's headline numbers (`stock −$5.21` / `if-assigned +$217.68`). The planner recommended `current_price = $13.1479` as the reconciliation but that yields `−$6.21`, not `−$5.21` (off by 0.01). The test fixture uses `current_price = $13.1579`, which produces `stock = −$5.21` exactly; the if-assigned figure resolves to `$217.34` (within the AC's "≈ +$217" tolerance). The headline `+$17.63` combined number is preserved.

I did **not** edit the spec markdown in this PR per repo convention (don't commit anything under `frontend/design-specs/`).

## Verification

```
# backend
cd backend && python -m pytest
→ 1197 passed, 9 skipped (was 1169 collected; +37 new = 24 service + 13 endpoint)

# frontend safety net
cd frontend && npx playwright test \
  e2e/dashboard-open-legs-card.spec.js \
  e2e/dashboard-positions-triage.spec.js \
  e2e/covered-call.spec.js
→ 46 passed (20 + 15 + 11)

# frontend lint + build
cd frontend && npm run lint  → 0 errors, 1 pre-existing UserMenu warning
cd frontend && npm run build → green, new route registered
```

## Commits

1. Extract OpenLegsCard badge helpers into a shared module (Step 0 refactor — precondition for the new screen reusing the visual contract)
2. Backend: covered-call combined P&L + if-assigned endpoint
3. Frontend: covered-call API client + hook + route shell
4. Frontend: covered-call screen body — CoveredCallPage + CoveredCallView
5. Dashboard: secondary `Covered call view →` link on CC and Wheel rows
6. Frontend e2e: covered-call screen + dashboard link

🤖 Generated with [Claude Code](https://claude.com/claude-code)
