### PR TITLE
v1.0.8 — Dashboard panel polish (closes #251 #252 #257 #258 #259)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -744,6 +744,12 @@ class DashboardOpenLeg(BaseModel):
     assignment_risk: DASHBOARD_ASSIGNMENT_RISK
     suggested_action: DASHBOARD_SUGGESTED_ACTION
     earnings_in_window: bool = False
+    # Contract count for the leg. Strict `int = 1` (not Optional) — the dict
+    # pass-through at `dashboard_legs.py:479` already coerces via
+    # `int(trade.get("quantity") or 1)`. Logically part of the core leg shape;
+    # predates the V1.0.6 economics block below. Made explicit in V1.0.8 (#252)
+    # so the InspectPanel `Credit received` line can scale by quantity.
+    quantity: int = 1
     # New in V1.0.4 (#240) — the §R6 rule-monitor verdict layer. All four
     # fields default so older payloads / tests that omit them still validate.
     verdict: DASHBOARD_VERDICT = "hold"

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -752,11 +752,13 @@ class DashboardOpenLeg(BaseModel):
     triggered_rules: list[DashboardRuleEvaluation] = []
     # New in V1.0.6 (#246) — coverage severity + dollar economics. All four
     # default so older payloads / tests that omit them still validate.
-    # coverage: "covered" / "naked" for a short call by Position.shares; None
-    # for a short put. premium is the per-share credit booked at open.
-    # pnl_dollars / cost_to_close are whole-position dollars (per-share value
-    # × 100 × quantity); both None whenever % CAPT is unavailable.
-    coverage: Optional[Literal["covered", "naked"]] = None
+    # coverage: "covered" / "partial" / "naked" for a short call by
+    # Position.shares vs. quantity × 100; None for a short put. premium is
+    # the per-share credit booked at open. pnl_dollars / cost_to_close are
+    # whole-position dollars (per-share value × 100 × quantity); both None
+    # whenever % CAPT is unavailable. ``partial`` (V1.0.8 / #251) covers the
+    # 0 < shares < quantity × 100 range — see dashboard_legs.derive_leg_economics.
+    coverage: Optional[Literal["covered", "partial", "naked"]] = None
     premium: Optional[float] = None
     pnl_dollars: Optional[float] = None
     cost_to_close: Optional[float] = None
@@ -1154,7 +1156,7 @@ class CoveredCallLegBreakdown(BaseModel):
     strike: float
     type: Literal["call", "put"]
     dte: int
-    coverage: Optional[Literal["covered", "naked"]] = None
+    coverage: Optional[Literal["covered", "partial", "naked"]] = None
     pnl_dollars: Optional[float] = None
     if_assigned_pnl: Optional[float] = None
 

--- a/backend/app/routers/options.py
+++ b/backend/app/routers/options.py
@@ -1,11 +1,17 @@
 import logging
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import get_db
 from app.models.schemas import OptionScanRequest, OptionScanResponse
 from app.services.options_scanner import OptionScanner, OptionScannerError
+from app.services.rejection_relax import (
+    NotRelaxableError,
+    RelaxPreviewRequest,
+    RelaxPreviewResponse,
+    preview_relax,
+)
 from app.services.rules_config import RulesConfig, load_rules_config
 from app.services.schwab_client import SchwabClient, SchwabClientError
 from app.services.schwab_auth import SchwabAuthError
@@ -82,6 +88,38 @@ def scan_options(
     """
     _resolve_scan_rules(req, load_rules_config(db))
     return scanner.scan(req)
+
+
+@router.post("/scan/relax", response_model=RelaxPreviewResponse)
+def scan_relax(
+    req: RelaxPreviewRequest,
+    db: DBSession = Depends(get_db),
+):
+    """Preview how many rejected strikes recover at a relaxed threshold.
+
+    Stateless what-if (issue #258, v1.0.8): the client echoes the
+    ``rejected`` array from the last scan; the server re-applies the
+    relaxed threshold to those strikes and returns the recovered set. No
+    market data is fetched. See :func:`app.services.rejection_relax.preview_relax`
+    for the relax math.
+
+    Errors (generic strings only, per CLAUDE.md):
+
+    - 400 ``"rule not relaxable"`` — binary or unknown rule family.
+    - 500 ``"Failed to compute relax preview"`` — unexpected internal failure.
+    """
+    try:
+        rules = load_rules_config(db)
+        return preview_relax(req, rules)
+    except NotRelaxableError:
+        raise HTTPException(status_code=400, detail="rule not relaxable")
+    except HTTPException:
+        raise
+    except Exception:  # noqa: BLE001 — last-resort generic boundary
+        logger.exception("Failed to compute relax preview for rule=%s", req.rule)
+        raise HTTPException(
+            status_code=500, detail="Failed to compute relax preview"
+        )
 
 
 @router.get("/earnings/{ticker}")

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -223,14 +223,19 @@ def derive_leg_economics(
 ) -> dict:
     """Return the coverage + dollar-economics payload for one open leg (#246).
 
-    ``coverage`` is derived from the ``shares`` key on the position dict, not
-    from any live option quote, so it survives the degraded path:
-    - short call & ``position_shares > 0``  → ``"covered"``
-    - short call & ``position_shares == 0`` → ``"naked"``
-    - a short put                           → ``None``
+    ``coverage`` is derived from the ``shares`` key on the position dict and
+    the ``quantity`` of contracts on the leg, not from any live option quote,
+    so it survives the degraded path. The tri-state (V1.0.8 / #251) is:
 
-    Coverage is binary — there is no "partially covered" state (a short 2-call
-    leg against 100 shares still reads ``"covered"``).
+    - short call & ``position_shares >= quantity * 100`` → ``"covered"``
+    - short call & ``0 < position_shares < quantity * 100`` → ``"partial"``
+    - short call & ``position_shares == 0`` → ``"naked"``
+    - a short put → ``None``
+
+    ``quantity`` missing / ``0`` / ``None`` degrades the tri-state to the
+    pre-#251 binary behavior (``"covered"`` if shares > 0, ``"naked"`` if
+    shares == 0) — preserves the v1.0.6 contract for legs that pre-date the
+    ``quantity`` field.
 
     ``pnl_dollars`` and ``cost_to_close`` are whole-position dollars
     (per-share value × :data:`OPTION_MULTIPLIER` × quantity) — the figures that
@@ -261,9 +266,19 @@ def derive_leg_economics(
         ``{"coverage", "premium", "pnl_dollars", "cost_to_close"}``.
     """
     if option_type == "call":
-        coverage: Literal["covered", "naked"] | None = (
-            "covered" if position_shares > 0 else "naked"
-        )
+        # Tri-state coverage (#251). ``quantity`` missing/0/None degrades to
+        # the pre-#251 binary fallback so legs that pre-date the quantity
+        # field still classify cleanly.
+        if position_shares <= 0:
+            coverage: Literal["covered", "partial", "naked"] | None = "naked"
+        elif quantity and quantity > 0:
+            underlying_needed = quantity * OPTION_MULTIPLIER
+            if position_shares >= underlying_needed:
+                coverage = "covered"
+            else:
+                coverage = "partial"
+        else:
+            coverage = "covered"
     else:
         coverage = None
 

--- a/backend/app/services/rejection_relax.py
+++ b/backend/app/services/rejection_relax.py
@@ -1,0 +1,483 @@
+"""Rejection-relax preview service (issue #258, v1.0.8).
+
+Backs the **stateless** ``POST /api/options/scan/relax`` endpoint that answers
+the user's question: "If I loosened rule X a little, how many of the strikes
+the scanner just rejected would come back?" The answer is computed purely
+from the ``rejected[]`` payload the client echoes from the most recent scan —
+the server **never re-fetches market data**.
+
+V1 contract (v1.0.8 freeze, see ``plans/have-the-cto-review-bubbly-orbit.md``):
+
+- 7 **relaxable** rule families, each with a locked relax recipe:
+
+  =================  ===================================================
+  Rule               Relax recipe
+  =================  ===================================================
+  delta_out_of_range Widen the band by ±0.05 on each side
+  low_open_interest  Floor ÷ 2
+  wide_bid_ask_spread Cap × 1.5
+  fails_10pct_rule   Required distance − 5 percentage points
+  below_cost_basis   Cost-basis floor − 5 percentage points
+  return_below_target Target − 1 percentage point
+  return_above_cap   Cap + 50 percentage points
+  =================  ===================================================
+
+- 2 **binary** rule families (``itm_put``, ``zero_bid``) — no meaningful
+  relaxation exists; the router raises ``HTTPException(400)`` with the
+  generic detail ``"rule not relaxable"``.
+
+The recovered set
+-----------------
+A strike "recovers" iff its ``rejection_reasons`` set:
+
+1. contains the relaxed rule, **and**
+2. **after** the relaxed threshold is re-applied, no longer trips that rule,
+   **and**
+3. has no *other* rejection reason (i.e. the relaxed rule was the **only**
+   rule it was failing — single-rule recovery).
+
+This third condition is what the spec calls "would actually come back if I
+loosened that rule a little." A strike failing two rules is not freed by
+relaxing one of them.
+
+Threshold text strings
+----------------------
+The endpoint returns pre-formatted ``current_threshold_text`` and
+``relaxed_threshold_text`` so the frontend does not need to know each rule's
+unit (count, percent, ratio, dollars). The two strings are pinned per rule
+in :data:`_THRESHOLD_FORMATTERS`.
+
+Generic-error discipline
+------------------------
+Per CLAUDE.md, raw exception messages never leak. The router maps any
+unexpected internal failure to a generic 500 ``"Failed to compute relax
+preview"``. Binary rules are surfaced as the generic 400 ``"rule not
+relaxable"`` — never the original code or the raw rule name.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from app.models.schemas import RejectedStrike
+from app.services.rules_config import RulesConfig
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public Pydantic shapes (the router's request and response bodies)
+# ---------------------------------------------------------------------------
+
+
+class RelaxPreviewRequest(BaseModel):
+    """Request body for ``POST /api/options/scan/relax``.
+
+    The client echoes the ``rejected`` array from the most recent scan; the
+    server never re-fetches market data. ``ticker`` and ``strategy`` are
+    carried for completeness / logging but are not required to compute the
+    recovered set.
+    """
+
+    ticker: str
+    strategy: str
+    rule: str
+    rejected: list[RejectedStrike] = Field(default_factory=list)
+
+
+class RecoveredStrike(BaseModel):
+    """A strike that would recover at the relaxed threshold."""
+
+    strike: float
+    expiration: str
+
+
+class RelaxPreviewResponse(BaseModel):
+    """Response body for ``POST /api/options/scan/relax``."""
+
+    rule: str
+    current_threshold_text: str
+    relaxed_threshold_text: str
+    recovered_count: int
+    recovered_strikes: list[RecoveredStrike]
+
+
+# ---------------------------------------------------------------------------
+# Rule classification
+# ---------------------------------------------------------------------------
+
+
+# The 7 rule families whose threshold has a meaningful "relax to X" recipe.
+RELAXABLE_RULES: frozenset[str] = frozenset(
+    {
+        "delta_out_of_range",
+        "low_open_interest",
+        "wide_bid_ask_spread",
+        "fails_10pct_rule",
+        "below_cost_basis",
+        "return_below_target",
+        "return_above_cap",
+    }
+)
+
+# The 2 binary rule families — no relaxation exists. Surfaced by the router
+# as a generic 400 ``"rule not relaxable"``.
+BINARY_RULES: frozenset[str] = frozenset({"itm_put", "zero_bid"})
+
+
+class NotRelaxableError(ValueError):
+    """Raised when the requested rule is binary / unknown. Mapped by the
+    router to a generic 400 with the canonical message.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Regexes for parsing the raw rejection-reason strings emitted by
+# ``OptionScanner._check_rejection`` and ``rejection_messages``.
+# ---------------------------------------------------------------------------
+
+
+_FAILS_10PCT_RE = re.compile(
+    r"^fails_10pct_rule:\s*strike\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*above basis,\s*"
+    r"requires\s*(?P<min>-?\d+(?:\.\d+)?)%\s*$"
+)
+_BELOW_COST_BASIS_RE = re.compile(
+    r"^below_cost_basis:\s*strike\s*\$(?P<strike>-?\d+(?:\.\d+)?)\s*<\s*"
+    r"floor\s*\$(?P<floor>-?\d+(?:\.\d+)?)\s*$"
+)
+_DELTA_OUT_OF_RANGE_RE = re.compile(
+    r"^delta_out_of_range:\s*\|(?P<delta>-?\d+(?:\.\d+)?)\|\s*not in\s*"
+    r"\[(?P<min>-?\d+(?:\.\d+)?),\s*(?P<max>-?\d+(?:\.\d+)?)\]\s*$"
+)
+_LOW_OI_RE = re.compile(
+    r"^low_open_interest:\s*(?P<oi>-?\d+)\s*<\s*(?P<min>-?\d+)\s*$"
+)
+_WIDE_SPREAD_RE = re.compile(
+    r"^wide_bid_ask_spread:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*>\s*"
+    r"(?P<max>-?\d+(?:\.\d+)?)%\s*$"
+)
+_RETURN_BELOW_RE = re.compile(
+    r"^return_below_target:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*<\s*"
+    r"(?P<min>-?\d+(?:\.\d+)?)%\s*$"
+)
+_RETURN_ABOVE_RE = re.compile(
+    r"^return_above_cap:\s*(?P<pct>-?\d+(?:\.\d+)?)%\s*>\s*"
+    r"(?P<max>-?\d+(?:\.\d+)?)%\s*$"
+)
+
+
+def _extract_rule_family(raw: str) -> Optional[str]:
+    """Return the rule family — the prefix up to the first colon.
+
+    Mirrors the frontend's ``extractRuleFamily`` in
+    ``scannerRejectionLabels.js``. Returns ``None`` for empty/unparseable
+    strings. The ``zero_bid`` family is emitted as a literal code (no
+    colon); we handle that branch explicitly.
+    """
+    if not raw:
+        return None
+    if raw == "zero_bid" or raw.startswith("zero_bid"):
+        return "zero_bid"
+    match = re.match(r"^([a-z0-9_]+)", raw, flags=re.IGNORECASE)
+    return match.group(1) if match else None
+
+
+# ---------------------------------------------------------------------------
+# Per-rule "would this still fire at the relaxed threshold?" predicates
+# ---------------------------------------------------------------------------
+#
+# Each predicate parses the raw rejection-reason string the scanner emitted,
+# extracts the observed value, and returns ``True`` iff the rule would
+# still fire under the relaxed threshold. Unparseable strings default to
+# ``True`` (still rejecting) — defensive: never claim a strike recovered
+# without proof.
+
+
+def _still_fails_fails_10pct(raw: str) -> bool:
+    match = _FAILS_10PCT_RE.match(raw)
+    if not match:
+        return True
+    pct = float(match.group("pct"))
+    requires = float(match.group("min"))
+    relaxed_requires = requires - 5.0  # -5pp
+    return pct < relaxed_requires
+
+
+def _still_fails_below_cost_basis(raw: str) -> bool:
+    match = _BELOW_COST_BASIS_RE.match(raw)
+    if not match:
+        return True
+    strike = float(match.group("strike"))
+    floor = float(match.group("floor"))
+    # Relax floor by -5 percentage points of *the floor itself*. Per V1
+    # contract: "floor -5pp" — the floor is a percent-margin threshold; the
+    # scanner persists it as a dollar floor that already encodes the
+    # percent. Drop the dollar floor by 5% of the original floor value
+    # (i.e. floor * (1 - 0.05) is the relaxed dollar floor, which is the
+    # spec's "5pp" applied to a 0-anchored percentage rule).
+    #
+    # Rationale: ``below_cost_basis`` is the bare at-or-above-basis floor
+    # gated by ``min_call_distance_from_cost_basis_pct`` (default 0). The
+    # raw rejection text gives us the resolved dollar floor; the only
+    # consistent way to translate "-5pp" into a dollar relaxation is to
+    # drop the floor by 5% of itself.
+    relaxed_floor = floor * (1.0 - 0.05)
+    return strike < relaxed_floor
+
+
+def _still_fails_delta(raw: str) -> bool:
+    match = _DELTA_OUT_OF_RANGE_RE.match(raw)
+    if not match:
+        return True
+    delta = abs(float(match.group("delta")))
+    min_d = float(match.group("min"))
+    max_d = float(match.group("max"))
+    # Widen the band by ±0.05 on each side.
+    relaxed_min = max(0.0, min_d - 0.05)
+    relaxed_max = min(1.0, max_d + 0.05)
+    return delta < relaxed_min or delta > relaxed_max
+
+
+def _still_fails_low_oi(raw: str) -> bool:
+    match = _LOW_OI_RE.match(raw)
+    if not match:
+        return True
+    oi = int(match.group("oi"))
+    min_oi = int(match.group("min"))
+    relaxed_min = max(0, min_oi // 2)
+    return oi < relaxed_min
+
+
+def _still_fails_wide_spread(raw: str) -> bool:
+    match = _WIDE_SPREAD_RE.match(raw)
+    if not match:
+        return True
+    pct = float(match.group("pct"))
+    max_pct = float(match.group("max"))
+    relaxed_max = max_pct * 1.5
+    return pct > relaxed_max
+
+
+def _still_fails_return_below(raw: str) -> bool:
+    match = _RETURN_BELOW_RE.match(raw)
+    if not match:
+        return True
+    pct = float(match.group("pct"))
+    min_pct = float(match.group("min"))
+    relaxed_min = min_pct - 1.0  # -1pp
+    return pct < relaxed_min
+
+
+def _still_fails_return_above(raw: str) -> bool:
+    match = _RETURN_ABOVE_RE.match(raw)
+    if not match:
+        return True
+    pct = float(match.group("pct"))
+    max_pct = float(match.group("max"))
+    relaxed_max = max_pct + 50.0  # +50pp
+    return pct > relaxed_max
+
+
+_STILL_FAILS_PREDICATES = {
+    "fails_10pct_rule": _still_fails_fails_10pct,
+    "below_cost_basis": _still_fails_below_cost_basis,
+    "delta_out_of_range": _still_fails_delta,
+    "low_open_interest": _still_fails_low_oi,
+    "wide_bid_ask_spread": _still_fails_wide_spread,
+    "return_below_target": _still_fails_return_below,
+    "return_above_cap": _still_fails_return_above,
+}
+
+
+# ---------------------------------------------------------------------------
+# Threshold formatters — return ``(current_text, relaxed_text)`` for the rule,
+# resolved against the persisted rules config.
+# ---------------------------------------------------------------------------
+
+
+def _fmt_pct(value: float) -> str:
+    """Format a whole-percent value compactly (drops trailing ``.0``)."""
+    if value == int(value):
+        return f"{int(value)}%"
+    return f"{value:.1f}%"
+
+
+def _fmt_int(value: int) -> str:
+    return f"{int(value)}"
+
+
+def _fmt_band(min_v: float, max_v: float) -> str:
+    return f"{min_v:.2f}–{max_v:.2f}"  # en-dash separator
+
+
+def _thresholds_fails_10pct(rules: RulesConfig) -> tuple[str, str]:
+    current = float(rules.entry.min_call_distance_pct)
+    relaxed = current - 5.0
+    return _fmt_pct(current), _fmt_pct(relaxed)
+
+
+def _thresholds_below_cost_basis(rules: RulesConfig) -> tuple[str, str]:
+    current = float(rules.entry.min_call_distance_from_cost_basis_pct)
+    relaxed = current - 5.0
+    return _fmt_pct(current), _fmt_pct(relaxed)
+
+
+def _thresholds_delta(rules: RulesConfig) -> tuple[str, str]:
+    # CSP is the default scan band; the popover does not (yet) know which
+    # delta band fired. The chosen band is informational text only — the
+    # actual recovered-set re-evaluation parses the raw rejection string
+    # which already carries the firing band's bounds.
+    band = rules.entry.delta_range_csp
+    current = _fmt_band(float(band.min), float(band.max))
+    relaxed_min = max(0.0, float(band.min) - 0.05)
+    relaxed_max = min(1.0, float(band.max) + 0.05)
+    relaxed = _fmt_band(relaxed_min, relaxed_max)
+    return current, relaxed
+
+
+def _thresholds_low_oi(rules: RulesConfig) -> tuple[str, str]:
+    current = int(rules.universe.min_open_interest)
+    relaxed = max(0, current // 2)
+    return _fmt_int(current), _fmt_int(relaxed)
+
+
+def _thresholds_wide_spread(rules: RulesConfig) -> tuple[str, str]:
+    current = float(rules.universe.max_bid_ask_spread_pct)
+    relaxed = current * 1.5
+    return _fmt_pct(current), _fmt_pct(relaxed)
+
+
+def _thresholds_return_below(rules: RulesConfig) -> tuple[str, str]:
+    current = float(rules.entry.min_monthly_return_pct)
+    relaxed = current - 1.0
+    return _fmt_pct(current), _fmt_pct(relaxed)
+
+
+def _thresholds_return_above(rules: RulesConfig) -> tuple[str, str]:
+    # The scanner has no persisted "max monthly return cap" — the
+    # ``return_above_cap`` rejection text carries the cap inline. Use the
+    # rejection text's cap when available; fall back to a "—" placeholder
+    # when no strike emitted the rule (the popover only opens for rules
+    # that have at least one rejection chip, so this fallback is defensive).
+    return ("—", "—")
+
+
+_THRESHOLD_FORMATTERS = {
+    "fails_10pct_rule": _thresholds_fails_10pct,
+    "below_cost_basis": _thresholds_below_cost_basis,
+    "delta_out_of_range": _thresholds_delta,
+    "low_open_interest": _thresholds_low_oi,
+    "wide_bid_ask_spread": _thresholds_wide_spread,
+    "return_below_target": _thresholds_return_below,
+    "return_above_cap": _thresholds_return_above,
+}
+
+
+def _threshold_texts_for_return_above(
+    rejected: list[RejectedStrike],
+) -> tuple[str, str]:
+    """Special-case ``return_above_cap`` — read the cap from a raw reason.
+
+    The scanner does not persist a "max monthly return cap" in
+    :class:`RulesConfig` (today). Pull the cap from the first matching
+    rejection string and apply ``+50pp``. Falls back to a ``"—"`` placeholder
+    when no parseable string is present.
+    """
+    for r in rejected:
+        for raw in r.rejection_reasons or []:
+            match = _RETURN_ABOVE_RE.match(raw)
+            if match:
+                cap = float(match.group("max"))
+                return _fmt_pct(cap), _fmt_pct(cap + 50.0)
+    return ("—", "—")
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def preview_relax(
+    req: RelaxPreviewRequest, rules: RulesConfig
+) -> RelaxPreviewResponse:
+    """Compute the recovered set under the relaxed threshold.
+
+    Args:
+        req: The request body — carries ``ticker``, ``strategy``, ``rule``,
+            and the ``rejected`` array echoed from the most recent scan.
+        rules: The persisted :class:`RulesConfig` — used to format the
+            ``current_threshold_text`` per rule.
+
+    Returns:
+        :class:`RelaxPreviewResponse` with the recovered count and (up to
+        the full set of) recovered strikes. Frontend truncates for display.
+
+    Raises:
+        :class:`NotRelaxableError`: when ``req.rule`` is in
+            :data:`BINARY_RULES` or unknown. The router maps this to a
+            generic 400.
+    """
+    rule = req.rule
+
+    if rule in BINARY_RULES or rule not in RELAXABLE_RULES:
+        raise NotRelaxableError("rule not relaxable")
+
+    predicate = _STILL_FAILS_PREDICATES[rule]
+
+    # Threshold-text resolution. ``return_above_cap`` reads its cap from the
+    # rejection-reason payload (no persisted config field) — handled
+    # explicitly so the formatter signature stays uniform.
+    if rule == "return_above_cap":
+        current_text, relaxed_text = _threshold_texts_for_return_above(
+            req.rejected
+        )
+    else:
+        current_text, relaxed_text = _THRESHOLD_FORMATTERS[rule](rules)
+
+    recovered: list[RecoveredStrike] = []
+    for r in req.rejected:
+        reasons = r.rejection_reasons or []
+        if not reasons:
+            continue
+        # The strike must be failing the requested rule.
+        families = {_extract_rule_family(raw) for raw in reasons}
+        families.discard(None)
+        if rule not in families:
+            continue
+        # The strike must be failing ONLY that rule (single-reason
+        # recovery; multi-reason rows still fail the other rules even when
+        # we relax this one).
+        if len(reasons) != 1 or len(families) != 1:
+            continue
+        raw = reasons[0]
+        if not predicate(raw):
+            recovered.append(
+                RecoveredStrike(strike=r.strike, expiration=r.expiration)
+            )
+
+    # Canonical sort: strike asc, expiration asc. Stable so equal strikes
+    # surface in payload order within the expiration tier.
+    recovered.sort(key=lambda s: (s.strike, s.expiration))
+
+    return RelaxPreviewResponse(
+        rule=rule,
+        current_threshold_text=current_text,
+        relaxed_threshold_text=relaxed_text,
+        recovered_count=len(recovered),
+        recovered_strikes=recovered,
+    )
+
+
+__all__ = [
+    "BINARY_RULES",
+    "RELAXABLE_RULES",
+    "NotRelaxableError",
+    "RecoveredStrike",
+    "RelaxPreviewRequest",
+    "RelaxPreviewResponse",
+    "preview_relax",
+]

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -1119,6 +1119,108 @@ class TestDeriveOpenLegsEconomics:
         assert leg["cost_to_close"] is None
         assert leg["premium"] == 0.521
 
+    # ---- V1.0.8 / #251 — partial-coverage tri-state ----
+
+    def test_wheel_position_per_leg_partial_coverage(self):
+        # 100 held shares + 2 short calls (200 shares' worth of obligation).
+        # Both call legs share the same position dict — the per-leg `quantity`
+        # is what flips them from `covered` to `partial`. The sell_put leg on
+        # the same wheel still reads `None` (coverage is a short-call axis).
+        positions = [
+            self._position(
+                "TSLA",
+                "p-tsla-partial",
+                [
+                    {
+                        "id": "t-call-2x",
+                        "trade_type": "sell_call",
+                        "strike": 260.0,
+                        "expiration": "2026-06-19",
+                        "premium": 3.00,
+                        "quantity": 2,
+                        "closed_at": None,
+                    },
+                    {
+                        "id": "t-put-1x",
+                        "trade_type": "sell_put",
+                        "strike": 220.0,
+                        "expiration": "2026-06-19",
+                        "premium": 2.50,
+                        "quantity": 1,
+                        "closed_at": None,
+                    },
+                ],
+                shares=100,
+            )
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"TSLA": 240.0},
+            today=date(2026, 5, 19),
+        )
+        by_id = {leg["id"]: leg for leg in legs}
+        # Only 100 of the 200 shares needed to back the 2 short calls — partial.
+        assert by_id["t-call-2x"]["coverage"] == "partial"
+        # The cash-secured put leg remains coverage-less.
+        assert by_id["t-put-1x"]["coverage"] is None
+
+    def test_partial_at_boundary(self):
+        # 99 shares vs. 1 short call (100 shares needed) — one share short of
+        # covered. The strict-inequality lower boundary of the `covered` branch.
+        positions = [
+            self._position(
+                "F",
+                "p-f-99",
+                [
+                    {
+                        "id": "t-f15c-99",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2026-06-26",
+                        "premium": 0.3834,
+                        "quantity": 1,
+                        "closed_at": None,
+                    }
+                ],
+                shares=99,
+            )
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"F": 13.50},
+            today=date(2026, 5, 19),
+        )
+        assert legs[0]["coverage"] == "partial"
+
+    def test_covered_when_shares_meet_obligation_exactly(self):
+        # 100 shares vs. 1 short call (100 shares needed) — the inclusive
+        # boundary of the `covered` branch. An exact match is `covered`, not
+        # `partial`. Pinned so a future refactor does not flip the `>=` to `>`.
+        positions = [
+            self._position(
+                "F",
+                "p-f-exact",
+                [
+                    {
+                        "id": "t-f15c-exact",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2026-06-26",
+                        "premium": 0.3834,
+                        "quantity": 1,
+                        "closed_at": None,
+                    }
+                ],
+                shares=100,
+            )
+        ]
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"F": 13.50},
+            today=date(2026, 5, 19),
+        )
+        assert legs[0]["coverage"] == "covered"
+
 
 class TestDashboardOpenLegSchemaBackwardCompat:
     """Schema-level guard: the V1.0.6 (#246) economics fields are optional.

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -1152,3 +1152,132 @@ class TestDashboardOpenLegSchemaBackwardCompat:
         assert leg.premium is None
         assert leg.pnl_dollars is None
         assert leg.cost_to_close is None
+
+
+class TestDashboardOpenLegQuantity:
+    """Quantity field + per-contract economics reconciliation (V1.0.8 #252).
+
+    The InspectPanel renders `Credit received = premium * 100 * quantity` on
+    the degraded path. These tests pin the schema field default and confirm
+    `derive_leg_economics` scales `pnl_dollars` / `cost_to_close` by the
+    trade's quantity (the field is wired through `dashboard_legs.py:479`).
+    """
+
+    def _position(
+        self,
+        ticker: str,
+        position_id: str,
+        trades: list[dict],
+        shares: int = 0,
+    ) -> dict:
+        return {
+            "id": position_id,
+            "ticker": ticker,
+            "shares": shares,
+            "trades": trades,
+        }
+
+    def test_quantity_field_defaults_to_1(self):
+        # A pre-#252 payload (no `quantity` key) must still validate, with
+        # `quantity` resolving to `1`. Protects backward compat with legacy
+        # tests and cached fixtures.
+        old_payload = {
+            "id": "leg-1",
+            "ticker": "AAPL",
+            "type": "put",
+            "strike": 175.0,
+            "expiration": "2026-05-08",
+            "dte": 7,
+            "moneyness": None,
+            "position_id": "pos-aapl",
+            "profit_target_status": {"captured_pct": None, "state": "unknown"},
+            "assignment_risk": "low",
+            "suggested_action": "hold",
+            "earnings_in_window": False,
+        }
+        leg = DashboardOpenLeg(**old_payload)
+        assert leg.quantity == 1
+
+    def test_quantity_2_dollars_reconcile(self):
+        # qty=2, premium=$3.00/sh, current_mid=$1.50/sh.
+        # Credit received  = premium * 100 * qty  = 3.00 * 100 * 2 = $600
+        # cost_to_close    = mid * 100 * qty      = 1.50 * 100 * 2 = $300
+        # pnl_dollars      = (prem-mid)*100*qty   = 1.50 * 100 * 2 = $300
+        # => credit_received == pnl_dollars + cost_to_close  (V1.0.6 §3.4)
+        positions = [
+            self._position(
+                "AAPL",
+                "p-aapl",
+                [
+                    {
+                        "id": "t-aapl175c",
+                        "trade_type": "sell_call",
+                        "strike": 175.0,
+                        "expiration": "2026-06-19",
+                        "premium": 3.00,
+                        "quantity": 2,
+                        "closed_at": None,
+                    }
+                ],
+                shares=200,
+            )
+        ]
+        option_marks = {("AAPL", "call", 175.0, "2026-06-19"): 1.50}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"AAPL": 170.0},
+            today=date(2026, 5, 19),
+            option_marks=option_marks,
+        )
+        leg = legs[0]
+        assert leg["quantity"] == 2
+        assert leg["pnl_dollars"] == 300.00
+        assert leg["cost_to_close"] == 300.00
+        # The reconciliation identity the InspectPanel relies on:
+        assert leg["pnl_dollars"] + leg["cost_to_close"] == leg["premium"] * 100 * leg["quantity"]
+
+    def test_quantity_3_economics_scale(self):
+        # Two-leg comparison: qty=1 vs qty=3 with identical premium/mid → the
+        # qty=3 leg's dollar figures are exactly 3× the qty=1 leg's. Confirms
+        # the field is wired through from `Trade.quantity` to the schema.
+        positions = [
+            self._position(
+                "F",
+                "p-f",
+                [
+                    {
+                        "id": "t-f15c-qty1",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2026-06-26",
+                        "premium": 0.3834,
+                        "quantity": 1,
+                        "closed_at": None,
+                    },
+                    {
+                        "id": "t-f15c-qty3",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2026-06-26",
+                        "premium": 0.3834,
+                        "quantity": 3,
+                        "closed_at": None,
+                    },
+                ],
+                shares=300,
+            )
+        ]
+        option_marks = {("F", "call", 15.0, "2026-06-26"): 0.155}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"F": 13.50},
+            today=date(2026, 5, 19),
+            option_marks=option_marks,
+        )
+        by_id = {leg["id"]: leg for leg in legs}
+        qty1 = by_id["t-f15c-qty1"]
+        qty3 = by_id["t-f15c-qty3"]
+        assert qty1["quantity"] == 1
+        assert qty3["quantity"] == 3
+        assert qty3["pnl_dollars"] == pytest.approx(qty1["pnl_dollars"] * 3)
+        assert qty3["cost_to_close"] == pytest.approx(qty1["cost_to_close"] * 3)

--- a/backend/tests/test_rejection_relax.py
+++ b/backend/tests/test_rejection_relax.py
@@ -1,0 +1,385 @@
+"""Tests for the rejection-relax preview service + endpoint (issue #258).
+
+Coverage maps directly to the V1 contract relax recipes locked in the
+v1.0.8 plan. The tests exercise the service via the FastAPI endpoint so
+they incidentally also assert the router wiring + Pydantic shapes.
+
+Test plan (~12 cases):
+
+1. Each of 7 relaxable rules: "would recover N" with a known fixture.
+2. Each of 2 binary rules: 400 with the canonical not-relaxable message.
+3. Empty ``rejected`` → 200, ``recovered_count: 0``, ``recovered_strikes: []``.
+4. Strike with TWO rejection reasons including the relaxed rule → does
+   NOT recover (still failing the other rule).
+5. Strike with ONLY the relaxed rule whose value is *still* below the
+   relaxed threshold → does NOT recover.
+"""
+
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _payload(rule: str, rejected: list[dict]) -> dict:
+    """Build the request body the endpoint expects."""
+    return {
+        "ticker": "F",
+        "strategy": "covered_call",
+        "rule": rule,
+        "rejected": rejected,
+    }
+
+
+def _post(client, body: dict):
+    return client.post("/api/options/scan/relax", json=body)
+
+
+# ---------------------------------------------------------------------------
+# Relaxable rule recoveries — one fixture per rule
+# ---------------------------------------------------------------------------
+
+
+def test_relax_delta_widens_band_and_recovers(client):
+    """``delta_out_of_range`` — band widens ±0.05; |0.38| is now inside
+    [0.15, 0.40], so the strike recovers.
+    """
+    rejected = [
+        {
+            "strike": 13.5,
+            "expiration": "2026-06-26",
+            "rejection_reasons": [
+                "delta_out_of_range: |0.38| not in [0.20, 0.35]"
+            ],
+            "human_reasons": [],
+        },
+        # A strike at 0.50 is still outside even after widening — does NOT
+        # recover.
+        {
+            "strike": 14.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": [
+                "delta_out_of_range: |0.50| not in [0.20, 0.35]"
+            ],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("delta_out_of_range", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["rule"] == "delta_out_of_range"
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"] == [
+        {"strike": 13.5, "expiration": "2026-06-26"}
+    ]
+
+
+def test_relax_low_oi_halves_floor_and_recovers(client):
+    """``low_open_interest`` — floor ÷ 2; OI=25 vs min=50 recovers when
+    new floor = 25.
+    """
+    rejected = [
+        # OI=30 vs original floor=50 → new floor=25 → 30 >= 25 → recovers.
+        {
+            "strike": 14.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["low_open_interest: 30 < 50"],
+            "human_reasons": [],
+        },
+        # OI=10 vs original floor=50 → new floor=25 → 10 < 25 → still fails.
+        {
+            "strike": 14.5,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["low_open_interest: 10 < 50"],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("low_open_interest", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"][0]["strike"] == 14.0
+
+
+def test_relax_wide_spread_caps_x_1_5_and_recovers(client):
+    """``wide_bid_ask_spread`` — cap × 1.5; 12% vs cap=10% recovers when
+    new cap=15%.
+    """
+    rejected = [
+        # spread 12% vs cap 10% → relaxed cap 15% → 12 <= 15 → recovers.
+        {
+            "strike": 5.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["wide_bid_ask_spread: 12.0% > 10.0%"],
+            "human_reasons": [],
+        },
+        # spread 22% vs cap 10% → relaxed cap 15% → 22 > 15 → still fails.
+        {
+            "strike": 6.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["wide_bid_ask_spread: 22.0% > 10.0%"],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("wide_bid_ask_spread", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"][0]["strike"] == 5.0
+
+
+def test_relax_fails_10pct_drops_required_by_5pp_and_recovers(client):
+    """``fails_10pct_rule`` — required distance − 5pp; strike at 6%
+    above basis vs 10% rule → new threshold 5% → 6 >= 5 → recovers.
+    """
+    rejected = [
+        # 6% above basis vs requires 10% → relaxed=5% → 6 >= 5 → recovers.
+        {
+            "strike": 14.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": [
+                "fails_10pct_rule: strike 6.0% above basis, requires 10.0%"
+            ],
+            "human_reasons": [],
+        },
+        # 3% vs requires 10% → relaxed=5% → 3 < 5 → still fails.
+        {
+            "strike": 13.5,
+            "expiration": "2026-06-26",
+            "rejection_reasons": [
+                "fails_10pct_rule: strike 3.0% above basis, requires 10.0%"
+            ],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("fails_10pct_rule", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"][0]["strike"] == 14.0
+
+
+def test_relax_below_cost_basis_drops_floor_and_recovers(client):
+    """``below_cost_basis`` — floor − 5pp (≈ floor × 0.95 at the default
+    0% baseline); strike $12.80 vs $13.21 floor → relaxed floor ≈ $12.55
+    → 12.80 >= 12.55 → recovers.
+    """
+    rejected = [
+        {
+            "strike": 12.80,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["below_cost_basis: strike $12.80 < floor $13.21"],
+            "human_reasons": [],
+        },
+        # Strike $10 is still below 0.95 * 13.21 ≈ 12.55 → still fails.
+        {
+            "strike": 10.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["below_cost_basis: strike $10.00 < floor $13.21"],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("below_cost_basis", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"][0]["strike"] == 12.80
+
+
+def test_relax_return_below_drops_target_by_1pp_and_recovers(client):
+    """``return_below_target`` — target − 1pp; 1.5% vs 2% target →
+    relaxed 1% → 1.5 >= 1 → recovers.
+    """
+    rejected = [
+        {
+            "strike": 14.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["return_below_target: 1.5% < 2.0%"],
+            "human_reasons": [],
+        },
+        # 0.5% vs 2.0% → relaxed 1.0% → 0.5 < 1.0 → still fails.
+        {
+            "strike": 15.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["return_below_target: 0.5% < 2.0%"],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("return_below_target", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"][0]["strike"] == 14.0
+
+
+def test_relax_return_above_lifts_cap_by_50pp_and_recovers(client):
+    """``return_above_cap`` — cap + 50pp; 120% vs 100% cap → relaxed 150%
+    → 120 <= 150 → recovers. Threshold text reads the cap inline (no
+    persisted config field today).
+    """
+    rejected = [
+        {
+            "strike": 8.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["return_above_cap: 120.0% > 100.0%"],
+            "human_reasons": [],
+        },
+        # 200% vs 100% → relaxed 150% → 200 > 150 → still fails.
+        {
+            "strike": 9.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["return_above_cap: 200.0% > 100.0%"],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("return_above_cap", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"][0]["strike"] == 8.0
+    # The cap is parsed out of the rejection text — assert both threshold
+    # texts are populated (not the "—" fallback).
+    assert data["current_threshold_text"] != "—"
+    assert data["relaxed_threshold_text"] != "—"
+
+
+# ---------------------------------------------------------------------------
+# Binary / unknown rules — 400 with the canonical generic detail
+# ---------------------------------------------------------------------------
+
+
+def test_relax_itm_put_is_not_relaxable_400(client):
+    """``itm_put`` is binary — endpoint returns 400 with the generic detail."""
+    rejected = [
+        {
+            "strike": 15.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["itm_put: strike $15.00 > price $13.50"],
+            "human_reasons": [],
+        }
+    ]
+    res = _post(client, _payload("itm_put", rejected))
+    assert res.status_code == 400
+    assert res.json()["detail"] == "rule not relaxable"
+
+
+def test_relax_zero_bid_is_not_relaxable_400(client):
+    """``zero_bid`` is binary — endpoint returns 400 with the generic detail."""
+    rejected = [
+        {
+            "strike": 15.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["zero_bid"],
+            "human_reasons": [],
+        }
+    ]
+    res = _post(client, _payload("zero_bid", rejected))
+    assert res.status_code == 400
+    assert res.json()["detail"] == "rule not relaxable"
+
+
+def test_relax_unknown_rule_is_not_relaxable_400(client):
+    """An unknown rule family is treated the same as a binary rule.
+
+    Defends the V1 contract against a stray frontend refactor that emits a
+    typo'd rule name.
+    """
+    res = _post(client, _payload("not_a_real_rule", []))
+    assert res.status_code == 400
+    assert res.json()["detail"] == "rule not relaxable"
+
+
+# ---------------------------------------------------------------------------
+# Boundary cases — empty payload, multi-reason rows
+# ---------------------------------------------------------------------------
+
+
+def test_relax_empty_rejected_returns_zero_count(client):
+    """An empty ``rejected`` payload still validates and returns a 200
+    with ``recovered_count: 0`` and an empty strike list.
+    """
+    res = _post(client, _payload("low_open_interest", []))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["rule"] == "low_open_interest"
+    assert data["recovered_count"] == 0
+    assert data["recovered_strikes"] == []
+    # Threshold text is still populated from rules_config.
+    assert data["current_threshold_text"] != ""
+    assert data["relaxed_threshold_text"] != ""
+
+
+def test_relax_multi_reason_strike_does_not_recover(client):
+    """A strike failing TWO rules — including the relaxed one — does NOT
+    recover. Relaxing one rule does not free a strike still failing the
+    other.
+    """
+    rejected = [
+        # Single-reason strike that DOES recover under low_open_interest
+        # relaxation.
+        {
+            "strike": 14.0,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["low_open_interest: 30 < 50"],
+            "human_reasons": [],
+        },
+        # Multi-reason strike — OI=30 would pass under the relaxed floor
+        # (25), but it is *also* failing delta_out_of_range. Relaxing OI
+        # alone does NOT free it.
+        {
+            "strike": 13.5,
+            "expiration": "2026-06-26",
+            "rejection_reasons": [
+                "low_open_interest: 30 < 50",
+                "delta_out_of_range: |0.42| not in [0.20, 0.35]",
+            ],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("low_open_interest", rejected))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["recovered_count"] == 1
+    assert data["recovered_strikes"] == [
+        {"strike": 14.0, "expiration": "2026-06-26"}
+    ]
+
+
+def test_relax_single_reason_still_failing_does_not_recover(client):
+    """A strike whose ONLY rejection is the relaxed rule but whose value
+    is still below the relaxed threshold does NOT recover.
+
+    Covers the negative branch of the single-reason recovery condition —
+    the relax math itself has to clear the strike, not just its
+    rejection-reason set.
+    """
+    rejected = [
+        # OI=5 vs original floor=50 → relaxed floor=25 → 5 < 25 → still fails.
+        {
+            "strike": 14.5,
+            "expiration": "2026-06-26",
+            "rejection_reasons": ["low_open_interest: 5 < 50"],
+            "human_reasons": [],
+        },
+    ]
+    res = _post(client, _payload("low_open_interest", rejected))
+    assert res.status_code == 200
+    assert res.json()["recovered_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Threshold-text format — anchors the locked V1 contract strings
+# ---------------------------------------------------------------------------
+
+
+def test_relax_low_oi_threshold_text_uses_rules_config(client):
+    """``current_threshold_text`` reads from the persisted rules_config;
+    the default ``min_open_interest`` is 500 → relaxed = 250.
+    """
+    res = _post(client, _payload("low_open_interest", []))
+    assert res.status_code == 200
+    data = res.json()
+    assert data["current_threshold_text"] == "500"
+    assert data["relaxed_threshold_text"] == "250"

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -254,6 +254,20 @@ export async function scanOptions(request) {
   return data;
 }
 
+// Rejected-strikes "Relax to X" preview (issue #258, v1.0.8).
+// Stateless what-if — client echoes the `rejected[]` array from the most
+// recent scan; the server never re-fetches market data. Mirrored test IDs
+// in `ScannerRejectedStrikesRelaxPopover.jsx`.
+export async function postRelaxPreview({ ticker, strategy, rule, rejected }) {
+  const { data } = await api.post('/api/options/scan/relax', {
+    ticker,
+    strategy,
+    rule,
+    rejected,
+  });
+  return data;
+}
+
 export async function getEarningsDate(ticker) {
   const { data } = await api.get(`/api/options/earnings/${encodeURIComponent(ticker)}`);
   return data;

--- a/frontend/components/dashboard/OpenLegsCard.jsx
+++ b/frontend/components/dashboard/OpenLegsCard.jsx
@@ -201,7 +201,10 @@ function InspectPanel({ leg }) {
   if (leg.pnl_dollars != null && leg.cost_to_close != null) {
     creditReceived = leg.pnl_dollars + leg.cost_to_close;
   } else if (leg.premium != null) {
-    creditReceived = leg.premium * 100;
+    // Degraded path (#252): scale by quantity so `Credit received` matches a
+    // multi-contract leg's true credit. `?? 1` is defensive — the schema
+    // default is `1` so this only matters for stale fixtures.
+    creditReceived = leg.premium * 100 * (leg.quantity ?? 1);
   }
   const verdict = leg.verdict || 'hold';
   // A "closing" verdict gets a "Buy to close" CTA; a quiet/review leg does not.

--- a/frontend/components/dashboard/openLegsBadges.js
+++ b/frontend/components/dashboard/openLegsBadges.js
@@ -43,13 +43,19 @@ export function dteBadgeClass(dte) {
 }
 
 /**
- * coverageBadge — the per-leg covered/naked pill (issue #246, spec §2).
+ * coverageBadge — the per-leg covered/partial/naked pill (issue #246 / #251).
  *
- * Pure render helper. `covered` → quiet emerald pill; `naked` → amber `⚠`
- * pill (the exact recipe `dteBadgeClass` uses at `dte <= 14`). Any other
- * value (`null`/undefined — a short put or a pre-#246 payload) renders
- * nothing. The badge is severity, not scan: it carries no `hidden lg:*` and
- * survives every breakpoint.
+ * Pure render helper. Three recipes:
+ *  - `covered` → quiet emerald pill (no glyph).
+ *  - `partial` → slate `⚠ Partial` pill (V1.0.8 / #251) — the same neutral
+ *    slate recipe `dteBadgeClass` uses at `dte > 14`, with the `⚠` glyph for
+ *    color-blind distinction from `covered`.
+ *  - `naked` → amber `⚠ Naked` pill (the exact recipe `dteBadgeClass` uses at
+ *    `dte <= 14`).
+ *
+ * Any other value (`null`/undefined — a short put or a pre-#246 payload)
+ * renders nothing. The badge is severity, not scan: it carries no
+ * `hidden lg:*` and survives every breakpoint.
  *
  * `testIdPrefix` makes the badge's `data-testid` unambiguous when the same
  * helper is rendered at two callsites (row vs. InspectPanel echo). The
@@ -66,6 +72,20 @@ export function coverageBadge(coverage, { testIdPrefix = 'dashboard-leg-row' } =
         className={`${PILL_SHAPE} bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300`}
       >
         Covered
+      </span>
+    );
+  }
+  if (coverage === 'partial') {
+    return (
+      <span
+        data-testid={`${testIdPrefix}-coverage`}
+        data-coverage="partial"
+        className={`${PILL_SHAPE} bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-200`}
+      >
+        <span aria-hidden="true" className="mr-0.5">
+          ⚠
+        </span>
+        Partial
       </span>
     );
   }

--- a/frontend/components/options/OptionScanner.jsx
+++ b/frontend/components/options/OptionScanner.jsx
@@ -219,8 +219,14 @@ export default function OptionScannerPage() {
               />
 
               {/* Rejected Strikes — humanized sentences via the backend
-                  `human_reasons` field. Spec §4.4. */}
-              <ScannerRejectedStrikes rejected={result.rejected} />
+                  `human_reasons` field. Spec §4.4. Ticker + strategy are
+                  forwarded for V1.0.8's "Relax to X" popover (#258) so the
+                  panel can echo them in the relax preview POST. */}
+              <ScannerRejectedStrikes
+                rejected={result.rejected}
+                ticker={result.ticker}
+                strategy={result.strategy}
+              />
             </>
           )}
         </main>

--- a/frontend/components/options/ScannerRejectedStrikes.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.jsx
@@ -12,9 +12,16 @@
 //      `rejection_reasons.length === 1`, replacing the right-aligned reason
 //      count. Reason text uses a fact-led "Would pass — …" framing.
 //
+// V1.0.8 (#259, W-E) layers per-row collapse on top of the 3-tier
+// stratification: rows with `rejection_reasons.length >= 3` render a one-line
+// preview ("$NN.NN YYYY-MM-DD  N reasons hidden  Show ▾") by default. A
+// single global localStorage flag (`scanner-rejected-strikes-row-collapsed`)
+// controls whether ALL ≥3-reason rows are collapsed or expanded together —
+// clicking any one toggle flips every collapsible row at once. 1- and
+// 2-reason rows are unchanged.
+//
 // The Card shell, the toggle button, the row test ID, and the
-// `visibleCount=20` cap + tail are unchanged. #259 (W-E) will later wrap
-// `RejectedRow` in a <details> for `rejection_reasons.length >= 3`.
+// `visibleCount=20` cap + tail are unchanged.
 //
 // Source of truth for human sentences remains the backend's `human_reasons`
 // field (populated by `backend/app/services/rejection_messages.py`); the
@@ -23,6 +30,7 @@
 //
 // Specs:
 //   - frontend/design-specs/issue-257-rejected-strikes-polish.md (V1.0.8)
+//   - frontend/design-specs/issue-259-collapse-3plus.md (V1.0.8)
 //   - frontend/design-specs/scanner-education-v0.5.7.md (Affordance 4)
 
 import { useMemo, useState } from 'react';
@@ -34,6 +42,36 @@ import {
   formatNearPassReason,
   labelForRuleFamily,
 } from './scannerRejectionLabels';
+
+// V1.0.8 / #259 — single global localStorage key that controls whether ALL
+// ≥3-reason rows render collapsed (default true) or expanded. The boolean is
+// stored as '1' (collapsed) / '0' (expanded) to match `ScannerStrategyPrimer`'s
+// convention. Pinned by the V1 contract — do not rename.
+const ROW_COLLAPSE_STORAGE_KEY = 'scanner-rejected-strikes-row-collapsed';
+
+// Persistence helpers — copied verbatim from `ScannerStrategyPrimer.jsx:52-71`
+// per the spec's "copy at two, promote at three" rule. Do not lift to a shared
+// utility until a third caller appears.
+function readPersistedCollapsed(key) {
+  if (typeof window === 'undefined') return true;
+  try {
+    const raw = window.localStorage.getItem(key);
+    if (raw === null) return true; // default = collapsed on first visit
+    return raw === '1';
+  } catch {
+    return true;
+  }
+}
+
+function writePersistedCollapsed(key, collapsed) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, collapsed ? '1' : '0');
+  } catch {
+    // localStorage may be disabled (Safari private mode, etc.) — silently
+    // ignore. The panel will still toggle visually within the session.
+  }
+}
 
 // Defensive fallback only — the backend is the canonical source.
 // Keys are the code prefix (everything before the colon in a raw rejection).
@@ -139,9 +177,14 @@ function NearPassBadge() {
   );
 }
 
-function RejectedRow({ rejection }) {
+function RejectedRow({ rejection, rowCollapsed, onToggleCollapsed }) {
   const rawReasons = rejection.rejection_reasons || [];
   const isNearPass = rawReasons.length === 1;
+  // Collapse trigger uses rawReasons.length (structural source), NOT
+  // humanReasons.length (humanized presentation). The threshold is the
+  // canonical rejection count, regardless of presentation transforms.
+  const collapsible = rawReasons.length >= 3;
+  const isCollapsed = collapsible && rowCollapsed;
 
   // For normal/structural rows continue to prefer the backend's
   // human_reasons; fall back to the client-side humanization only when the
@@ -158,11 +201,14 @@ function RejectedRow({ rejection }) {
     ? formatNearPassReason(rawReasons[0]) || humanReasons[0]
     : null;
 
-  return (
-    <li
-      data-testid="scanner-rejected-strike-row"
-      className="py-2 border-b border-slate-100 dark:border-slate-700 last:border-0"
-    >
+  // Row body — strike + expiration header line, the count/badge cluster, and
+  // (when expanded) the reason text/bullets. For ≥3-reason rows this body is
+  // wrapped in a <div data-testid="scanner-rejected-strike-group"
+  // data-collapsed="…"> so Playwright can target the collapsible-row group
+  // without breaking W-A's existing `scanner-rejected-strike-row` assertions
+  // (the <li> retains the row testid for every row, collapsible or not).
+  const body = (
+    <>
       <div className="flex items-baseline justify-between gap-3 mb-1">
         <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
           ${rejection.strike.toFixed(2)} {rejection.expiration}
@@ -170,14 +216,29 @@ function RejectedRow({ rejection }) {
         {isNearPass ? (
           <NearPassBadge />
         ) : (
-          <span className="text-xs text-slate-500 dark:text-slate-400">
-            {humanReasons.length === 1
-              ? '1 reason'
-              : `${humanReasons.length} reasons`}
-          </span>
+          <div className="flex items-baseline gap-2">
+            <span className="text-xs text-slate-500 dark:text-slate-400">
+              {isCollapsed
+                ? `${rawReasons.length} reasons hidden`
+                : humanReasons.length === 1
+                ? '1 reason'
+                : `${humanReasons.length} reasons`}
+            </span>
+            {collapsible && (
+              <button
+                type="button"
+                onClick={onToggleCollapsed}
+                data-testid="scanner-rejected-strike-group-toggle"
+                className="text-xs text-blue-600 dark:text-blue-300 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+                aria-expanded={!isCollapsed}
+              >
+                {isCollapsed ? 'Show ▾' : 'Hide ▴'}
+              </button>
+            )}
+          </div>
         )}
       </div>
-      {isNearPass ? (
+      {isCollapsed ? null : isNearPass ? (
         <p className="text-xs text-slate-600 dark:text-slate-300">
           {nearPassSentence}
         </p>
@@ -194,6 +255,24 @@ function RejectedRow({ rejection }) {
             <li key={i}>{r}</li>
           ))}
         </ul>
+      )}
+    </>
+  );
+
+  return (
+    <li
+      data-testid="scanner-rejected-strike-row"
+      className="py-2 border-b border-slate-100 dark:border-slate-700 last:border-0"
+    >
+      {collapsible ? (
+        <div
+          data-testid="scanner-rejected-strike-group"
+          data-collapsed={rowCollapsed ? 'true' : 'false'}
+        >
+          {body}
+        </div>
+      ) : (
+        body
       )}
     </li>
   );
@@ -231,6 +310,21 @@ export default function ScannerRejectedStrikes({
   const [open, setOpen] = useState(defaultOpen);
   const [sortField, setSortField] = useState('failure_count');
   const [sortDir, setSortDir] = useState('asc');
+  // #259 / W-E — single global flag at the section level. All ≥3-reason rows
+  // read this value; clicking any toggle flips it for the whole panel.
+  // Initialized from localStorage in the useState callback to avoid
+  // useEffect (matches `ScannerStrategyPrimer` precedent — see issue #198).
+  const [rowCollapsed, setRowCollapsed] = useState(() =>
+    readPersistedCollapsed(ROW_COLLAPSE_STORAGE_KEY)
+  );
+
+  const handleToggleRowCollapsed = () => {
+    setRowCollapsed((prev) => {
+      const next = !prev;
+      writePersistedCollapsed(ROW_COLLAPSE_STORAGE_KEY, next);
+      return next;
+    });
+  };
 
   const handleSort = (field) => {
     if (sortField === field) {
@@ -324,6 +418,8 @@ export default function ScannerRejectedStrikes({
                 <RejectedRow
                   key={`${r.strike}-${r.expiration}-${i}`}
                   rejection={r}
+                  rowCollapsed={rowCollapsed}
+                  onToggleCollapsed={handleToggleRowCollapsed}
                 />
               ))}
             </ul>

--- a/frontend/components/options/ScannerRejectedStrikes.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.jsx
@@ -1,18 +1,39 @@
-// Humanized rejected-strikes disclosure. Replaces the inline red
-// `rejection_reasons` join with a bulleted list of plain-English sentences
-// in neutral slate color.
+// Rejected Strikes panel — humanized + sortable + summarized.
 //
-// Source of truth for the human sentences is the backend's `human_reasons`
-// field on each `RejectedStrike` (populated by
-// `backend/app/services/rejection_messages.py`). The fallback CLIENT_COPY
-// map below is purely defensive — if the backend ever returns an empty
-// `human_reasons` (legacy payload, mis-deploy), the client maps raw codes
-// to short sentences so the user is not staring at machine codes. Unknown
-// raw codes degrade to the raw string unchanged.
+// Phase A (#190) introduced the human-sentence rendering of `human_reasons`.
+// V1.0.8 (#257) layers three additive pieces on top:
+//   1. Sort row above the list — three sort fields (strike / expiration /
+//      failure_count). Default `failure_count_asc` (closest-to-passing first).
+//      State component-local; no localStorage.
+//   2. Per-rule summary band — one chip per non-zero rule family, count-desc
+//      with canonical-order tie-break. Chip is a <button> (W-D's #258
+//      popover anchors here — this issue ships an inert click target).
+//   3. Near-pass badge — emerald "One rule away" pill on rows with
+//      `rejection_reasons.length === 1`, replacing the right-aligned reason
+//      count. Reason text uses a fact-led "Would pass — …" framing.
 //
-// Spec: frontend/design-specs/scanner-education-v0.5.7.md (Affordance 4)
+// The Card shell, the toggle button, the row test ID, and the
+// `visibleCount=20` cap + tail are unchanged. #259 (W-E) will later wrap
+// `RejectedRow` in a <details> for `rejection_reasons.length >= 3`.
+//
+// Source of truth for human sentences remains the backend's `human_reasons`
+// field (populated by `backend/app/services/rejection_messages.py`); the
+// CLIENT_COPY fallback below is purely defensive. Near-pass framing reads the
+// raw `rejection_reasons` so it can extract the parameters (delta, OI, etc.).
+//
+// Specs:
+//   - frontend/design-specs/issue-257-rejected-strikes-polish.md (V1.0.8)
+//   - frontend/design-specs/scanner-education-v0.5.7.md (Affordance 4)
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+
+import {
+  CANONICAL_RULE_ORDER,
+  REJECTION_RULE_LABELS,
+  extractRuleFamily,
+  formatNearPassReason,
+  labelForRuleFamily,
+} from './scannerRejectionLabels';
 
 // Defensive fallback only — the backend is the canonical source.
 // Keys are the code prefix (everything before the colon in a raw rejection).
@@ -36,16 +57,106 @@ const CLIENT_COPY_FALLBACK = {
 function humanizeFallback(raw) {
   // Extract the code prefix (before the first colon) and look it up. If the
   // raw string has no colon, treat the whole string as the code.
-  const codeMatch = /^([a-z_]+)/i.exec(raw);
-  const code = codeMatch ? codeMatch[1] : raw;
+  const code = extractRuleFamily(raw) || raw;
   return CLIENT_COPY_FALLBACK[code] || raw;
 }
 
+// Aggregate the rejected[] payload into a count per rule family. Per-strike
+// dedupe inside `families` is defensive — a strike that emitted two
+// `delta_out_of_range` codes (shouldn't happen, but be safe) still counts
+// once toward `delta_out_of_range`. The summary answers "how many strikes
+// were rejected by rule X," not "how many reason-strings mention X."
+function summarizeRejections(rejected) {
+  const counts = new Map();
+  for (const r of rejected) {
+    const families = new Set();
+    for (const reason of r.rejection_reasons || []) {
+      const family = extractRuleFamily(reason);
+      if (family) families.add(family);
+    }
+    for (const f of families) {
+      counts.set(f, (counts.get(f) || 0) + 1);
+    }
+  }
+  // Count desc; ties broken by canonical rule order.
+  return Array.from(counts.entries()).sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    const aIdx = CANONICAL_RULE_ORDER.indexOf(a[0]);
+    const bIdx = CANONICAL_RULE_ORDER.indexOf(b[0]);
+    // Unknown families sort last; preserve relative order among unknowns.
+    const aRank = aIdx === -1 ? Number.MAX_SAFE_INTEGER : aIdx;
+    const bRank = bIdx === -1 ? Number.MAX_SAFE_INTEGER : bIdx;
+    return aRank - bRank;
+  });
+}
+
+function SortHeader({ field, label, sortField, sortDir, onSort }) {
+  const active = sortField === field;
+  const className = active
+    ? 'text-xs font-medium text-slate-700 dark:text-slate-200 cursor-pointer select-none focus:outline-none focus:ring-2 focus:ring-blue-500 rounded'
+    : 'text-xs font-medium text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 cursor-pointer select-none focus:outline-none focus:ring-2 focus:ring-blue-500 rounded';
+  return (
+    <button
+      type="button"
+      data-testid={`scanner-rejected-strikes-sort-${field}`}
+      onClick={() => onSort(field)}
+      className={className}
+    >
+      {label}
+      {active && (
+        <span aria-hidden className="ml-0.5">
+          {sortDir === 'asc' ? '↑' : '↓'}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function SummaryChip({ family, count }) {
+  const label = labelForRuleFamily(family);
+  return (
+    <button
+      type="button"
+      data-testid={`scanner-rejected-strikes-summary-rule-${family}`}
+      data-count={count}
+      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-slate-100 text-slate-700 dark:bg-slate-700/60 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600/60 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer transition-colors"
+    >
+      <span>{label}</span>
+      <span aria-hidden>&middot;</span>
+      <span className="tabular-nums font-medium">{count}</span>
+    </button>
+  );
+}
+
+function NearPassBadge() {
+  return (
+    <span
+      data-testid="scanner-rejected-strike-badge-near-pass"
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300"
+    >
+      One rule away
+    </span>
+  );
+}
+
 function RejectedRow({ rejection }) {
-  const reasons =
+  const rawReasons = rejection.rejection_reasons || [];
+  const isNearPass = rawReasons.length === 1;
+
+  // For normal/structural rows continue to prefer the backend's
+  // human_reasons; fall back to the client-side humanization only when the
+  // payload is empty (legacy / mis-deploy).
+  const humanReasons =
     rejection.human_reasons && rejection.human_reasons.length > 0
       ? rejection.human_reasons
-      : (rejection.rejection_reasons || []).map(humanizeFallback);
+      : rawReasons.map(humanizeFallback);
+
+  // For near-pass rows, render the fact-led "Would pass — …" sentence
+  // computed from the raw rejection_reasons[0] (so we can extract the
+  // observed value, the threshold, and the gap).
+  const nearPassSentence = isNearPass
+    ? formatNearPassReason(rawReasons[0]) || humanReasons[0]
+    : null;
 
   return (
     <li
@@ -56,15 +167,30 @@ function RejectedRow({ rejection }) {
         <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
           ${rejection.strike.toFixed(2)} {rejection.expiration}
         </span>
-        <span className="text-xs text-slate-500 dark:text-slate-400">
-          {reasons.length === 1 ? '1 reason' : `${reasons.length} reasons`}
-        </span>
+        {isNearPass ? (
+          <NearPassBadge />
+        ) : (
+          <span className="text-xs text-slate-500 dark:text-slate-400">
+            {humanReasons.length === 1
+              ? '1 reason'
+              : `${humanReasons.length} reasons`}
+          </span>
+        )}
       </div>
-      {reasons.length === 1 ? (
-        <p className="text-xs text-slate-600 dark:text-slate-300">{reasons[0]}</p>
+      {isNearPass ? (
+        <p className="text-xs text-slate-600 dark:text-slate-300">
+          {nearPassSentence}
+        </p>
+      ) : humanReasons.length === 1 ? (
+        // Defensive branch — should only hit when rawReasons.length !== 1 but
+        // humanReasons.length === 1 (legacy payload mismatch). Mirrors the
+        // pre-V1.0.8 single-sentence rendering.
+        <p className="text-xs text-slate-600 dark:text-slate-300">
+          {humanReasons[0]}
+        </p>
       ) : (
         <ul className="list-disc list-outside ml-5 space-y-0.5 text-xs text-slate-600 dark:text-slate-300">
-          {reasons.map((r, i) => (
+          {humanReasons.map((r, i) => (
             <li key={i}>{r}</li>
           ))}
         </ul>
@@ -73,16 +199,65 @@ function RejectedRow({ rejection }) {
   );
 }
 
+function compareRejections(a, b, field, dir) {
+  let av;
+  let bv;
+  switch (field) {
+    case 'strike':
+      av = a.strike ?? 0;
+      bv = b.strike ?? 0;
+      break;
+    case 'expiration':
+      // ISO YYYY-MM-DD sorts lexicographically — no Date parse needed.
+      av = a.expiration ?? '';
+      bv = b.expiration ?? '';
+      break;
+    case 'failure_count':
+    default:
+      av = (a.rejection_reasons || []).length;
+      bv = (b.rejection_reasons || []).length;
+      break;
+  }
+  if (av < bv) return dir === 'asc' ? -1 : 1;
+  if (av > bv) return dir === 'asc' ? 1 : -1;
+  return 0;
+}
+
 export default function ScannerRejectedStrikes({
   rejected = [],
   defaultOpen = false,
   visibleCount = 20,
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  const [sortField, setSortField] = useState('failure_count');
+  const [sortDir, setSortDir] = useState('asc');
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  };
+
+  // Summary aggregates the FULL payload — independent of sort and visibleCount.
+  // The user's question "which rule is the binding constraint?" is about the
+  // whole result set, not just the top 20.
+  const summary = useMemo(() => summarizeRejections(rejected), [rejected]);
+
+  // Sort is applied BEFORE the visibleCount slice — so the 20 rows we show
+  // are the top 20 by current sort, not the first 20 in payload order.
+  const sorted = useMemo(() => {
+    const arr = [...rejected];
+    arr.sort((a, b) => compareRejections(a, b, sortField, sortDir));
+    return arr;
+  }, [rejected, sortField, sortDir]);
+
   if (rejected.length === 0) return null;
 
-  const shown = rejected.slice(0, visibleCount);
-  const hiddenCount = rejected.length - shown.length;
+  const shown = sorted.slice(0, visibleCount);
+  const hiddenCount = sorted.length - shown.length;
 
   return (
     <section
@@ -102,19 +277,69 @@ export default function ScannerRejectedStrikes({
         </span>
       </button>
       {open && (
-        <div className="px-4 pb-4">
-          <ul className="space-y-0">
-            {shown.map((r, i) => (
-              <RejectedRow key={i} rejection={r} />
+        <>
+          {/* Sort row */}
+          <div className="flex items-center flex-wrap gap-3 px-4 pt-3 pb-2 text-xs border-t border-slate-100 dark:border-slate-700">
+            <span className="text-slate-500 dark:text-slate-400">Sort by:</span>
+            <SortHeader
+              field="strike"
+              label="Strike"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <SortHeader
+              field="expiration"
+              label="Exp."
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+            <SortHeader
+              field="failure_count"
+              label="Failures"
+              sortField={sortField}
+              sortDir={sortDir}
+              onSort={handleSort}
+            />
+          </div>
+
+          {/* Summary band */}
+          <div
+            data-testid="scanner-rejected-strikes-summary"
+            className="px-4 py-3 border-t border-slate-100 dark:border-slate-700 flex items-baseline flex-wrap gap-x-3 gap-y-2 text-xs"
+          >
+            <span className="text-slate-500 dark:text-slate-400 shrink-0">
+              Of {rejected.length} rejected:
+            </span>
+            {summary.map(([family, count]) => (
+              <SummaryChip key={family} family={family} count={count} />
             ))}
-          </ul>
-          {hiddenCount > 0 && (
-            <p className="text-xs text-slate-500 dark:text-slate-400 mt-2">
-              …and {hiddenCount} more not shown.
-            </p>
-          )}
-        </div>
+          </div>
+
+          {/* Row list */}
+          <div className="px-4 pb-4 border-t border-slate-100 dark:border-slate-700 pt-1">
+            <ul className="space-y-0">
+              {shown.map((r, i) => (
+                <RejectedRow
+                  key={`${r.strike}-${r.expiration}-${i}`}
+                  rejection={r}
+                />
+              ))}
+            </ul>
+            {hiddenCount > 0 && (
+              <p className="text-xs text-slate-500 dark:text-slate-400 mt-2">
+                &hellip;and {hiddenCount} more not shown.
+              </p>
+            )}
+          </div>
+        </>
       )}
     </section>
   );
 }
+
+// Re-export the labels const for downstream consumers (e.g. W-D's relax
+// popover). Keeps the import path single — callers can grab labels off the
+// panel module without knowing about scannerRejectionLabels.js.
+export { REJECTION_RULE_LABELS };

--- a/frontend/components/options/ScannerRejectedStrikes.jsx
+++ b/frontend/components/options/ScannerRejectedStrikes.jsx
@@ -6,8 +6,10 @@
 //      failure_count). Default `failure_count_asc` (closest-to-passing first).
 //      State component-local; no localStorage.
 //   2. Per-rule summary band — one chip per non-zero rule family, count-desc
-//      with canonical-order tie-break. Chip is a <button> (W-D's #258
-//      popover anchors here — this issue ships an inert click target).
+//      with canonical-order tie-break. Chip is a <button>; W-D (#258) wires
+//      its `onClick` to the Relax-to-X popover (see imports below). Binary
+//      rules (`itm_put`, `zero_bid`) render in a disabled register with a
+//      title hint and short-circuit before the popover opens.
 //   3. Near-pass badge — emerald "One rule away" pill on rows with
 //      `rejection_reasons.length === 1`, replacing the right-aligned reason
 //      count. Reason text uses a fact-led "Would pass — …" framing.
@@ -27,6 +29,9 @@
 
 import { useMemo, useState } from 'react';
 
+import { postRelaxPreview } from '../../api/client';
+
+import ScannerRejectedStrikesRelaxPopover from './ScannerRejectedStrikesRelaxPopover';
 import {
   CANONICAL_RULE_ORDER,
   REJECTION_RULE_LABELS,
@@ -34,6 +39,16 @@ import {
   formatNearPassReason,
   labelForRuleFamily,
 } from './scannerRejectionLabels';
+
+// Binary rule families — no meaningful "relax to X" exists. The chip is
+// visually disabled and the click handler short-circuits so the popover
+// never opens. The backend returns 400 "rule not relaxable" if asked.
+const BINARY_RULES = new Set(['itm_put', 'zero_bid']);
+
+const BINARY_RULE_HINTS = {
+  itm_put: 'Not relaxable — itm_put is a yes/no rule',
+  zero_bid: 'Not relaxable — zero bid means no market',
+};
 
 // Defensive fallback only — the backend is the canonical source.
 // Keys are the code prefix (everything before the colon in a raw rejection).
@@ -112,14 +127,34 @@ function SortHeader({ field, label, sortField, sortDir, onSort }) {
   );
 }
 
-function SummaryChip({ family, count }) {
+function SummaryChip({ family, count, onClick }) {
   const label = labelForRuleFamily(family);
+  const isBinary = BINARY_RULES.has(family);
+
+  // Binary rules render in a desaturated, disabled register (per V1.0.8
+  // spec §2.1) — they keep their count but cannot open the popover; the
+  // click handler short-circuits AND the chip carries the `disabled` +
+  // `aria-disabled` attributes so user agents will not fire the click in
+  // most cases. The title hint teaches the user *why* relax is not offered.
+  const className = isBinary
+    ? 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-slate-50 text-slate-400 dark:bg-slate-800 dark:text-slate-500 cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-slate-400 transition-colors'
+    : 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-slate-100 text-slate-700 dark:bg-slate-700/60 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600/60 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer transition-colors';
+
+  const handleClick = (e) => {
+    if (isBinary) return; // §2.1 — defensive; chip is already disabled.
+    if (onClick) onClick(e.currentTarget);
+  };
+
   return (
     <button
       type="button"
       data-testid={`scanner-rejected-strikes-summary-rule-${family}`}
       data-count={count}
-      className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs bg-slate-100 text-slate-700 dark:bg-slate-700/60 dark:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-600/60 focus:outline-none focus:ring-2 focus:ring-blue-500 cursor-pointer transition-colors"
+      onClick={handleClick}
+      disabled={isBinary || undefined}
+      aria-disabled={isBinary || undefined}
+      title={isBinary ? BINARY_RULE_HINTS[family] : undefined}
+      className={className}
     >
       <span>{label}</span>
       <span aria-hidden>&middot;</span>
@@ -227,10 +262,60 @@ export default function ScannerRejectedStrikes({
   rejected = [],
   defaultOpen = false,
   visibleCount = 20,
+  ticker = null,
+  strategy = null,
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const [sortField, setSortField] = useState('failure_count');
   const [sortDir, setSortDir] = useState('asc');
+
+  // V1.0.8 "Relax to X" popover state (#258). Single-instance — only one
+  // popover open at a time. Switching rules updates `rule` + `anchorEl` and
+  // re-fetches; closing nulls the whole object.
+  //   state ∈ { 'idle', 'loading', 'ready', 'error' }
+  const [popover, setPopover] = useState({
+    rule: null,
+    state: 'idle',
+    data: null,
+    anchorEl: null,
+  });
+
+  const openRelaxFor = async (family, chipEl) => {
+    if (BINARY_RULES.has(family)) return; // §2.1 — redundant with disabled chip.
+    setPopover({ rule: family, state: 'loading', data: null, anchorEl: chipEl });
+    try {
+      const data = await postRelaxPreview({
+        ticker,
+        strategy,
+        rule: family,
+        rejected,
+      });
+      // The `p.rule === family` guard protects against a stale response
+      // landing after the user has already switched chips or closed.
+      setPopover((p) =>
+        p.rule === family ? { ...p, state: 'ready', data } : p,
+      );
+    } catch {
+      setPopover((p) =>
+        p.rule === family ? { ...p, state: 'error', data: null } : p,
+      );
+    }
+  };
+
+  const closePopover = () => {
+    // Return focus to the chip that opened the popover.
+    const anchor = popover.anchorEl;
+    setPopover({ rule: null, state: 'idle', data: null, anchorEl: null });
+    if (anchor && typeof anchor.focus === 'function') {
+      anchor.focus();
+    }
+  };
+
+  const retryPopover = () => {
+    if (popover.rule && popover.anchorEl) {
+      openRelaxFor(popover.rule, popover.anchorEl);
+    }
+  };
 
   const handleSort = (field) => {
     if (sortField === field) {
@@ -260,6 +345,7 @@ export default function ScannerRejectedStrikes({
   const hiddenCount = sorted.length - shown.length;
 
   return (
+    <>
     <section
       data-testid="scanner-rejected-strikes"
       className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl"
@@ -313,7 +399,12 @@ export default function ScannerRejectedStrikes({
               Of {rejected.length} rejected:
             </span>
             {summary.map(([family, count]) => (
-              <SummaryChip key={family} family={family} count={count} />
+              <SummaryChip
+                key={family}
+                family={family}
+                count={count}
+                onClick={(chipEl) => openRelaxFor(family, chipEl)}
+              />
             ))}
           </div>
 
@@ -336,6 +427,19 @@ export default function ScannerRejectedStrikes({
         </>
       )}
     </section>
+    {/* V1.0.8 #258 — Relax to X popover. Owned by the panel, anchored to
+        whichever chip last fired `openRelaxFor`. Single-instance; closing
+        nulls the popover state and returns focus to the chip. */}
+    <ScannerRejectedStrikesRelaxPopover
+      open={popover.rule !== null}
+      anchorEl={popover.anchorEl}
+      rule={popover.rule}
+      state={popover.state}
+      data={popover.data}
+      onClose={closePopover}
+      onRetry={retryPopover}
+    />
+    </>
   );
 }
 

--- a/frontend/components/options/ScannerRejectedStrikesRelaxPopover.jsx
+++ b/frontend/components/options/ScannerRejectedStrikesRelaxPopover.jsx
@@ -1,0 +1,305 @@
+// Rejected Strikes "Relax to X" preview popover (issue #258, V1.0.8).
+//
+// Anchors below the rule chip the parent (ScannerRejectedStrikes.jsx) clicked.
+// Pure presentational + lifecycle: the fetch is owned by the parent so the
+// popover can be tested in isolation against the four state branches —
+// `loading`, `ready` (with `recovered_count > 0` or `== 0`), `error`. Closed
+// is `open === false` → returns `null`.
+//
+// Placement: roll-your-own (no library — V1 plan §S4). The component reads
+// the chip's `getBoundingClientRect()` on open, places itself 8px below the
+// chip, and flips above when the popover would overflow the viewport bottom.
+// On resize or scroll it closes (per spec §4.1 — no live tracking).
+// Renders to a `document.body` portal so its stacking context is independent
+// of the scrollable rejected-strikes container.
+//
+// ARIA: `role="dialog"` + `aria-modal="true"` + focus-on-open + Escape +
+// click-outside dismiss. Focus returns to the trigger chip (parent owns the
+// focus-return wiring via the close handler).
+//
+// Spec: frontend/design-specs/issue-258-relax-to-x-preview.md
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+import { REJECTION_RULE_LABELS } from './scannerRejectionLabels';
+
+const POPOVER_WIDTH = 320; // matches the spec's `w-80`
+const ANCHOR_GAP = 8;
+
+function computePlacement(anchorEl) {
+  if (!anchorEl || typeof window === 'undefined') {
+    return { top: 0, left: 0, placement: 'below' };
+  }
+  const rect = anchorEl.getBoundingClientRect();
+  const viewportH = window.innerHeight;
+  const viewportW = window.innerWidth;
+
+  // We do not know the popover's measured height before paint; use a rough
+  // estimate (max-h-96 = 384px) to decide whether to flip. The actual rendered
+  // height varies per state but is always <= 384px.
+  const ESTIMATED_HEIGHT = 320;
+
+  const fitsBelow =
+    rect.bottom + ESTIMATED_HEIGHT + ANCHOR_GAP <= viewportH;
+  const placement = fitsBelow ? 'below' : 'above';
+
+  const top =
+    placement === 'below'
+      ? rect.bottom + ANCHOR_GAP + window.scrollY
+      : rect.top - ESTIMATED_HEIGHT - ANCHOR_GAP + window.scrollY;
+
+  // Horizontal — left-align to chip, then clamp into viewport with an 8px
+  // gutter. ``window.scrollX`` lets the absolute-positioned portal handle a
+  // horizontally-scrolled page (rare).
+  let left = rect.left + window.scrollX;
+  const maxLeft = window.scrollX + viewportW - POPOVER_WIDTH - 8;
+  if (left > maxLeft) left = maxLeft;
+  if (left < window.scrollX + 8) left = window.scrollX + 8;
+
+  return { top, left, placement };
+}
+
+function SkeletonBody() {
+  return (
+    <div className="space-y-2">
+      <div className="bg-slate-200 dark:bg-slate-700 rounded h-3 animate-pulse w-3/4" />
+      <div className="bg-slate-200 dark:bg-slate-700 rounded h-3 animate-pulse w-1/2" />
+      <div className="bg-slate-200 dark:bg-slate-700 rounded h-3 animate-pulse w-2/3" />
+      <div className="bg-slate-200 dark:bg-slate-700 rounded h-3 animate-pulse w-2/3" />
+    </div>
+  );
+}
+
+function ErrorBody({ onRetry, retryRef }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-yellow-700 dark:text-yellow-300">
+        <span aria-hidden className="mr-1">
+          ⚠
+        </span>
+        Couldn&apos;t compute preview.
+      </p>
+      <button
+        ref={retryRef}
+        type="button"
+        onClick={onRetry}
+        className="text-sm text-blue-600 dark:text-blue-400 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+function ReadyBody({ rule, data }) {
+  const label = REJECTION_RULE_LABELS[rule] || rule;
+  const lower = label.toLowerCase();
+  const count = Number(data?.recovered_count ?? 0);
+  const strikes = Array.isArray(data?.recovered_strikes)
+    ? data.recovered_strikes
+    : [];
+  const previewStrikes = strikes.slice(0, 5);
+  const overflow = Math.max(0, count - previewStrikes.length);
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs">
+        <span className="text-slate-500 dark:text-slate-400">
+          Loosen {lower} from{' '}
+        </span>
+        <span className="tabular-nums text-slate-700 dark:text-slate-200">
+          {data?.current_threshold_text ?? '—'}
+        </span>
+        <span className="text-slate-400 mx-1" aria-hidden>
+          →
+        </span>
+        <span className="tabular-nums text-emerald-700 dark:text-emerald-300">
+          {data?.relaxed_threshold_text ?? '—'}
+        </span>
+      </p>
+
+      {count > 0 ? (
+        <p className="text-sm font-medium">
+          <span aria-hidden className="mr-1 text-emerald-600 dark:text-emerald-300">
+            ▸
+          </span>
+          <span
+            data-testid="scanner-rejected-strikes-relax-recovered-count"
+            data-count={count}
+            className="text-emerald-700 dark:text-emerald-300"
+          >
+            {count === 1 ? '1 strike' : `${count} strikes`}
+          </span>{' '}
+          <span className="text-slate-700 dark:text-slate-200 font-normal">
+            would recover
+          </span>
+        </p>
+      ) : (
+        <p
+          data-testid="scanner-rejected-strikes-relax-recovered-count"
+          data-count="0"
+          className="text-sm text-slate-500 dark:text-slate-400"
+        >
+          No strikes would recover at the relaxed threshold.
+        </p>
+      )}
+
+      {count > 0 && previewStrikes.length > 0 && (
+        <ul className="space-y-1 text-xs tabular-nums text-slate-700 dark:text-slate-200">
+          {previewStrikes.map((s, i) => (
+            <li key={`${s.strike}-${s.expiration}-${i}`}>
+              ${Number(s.strike).toFixed(2)} · {s.expiration}
+            </li>
+          ))}
+          {overflow > 0 && (
+            <li className="text-slate-500 dark:text-slate-400">
+              + {overflow} more
+            </li>
+          )}
+        </ul>
+      )}
+
+      <p className="text-[11px] text-slate-500 dark:text-slate-400 mt-3">
+        Preview only — does not re-run the scan.
+      </p>
+    </div>
+  );
+}
+
+export default function ScannerRejectedStrikesRelaxPopover({
+  open,
+  anchorEl,
+  rule,
+  state,
+  data,
+  onClose,
+  onRetry,
+}) {
+  const rootRef = useRef(null);
+  const closeBtnRef = useRef(null);
+  const retryBtnRef = useRef(null);
+
+  const [position, setPosition] = useState({ top: 0, left: 0, placement: 'below' });
+  const [mounted, setMounted] = useState(false);
+
+  // SSR safety — `createPortal(..., document.body)` would crash during SSR
+  // because `document` is undefined. Only render the portal after mount.
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // Recompute placement when opening or when the rule (and therefore the
+  // anchor) changes.
+  useLayoutEffect(() => {
+    if (!open || !anchorEl) return;
+    setPosition(computePlacement(anchorEl));
+  }, [open, anchorEl, rule]);
+
+  // Resize + scroll close the popover (per spec §4.1 — no live tracking).
+  useEffect(() => {
+    if (!open) return undefined;
+    const handler = () => onClose && onClose();
+    window.addEventListener('resize', handler);
+    window.addEventListener('scroll', handler, true);
+    return () => {
+      window.removeEventListener('resize', handler);
+      window.removeEventListener('scroll', handler, true);
+    };
+  }, [open, onClose]);
+
+  // Escape key + click-outside dismiss + focus management.
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose && onClose();
+      } else if (e.key === 'Tab') {
+        // Tiny focus trap — cycle between close and retry (when present).
+        const focusables = [closeBtnRef.current, retryBtnRef.current].filter(
+          Boolean,
+        );
+        if (focusables.length <= 1) {
+          e.preventDefault();
+          if (focusables[0]) focusables[0].focus();
+          return;
+        }
+        const idx = focusables.indexOf(document.activeElement);
+        e.preventDefault();
+        const next = e.shiftKey
+          ? focusables[(idx - 1 + focusables.length) % focusables.length]
+          : focusables[(idx + 1) % focusables.length];
+        next && next.focus();
+      }
+    };
+    const handlePointer = (e) => {
+      const root = rootRef.current;
+      if (!root) return;
+      if (root.contains(e.target)) return;
+      if (anchorEl && anchorEl.contains(e.target)) return; // chip click handled by parent
+      onClose && onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    document.addEventListener('pointerdown', handlePointer, true);
+    // Focus the close button after paint — gives screen-readers the popover
+    // semantics before they fight the trapping logic.
+    queueMicrotask(() => {
+      if (closeBtnRef.current) closeBtnRef.current.focus();
+    });
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+      document.removeEventListener('pointerdown', handlePointer, true);
+    };
+  }, [open, anchorEl, onClose]);
+
+  if (!open || !mounted) return null;
+
+  const label = REJECTION_RULE_LABELS[rule] || rule;
+
+  const popover = (
+    <div
+      ref={rootRef}
+      data-testid="scanner-rejected-strikes-relax-popover"
+      data-state={state}
+      data-rule={rule}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Relax ${label}`}
+      style={{
+        position: 'absolute',
+        top: position.top,
+        left: position.left,
+        width: POPOVER_WIDTH,
+      }}
+      className="z-50 max-h-96 overflow-y-auto bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-lg p-4"
+    >
+      <div
+        data-testid={`scanner-rejected-strikes-relax-rule-${rule}`}
+        className="flex items-start justify-between gap-2 mb-3"
+      >
+        <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
+          Relax · {label}
+        </p>
+        <button
+          ref={closeBtnRef}
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          data-testid="scanner-rejected-strikes-relax-popover-close"
+          className="text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded w-6 h-6 flex items-center justify-center"
+        >
+          <span aria-hidden>×</span>
+        </button>
+      </div>
+
+      {state === 'loading' && <SkeletonBody />}
+      {state === 'error' && (
+        <ErrorBody onRetry={onRetry} retryRef={retryBtnRef} />
+      )}
+      {state === 'ready' && <ReadyBody rule={rule} data={data} />}
+    </div>
+  );
+
+  return createPortal(popover, document.body);
+}

--- a/frontend/components/options/ScannerRejectedStrikesRelaxPopover.jsx
+++ b/frontend/components/options/ScannerRejectedStrikesRelaxPopover.jsx
@@ -19,7 +19,7 @@
 //
 // Spec: frontend/design-specs/issue-258-relax-to-x-preview.md
 
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { REJECTION_RULE_LABELS } from './scannerRejectionLabels';
@@ -180,21 +180,19 @@ export default function ScannerRejectedStrikesRelaxPopover({
   const closeBtnRef = useRef(null);
   const retryBtnRef = useRef(null);
 
-  const [position, setPosition] = useState({ top: 0, left: 0, placement: 'below' });
-  const [mounted, setMounted] = useState(false);
-
-  // SSR safety — `createPortal(..., document.body)` would crash during SSR
-  // because `document` is undefined. Only render the portal after mount.
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  // Recompute placement when opening or when the rule (and therefore the
-  // anchor) changes.
-  useLayoutEffect(() => {
-    if (!open || !anchorEl) return;
-    setPosition(computePlacement(anchorEl));
+  // Placement is a pure function of the anchor element (and the rule, which
+  // is folded in to force a recompute when the chip changes). Memoizing
+  // avoids the setState-in-effect anti-pattern entirely — the placement is
+  // recomputed *during render* whenever its inputs change.
+  const position = useMemo(() => {
+    if (!open || !anchorEl) return { top: 0, left: 0, placement: 'below' };
+    return computePlacement(anchorEl);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, anchorEl, rule]);
+
+  // SSR / hydration safety — `createPortal(..., document.body)` requires
+  // `document`. Guard the early return below on `typeof document`.
+  const canRenderPortal = typeof document !== 'undefined';
 
   // Resize + scroll close the popover (per spec §4.1 — no live tracking).
   useEffect(() => {
@@ -253,7 +251,7 @@ export default function ScannerRejectedStrikesRelaxPopover({
     };
   }, [open, anchorEl, onClose]);
 
-  if (!open || !mounted) return null;
+  if (!open || !canRenderPortal) return null;
 
   const label = REJECTION_RULE_LABELS[rule] || rule;
 

--- a/frontend/components/options/scannerRejectionLabels.js
+++ b/frontend/components/options/scannerRejectionLabels.js
@@ -46,12 +46,14 @@ export const CANONICAL_RULE_ORDER = [
 ];
 
 // Extract the rule family — the prefix up to the first colon — from a raw
-// rejection-reason string. Mirrors the existing `humanizeFallback` regex at
-// `ScannerRejectedStrikes.jsx:39` so the summary aggregator and the per-row
-// fallback agree.
+// rejection-reason string. The character class `[a-z0-9_]+` matches the
+// scanner's emitted family names, including `fails_10pct_rule` (which the
+// original `humanizeFallback` regex at `ScannerRejectedStrikes.jsx` would
+// have truncated at the first digit — pre-existing bug; the per-row branch
+// then fell back to the raw string).
 export function extractRuleFamily(raw) {
   if (!raw) return null;
-  const match = /^([a-z_]+)/i.exec(raw);
+  const match = /^([a-z0-9_]+)/i.exec(raw);
   return match ? match[1] : null;
 }
 

--- a/frontend/components/options/scannerRejectionLabels.js
+++ b/frontend/components/options/scannerRejectionLabels.js
@@ -1,0 +1,239 @@
+// Single source of truth for human labels and near-pass framing for the
+// options-scanner Rejected Strikes panel.
+//
+// `REJECTION_RULE_LABELS` is the const map V1.0.8 pins as the canonical human
+// label per rule family — used by the summary-band chips in
+// `ScannerRejectedStrikes.jsx` and (post-merge) by W-D's relax-popover so the
+// two surfaces agree on label text.
+//
+// `formatNearPassReason(raw)` reads a raw rejection-reason string (the same
+// machine-parseable form produced by `app/services/rejection_messages.py`'s
+// regexes) and returns a fact-led near-pass sentence — the pattern is
+// `"Would pass — {observed} {operator} {threshold} ({gap})."` per design spec
+// §4.2.B. Binary rules (`itm_put`, `zero_bid`) get a `(binary: this rule has no
+// relax threshold)` suffix. Unknown / unparseable codes fall back to the raw
+// string unchanged — defensive, never crash.
+//
+// Spec: frontend/design-specs/issue-257-rejected-strikes-polish.md (§3.4, §4.2)
+
+export const REJECTION_RULE_LABELS = {
+  fails_10pct_rule: 'Distance from basis',
+  below_cost_basis: 'Cost basis',
+  itm_put: 'In-the-money',
+  delta_out_of_range: 'Delta',
+  low_open_interest: 'Open interest',
+  zero_bid: 'Zero bid',
+  wide_bid_ask_spread: 'Spread',
+  return_below_target: 'Return below target',
+  return_above_cap: 'Return above cap',
+  iv_rank_below_floor: 'IV rank',
+};
+
+// Canonical rule order — matches the order `_check_rejection` appends to
+// `reasons` in `backend/app/services/options_scanner.py`. Used to break ties
+// when two rule families have identical reject counts.
+export const CANONICAL_RULE_ORDER = [
+  'fails_10pct_rule',
+  'below_cost_basis',
+  'itm_put',
+  'delta_out_of_range',
+  'low_open_interest',
+  'zero_bid',
+  'wide_bid_ask_spread',
+  'return_below_target',
+  'return_above_cap',
+  'iv_rank_below_floor',
+];
+
+// Extract the rule family — the prefix up to the first colon — from a raw
+// rejection-reason string. Mirrors the existing `humanizeFallback` regex at
+// `ScannerRejectedStrikes.jsx:39` so the summary aggregator and the per-row
+// fallback agree.
+export function extractRuleFamily(raw) {
+  if (!raw) return null;
+  const match = /^([a-z_]+)/i.exec(raw);
+  return match ? match[1] : null;
+}
+
+// Human-friendly fallback label for an unknown rule family. Should never
+// surface in practice (the const map above covers every family the scanner
+// emits) — this is purely defensive against a stale UI / new backend rule.
+export function fallbackRuleLabel(family) {
+  if (!family) return 'Unknown';
+  const spaced = family.replace(/_/g, ' ');
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function labelForRuleFamily(family) {
+  return REJECTION_RULE_LABELS[family] || fallbackRuleLabel(family);
+}
+
+// ---------------------------------------------------------------------------
+// Near-pass framing — per-family regex parsers.
+// ---------------------------------------------------------------------------
+//
+// Each parser reads the same f-string shape produced by `options_scanner.py`'s
+// `_check_rejection` and `rejection_messages.py`'s regexes, extracts the
+// numbers, and renders a fact-led "Would pass — …" sentence with an explicit
+// gap parenthetical so the user can see at a glance how close they are.
+//
+// Pattern: `Would pass — {observed} {operator} {threshold} ({gap}).`
+
+const NEAR_PASS_REGEXES = {
+  fails_10pct_rule: /^fails_10pct_rule:\s*strike\s*(-?\d+(?:\.\d+)?)%\s*above basis,\s*requires\s*(-?\d+(?:\.\d+)?)%/i,
+  below_cost_basis: /^below_cost_basis:\s*strike\s*\$(-?\d+(?:\.\d+)?)\s*<\s*floor\s*\$(-?\d+(?:\.\d+)?)/i,
+  itm_put: /^itm_put:\s*strike\s*\$(-?\d+(?:\.\d+)?)\s*>\s*price\s*\$(-?\d+(?:\.\d+)?)/i,
+  delta_out_of_range: /^delta_out_of_range:\s*\|(-?\d+(?:\.\d+)?)\|\s*not in\s*\[(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)\]/i,
+  low_open_interest: /^low_open_interest:\s*(-?\d+)\s*<\s*(-?\d+)/i,
+  return_below_target: /^return_below_target:\s*(-?\d+(?:\.\d+)?)%\s*<\s*(-?\d+(?:\.\d+)?)%/i,
+  return_above_cap: /^return_above_cap:\s*(-?\d+(?:\.\d+)?)%\s*>\s*(-?\d+(?:\.\d+)?)%/i,
+  wide_bid_ask_spread: /^wide_bid_ask_spread:\s*(-?\d+(?:\.\d+)?)%\s*>\s*(-?\d+(?:\.\d+)?)%/i,
+  iv_rank_below_floor: /^iv_rank_below_floor:\s*(-?\d+(?:\.\d+)?)\s*<\s*(-?\d+(?:\.\d+)?)/i,
+};
+
+// Format a percentage gap with pp ("percentage points") suffix.
+function fmtPp(value, decimals = 2) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  return `${n.toFixed(decimals)}pp`;
+}
+
+function fmtPct(value, decimals = 1) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  return `${n.toFixed(decimals)}%`;
+}
+
+function fmtDollars(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return String(value);
+  return `$${n.toFixed(2)}`;
+}
+
+function nearPassFails10pct(match) {
+  const pct = parseFloat(match[1]);
+  const requires = parseFloat(match[2]);
+  const gap = requires - pct;
+  return `Would pass — strike is ${pct.toFixed(1)}% above basis, your ${requires.toFixed(1)}% rule requires ${requires.toFixed(1)}% (${fmtPp(gap, 1)} short).`;
+}
+
+function nearPassBelowCostBasis(match) {
+  const strike = parseFloat(match[1]);
+  const floor = parseFloat(match[2]);
+  const gap = floor - strike;
+  return `Would pass — strike ${fmtDollars(strike)} is below your ${fmtDollars(floor)} floor (${fmtDollars(gap)} short).`;
+}
+
+function nearPassItmPut(match) {
+  const strike = parseFloat(match[1]);
+  const price = parseFloat(match[2]);
+  return `Would pass — strike ${fmtDollars(strike)} is above current price ${fmtDollars(price)} (binary: this rule has no relax threshold).`;
+}
+
+function nearPassDelta(match) {
+  const delta = parseFloat(match[1]);
+  const minDelta = parseFloat(match[2]);
+  const maxDelta = parseFloat(match[3]);
+  const absDelta = Math.abs(delta);
+  let gap;
+  if (absDelta > maxDelta) {
+    gap = absDelta - maxDelta;
+    return `Would pass — delta ${delta.toFixed(2)} is outside your ${minDelta.toFixed(2)}–${maxDelta.toFixed(2)} range (${gap.toFixed(2)} over).`;
+  }
+  if (absDelta < minDelta) {
+    gap = minDelta - absDelta;
+    return `Would pass — delta ${delta.toFixed(2)} is outside your ${minDelta.toFixed(2)}–${maxDelta.toFixed(2)} range (${gap.toFixed(2)} short).`;
+  }
+  // Defensive — shouldn't happen if scanner emitted this code.
+  return `Would pass — delta ${delta.toFixed(2)} is outside your ${minDelta.toFixed(2)}–${maxDelta.toFixed(2)} range.`;
+}
+
+function nearPassLowOi(match) {
+  const oi = parseInt(match[1], 10);
+  const minOi = parseInt(match[2], 10);
+  const gap = minOi - oi;
+  return `Would pass — open interest ${oi} is below your ${minOi} minimum (${gap} short).`;
+}
+
+function nearPassReturnBelow(match) {
+  const pct = parseFloat(match[1]);
+  const minPct = parseFloat(match[2]);
+  const gap = minPct - pct;
+  return `Would pass — return ${fmtPct(pct, 2)} is below your ${fmtPct(minPct, 1)} target (${fmtPp(gap, 2)} short).`;
+}
+
+function nearPassReturnAbove(match) {
+  const pct = parseFloat(match[1]);
+  const maxPct = parseFloat(match[2]);
+  const gap = pct - maxPct;
+  return `Would pass — return ${fmtPct(pct, 2)} is above your ${fmtPct(maxPct, 1)} cap (${fmtPp(gap, 2)} over).`;
+}
+
+function nearPassWideSpread(match) {
+  const pct = parseFloat(match[1]);
+  const maxPct = parseFloat(match[2]);
+  const gap = pct - maxPct;
+  return `Would pass — spread ${fmtPct(pct, 1)} is above your ${fmtPct(maxPct, 1)} cap (${fmtPp(gap, 1)} over).`;
+}
+
+function nearPassIvRank(match) {
+  const rank = parseFloat(match[1]);
+  const minRank = parseFloat(match[2]);
+  const gap = minRank - rank;
+  return `Would pass — IV rank ${rank.toFixed(0)} is below your ${minRank.toFixed(0)} floor (${gap.toFixed(0)} short).`;
+}
+
+const NEAR_PASS_FORMATTERS = {
+  fails_10pct_rule: nearPassFails10pct,
+  below_cost_basis: nearPassBelowCostBasis,
+  itm_put: nearPassItmPut,
+  delta_out_of_range: nearPassDelta,
+  low_open_interest: nearPassLowOi,
+  return_below_target: nearPassReturnBelow,
+  return_above_cap: nearPassReturnAbove,
+  wide_bid_ask_spread: nearPassWideSpread,
+  iv_rank_below_floor: nearPassIvRank,
+};
+
+// `zero_bid` is a literal code (no parameters) — handled out-of-band.
+const ZERO_BID_NEAR_PASS =
+  'Would pass — but no buyer is showing a bid (binary: this rule has no relax threshold).';
+
+/**
+ * Format a single raw rejection-reason string as a fact-led near-pass sentence.
+ *
+ * Pattern: `Would pass — {observed} {operator} {threshold} ({gap}).` Binary
+ * rules (`itm_put`, `zero_bid`) get a `(binary: this rule has no relax
+ * threshold)` suffix. Unknown / unparseable codes fall back to the raw string
+ * unchanged so we never blank the user out.
+ *
+ * @param {string} raw - The raw rejection-reason string (e.g.
+ *   `"delta_out_of_range: |0.38| not in [0.20, 0.35]"`).
+ * @returns {string} A near-pass framed sentence, or the raw string unchanged.
+ */
+export function formatNearPassReason(raw) {
+  if (!raw || typeof raw !== 'string') return String(raw ?? '');
+  const trimmed = raw.trim();
+
+  // Special-case zero_bid (literal code, no parameters).
+  if (trimmed === 'zero_bid' || trimmed.startsWith('zero_bid:')) {
+    return ZERO_BID_NEAR_PASS;
+  }
+
+  const family = extractRuleFamily(trimmed);
+  if (!family) return raw;
+
+  const re = NEAR_PASS_REGEXES[family];
+  const formatter = NEAR_PASS_FORMATTERS[family];
+  if (!re || !formatter) return raw;
+
+  const match = re.exec(trimmed);
+  if (!match) return raw;
+
+  try {
+    return formatter(match);
+  } catch {
+    // Defensive — never crash; show the raw string.
+    return raw;
+  }
+}

--- a/frontend/e2e/dashboard-open-legs-card.spec.js
+++ b/frontend/e2e/dashboard-open-legs-card.spec.js
@@ -518,3 +518,79 @@ test.describe('OpenLegsCard (V1.0.6 — coverage badge + dollar P&L)', () => {
     await expect(pnl).toHaveAttribute('data-pnl-sign', 'none');
   });
 });
+
+test.describe('OpenLegsCard (V1.0.8 #252 — quantity scales degraded Credit received)', () => {
+  // The primary path (`pnl_dollars + cost_to_close`) is already qty-scaled by
+  // `derive_leg_economics`. These tests pin the degraded fallback formula in
+  // `OpenLegsCard.jsx:204`: `creditReceived = premium * 100 * (quantity ?? 1)`.
+  //
+  // A qty=2 leg with both dollar figures null falls through to the degraded
+  // branch, so we can assert the scaled-credit value lands in the InspectPanel.
+
+  test('qty=2 degraded leg renders premium * 100 * 2 in Credit received', async ({ page }) => {
+    const leg = makeLeg({
+      id: 'leg-qty2',
+      ticker: 'AAPL',
+      type: 'call',
+      strike: 175.0,
+      expiration: '2026-06-19',
+      dte: 31,
+      moneyness: { state: 'OTM', distance_pct: 0.03, distance_dollars: 5 },
+      profit_target_status: { captured_pct: null, state: 'unknown' },
+      assignment_risk: 'low',
+      verdict: 'hold',
+      coverage: 'covered',
+      premium: 3.0,
+      quantity: 2,
+      // Degraded — no live mid → both dollar figures null. The InspectPanel
+      // must still compute Credit received = $3.00 * 100 * 2 = $600.00.
+      pnl_dollars: null,
+      cost_to_close: null,
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    const economics = page.getByTestId('dashboard-leg-inspect-economics-leg-qty2');
+    await expect(economics).toBeVisible();
+    await expect(economics).toContainText('$600.00');
+    // The Cost to close / P&L cells degrade to `—`.
+    await expect(economics).toContainText('Cost to close —');
+  });
+
+  test('qty=1 leg preserves the pre-#252 Credit received value (regression sanity)', async ({
+    page,
+  }) => {
+    // Identical fixture to the qty=2 case but with quantity=1 → Credit
+    // received = $3.00 * 100 * 1 = $300.00. Guards against an accidental
+    // off-by-quantity regression on the single-contract happy path.
+    const leg = makeLeg({
+      id: 'leg-qty1',
+      ticker: 'AAPL',
+      type: 'call',
+      strike: 175.0,
+      expiration: '2026-06-19',
+      dte: 31,
+      moneyness: { state: 'OTM', distance_pct: 0.03, distance_dollars: 5 },
+      profit_target_status: { captured_pct: null, state: 'unknown' },
+      assignment_risk: 'low',
+      verdict: 'hold',
+      coverage: 'covered',
+      premium: 3.0,
+      quantity: 1,
+      pnl_dollars: null,
+      cost_to_close: null,
+    });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    const economics = page.getByTestId('dashboard-leg-inspect-economics-leg-qty1');
+    await expect(economics).toBeVisible();
+    await expect(economics).toContainText('$300.00');
+  });
+});

--- a/frontend/e2e/dashboard-open-legs-card.spec.js
+++ b/frontend/e2e/dashboard-open-legs-card.spec.js
@@ -517,4 +517,74 @@ test.describe('OpenLegsCard (V1.0.6 — coverage badge + dollar P&L)', () => {
     await expect(pnl).toHaveText('—');
     await expect(pnl).toHaveAttribute('data-pnl-sign', 'none');
   });
+
+  // ---- V1.0.8 / #251 — partial-coverage tri-state ----
+
+  function partialLeg(overrides = {}) {
+    // The 50-shares / 1-call worked example from issue #251 spec §0.
+    // Backend already classifies coverage; the frontend just renders whatever
+    // value the payload carries (no shares-vs-quantity math on the client).
+    return makeLeg({
+      id: 'leg-f15c-partial',
+      ticker: 'F',
+      type: 'call',
+      strike: 15.0,
+      expiration: '2026-06-26',
+      dte: 38,
+      moneyness: { state: 'OTM', distance_pct: 0.124, distance_dollars: 1.86 },
+      profit_target_status: { captured_pct: 0.4, state: 'in_progress' },
+      assignment_risk: 'low',
+      verdict: 'hold',
+      coverage: 'partial',
+      premium: 0.3834,
+      pnl_dollars: 15.34,
+      cost_to_close: 23.0,
+      ...overrides,
+    });
+  }
+
+  test('coverage badge renders "⚠ Partial" for a 50sh / 1-call leg', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [partialLeg()] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const badge = page.getByTestId('dashboard-leg-row-coverage').first();
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveAttribute('data-coverage', 'partial');
+    await expect(badge).toContainText('Partial');
+    // Slate neutral recipe — distinct from amber `naked` and emerald `covered`.
+    await expect(badge).toHaveClass(/bg-slate-100/);
+  });
+
+  test('100 shares / 2 short calls → both call legs render partial', async ({ page }) => {
+    // A multi-contract income-harvest posture: only half of the share
+    // obligation is backed. Both legs surface the same partial pill.
+    const legA = partialLeg({ id: 'leg-tsla-call-a', ticker: 'TSLA', strike: 260.0 });
+    const legB = partialLeg({ id: 'leg-tsla-call-b', ticker: 'TSLA', strike: 270.0 });
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [legA, legB] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const badges = page.getByTestId('dashboard-leg-row-coverage');
+    await expect(badges).toHaveCount(2);
+    await expect(badges.nth(0)).toHaveAttribute('data-coverage', 'partial');
+    await expect(badges.nth(1)).toHaveAttribute('data-coverage', 'partial');
+  });
+
+  test('InspectPanel echoes the partial coverage badge', async ({ page }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [partialLeg()] });
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await page.getByTestId('dashboard-leg-row').first().click();
+    // Same testid format as the covered/naked echoes — the helper plumbs
+    // `testIdPrefix` through all three branches.
+    const echo = page.getByTestId('dashboard-leg-inspect-leg-f15c-partial-coverage');
+    await expect(echo).toBeVisible();
+    await expect(echo).toHaveAttribute('data-coverage', 'partial');
+    await expect(echo).toContainText('Partial');
+  });
 });

--- a/frontend/e2e/scanner-education.spec.js
+++ b/frontend/e2e/scanner-education.spec.js
@@ -277,15 +277,395 @@ test.describe('Scanner education — humanized rejected strikes', () => {
     // Open the disclosure.
     await page.getByTestId('scanner-rejected-strikes-toggle').click();
 
-    // Human sentence visible.
-    await expect(disclosure).toContainText(
-      'Strike sits -5.4% above your $13.21 basis'
-    );
+    // 1-reason strike ($12.50) now renders the V1.0.8 near-pass framing
+    // ('Would pass — …') instead of the legacy human_reasons[0] sentence.
+    // 2-reason strike ($16.00) still renders the bulleted human_reasons.
+    await expect(disclosure).toContainText('Would pass');
     await expect(disclosure).toContainText('Only 12 contracts open');
 
-    // Raw machine code NOT visible to the user.
+    // Raw machine code NOT visible to the user (still the canonical
+    // humanization AC — applies to both the near-pass framed sentence and
+    // the bulleted human-reasons branch).
     await expect(disclosure).not.toContainText('fails_10pct_rule:');
     await expect(disclosure).not.toContainText('delta_out_of_range:');
     await expect(disclosure).not.toContainText('low_open_interest:');
+  });
+});
+
+// ============================================================================
+// V1.0.8 / #257 — Rejected Strikes sort + summary + near-pass badge
+// ============================================================================
+//
+// Appended block. Tests:
+//   - Default sort = failure_count_asc — row order asserts 1-reason → 2 → 5.
+//   - Clicking each sort header re-orders rows (strike, expiration, failures).
+//   - Summary band renders chips count-desc; each chip has data-count.
+//   - Near-pass badge renders ONLY on rows with rejection_reasons.length === 1.
+//   - 3-tier stratification: 1 → near-pass badge; 2 → 'reasons' count text;
+//     ≥3 → unchanged structural treatment.
+
+// Multi-tier payload — five rejected strikes covering all three tiers.
+// Row-by-row:
+//   $13.50 / 2026-06-26 — 1 reason   (near-pass, delta out of range)
+//   $14.00 / 2026-06-26 — 1 reason   (near-pass, low open interest)
+//   $13.00 / 2026-07-31 — 2 reasons  (normal)
+//   $5.00  / 2026-06-26 — 5 reasons  (structural — below cost basis dominates)
+//   $6.00  / 2026-07-31 — 5 reasons  (structural)
+// Rule-family counts across all five strikes:
+//   below_cost_basis        : 2  ($5.00, $6.00)
+//   delta_out_of_range      : 4  ($13.50, $13.00, $5.00, $6.00)
+//   low_open_interest       : 4  ($14.00, $13.00, $5.00, $6.00)
+//   wide_bid_ask_spread     : 2  ($5.00, $6.00)
+//   fails_10pct_rule        : 2  ($5.00, $6.00)
+// Order count-desc, canonical-order tie-break:
+//   delta_out_of_range (4), low_open_interest (4), fails_10pct_rule (2),
+//   below_cost_basis (2), wide_bid_ask_spread (2)
+const TIERED_SCAN_PAYLOAD = {
+  ticker: 'F',
+  current_price: 13.21,
+  strategy: 'covered_call',
+  scan_time: '2026-05-20T12:00:00Z',
+  earnings_date: null,
+  iv_rank: null,
+  recommendations: [],
+  rejected: [
+    // Index 0 — 1 reason (near-pass, delta)
+    {
+      strike: 13.5,
+      expiration: '2026-06-26',
+      rejection_reasons: ['delta_out_of_range: |0.38| not in [0.20, 0.35]'],
+      human_reasons: [
+        'Delta +0.38 is outside your 0.20–0.35 range — too close to the money.',
+      ],
+    },
+    // Index 1 — 1 reason (near-pass, OI)
+    {
+      strike: 14.0,
+      expiration: '2026-06-26',
+      rejection_reasons: ['low_open_interest: 25 < 50'],
+      human_reasons: [
+        'Only 25 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+      ],
+    },
+    // Index 2 — 2 reasons (normal)
+    {
+      strike: 13.0,
+      expiration: '2026-07-31',
+      rejection_reasons: [
+        'delta_out_of_range: |0.42| not in [0.20, 0.35]',
+        'low_open_interest: 18 < 50',
+      ],
+      human_reasons: [
+        'Delta +0.42 is outside your 0.20–0.35 range — too close to the money.',
+        'Only 18 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+      ],
+    },
+    // Index 3 — 5 reasons (structural)
+    {
+      strike: 5.0,
+      expiration: '2026-06-26',
+      rejection_reasons: [
+        'fails_10pct_rule: strike -62.2% above basis, requires 10.0%',
+        'below_cost_basis: strike $5.00 < floor $13.21',
+        'delta_out_of_range: |0.92| not in [0.20, 0.35]',
+        'low_open_interest: 8 < 50',
+        'wide_bid_ask_spread: 22.5% > 10.0%',
+      ],
+      human_reasons: [
+        'Strike sits -62.2% above your $13.21 basis, but the 10.0% rule requires at least that much room.',
+        'Strike $5.00 is below your $13.21 cost-basis floor — if assigned, you would lock in a loss on the shares.',
+        'Delta +0.92 is outside your 0.20–0.35 range — too close to the money.',
+        'Only 8 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+        'The bid/ask spread is 22.5% of the mid price — wider than your 10.0% limit.',
+      ],
+    },
+    // Index 4 — 5 reasons (structural)
+    {
+      strike: 6.0,
+      expiration: '2026-07-31',
+      rejection_reasons: [
+        'fails_10pct_rule: strike -54.6% above basis, requires 10.0%',
+        'below_cost_basis: strike $6.00 < floor $13.21',
+        'delta_out_of_range: |0.88| not in [0.20, 0.35]',
+        'low_open_interest: 12 < 50',
+        'wide_bid_ask_spread: 18.0% > 10.0%',
+      ],
+      human_reasons: [
+        'Strike sits -54.6% above your $13.21 basis, but the 10.0% rule requires at least that much room.',
+        'Strike $6.00 is below your $13.21 cost-basis floor — if assigned, you would lock in a loss on the shares.',
+        'Delta +0.88 is outside your 0.20–0.35 range — too close to the money.',
+        'Only 12 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+        'The bid/ask spread is 18.0% of the mid price — wider than your 10.0% limit.',
+      ],
+    },
+  ],
+  market_context: {},
+};
+
+function setupTieredMocks(page) {
+  return Promise.all([
+    page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          configured: true,
+          valid: true,
+          error: null,
+          token_expiry: null,
+        }),
+      })
+    ),
+    page.route('**/api/options/scan', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(TIERED_SCAN_PAYLOAD),
+      })
+    ),
+  ]);
+}
+
+// Helper — open the panel and return the locator for all row strike+exp labels
+// in DOM order. We read the first <span> in each row (the "$X.XX YYYY-MM-DD"
+// header text) so we can assert on the order without depending on the badge
+// chrome.
+async function openPanelAndGetRowLabels(page) {
+  await page.getByTestId('scanner-rejected-strikes-toggle').click();
+  const rows = page.getByTestId('scanner-rejected-strike-row');
+  await expect(rows.first()).toBeVisible();
+  return rows.locator('> div > span').first();
+}
+
+test.describe('Scanner education — Rejected Strikes sort + summary + near-pass (#257)', () => {
+  test('default sort is failure_count_asc — 1-reason rows surface first', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+
+    await expect(page.getByTestId('scanner-rejected-strikes')).toBeVisible();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    await expect(rows).toHaveCount(5);
+
+    // Default sort = failure_count asc — order:
+    //   1-reason rows first (in payload order: $13.50, $14.00),
+    //   then 2-reason ($13.00),
+    //   then 5-reason ($5.00, $6.00).
+    await expect(rows.nth(0)).toContainText('$13.50');
+    await expect(rows.nth(1)).toContainText('$14.00');
+    await expect(rows.nth(2)).toContainText('$13.00');
+    await expect(rows.nth(3)).toContainText('$5.00');
+    await expect(rows.nth(4)).toContainText('$6.00');
+
+    // Active sort header carries the asc arrow (↑).
+    await expect(page.getByTestId('scanner-rejected-strikes-sort-failure_count')).toContainText('↑');
+  });
+
+  test('clicking Strike sort reorders rows by strike asc; toggling reverses to desc', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    await page.getByTestId('scanner-rejected-strikes-sort-strike').click();
+
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    await expect(rows.nth(0)).toContainText('$5.00');
+    await expect(rows.nth(1)).toContainText('$6.00');
+    await expect(rows.nth(2)).toContainText('$13.00');
+    await expect(rows.nth(3)).toContainText('$13.50');
+    await expect(rows.nth(4)).toContainText('$14.00');
+
+    // Active header has the asc arrow.
+    await expect(page.getByTestId('scanner-rejected-strikes-sort-strike')).toContainText('↑');
+
+    // Clicking the active header again toggles to desc.
+    await page.getByTestId('scanner-rejected-strikes-sort-strike').click();
+    await expect(rows.nth(0)).toContainText('$14.00');
+    await expect(rows.nth(4)).toContainText('$5.00');
+    await expect(page.getByTestId('scanner-rejected-strikes-sort-strike')).toContainText('↓');
+  });
+
+  test('clicking Expiration sort reorders rows by ISO date asc', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    await page.getByTestId('scanner-rejected-strikes-sort-expiration').click();
+
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    // 2026-06-26 group first (payload-stable inside the group): $13.50, $14.00, $5.00
+    // Then 2026-07-31: $13.00, $6.00
+    await expect(rows.nth(0)).toContainText('2026-06-26');
+    await expect(rows.nth(1)).toContainText('2026-06-26');
+    await expect(rows.nth(2)).toContainText('2026-06-26');
+    await expect(rows.nth(3)).toContainText('2026-07-31');
+    await expect(rows.nth(4)).toContainText('2026-07-31');
+
+    await expect(page.getByTestId('scanner-rejected-strikes-sort-expiration')).toContainText('↑');
+  });
+
+  test('clicking the active failure_count sort toggles asc → desc; 5-reason rows surface first', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // failure_count is already active (default) — click toggles to desc.
+    await page.getByTestId('scanner-rejected-strikes-sort-failure_count').click();
+
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    await expect(rows.nth(0)).toContainText('$5.00');
+    await expect(rows.nth(1)).toContainText('$6.00');
+    await expect(rows.nth(2)).toContainText('$13.00');
+    // Near-pass rows sink to the bottom.
+    await expect(rows.nth(3)).toContainText('$13.50');
+    await expect(rows.nth(4)).toContainText('$14.00');
+
+    await expect(page.getByTestId('scanner-rejected-strikes-sort-failure_count')).toContainText('↓');
+  });
+
+  test('summary band renders chips count-desc with data-count attributes', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    const summary = page.getByTestId('scanner-rejected-strikes-summary');
+    await expect(summary).toBeVisible();
+    await expect(summary).toContainText('Of 5 rejected:');
+
+    // Counts (per-strike dedupe inside the aggregator):
+    //   delta_out_of_range: 4, low_open_interest: 4, fails_10pct_rule: 2,
+    //   below_cost_basis: 2, wide_bid_ask_spread: 2.
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-summary-rule-delta_out_of_range')
+    ).toHaveAttribute('data-count', '4');
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-summary-rule-low_open_interest')
+    ).toHaveAttribute('data-count', '4');
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-summary-rule-fails_10pct_rule')
+    ).toHaveAttribute('data-count', '2');
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-summary-rule-below_cost_basis')
+    ).toHaveAttribute('data-count', '2');
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-summary-rule-wide_bid_ask_spread')
+    ).toHaveAttribute('data-count', '2');
+
+    // Chip labels come from REJECTION_RULE_LABELS — assert the human labels
+    // render, not raw machine codes.
+    await expect(summary).toContainText('Delta');
+    await expect(summary).toContainText('Open interest');
+    await expect(summary).toContainText('Distance from basis');
+    await expect(summary).toContainText('Cost basis');
+    await expect(summary).toContainText('Spread');
+
+    // DOM order: count-desc, with canonical-rule-order tie-break. The two
+    // count-4 chips come first; delta_out_of_range precedes low_open_interest
+    // in canonical order. Among the count-2 chips, fails_10pct_rule precedes
+    // below_cost_basis precedes wide_bid_ask_spread.
+    const chips = summary.locator('button[data-testid^="scanner-rejected-strikes-summary-rule-"]');
+    await expect(chips).toHaveCount(5);
+    await expect(chips.nth(0)).toHaveAttribute(
+      'data-testid',
+      'scanner-rejected-strikes-summary-rule-delta_out_of_range'
+    );
+    await expect(chips.nth(1)).toHaveAttribute(
+      'data-testid',
+      'scanner-rejected-strikes-summary-rule-low_open_interest'
+    );
+    await expect(chips.nth(2)).toHaveAttribute(
+      'data-testid',
+      'scanner-rejected-strikes-summary-rule-fails_10pct_rule'
+    );
+    await expect(chips.nth(3)).toHaveAttribute(
+      'data-testid',
+      'scanner-rejected-strikes-summary-rule-below_cost_basis'
+    );
+    await expect(chips.nth(4)).toHaveAttribute(
+      'data-testid',
+      'scanner-rejected-strikes-summary-rule-wide_bid_ask_spread'
+    );
+  });
+
+  test('near-pass badge renders only on rows with exactly 1 rejection reason; 3-tier stratification', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    await expect(rows).toHaveCount(5);
+
+    // Exactly two near-pass badges in total — one per single-reason row.
+    const badges = page.getByTestId('scanner-rejected-strike-badge-near-pass');
+    await expect(badges).toHaveCount(2);
+    await expect(badges.first()).toContainText('One rule away');
+
+    // Tier 1 — near-pass rows have the badge and the fact-led 'Would pass —'
+    // sentence; the '1 reason' text MUST NOT appear in those rows.
+    const nearPassRow1 = rows.nth(0);
+    await expect(nearPassRow1).toContainText('$13.50');
+    await expect(
+      nearPassRow1.getByTestId('scanner-rejected-strike-badge-near-pass')
+    ).toBeVisible();
+    await expect(nearPassRow1).toContainText('Would pass');
+    await expect(nearPassRow1).toContainText('delta 0.38');
+    await expect(nearPassRow1).toContainText('0.03 over');
+    await expect(nearPassRow1).not.toContainText('1 reason');
+
+    const nearPassRow2 = rows.nth(1);
+    await expect(nearPassRow2).toContainText('$14.00');
+    await expect(
+      nearPassRow2.getByTestId('scanner-rejected-strike-badge-near-pass')
+    ).toBeVisible();
+    await expect(nearPassRow2).toContainText('Would pass');
+    await expect(nearPassRow2).toContainText('open interest 25');
+    await expect(nearPassRow2).toContainText('25 short');
+
+    // Tier 2 — normal row (2 reasons): no near-pass badge, '2 reasons' text,
+    // bulleted human sentences (unchanged from pre-#257 treatment).
+    const normalRow = rows.nth(2);
+    await expect(normalRow).toContainText('$13.00');
+    await expect(
+      normalRow.getByTestId('scanner-rejected-strike-badge-near-pass')
+    ).toHaveCount(0);
+    await expect(normalRow).toContainText('2 reasons');
+    await expect(normalRow).toContainText('Delta +0.42');
+    await expect(normalRow).toContainText('Only 18 contracts open');
+
+    // Tier 3 — structural row (5 reasons): no near-pass badge, '5 reasons'
+    // text, bulleted list. Treatment unchanged in this spec (#259 will wrap
+    // these in a <details>).
+    const structuralRow = rows.nth(3);
+    await expect(structuralRow).toContainText('$5.00');
+    await expect(
+      structuralRow.getByTestId('scanner-rejected-strike-badge-near-pass')
+    ).toHaveCount(0);
+    await expect(structuralRow).toContainText('5 reasons');
+    await expect(structuralRow).toContainText('cost-basis floor');
   });
 });

--- a/frontend/e2e/scanner-education.spec.js
+++ b/frontend/e2e/scanner-education.spec.js
@@ -669,3 +669,335 @@ test.describe('Scanner education — Rejected Strikes sort + summary + near-pass
     await expect(structuralRow).toContainText('cost-basis floor');
   });
 });
+
+// ============================================================================
+// V1.0.8 / #258 — Rejected Strikes "Relax to X" preview popover
+// ============================================================================
+//
+// Appended block. Tests:
+//   - Clicking a summary-band chip opens the popover anchored to that chip.
+//   - Mocked /relax response renders data-state="ready" + recovered-count.
+//   - Close button + Escape both dismiss.
+//   - Binary-rule chip (`itm_put`) is `aria-disabled` and click is a no-op.
+//   - Error state: mocked endpoint failure → data-state="error".
+//   - Empty recovered_count=0 → slate-tone empty copy, no strike list.
+
+// Fixed mocked relax payload — used by the "ready" + recovered_count > 0 case.
+const RELAX_PAYLOAD_LOW_OI = {
+  rule: 'low_open_interest',
+  current_threshold_text: '500',
+  relaxed_threshold_text: '250',
+  recovered_count: 3,
+  recovered_strikes: [
+    { strike: 14.0, expiration: '2026-06-26' },
+    { strike: 14.5, expiration: '2026-06-26' },
+    { strike: 15.0, expiration: '2026-07-31' },
+  ],
+};
+
+// Payload used by the empty-state test — endpoint returns 200 with zero count.
+const RELAX_PAYLOAD_EMPTY = {
+  rule: 'delta_out_of_range',
+  current_threshold_text: '0.20–0.35',
+  relaxed_threshold_text: '0.15–0.40',
+  recovered_count: 0,
+  recovered_strikes: [],
+};
+
+function setupRelaxMocks(page, { relaxStatus = 200, relaxBody = RELAX_PAYLOAD_LOW_OI } = {}) {
+  return Promise.all([
+    page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          configured: true,
+          valid: true,
+          error: null,
+          token_expiry: null,
+        }),
+      }),
+    ),
+    page.route('**/api/options/scan', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(TIERED_SCAN_PAYLOAD),
+      }),
+    ),
+    page.route('**/api/options/scan/relax', (route) =>
+      route.fulfill({
+        status: relaxStatus,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          relaxStatus >= 400 ? { detail: 'Failed to compute relax preview' } : relaxBody,
+        ),
+      }),
+    ),
+  ]);
+}
+
+test.describe('Scanner education — Relax-to-X preview popover (#258)', () => {
+  test('clicking a relaxable chip opens the popover and renders the ready state', async ({
+    page,
+  }) => {
+    await setupRelaxMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Popover not rendered until the chip is clicked.
+    await expect(page.getByTestId('scanner-rejected-strikes-relax-popover')).toHaveCount(0);
+
+    // Click the low_open_interest chip — popover opens.
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-low_open_interest')
+      .click();
+
+    const popover = page.getByTestId('scanner-rejected-strikes-relax-popover');
+    await expect(popover).toBeVisible();
+
+    // Eventually settles to data-state="ready".
+    await expect(popover).toHaveAttribute('data-state', 'ready');
+    await expect(popover).toHaveAttribute('data-rule', 'low_open_interest');
+
+    // Recovered count matches the mocked payload.
+    const count = page.getByTestId('scanner-rejected-strikes-relax-recovered-count');
+    await expect(count).toHaveAttribute('data-count', '3');
+    await expect(count).toContainText('3 strikes');
+
+    // Threshold delta line shows current → relaxed values.
+    await expect(popover).toContainText('500');
+    await expect(popover).toContainText('250');
+
+    // Strike list renders the first 3 mocked strikes.
+    await expect(popover).toContainText('$14.00');
+    await expect(popover).toContainText('$15.00');
+
+    // Footer disclaimer.
+    await expect(popover).toContainText('Preview only');
+
+    // Per-rule scoped test ID is present (selector convenience for tests).
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-relax-rule-low_open_interest'),
+    ).toBeVisible();
+  });
+
+  test('close button and Escape both dismiss the popover', async ({ page }) => {
+    await setupRelaxMocks(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Open via click.
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-low_open_interest')
+      .click();
+    const popover = page.getByTestId('scanner-rejected-strikes-relax-popover');
+    await expect(popover).toBeVisible();
+
+    // Close via the × button.
+    await page.getByTestId('scanner-rejected-strikes-relax-popover-close').click();
+    await expect(page.getByTestId('scanner-rejected-strikes-relax-popover')).toHaveCount(0);
+
+    // Re-open + close via Escape.
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-low_open_interest')
+      .click();
+    await expect(page.getByTestId('scanner-rejected-strikes-relax-popover')).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('scanner-rejected-strikes-relax-popover')).toHaveCount(0);
+  });
+
+  test('binary-rule chip (itm_put) is disabled and clicking it does NOT open the popover', async ({
+    page,
+  }) => {
+    // Bolt an `itm_put` rejection onto the canonical covered_call tiered
+    // payload so the chip renders alongside the relaxable chips. The chip
+    // is the unit under test — the popover's wire-up does not care which
+    // scanner strategy emitted the rejection.
+    const itmPutPayload = {
+      ...TIERED_SCAN_PAYLOAD,
+      rejected: [
+        ...TIERED_SCAN_PAYLOAD.rejected,
+        {
+          strike: 15.0,
+          expiration: '2026-06-26',
+          rejection_reasons: ['itm_put: strike $15.00 > price $13.21'],
+          human_reasons: [
+            'Put is already in the money. CSPs work best below current price.',
+          ],
+        },
+      ],
+    };
+
+    await Promise.all([
+      page.route('**/api/settings/health/schwab', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            configured: true,
+            valid: true,
+            error: null,
+            token_expiry: null,
+          }),
+        }),
+      ),
+      page.route('**/api/options/scan', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(itmPutPayload),
+        }),
+      ),
+      // Endpoint should NEVER be hit — assert via routing not invoked.
+      page.route('**/api/options/scan/relax', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({}),
+        }),
+      ),
+    ]);
+
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    const chip = page.getByTestId('scanner-rejected-strikes-summary-rule-itm_put');
+    await expect(chip).toBeVisible();
+    await expect(chip).toHaveAttribute('aria-disabled', 'true');
+    await expect(chip).toBeDisabled();
+
+    // A click on a disabled <button> is a no-op for HTML; assert force-click
+    // also short-circuits via the handler.
+    await chip.click({ force: true });
+    await expect(page.getByTestId('scanner-rejected-strikes-relax-popover')).toHaveCount(0);
+  });
+
+  test('error state — mocked endpoint failure renders data-state="error"', async ({
+    page,
+  }) => {
+    await setupRelaxMocks(page, { relaxStatus: 500 });
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-low_open_interest')
+      .click();
+
+    const popover = page.getByTestId('scanner-rejected-strikes-relax-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover).toHaveAttribute('data-state', 'error');
+    await expect(popover).toContainText("Couldn't compute preview");
+    await expect(popover.getByRole('button', { name: 'Try again' })).toBeVisible();
+  });
+
+  test('empty state — recovered_count: 0 renders slate-tone empty copy and no strike list', async ({
+    page,
+  }) => {
+    await setupRelaxMocks(page, { relaxBody: RELAX_PAYLOAD_EMPTY });
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-delta_out_of_range')
+      .click();
+
+    const popover = page.getByTestId('scanner-rejected-strikes-relax-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover).toHaveAttribute('data-state', 'ready');
+
+    const count = page.getByTestId('scanner-rejected-strikes-relax-recovered-count');
+    await expect(count).toHaveAttribute('data-count', '0');
+    await expect(count).toContainText('No strikes would recover');
+
+    // No example-strike list (the bullets are an `<li>` carrying a `$` —
+    // assert none of the visible $ figures from the relax payload made it
+    // into the popover).
+    await expect(popover).not.toContainText('+');
+    // Threshold text still renders.
+    await expect(popover).toContainText('0.20–0.35');
+  });
+
+  test('switching chips re-fetches and updates the popover', async ({ page }) => {
+    // Second mocked payload for delta_out_of_range.
+    const relaxDeltaPayload = {
+      rule: 'delta_out_of_range',
+      current_threshold_text: '0.20–0.35',
+      relaxed_threshold_text: '0.15–0.40',
+      recovered_count: 1,
+      recovered_strikes: [{ strike: 13.5, expiration: '2026-06-26' }],
+    };
+
+    let callCount = 0;
+    await Promise.all([
+      page.route('**/api/settings/health/schwab', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            configured: true,
+            valid: true,
+            error: null,
+            token_expiry: null,
+          }),
+        }),
+      ),
+      page.route('**/api/options/scan', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(TIERED_SCAN_PAYLOAD),
+        }),
+      ),
+      page.route('**/api/options/scan/relax', async (route) => {
+        callCount += 1;
+        const req = JSON.parse(route.request().postData() || '{}');
+        const body =
+          req.rule === 'delta_out_of_range' ? relaxDeltaPayload : RELAX_PAYLOAD_LOW_OI;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(body),
+        });
+      }),
+    ]);
+
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Open OI popover.
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-low_open_interest')
+      .click();
+    const popover = page.getByTestId('scanner-rejected-strikes-relax-popover');
+    await expect(popover).toBeVisible();
+    await expect(popover).toHaveAttribute('data-rule', 'low_open_interest');
+    await expect(popover).toHaveAttribute('data-state', 'ready');
+
+    // Switch to delta — popover re-anchors and re-fetches.
+    await page
+      .getByTestId('scanner-rejected-strikes-summary-rule-delta_out_of_range')
+      .click();
+    await expect(popover).toHaveAttribute('data-rule', 'delta_out_of_range');
+    await expect(popover).toHaveAttribute('data-state', 'ready');
+    await expect(
+      page.getByTestId('scanner-rejected-strikes-relax-recovered-count'),
+    ).toHaveAttribute('data-count', '1');
+
+    // Two fetches: one per chip click.
+    expect(callCount).toBe(2);
+  });
+});
+

--- a/frontend/e2e/scanner-education.spec.js
+++ b/frontend/e2e/scanner-education.spec.js
@@ -657,15 +657,294 @@ test.describe('Scanner education — Rejected Strikes sort + summary + near-pass
     await expect(normalRow).toContainText('Delta +0.42');
     await expect(normalRow).toContainText('Only 18 contracts open');
 
-    // Tier 3 — structural row (5 reasons): no near-pass badge, '5 reasons'
-    // text, bulleted list. Treatment unchanged in this spec (#259 will wrap
-    // these in a <details>).
+    // Tier 3 — structural row (5 reasons): no near-pass badge, bulleted list.
+    // Since #259 (W-E) merged, ≥3-reason rows render collapsed by default —
+    // expand via the group toggle so the bulleted reason text becomes
+    // assertable. (The pre-merge phrasing '5 reasons' is now '5 reasons hidden'
+    // in the collapsed state — `toContainText('5 reasons')` still matches as
+    // a substring either way.)
     const structuralRow = rows.nth(3);
     await expect(structuralRow).toContainText('$5.00');
     await expect(
       structuralRow.getByTestId('scanner-rejected-strike-badge-near-pass')
     ).toHaveCount(0);
     await expect(structuralRow).toContainText('5 reasons');
+    await structuralRow.getByTestId('scanner-rejected-strike-group-toggle').click();
     await expect(structuralRow).toContainText('cost-basis floor');
+  });
+});
+
+// ============================================================================
+// V1.0.8 / #259 — Collapse-by-default for rejected strikes with ≥3 reasons
+// ============================================================================
+//
+// Appended block (S1 — append-only). Tests:
+//   - Default render: a row with `rejection_reasons.length >= 3` is wrapped
+//     in `scanner-rejected-strike-group` with `data-collapsed="true"`.
+//   - Toggling `Show ▾` on any group flips the single global flag —
+//     EVERY ≥3-reason row's `data-collapsed` flips to `"false"`.
+//   - localStorage key `scanner-rejected-strikes-row-collapsed` persists
+//     across `page.reload()`.
+//   - Rows with `<3` reasons are NOT wrapped in the collapse group
+//     (no `scanner-rejected-strike-group` testid).
+//   - Threshold boundary: exactly 3 reasons → collapsible; exactly 2 → not.
+//
+// Reuses TIERED_SCAN_PAYLOAD and setupTieredMocks defined above (5 rejected
+// strikes: 1, 1, 2, 5, 5 reasons — gives us 2 ≥3-reason groups for the
+// "all flip together" assertion). A separate BOUNDARY_SCAN_PAYLOAD covers the
+// 3-vs-2 threshold edge.
+
+// Boundary payload — two rejected strikes, one with exactly 2 reasons
+// (NOT collapsible) and one with exactly 3 reasons (collapsible). Asserts
+// the `>= 3` threshold inclusively.
+const BOUNDARY_SCAN_PAYLOAD = {
+  ticker: 'F',
+  current_price: 13.21,
+  strategy: 'covered_call',
+  scan_time: '2026-05-20T12:00:00Z',
+  earnings_date: null,
+  iv_rank: null,
+  recommendations: [],
+  rejected: [
+    // 2-reason row — NOT collapsible (just below the threshold).
+    {
+      strike: 13.0,
+      expiration: '2026-07-31',
+      rejection_reasons: [
+        'delta_out_of_range: |0.42| not in [0.20, 0.35]',
+        'low_open_interest: 18 < 50',
+      ],
+      human_reasons: [
+        'Delta +0.42 is outside your 0.20–0.35 range — too close to the money.',
+        'Only 18 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+      ],
+    },
+    // 3-reason row — collapsible exactly at the threshold.
+    {
+      strike: 7.0,
+      expiration: '2026-07-31',
+      rejection_reasons: [
+        'fails_10pct_rule: strike -47.0% above basis, requires 10.0%',
+        'delta_out_of_range: |0.85| not in [0.20, 0.35]',
+        'low_open_interest: 11 < 50',
+      ],
+      human_reasons: [
+        'Strike sits -47.0% above your $13.21 basis, but the 10.0% rule requires at least that much room.',
+        'Delta +0.85 is outside your 0.20–0.35 range — too close to the money.',
+        'Only 11 contracts open — too thin to trade comfortably (the scanner requires at least 50).',
+      ],
+    },
+  ],
+  market_context: {},
+};
+
+function setupBoundaryMocks(page) {
+  return Promise.all([
+    page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          configured: true,
+          valid: true,
+          error: null,
+          token_expiry: null,
+        }),
+      })
+    ),
+    page.route('**/api/options/scan', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(BOUNDARY_SCAN_PAYLOAD),
+      })
+    ),
+  ]);
+}
+
+// Helper — clear the row-collapse localStorage key so the default-collapsed
+// branch is exercised deterministically. We `goto('/options')` first so the
+// page origin is available to `localStorage.removeItem`. Mirrors
+// `clearScannerStorage` above; kept local to the #259 block so it does not
+// disturb upstream tests.
+async function clearRowCollapseStorage(page) {
+  await page.goto('/options');
+  await page.evaluate(() => {
+    try {
+      window.localStorage.removeItem('scanner-rejected-strikes-row-collapsed');
+    } catch {
+      // ignore
+    }
+  });
+}
+
+test.describe('Scanner education — Rejected Strikes ≥3-reason collapse (#259)', () => {
+  test('rows with >= 3 reasons render collapsed by default (data-collapsed="true")', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await clearRowCollapseStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Two ≥3-reason groups in the tiered payload (the two 5-reason rows).
+    const groups = page.getByTestId('scanner-rejected-strike-group');
+    await expect(groups).toHaveCount(2);
+
+    // Both render collapsed on first visit (default = true).
+    await expect(groups.nth(0)).toHaveAttribute('data-collapsed', 'true');
+    await expect(groups.nth(1)).toHaveAttribute('data-collapsed', 'true');
+
+    // Each collapsed group exposes a `Show ▾` toggle and the "N reasons hidden"
+    // phrase — and the reason bullets are NOT in the DOM yet.
+    const toggles = page.getByTestId('scanner-rejected-strike-group-toggle');
+    await expect(toggles).toHaveCount(2);
+    await expect(toggles.first()).toContainText('Show');
+    await expect(groups.first()).toContainText('5 reasons hidden');
+    await expect(groups.first()).not.toContainText('cost-basis floor');
+  });
+
+  test('clicking Show on one ≥3-reason group expands ALL ≥3-reason groups (single global flag)', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await clearRowCollapseStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    const groups = page.getByTestId('scanner-rejected-strike-group');
+    await expect(groups).toHaveCount(2);
+
+    // Click the first group's toggle — the single global flag flips, so
+    // BOTH groups expand simultaneously.
+    await page
+      .getByTestId('scanner-rejected-strike-group-toggle')
+      .first()
+      .click();
+
+    await expect(groups.nth(0)).toHaveAttribute('data-collapsed', 'false');
+    await expect(groups.nth(1)).toHaveAttribute('data-collapsed', 'false');
+
+    // Bullet text is now rendered in both groups; toggle wording flips to Hide.
+    await expect(groups.nth(0)).toContainText('cost-basis floor');
+    await expect(groups.nth(1)).toContainText('cost-basis floor');
+    await expect(
+      page.getByTestId('scanner-rejected-strike-group-toggle').first()
+    ).toContainText('Hide');
+
+    // Clicking Hide on the second group re-collapses both.
+    await page
+      .getByTestId('scanner-rejected-strike-group-toggle')
+      .nth(1)
+      .click();
+    await expect(groups.nth(0)).toHaveAttribute('data-collapsed', 'true');
+    await expect(groups.nth(1)).toHaveAttribute('data-collapsed', 'true');
+  });
+
+  test('collapse state persists across page reload via localStorage', async ({ page }) => {
+    await setupTieredMocks(page);
+    await clearRowCollapseStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Expand — flag flips to '0'.
+    await page
+      .getByTestId('scanner-rejected-strike-group-toggle')
+      .first()
+      .click();
+    await expect(
+      page.getByTestId('scanner-rejected-strike-group').first()
+    ).toHaveAttribute('data-collapsed', 'false');
+
+    // Inspect the localStorage value directly — boolean '0' (expanded).
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem('scanner-rejected-strikes-row-collapsed')
+    );
+    expect(stored).toBe('0');
+
+    // Reload — the expanded state survives (need to re-open the panel and
+    // re-run the scan because the panel mock state does not auto-persist).
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    const groups = page.getByTestId('scanner-rejected-strike-group');
+    await expect(groups.first()).toHaveAttribute('data-collapsed', 'false');
+    await expect(groups.first()).toContainText('cost-basis floor');
+  });
+
+  test('rows with < 3 reasons are NOT wrapped in the collapse group', async ({
+    page,
+  }) => {
+    await setupTieredMocks(page);
+    await clearRowCollapseStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // The tiered payload has 5 rejected strikes — 1, 1, 2, 5, 5 reasons.
+    // Only the two 5-reason rows are wrapped; the three rows with <3
+    // reasons render the normal treatment (no group testid, no toggle).
+    const groups = page.getByTestId('scanner-rejected-strike-group');
+    const toggles = page.getByTestId('scanner-rejected-strike-group-toggle');
+    await expect(groups).toHaveCount(2);
+    await expect(toggles).toHaveCount(2);
+
+    // Row 2 of the default sort (`failure_count_asc`) is the 2-reason row —
+    // it must not carry the group testid or the toggle.
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    const twoReasonRow = rows.nth(2);
+    await expect(twoReasonRow).toContainText('$13.00');
+    await expect(twoReasonRow).toContainText('2 reasons');
+    await expect(
+      twoReasonRow.getByTestId('scanner-rejected-strike-group')
+    ).toHaveCount(0);
+    await expect(
+      twoReasonRow.getByTestId('scanner-rejected-strike-group-toggle')
+    ).toHaveCount(0);
+  });
+
+  test('threshold boundary — exactly 3 reasons collapses, exactly 2 does not', async ({
+    page,
+  }) => {
+    await setupBoundaryMocks(page);
+    await clearRowCollapseStorage(page);
+    await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.21');
+    await page.waitForLoadState('networkidle');
+    await page.getByRole('button', { name: 'Scan Options' }).click();
+    await page.getByTestId('scanner-rejected-strikes-toggle').click();
+
+    // Exactly one collapsible group — the 3-reason row.
+    const groups = page.getByTestId('scanner-rejected-strike-group');
+    await expect(groups).toHaveCount(1);
+    await expect(groups.first()).toHaveAttribute('data-collapsed', 'true');
+    await expect(groups.first()).toContainText('3 reasons hidden');
+
+    // The 2-reason row is rendered as a normal row (no group testid).
+    // Default sort = failure_count_asc, so rows.nth(0) is the 2-reason row
+    // ($13.00) and rows.nth(1) is the 3-reason row ($7.00).
+    const rows = page.getByTestId('scanner-rejected-strike-row');
+    await expect(rows).toHaveCount(2);
+    const twoReasonRow = rows.nth(0);
+    await expect(twoReasonRow).toContainText('$13.00');
+    await expect(twoReasonRow).toContainText('2 reasons');
+    await expect(
+      twoReasonRow.getByTestId('scanner-rejected-strike-group')
+    ).toHaveCount(0);
+
+    // Sanity check — the 3-reason row IS the collapsible group.
+    const threeReasonRow = rows.nth(1);
+    await expect(threeReasonRow).toContainText('$7.00');
+    await expect(
+      threeReasonRow.getByTestId('scanner-rejected-strike-group')
+    ).toHaveCount(1);
   });
 });


### PR DESCRIPTION
## What ships

**v1.0.8** bundles 5 issues across two dashboard surfaces:

| # | Title |
|---|---|
| **#257** | Rejected Strikes panel — sort by failure count + per-rule summary band + one-rule-away highlight |
| **#258** | Rejected Strikes panel — "Relax to X" preview popover for chip-anchored rule loosening |
| **#259** | Rejected Strikes panel — collapse-by-default for rows failing ≥3 rules |
| **#251** | Open option legs — partial-coverage tri-state (`covered`/`partial`/`naked`) when shares < quantity × 100 |
| **#252** | Quantity field on `DashboardOpenLeg` — degraded-path Credit Received now scales correctly for qty > 1 |

## How it was built — 5-worker parallel execution

8-worker DAG from v1.0.7 compressed to 5 for the smaller v1.0.8 surface:

| Wave | Workers (parallel within wave) |
|---|---|
| **D** (design, ║) | Designer #257 + #258 + #259 + #251 |
| **0** | V1 contract freeze |
| **1** (impl, ║) | W-A (#257 rewrite), W-B (#251 tri-state), W-C (#252 quantity field) |
| **2** (impl, ║) | W-D (#258 popover), W-E (#259 collapse) — both gate on W-A merged |

Single integration branch `feat/v1.0.8`; sub-branches merge in; this is the single PR to main. Wall-clock: ~75 min from "plan approved" to "PR opened."

## Highlights

- **#257 caught a pre-existing bug:** the panel's rule-family extraction regex was truncating `fails_10pct_rule` at the digit. Fixed in W-A's commit `31d18a7` as a hygiene side-quest.
- **#258 is the codebase's first popover primitive** — ~280 LOC roll-your-own (no new library deps), portal-rendered for stacking-context independence, auto-flips above when at viewport bottom edge.
- **#251 plan amendment caught at design time:** the designer noticed the v1.0.8 plan missed `CoveredCallLegBreakdown.coverage` (a sibling Literal at `schemas.py:1159`). W-B added it; no follow-up issue needed.
- **#259 reused `ScannerStrategyPrimer`'s collapse pattern** verbatim per the designer's "copy-at-two, promote-at-three" rule.

## Verification at `17d876e`

- **Backend pytest:** 1262 passed, 9 skipped, 0 failed.
- **Frontend Playwright** (`scanner-education.spec.js` + `dashboard-open-legs-card.spec.js` in scope): 47 passed (24 in scanner-education incl. 11 new for v1.0.8; 23 in dashboard-open-legs-card incl. 6 new for v1.0.8).
- **Lint + build:** clean.

## Notable decisions

- **`coverage="partial"` → slate** (`RISK_VISUALS.low` recipe), label `⚠ Partial`. Slate avoids overloading amber (already used for Naked / DTE-14 / dte_review). Color-blind distinction preserved via the `⚠` glyph.
- **Default Rejected Strikes sort:** `failure_count_asc` (closest-to-passing first; the actionable strikes rise to the top).
- **#258 binary rules** (`itm_put`, `zero_bid`): chip disabled with `aria-disabled` + hover hint. The popover doesn't open. Backend returns 400 "rule not relaxable" if called.
- **#259 collapse:** single global state flag (per-row visual rendering); clicking ANY toggle expands all ≥3-reason rows together.
- **#252 `quantity` field:** strict `int = 1` (not Optional). The dict pass-through at `dashboard_legs.py:479` already coerces.

## v1.0.6 carry-overs cleared

`#251` and `#252` were both deferred from v1.0.6 as follow-ups. v1.0.8 absorbs them into the same release as the rejected-strikes UX work. Backlog cleanup ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)