### PR TITLE
v1.0.10 — Bug bundle (closes #277 #278 #274 #276 #164 #172)

### DIFF
--- a/backend/app/logging_axiom.py
+++ b/backend/app/logging_axiom.py
@@ -120,7 +120,13 @@ def _format_timestamp(created: float) -> str:
 class _AxiomWorker(threading.Thread):
     """Daemon thread that drains the queue and POSTs batches to Axiom."""
 
-    def __init__(self, q: "queue.Queue[dict[str, Any]]", token: str, dataset: str) -> None:
+    def __init__(
+        self,
+        q: "queue.Queue[dict[str, Any]]",
+        token: str,
+        dataset: str,
+        handler: "AxiomHandler | None" = None,
+    ) -> None:
         super().__init__(name="axiom-log-worker", daemon=True)
         self._q = q
         self._url = AXIOM_INGEST_URL.format(dataset=dataset)
@@ -135,6 +141,12 @@ class _AxiomWorker(threading.Thread):
         self._stop_event = threading.Event()
         self._warn_state: dict[str, float] = {}
         self._client = httpx.Client(timeout=HTTP_TIMEOUT_S)
+        # Back-reference to the owning :class:`AxiomHandler` so the worker
+        # can publish per-flush bookkeeping (``last_flush_at`` / ``last_flush_error``)
+        # via the handler's locked setters. May be ``None`` in unit tests
+        # that construct a worker directly; the setters short-circuit in
+        # that case.
+        self._handler = handler
 
     def stop(self) -> None:
         """Signal the worker loop to exit after the next batch flush."""
@@ -162,7 +174,14 @@ class _AxiomWorker(threading.Thread):
         return batch
 
     def _flush(self, batch: list[dict[str, Any]]) -> None:
-        """POST ``batch`` to the Axiom ingest endpoint, swallowing all errors."""
+        """POST ``batch`` to the Axiom ingest endpoint, swallowing all errors.
+
+        On success (2xx/3xx) publishes a sanitized ``last_flush_at`` timestamp
+        on the parent handler and clears any prior error. On failure publishes
+        a short, sanitized ``last_flush_error`` (status code or exception
+        class name — never ``str(e)``, response body, or headers). These
+        fields back the ``/api/health`` logging self-monitoring block (#274).
+        """
         if not batch:
             return
         try:
@@ -177,18 +196,32 @@ class _AxiomWorker(threading.Thread):
                     "http_4xx_5xx",
                     f"ingest failed status={resp.status_code}",
                 )
+                if self._handler is not None:
+                    self._handler._set_last_flush_err(
+                        f"ingest failed status={resp.status_code}"
+                    )
+            elif self._handler is not None:
+                self._handler._set_last_flush_ok(_format_timestamp(time.time()))
         except httpx.HTTPError as e:
             _warn_throttled(
                 self._warn_state,
                 "http_error",
                 f"ingest transport error: {type(e).__name__}",
             )
+            if self._handler is not None:
+                self._handler._set_last_flush_err(
+                    f"ingest transport error: {type(e).__name__}"
+                )
         except Exception as e:  # noqa: BLE001 — last-resort safety net
             _warn_throttled(
                 self._warn_state,
                 "unknown",
                 f"ingest unknown error: {type(e).__name__}",
             )
+            if self._handler is not None:
+                self._handler._set_last_flush_err(
+                    f"ingest unknown error: {type(e).__name__}"
+                )
 
     def run(self) -> None:
         """Main worker loop — drain and flush until :meth:`stop` is signalled."""
@@ -220,9 +253,17 @@ class AxiomHandler(logging.Handler):
     def __init__(self, token: str, dataset: str) -> None:
         super().__init__()
         self._q: "queue.Queue[dict[str, Any]]" = queue.Queue(maxsize=QUEUE_MAX)
-        self._worker = _AxiomWorker(self._q, token, dataset)
         self._warn_state: dict[str, float] = {}
         self._dropped = 0
+        # Lock covers concurrent reads (from ``/api/health`` request threads)
+        # and writes (from the daemon worker after each flush). Both fields
+        # are scalars so the critical section is microseconds — issue #274.
+        self._stats_lock = threading.Lock()
+        self._last_flush_at: str | None = None
+        self._last_flush_error: str | None = None
+        # Pass ``self`` so the worker can publish per-flush state through
+        # the locked setters below.
+        self._worker = _AxiomWorker(self._q, token, dataset, handler=self)
         self._worker.start()
         atexit.register(self._atexit_flush)
 
@@ -230,6 +271,65 @@ class AxiomHandler(logging.Handler):
     def dropped(self) -> int:
         """Total number of events dropped due to a full queue since startup."""
         return self._dropped
+
+    @property
+    def queue_depth(self) -> int:
+        """Current number of events waiting in the in-process queue.
+
+        Per the CPython docs, ``queue.Queue.qsize()`` is *approximate* under
+        concurrent access — that is acceptable for the ``/api/health``
+        observability surface (#274), which only needs an order-of-magnitude
+        signal for queue saturation, not a transactionally consistent count.
+        """
+        return self._q.qsize()
+
+    @property
+    def queue_capacity(self) -> int:
+        """Configured maximum queue size (``QUEUE_MAX`` at construction time)."""
+        return self._q.maxsize
+
+    @property
+    def last_flush_at(self) -> str | None:
+        """ISO 8601 timestamp of the most recent successful Axiom flush.
+
+        ``None`` until at least one batch has flushed with a 2xx/3xx
+        response. Read under :attr:`_stats_lock` to pair with the worker's
+        write side.
+        """
+        with self._stats_lock:
+            return self._last_flush_at
+
+    @property
+    def last_flush_error(self) -> str | None:
+        """Sanitized short message from the most recent failed flush.
+
+        ``None`` when the last flush attempt succeeded (or no flush has run
+        yet). Never contains raw exception text, response body, or response
+        headers — only the status code or exception class name.
+        """
+        with self._stats_lock:
+            return self._last_flush_error
+
+    def _set_last_flush_ok(self, timestamp: str) -> None:
+        """Worker-side hook: record a successful flush + clear any prior error.
+
+        Called by :class:`_AxiomWorker._flush` after a 2xx/3xx ingest response.
+        Locked because the request thread reads these fields via
+        ``/api/health``.
+        """
+        with self._stats_lock:
+            self._last_flush_at = timestamp
+            self._last_flush_error = None
+
+    def _set_last_flush_err(self, message: str) -> None:
+        """Worker-side hook: record a sanitized failure message.
+
+        Callers (only :class:`_AxiomWorker._flush`) must pre-sanitize the
+        message — no PII, no ``str(e)``, no response body. The handler does
+        not re-sanitize, only locks the write.
+        """
+        with self._stats_lock:
+            self._last_flush_error = message
 
     def _atexit_flush(self) -> None:
         """Best-effort flush on interpreter exit. Bounded by :data:`ATEXIT_FLUSH_TIMEOUT_S`."""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -207,8 +207,8 @@ async def value_error_handler(request: Request, exc: ValueError):
 
 
 # --- Health check ---
-
-
-@app.get("/api/health")
-def health_check():
-    return {"status": "ok"}
+# Issue #274: the inline ``GET /api/health`` handler moved to
+# :mod:`app.routers.health` so the endpoint can return an Axiom logging
+# self-monitoring block. The router is mounted at ``prefix="/api/health"``
+# elsewhere in this module, so the new ``@router.get("")`` resolves to the
+# same external URL.

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -592,6 +592,12 @@ class DashboardSchwabStatus(BaseModel):
     configured: bool
     valid: bool
     expires_at: Optional[str] = None
+    # Issue #277: non-null when live Schwab calls (quotes / option chains)
+    # failed during this dashboard load. The frontend uses this as a
+    # discriminator to render "Schwab calls failing" vs the legacy
+    # "Schwab token expiring" warn label. Optional + defaulted so older
+    # callers / tests that omit the field still validate.
+    error: Optional[str] = None
 
 
 class DashboardFredStatus(BaseModel):

--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -37,6 +37,91 @@ def check_sources():
     return results
 
 
+@router.get("")
+def health_check() -> dict:
+    """Top-level health probe with optional Axiom logging self-monitoring.
+
+    Replaces the legacy inline ``GET /api/health`` handler in ``app.main``
+    (issue #274). The endpoint is intentionally cheap — no outbound HTTP,
+    no Axiom API calls, no DB hits. It reads in-process state only.
+
+    Response shape is unconditional: when Axiom is disabled, the
+    ``logging`` block still renders with zeroed counters and ``null``
+    timestamps so frontend/operator consumers see a stable schema.
+    """
+    return {"status": "ok", "logging": _build_logging_stats()}
+
+
+def _get_axiom_handler():
+    """Return the first :class:`AxiomHandler` attached to the root logger, or ``None``.
+
+    Imported lazily to avoid pulling ``httpx`` (a transitive of
+    :mod:`app.logging_axiom`) into the import graph of any caller that
+    only needs the legacy ``/sources`` probe. Also avoids a circular
+    import on cold start.
+    """
+    from app.logging_axiom import AxiomHandler
+
+    for h in logging.getLogger().handlers:
+        if isinstance(h, AxiomHandler):
+            return h
+    return None
+
+
+def _safe_get(handler, attr: str, default):
+    """Read ``handler.<attr>`` with a try/except fallback.
+
+    A logging-internal hiccup (e.g. a non-thread-safe ``qsize()`` raising
+    under contention on some platforms) must not be allowed to 500 the
+    health endpoint. We log at debug level and fall back to the schema's
+    documented default per #274.
+    """
+    try:
+        return getattr(handler, attr)
+    except Exception as e:  # noqa: BLE001 — health must never bubble logging errors
+        logger.debug("axiom handler attr %s raised %s", attr, type(e).__name__)
+        return default
+
+
+def _build_logging_stats() -> dict:
+    """Build the ``logging`` subsection of the ``/api/health`` payload.
+
+    Schema is frozen by the v1.0.10 plan §2.3:
+
+    - ``axiom_enabled`` — true iff ``settings.axiom_api_token`` is truthy.
+    - ``queue_depth`` — current in-process queue depth (approximate per
+      :py:meth:`queue.Queue.qsize`).
+    - ``queue_capacity`` — configured max queue size (default 1000).
+    - ``dropped_total`` — process-lifetime overflow count (handler.dropped).
+    - ``last_flush_at`` — RFC3339 timestamp of the last 2xx ingest, or null.
+    - ``last_flush_error`` — sanitized error message, or null.
+
+    When the Axiom handler is not attached (token unset, init failure), the
+    block renders with the same shape and zero/null defaults so consumers
+    never need to branch on presence.
+    """
+    from app.config import settings
+
+    handler = _get_axiom_handler()
+    if handler is None:
+        return {
+            "axiom_enabled": bool(getattr(settings, "axiom_api_token", None)),
+            "queue_depth": 0,
+            "queue_capacity": 1000,
+            "dropped_total": 0,
+            "last_flush_at": None,
+            "last_flush_error": None,
+        }
+    return {
+        "axiom_enabled": True,
+        "queue_depth": _safe_get(handler, "queue_depth", 0),
+        "queue_capacity": _safe_get(handler, "queue_capacity", 1000),
+        "dropped_total": _safe_get(handler, "dropped", 0),
+        "last_flush_at": _safe_get(handler, "last_flush_at", None),
+        "last_flush_error": _safe_get(handler, "last_flush_error", None),
+    }
+
+
 def _check_alpha_vantage() -> dict:
     """Check Alpha Vantage API availability."""
     try:

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -290,10 +290,14 @@ def _largest_loser_action(
     amount_dollars = _format_dollar(worst["unrealized_pl"])
     pct = worst.get("pl_pct")
     amount_pct = _format_signed_pct(pct) if pct is not None else ""
+    # Issue #164: single space between ticker and dollar amount.
+    # The earlier ``f"{ticker}  {amount_dollars}"`` rendered as
+    # ``AAPL  -$1,234`` in the UI; the frontend prints the string verbatim
+    # so the double space was a visible cosmetic defect.
     amount = (
-        f"{ticker}  {amount_dollars} ({amount_pct})"
+        f"{ticker} {amount_dollars} ({amount_pct})"
         if amount_pct
-        else f"{ticker}  {amount_dollars}"
+        else f"{ticker} {amount_dollars}"
     )
     return {
         "id": f"position.large_loser.{worst['id']}",

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -55,6 +55,10 @@ def _build_schwab_status() -> tuple[dict, bool]:
     """Return (status_dict, is_configured). Skips the live HTTP probe — the
     detail card can call /api/settings/health/schwab if the user wants live
     validation. Returning early keeps p95 dashboard latency low.
+
+    The ``error`` field is initialised to ``None`` and overwritten by
+    :func:`build_dashboard_payload` when ``schwab_failed`` flips after the
+    parallel quote / option-chain fan-out (issue #277).
     """
     mgr = SchwabTokenManager()
     configured = mgr.is_configured()
@@ -63,6 +67,7 @@ def _build_schwab_status() -> tuple[dict, bool]:
             "configured": configured,
             "valid": configured,  # static fallback; see plan §4.5 / risk #2
             "expires_at": mgr.get_refresh_token_expiry(),
+            "error": None,
         },
         configured,
     )
@@ -731,6 +736,18 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         schwab_failed
         or cache_status["stale"] + cache_status["very_stale"] > 0
     )
+
+    # Issue #277: reconcile the Schwab pill with the live-call outcome.
+    # ``_build_schwab_status`` reports the token-row state only (configured +
+    # refresh-token expiry); it has no visibility into whether the parallel
+    # quote / option-chain fans actually succeeded. When ``schwab_failed`` is
+    # set we downgrade ``valid`` to ``False`` and surface a frozen ``error``
+    # string so the frontend can disambiguate "token expiring" from "calls
+    # failing this load". The string is the discriminator only — the visible
+    # pill label is built by the frontend.
+    if schwab_failed and schwab_status.get("valid"):
+        schwab_status["valid"] = False
+        schwab_status["error"] = "Schwab API calls failing this load"
 
     return {
         "generated_at": now,

--- a/backend/app/services/journal.py
+++ b/backend/app/services/journal.py
@@ -81,7 +81,17 @@ def _build_position_response(position: Position) -> dict:
     adjusted_cost_basis = compute_adjusted_basis(
         position.broker_cost_basis, premiums_for_adjusted_basis
     )
-    min_compliant_cc_strike = compute_min_cc_strike(adjusted_cost_basis, position.shares)
+    # Issue #278: caller-side guard avoids the noisy WARNING the function
+    # emits for the legitimate ``shares=0`` short-circuit case (one closed
+    # position would otherwise log once per dashboard load). The function's
+    # own guard stays in place for accidental direct callers and for any
+    # ``shares<0`` data-integrity surprise that still warrants a warning.
+    if position.shares > 0:
+        min_compliant_cc_strike = compute_min_cc_strike(
+            adjusted_cost_basis, position.shares
+        )
+    else:
+        min_compliant_cc_strike = 0.0
 
     return {
         "id": position.id,

--- a/backend/app/services/journal.py
+++ b/backend/app/services/journal.py
@@ -86,12 +86,15 @@ def _build_position_response(position: Position) -> dict:
     # position would otherwise log once per dashboard load). The function's
     # own guard stays in place for accidental direct callers and for any
     # ``shares<0`` data-integrity surprise that still warrants a warning.
-    if position.shares > 0:
+    # Guard short-circuits ONLY ``shares == 0`` so negative-shares (data
+    # corruption) still reach :func:`compute_min_cc_strike` and trigger the
+    # defensive WARNING — see test_build_position_response_warns_for_negative_shares.
+    if position.shares == 0:
+        min_compliant_cc_strike = 0.0
+    else:
         min_compliant_cc_strike = compute_min_cc_strike(
             adjusted_cost_basis, position.shares
         )
-    else:
-        min_compliant_cc_strike = 0.0
 
     return {
         "id": position.id,

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -1086,3 +1086,61 @@ class TestProfitTakeCardThreadsManagementThresholds:
         assert captured["dte_review_days"] == 30
         assert captured["expiration_warning_days"] == 10
 
+
+
+# ---------------------------------------------------------------------------
+# Issue #164 — large_loser subject must use a single space, not double
+# ---------------------------------------------------------------------------
+
+
+class TestLargeLoserSubjectSpacingIssue164:
+    """``position.large_loser`` ``subject.amount`` uses a single space.
+
+    Prior code rendered ``"AAPL  -$1,234 (-12.3%)"`` (two spaces) because
+    the f-string template hardcoded ``"{ticker}  {amount_dollars}"``. The
+    frontend prints the string verbatim, so the double space was a visible
+    cosmetic defect.
+    """
+
+    def test_subject_amount_uses_single_space_with_pct(self):
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-loser", "TSLA", unrealized_pl=-2000.0, pl_pct=-0.20),
+            ],
+            open_legs=[],
+        )
+        loser = next(
+            a for a in actions if a["action_id"] == "position.large_loser"
+        )
+        amount = loser["subject"]["amount"]
+        assert amount.startswith("TSLA -$"), (
+            f"expected 'TSLA -$' prefix (single space), got {amount!r}"
+        )
+        assert "  " not in amount, (
+            f"subject.amount must not contain a double space: {amount!r}"
+        )
+
+    def test_subject_amount_uses_single_space_when_pct_is_none(self):
+        # The no-pct branch hits the alternate f-string at L296 — same
+        # spacing rule must hold even though the trailing ``({pct})`` is
+        # absent from the rendered string.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[
+                _position("p-loser", "AMZN", unrealized_pl=-1500.0, pl_pct=None),
+            ],
+            open_legs=[],
+        )
+        loser = next(
+            a for a in actions if a["action_id"] == "position.large_loser"
+        )
+        amount = loser["subject"]["amount"]
+        # No pct → string ends after the dollar amount, no parens.
+        assert amount.startswith("AMZN -$")
+        assert "(" not in amount
+        assert "  " not in amount, (
+            f"subject.amount must not contain a double space: {amount!r}"
+        )

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -413,7 +413,13 @@ class TestRouteProtection:
     """Verify health is public and protected routes require auth when configured."""
 
     def test_health_check_is_public(self):
-        """The /api/health endpoint works without auth."""
+        """The /api/health endpoint works without auth.
+
+        Issue #274 (bridge edit): the response body gained an additive
+        ``logging`` self-monitoring subsection. The "public + 200 + status
+        ok" contract is preserved as a substring assertion rather than
+        strict-equality.
+        """
         from app.main import app
 
         client = TestClient(app)
@@ -423,7 +429,8 @@ class TestRouteProtection:
             resp = client.get("/api/health")
 
         assert resp.status_code == 200
-        assert resp.json() == {"status": "ok"}
+        body = resp.json()
+        assert body["status"] == "ok"
 
     def test_protected_route_returns_401_when_auth_enabled(self):
         """A protected endpoint returns 401 without auth when NEXTAUTH_SECRET is set."""

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -758,3 +758,154 @@ def test_dashboard_profit_take_card_matches_leg_verdict(client, monkeypatch):
     assert len(cards) == 1
     assert cards[0]["tone"] == "opportunity"
     assert cards[0]["priority"] == "P1"
+
+
+# -- Issue #277: Schwab pill honesty -----------------------------------------
+#
+# The token-row check in ``_build_schwab_status`` cannot detect that *live*
+# Schwab calls failed during this dashboard load. Issue #277 anchors the
+# fix: ``build_dashboard_payload`` reconciles ``status.schwab`` with the
+# ``schwab_failed`` flag already produced by ``_fetch_quotes_parallel`` and
+# ``_fetch_option_chains_parallel``. These tests pin the new contract.
+
+
+def test_schwab_pill_downgrades_to_invalid_when_quotes_fail(client, monkeypatch):
+    """When the live quote fan returns ``schwab_failed=True`` the dashboard
+    must downgrade ``status.schwab.valid`` to ``False`` and surface the
+    frozen ``error`` discriminator (issue #277).
+    """
+    from app.services.schwab_client import SchwabClientError
+
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="")
+
+    def fake_get_quote(self, ticker):
+        raise SchwabClientError("simulated outage")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote", fake_get_quote
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    schwab = data["status"]["schwab"]
+    assert schwab["configured"] is True
+    assert schwab["valid"] is False
+    assert schwab["error"] == "Schwab API calls failing this load"
+
+
+def test_schwab_pill_stays_valid_on_success(client, monkeypatch):
+    """Happy path: live calls succeed, ``status.schwab`` stays
+    ``{valid: True, error: None}`` (issue #277 regression guard).
+    """
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 174.0},
+    )
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        lambda self, ticker, *args, **kwargs: {
+            "putExpDateMap": {
+                "2026-05-08:3": {
+                    "175.0": [{"strikePrice": 175.0, "mark": 0.90}],
+                }
+            }
+        },
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    schwab = data["status"]["schwab"]
+    assert schwab["configured"] is True
+    assert schwab["valid"] is True
+    assert schwab["error"] is None
+
+
+def test_schwab_pill_downgrades_when_chains_fail_but_quotes_succeed(
+    client, monkeypatch
+):
+    """A failed option-chain fetch (quotes still OK) must still downgrade
+    the pill to ``valid=False`` with the frozen error string (issue #277).
+    The existing graceful-degradation behaviour (sources_unavailable) is
+    preserved.
+    """
+    from app.services.schwab_client import SchwabClientError
+
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 174.0},
+    )
+
+    def fake_get_option_chain(self, ticker, *args, **kwargs):
+        raise SchwabClientError("simulated chain outage")
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        fake_get_option_chain,
+    )
+
+    pid = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    schwab = data["status"]["schwab"]
+    assert schwab["valid"] is False
+    assert schwab["error"] == "Schwab API calls failing this load"
+    # Existing graceful-degradation behaviour is preserved.
+    assert "schwab" in data["data_meta"]["sources_unavailable"]
+    assert data["data_meta"]["is_stale"] is True
+
+
+def test_schwab_pill_error_field_absent_when_schwab_not_configured(
+    client, monkeypatch
+):
+    """When Schwab is not configured the pill stays in its existing
+    ``not connected`` state and ``error`` is ``None`` (no live call was
+    attempted, so no live failure to surface). Regression guard for
+    issue #277.
+    """
+    _patch_status(monkeypatch, schwab_configured=False, fred_key="")
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    schwab = data["status"]["schwab"]
+    assert schwab["configured"] is False
+    assert schwab["valid"] is False
+    assert schwab["error"] is None
+

--- a/backend/tests/test_integration_health.py
+++ b/backend/tests/test_integration_health.py
@@ -1,3 +1,4 @@
+import queue
 from unittest.mock import patch, MagicMock
 
 from app.services.slack_notifier import SlackNotifier
@@ -197,7 +198,7 @@ class TestLoggingSelfMonitoring:
             while True:
                 try:
                     handler._q.get_nowait()
-                except Exception:
+                except queue.Empty:
                     break
             for _ in range(handler.queue_capacity + 3):
                 handler.emit(record)

--- a/backend/tests/test_integration_health.py
+++ b/backend/tests/test_integration_health.py
@@ -5,9 +5,19 @@ from app.services.slack_notifier import SlackNotifier
 
 class TestHealthEndpoints:
     def test_health_check(self, client):
+        """Top-level health probe returns ``status: ok`` and a logging block.
+
+        Issue #274: bridge edit from the legacy ``{"status": "ok"}``
+        equality check. The endpoint moved from an inline handler in
+        ``app.main`` to ``app.routers.health`` and gained an additive
+        ``logging`` self-monitoring subsection. The status-only contract
+        is preserved as a substring assertion.
+        """
         response = client.get("/api/health")
         assert response.status_code == 200
-        assert response.json() == {"status": "ok"}
+        body = response.json()
+        assert body["status"] == "ok"
+        assert "logging" in body
 
     def test_health_sources(self, client):
         with (
@@ -73,3 +83,247 @@ class TestHealthEndpoints:
             call_args = [c.args for c in notifier.notify_health_degraded.call_args_list]
             sources_notified = {args[0] for args in call_args}
             assert sources_notified == {"fred", "schwab"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #274 — /api/health logging self-monitoring block
+# ---------------------------------------------------------------------------
+
+
+class TestLoggingSelfMonitoring:
+    """The ``/api/health`` body includes an Axiom-handler ``logging`` subsection.
+
+    Schema is frozen by the v1.0.10 plan §2.3. These tests assert the
+    field names + types + defaults exactly. Implementation-internal state
+    (handler class, lock semantics) is intentionally not asserted.
+    """
+
+    _EXPECTED_KEYS = {
+        "axiom_enabled",
+        "queue_depth",
+        "queue_capacity",
+        "dropped_total",
+        "last_flush_at",
+        "last_flush_error",
+    }
+
+    def test_health_includes_logging_block_when_axiom_disabled(self, client):
+        """No token → zero/null defaults, schema still present, HTTP 200."""
+        with patch("app.routers.health._get_axiom_handler", return_value=None), \
+             patch("app.config.settings.axiom_api_token", None, create=True):
+            response = client.get("/api/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert "logging" in body
+        log = body["logging"]
+        assert set(log.keys()) == self._EXPECTED_KEYS
+        assert log == {
+            "axiom_enabled": False,
+            "queue_depth": 0,
+            "queue_capacity": 1000,
+            "dropped_total": 0,
+            "last_flush_at": None,
+            "last_flush_error": None,
+        }
+
+    def test_health_logging_block_when_axiom_enabled_zero_traffic(self, client):
+        """Axiom attached but no flushes yet → ``axiom_enabled=true`` and nulls."""
+        from app import logging_axiom
+        from app.logging_axiom import AxiomHandler
+
+        # Patch httpx at construction time so the worker has a fake client
+        # and cannot touch the network before we stop() it.
+        with patch.object(logging_axiom, "httpx") as mock_httpx:
+            mock_httpx.Client.return_value = MagicMock()
+            mock_httpx.HTTPError = Exception
+            handler = AxiomHandler(token="t", dataset="d")
+        # Halt the worker so it can't race with the request thread reading
+        # last_flush_*; the test asserts pre-flush state only.
+        handler._worker.stop()
+        handler._worker.join(timeout=1.0)
+        try:
+            with patch("app.routers.health._get_axiom_handler", return_value=handler):
+                response = client.get("/api/health")
+            assert response.status_code == 200
+            log = response.json()["logging"]
+            assert set(log.keys()) == self._EXPECTED_KEYS
+            assert log["axiom_enabled"] is True
+            assert log["queue_depth"] == 0
+            assert log["queue_capacity"] == 1000
+            assert log["dropped_total"] == 0
+            assert log["last_flush_at"] is None
+            assert log["last_flush_error"] is None
+        finally:
+            handler._atexit_flush()
+
+    def test_health_logging_dropped_total_reflects_overflow(self, client, monkeypatch):
+        """Overflowing the handler's queue increments ``dropped_total``."""
+        from app import logging_axiom
+        from app.logging_axiom import AxiomHandler
+
+        # Shrink the queue + the worker's blocking-get so ``stop() + join()``
+        # actually halts the worker before our emit() loop races with it.
+        monkeypatch.setattr(logging_axiom, "QUEUE_MAX", 2)
+        monkeypatch.setattr(logging_axiom, "BATCH_TIMEOUT_S", 0.05)
+
+        # Also patch ``httpx`` at construction time so the worker has a
+        # fake client and cannot reach the network even if it briefly
+        # drains an item before stopping.
+        with patch.object(logging_axiom, "httpx") as mock_httpx:
+            mock_httpx.Client.return_value = MagicMock()
+            mock_httpx.HTTPError = Exception
+            handler = AxiomHandler(token="t", dataset="d")
+        # Wait for the worker to definitively exit. BATCH_TIMEOUT_S above is
+        # 0.05s, so join(timeout=1.0) is ~20x the blocking window.
+        handler._worker.stop()
+        handler._worker.join(timeout=1.0)
+        assert not handler._worker.is_alive(), "worker must be halted before emit"
+        try:
+            # Fill (2) then overflow by 3 → at least 3 drops.
+            record = logging.LogRecord(
+                name="test.health",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg="msg",
+                args=None,
+                exc_info=None,
+            )
+            record.request_id = "-"  # type: ignore[attr-defined]
+            # Drain whatever the worker may have pulled before stop() took
+            # effect, so the dropped-count assertion below measures our
+            # overflow delta only.
+            while True:
+                try:
+                    handler._q.get_nowait()
+                except Exception:
+                    break
+            for _ in range(handler.queue_capacity + 3):
+                handler.emit(record)
+            assert handler.dropped >= 3
+
+            with patch("app.routers.health._get_axiom_handler", return_value=handler):
+                response = client.get("/api/health")
+            assert response.status_code == 200
+            log = response.json()["logging"]
+            assert log["dropped_total"] >= 3
+            assert log["queue_capacity"] == 2
+            assert log["queue_depth"] == 2
+        finally:
+            handler._atexit_flush()
+
+    def test_health_endpoint_makes_no_outbound_http(self, client):
+        """The endpoint must never reach the network when answering."""
+        # If anything inside /api/health tried to make an httpx call, this
+        # patch on the axiom module's bound ``httpx`` would raise. The
+        # endpoint must still return 200.
+        with patch("app.logging_axiom.httpx") as mock_httpx:
+            mock_httpx.Client.side_effect = AssertionError(
+                "/api/health must not construct an httpx client"
+            )
+            mock_httpx.HTTPError = Exception
+            response = client.get("/api/health")
+        assert response.status_code == 200
+        assert response.json()["status"] == "ok"
+
+    def test_health_returns_200_when_handler_attr_raises(self, client):
+        """Defensive: a logging-internal hiccup must not 500 the health endpoint."""
+        # Build a fake handler that raises on queue_depth read. The endpoint
+        # should swallow the error and fall back to the documented default.
+        class _ExplodingHandler:
+            @property
+            def queue_depth(self) -> int:
+                raise RuntimeError("kaboom")
+
+            @property
+            def queue_capacity(self) -> int:
+                return 1000
+
+            @property
+            def dropped(self) -> int:
+                return 0
+
+            @property
+            def last_flush_at(self) -> str | None:
+                return None
+
+            @property
+            def last_flush_error(self) -> str | None:
+                return None
+
+        with patch("app.routers.health._get_axiom_handler", return_value=_ExplodingHandler()):
+            response = client.get("/api/health")
+        assert response.status_code == 200
+        log = response.json()["logging"]
+        # Fallback default per the helper's docstring.
+        assert log["queue_depth"] == 0
+        # Other fields still resolve normally.
+        assert log["queue_capacity"] == 1000
+        assert log["axiom_enabled"] is True
+
+    def test_health_logging_block_axiom_enabled_reflects_token_when_no_handler(self, client):
+        """``axiom_enabled`` follows the token even when the handler is missing.
+
+        Covers the edge case where the settings token is set but
+        ``setup_logging()`` failed to attach a handler (init crash). The
+        schema must still render and report the truthiness of the token so
+        operators can distinguish "Axiom unconfigured" from "Axiom misconfigured".
+        """
+        from app import config as cfg
+
+        with patch.object(cfg.settings, "axiom_api_token", "test-tok", create=True), \
+             patch("app.routers.health._get_axiom_handler", return_value=None):
+            response = client.get("/api/health")
+        assert response.status_code == 200
+        log = response.json()["logging"]
+        assert log["axiom_enabled"] is True
+        assert log["queue_depth"] == 0
+        assert log["queue_capacity"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# Issue #274 — unit coverage on AxiomHandler last_flush_* bookkeeping
+# ---------------------------------------------------------------------------
+
+
+class TestAxiomHandlerFlushBookkeeping:
+    """The handler exposes ``last_flush_at`` / ``last_flush_error`` written by the worker.
+
+    These cover the new instance state plumbing — the actual end-to-end
+    integration with the worker's HTTP path is covered by the test_logging_axiom
+    suite. Here we drive the setters directly so we never hit the network.
+    """
+
+    def test_last_flush_ok_sets_timestamp_clears_error(self):
+        from app.logging_axiom import AxiomHandler
+
+        handler = AxiomHandler(token="t", dataset="d")
+        try:
+            handler._set_last_flush_err("ingest failed status=401")
+            assert handler.last_flush_error == "ingest failed status=401"
+            assert handler.last_flush_at is None
+
+            handler._set_last_flush_ok("2026-05-22T12:00:00.000Z")
+            assert handler.last_flush_at == "2026-05-22T12:00:00.000Z"
+            assert handler.last_flush_error is None
+        finally:
+            handler._atexit_flush()
+
+    def test_queue_depth_and_capacity_accessors(self, monkeypatch):
+        from app import logging_axiom
+        from app.logging_axiom import AxiomHandler
+
+        monkeypatch.setattr(logging_axiom, "QUEUE_MAX", 7)
+        handler = AxiomHandler(token="t", dataset="d")
+        try:
+            assert handler.queue_capacity == 7
+            assert handler.queue_depth == 0
+        finally:
+            handler._atexit_flush()
+
+
+# Required import for the new tests above — placed at file bottom because
+# the existing imports are minimal; an in-file import keeps the bridge edit
+# narrow and avoids reshuffling test_integration_health's header.
+import logging  # noqa: E402

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -219,3 +219,36 @@ def test_compute_min_cc_strike_direct_call_still_warns_for_zero_shares(caplog):
         result = compute_min_cc_strike(1000.0, 0)
     assert result == 0.0
     assert "compute_min_cc_strike called with shares=0" in caplog.text
+
+
+def test_build_position_response_warns_for_negative_shares(db_session, caplog):
+    """Negative-shares (data corruption) still reaches the defensive WARNING path.
+
+    CodeRabbit triage on PR #279: the issue #278 caller-side guard was
+    initially written as ``if position.shares > 0`` which also swallowed the
+    ``shares < 0`` case, contradicting the comment that says negative shares
+    should still hit :func:`compute_min_cc_strike`'s defensive warning. The
+    guard was tightened to ``if position.shares == 0`` — this test locks in
+    the negative-shares contract so the regression cannot recur.
+    """
+    from app.services.journal import _build_position_response
+
+    corrupt = Position(
+        id=str(uuid.uuid4()),
+        ticker="BAD",
+        shares=-10,
+        broker_cost_basis=1_000.0,
+        status="open",
+        strategy="csp",
+        opened_at="2025-01-01T00:00:00Z",
+    )
+    db_session.add(corrupt)
+    db_session.commit()
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="app.services.journal"):
+        result = _build_position_response(corrupt)
+
+    assert "compute_min_cc_strike called with shares=-10" in caplog.text
+    assert result["min_compliant_cc_strike"] == 0.0
+    assert result["shares"] == -10

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -144,3 +144,78 @@ def test_clear_all_journal_data_returns_counts(db_session):
 def test_clear_all_journal_data_empty_db(db_session):
     result = clear_all_journal_data(db_session)
     assert result == {"deleted_positions": 0, "deleted_trades": 0}
+
+
+# --- Issue #278: caller-side guard against compute_min_cc_strike log spam ---
+
+
+def test_build_position_response_no_warning_for_shares_zero(db_session, caplog):
+    """``_build_position_response`` must not emit the noisy ``shares=0`` WARNING.
+
+    Issue #278: ``_build_position_response`` is the hot-path caller that runs
+    once per position on every dashboard load. Closed/cleared positions with
+    ``shares=0`` were producing one identical WARNING per load per position,
+    which dominated Axiom ingest. The caller-side guard skips
+    :func:`compute_min_cc_strike` entirely when shares <= 0 so the function's
+    defensive WARNING never fires for the legitimate short-circuit case.
+    """
+    from app.services.journal import _build_position_response
+
+    closed = Position(
+        id=str(uuid.uuid4()),
+        ticker="AAPL",
+        shares=0,
+        broker_cost_basis=0.0,
+        status="closed",
+        strategy="csp",
+        opened_at="2025-01-01T00:00:00Z",
+    )
+    db_session.add(closed)
+    db_session.commit()
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="app.services.journal"):
+        result = _build_position_response(closed)
+
+    assert "compute_min_cc_strike called with shares=" not in caplog.text
+    assert result["min_compliant_cc_strike"] == 0.0
+    assert result["shares"] == 0
+
+
+def test_build_position_response_still_computes_for_positive_shares(db_session, caplog):
+    """Positive-shares path is unchanged: real call, no warning, real value."""
+    from app.services.journal import _build_position_response
+
+    open_pos = Position(
+        id=str(uuid.uuid4()),
+        ticker="MSFT",
+        shares=100,
+        broker_cost_basis=10_000.0,
+        status="open",
+        strategy="csp",
+        opened_at="2025-01-01T00:00:00Z",
+    )
+    db_session.add(open_pos)
+    db_session.commit()
+
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="app.services.journal"):
+        result = _build_position_response(open_pos)
+
+    assert "compute_min_cc_strike called with shares=" not in caplog.text
+    # 10_000 / 100 * 1.10 = 110.0
+    assert result["min_compliant_cc_strike"] == 110.0
+
+
+def test_compute_min_cc_strike_direct_call_still_warns_for_zero_shares(caplog):
+    """Direct calls to :func:`compute_min_cc_strike` still emit the defensive WARNING.
+
+    The fix in #278 is caller-side only — the function's own guard remains in
+    place so accidental direct callers (or any future caller that does not
+    pre-filter) still see the warning at the def site.
+    """
+    caplog.clear()
+    with caplog.at_level("WARNING", logger="app.services.journal"):
+        result = compute_min_cc_strike(1000.0, 0)
+    assert result == 0.0
+    assert "compute_min_cc_strike called with shares=0" in caplog.text

--- a/backend/tests/test_logging_axiom.py
+++ b/backend/tests/test_logging_axiom.py
@@ -579,3 +579,105 @@ class TestWorkerBatching:
             assert q.qsize() == 15
         finally:
             worker.stop()
+
+
+# ---------------------------------------------------------------------------
+# Issue #274 — handler exposes flush bookkeeping for /api/health
+# ---------------------------------------------------------------------------
+
+
+class TestFlushBookkeepingIssue274:
+    """Worker writes ``last_flush_at`` / ``last_flush_error`` through the handler.
+
+    These tests drive ``_AxiomWorker._flush`` directly (no real network) so
+    we can assert that each branch (2xx, 4xx, transport error, generic
+    exception) publishes the expected sanitized state on the handler.
+    """
+
+    def test_successful_flush_sets_last_flush_at_clears_error(self):
+        handler = AxiomHandler(token="t", dataset="d")
+        try:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            handler._worker._client = MagicMock()
+            handler._worker._client.post.return_value = mock_resp
+
+            # Pre-seed an error to confirm the success branch clears it.
+            handler._set_last_flush_err("old")
+
+            handler._worker._flush([{"_time": "now", "message": "hi"}])
+
+            assert handler.last_flush_error is None
+            assert handler.last_flush_at is not None
+            # Sanity-check the format — ``_format_timestamp`` produces
+            # ``YYYY-MM-DDTHH:MM:SS.mmmZ``.
+            assert handler.last_flush_at.endswith("Z")
+            assert "T" in handler.last_flush_at
+        finally:
+            _stop_handler(handler)
+
+    def test_4xx_flush_sets_sanitized_error_only_status(self, capsys):
+        handler = AxiomHandler(token="t", dataset="d")
+        try:
+            mock_resp = MagicMock()
+            mock_resp.status_code = 401
+            handler._worker._client = MagicMock()
+            handler._worker._client.post.return_value = mock_resp
+
+            handler._worker._flush([{"_time": "now", "message": "hi"}])
+
+            assert handler.last_flush_error == "ingest failed status=401"
+            # No PII, no body, no headers leaked.
+            captured = capsys.readouterr()
+            assert "ingest failed status=401" in captured.err
+            # last_flush_at should not advance on failure.
+            assert handler.last_flush_at is None
+        finally:
+            _stop_handler(handler)
+
+    def test_transport_error_records_exception_class_name_only(self):
+        handler = AxiomHandler(token="t", dataset="d")
+        try:
+            handler._worker._client = MagicMock()
+            handler._worker._client.post.side_effect = httpx.ConnectError("nope")
+
+            handler._worker._flush([{"_time": "now", "message": "hi"}])
+
+            # Only the class name leaks — never str(e).
+            assert handler.last_flush_error == "ingest transport error: ConnectError"
+            assert "nope" not in (handler.last_flush_error or "")
+            assert handler.last_flush_at is None
+        finally:
+            _stop_handler(handler)
+
+    def test_generic_exception_records_exception_class_name_only(self):
+        handler = AxiomHandler(token="t", dataset="d")
+        try:
+            handler._worker._client = MagicMock()
+            handler._worker._client.post.side_effect = RuntimeError("explode-detail")
+
+            handler._worker._flush([{"_time": "now", "message": "hi"}])
+
+            assert handler.last_flush_error == "ingest unknown error: RuntimeError"
+            assert "explode-detail" not in (handler.last_flush_error or "")
+        finally:
+            _stop_handler(handler)
+
+    def test_worker_without_handler_back_reference_is_a_noop_on_bookkeeping(self):
+        """A worker constructed without a handler back-ref must not crash."""
+        # Build a worker directly (no handler) — the production code always
+        # passes one, but test-helpers may not.
+        import queue as _queue
+
+        q: "_queue.Queue[dict[str, object]]" = _queue.Queue(maxsize=10)
+        worker = _AxiomWorker(q, "t", "d")  # no handler kwarg
+        try:
+            worker._client = MagicMock()
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            worker._client.post.return_value = mock_resp
+
+            # Should not raise even though there is no handler to publish to.
+            worker._flush([{"_time": "now", "message": "hi"}])
+        finally:
+            worker.stop()

--- a/frontend/components/dashboard/KpiRow.jsx
+++ b/frontend/components/dashboard/KpiRow.jsx
@@ -34,9 +34,14 @@ function plColor(value) {
   return undefined;
 }
 
+/**
+ * Format a currency value with a signed prefix, special-casing zero per
+ * spec §14.3: zero-state aggregate tiles render `$0` (no `+`, no decimals).
+ */
 function signedCurrency(value) {
   if (value == null) return '—';
-  return `${value >= 0 ? '+' : ''}${formatCurrency(value)}`;
+  if (value === 0) return '$0';
+  return `${value > 0 ? '+' : ''}${formatCurrency(value)}`;
 }
 
 export default function KpiRow({ kpis }) {
@@ -86,7 +91,7 @@ export default function KpiRow({ kpis }) {
 
   // Premium collected (lifetime) — aggregate; empty state is $0 / 0 trades.
   const premiumTotal = kpis.premium_collected_total ?? 0;
-  const premiumValue = `${premiumTotal >= 0 ? '+' : ''}${formatCurrency(premiumTotal)}`;
+  const premiumValue = signedCurrency(premiumTotal);
   const premiumTradesCount = kpis.premium_collected_trades ?? 0;
   const premiumSubtext = `${premiumTradesCount} trades`;
 

--- a/frontend/components/dashboard/StatusStrip.jsx
+++ b/frontend/components/dashboard/StatusStrip.jsx
@@ -12,7 +12,15 @@ function schwabPill(schwab) {
     return { state: 'error', label: 'Schwab not connected' };
   }
   if (!schwab.valid) {
-    return { state: 'warn', label: 'Schwab token expiring' };
+    // Issue #277: ``schwab.error`` is non-null when the parallel quote /
+    // option-chain fans failed during this dashboard load. Both branches
+    // stay on the existing ``warn`` (yellow) state — the visual language is
+    // already correct; only the label needs to disambiguate "token
+    // expiring" from "live calls failing".
+    return {
+      state: 'warn',
+      label: schwab.error ? 'Schwab calls failing' : 'Schwab token expiring',
+    };
   }
   return { state: 'ok', label: 'Schwab connected' };
 }

--- a/frontend/e2e/dashboard-kpi-row.spec.js
+++ b/frontend/e2e/dashboard-kpi-row.spec.js
@@ -169,7 +169,7 @@ test.describe('KPI row (V0.5 — 7 tiles)', () => {
     await expect(tile).toContainText('Position with the largest unrealized loss.');
   });
 
-  test('empty Realized P/L renders $0 / 0% (not em-dash per spec §14.3)', async ({ page }) => {
+  test('empty Realized P/L renders $0 / 0% (zero-guard, not +$0.00, per spec §14.3)', async ({ page }) => {
     await mockDashboard(page, {
       ...BASE_PAYLOAD,
       status: { ...BASE_PAYLOAD.status, journal: { positions_count: 0 } },
@@ -179,11 +179,12 @@ test.describe('KPI row (V0.5 — 7 tiles)', () => {
     await page.waitForLoadState('networkidle');
 
     const tile = page.getByTestId('kpi-realized-pl');
-    await expect(tile).toContainText('+$0.00');
+    await expect(tile).toContainText('$0');
+    await expect(tile).not.toContainText('+$0.00');
     await expect(tile).toContainText('0% lifetime');
   });
 
-  test('empty Premium renders $0 / 0 trades', async ({ page }) => {
+  test('empty Premium renders $0 / 0 trades (zero-guard, not +$0.00, per spec §14.3)', async ({ page }) => {
     await mockDashboard(page, {
       ...BASE_PAYLOAD,
       status: { ...BASE_PAYLOAD.status, journal: { positions_count: 0 } },
@@ -193,7 +194,8 @@ test.describe('KPI row (V0.5 — 7 tiles)', () => {
     await page.waitForLoadState('networkidle');
 
     const tile = page.getByTestId('kpi-premium-lifetime');
-    await expect(tile).toContainText('+$0.00');
+    await expect(tile).toContainText('$0');
+    await expect(tile).not.toContainText('+$0.00');
     await expect(tile).toContainText('0 trades');
   });
 
@@ -244,4 +246,36 @@ test.describe('KPI row (V0.5 — 7 tiles)', () => {
     const wrapperClass = await wrapperHandle.evaluate((el) => el.className);
     expect(wrapperClass).toContain('col-span-2');
   });
+  test('signedCurrency zero-guard is symmetric: realized + premium use $0, unrealized stays +$0.00', async ({ page }) => {
+    // Issue #172 spec §14.3 zero-guard applies to aggregate tiles only
+    // (realized P/L + premium collected). Unrealized P/L is a current-state
+    // pointer, not an aggregate, and intentionally retains the +$0.00 format
+    // when value === 0. Guards against an accidental over-bleed of the fix.
+    const zeroKpis = {
+      ...EMPTY_KPIS,
+      unrealized_pl: 0,
+      unrealized_pl_pct: 0,
+    };
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      status: { ...BASE_PAYLOAD.status, journal: { positions_count: 0 } },
+      kpis: zeroKpis,
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Aggregate tiles: zero-guarded
+    const realized = page.getByTestId('kpi-realized-pl');
+    await expect(realized).toContainText('$0');
+    await expect(realized).not.toContainText('+$0.00');
+
+    const premium = page.getByTestId('kpi-premium-lifetime');
+    await expect(premium).toContainText('$0');
+    await expect(premium).not.toContainText('+$0.00');
+
+    // Pointer tile: unchanged (+$0.00 is fine for unrealized at zero)
+    const unrealized = page.getByTestId('kpi-unrealized-pl');
+    await expect(unrealized).toContainText('+$0.00');
+  });
+
 });

--- a/frontend/e2e/dashboard.spec.js
+++ b/frontend/e2e/dashboard.spec.js
@@ -311,4 +311,67 @@ test.describe('Dashboard route', () => {
     await expect(header.getByRole('link', { name: 'Dashboard', exact: true })).toBeVisible();
     await expect(header.getByRole('link', { name: 'Analysis', exact: true })).toBeVisible();
   });
+
+  // Issue #277: when live Schwab calls fail mid-load, the pill must show
+  // ``Schwab calls failing`` (yellow warn) instead of the previous false
+  // ``Schwab connected`` green or the unrelated ``Schwab token expiring``.
+  // The backend signal is ``status.schwab.error`` being a non-null string;
+  // the visible label is the discriminator the frontend renders.
+  test('Schwab pill shows "Schwab calls failing" when status.schwab.error is set', async ({ page }) => {
+    const CALLS_FAILING_PAYLOAD = {
+      ...POPULATED_PAYLOAD,
+      status: {
+        ...POPULATED_PAYLOAD.status,
+        schwab: {
+          configured: true,
+          valid: false,
+          expires_at: '2026-05-12T00:00:00+00:00',
+          error: 'Schwab API calls failing this load',
+        },
+      },
+      data_meta: {
+        is_stale: true,
+        fetched_at: '2026-05-05T13:42:00+00:00',
+        sources_unavailable: ['schwab'],
+      },
+    };
+
+    await mockDashboard(page, CALLS_FAILING_PAYLOAD);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const pill = page.getByTestId('status-pill-schwab');
+    await expect(pill).toContainText('Schwab calls failing');
+    await expect(pill).not.toContainText('Schwab token expiring');
+    await expect(pill).not.toContainText('Schwab connected');
+    // The warn dot uses bg-yellow-500 (StatusPill.jsx STATE_CLASSES.warn).
+    await expect(pill.locator('.bg-yellow-500')).toBeVisible();
+  });
+
+  // Issue #277 regression guard: when ``status.schwab.error`` is null but the
+  // refresh token is expiring (``valid: false``), the existing
+  // ``Schwab token expiring`` label still renders. Confirms the new branch
+  // does not regress the legacy warn case.
+  test('Schwab pill still shows "Schwab token expiring" when error is null and valid is false', async ({ page }) => {
+    const TOKEN_EXPIRING_PAYLOAD = {
+      ...POPULATED_PAYLOAD,
+      status: {
+        ...POPULATED_PAYLOAD.status,
+        schwab: {
+          configured: true,
+          valid: false,
+          expires_at: '2026-05-12T00:00:00+00:00',
+          error: null,
+        },
+      },
+    };
+
+    await mockDashboard(page, TOKEN_EXPIRING_PAYLOAD);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const pill = page.getByTestId('status-pill-schwab');
+    await expect(pill).toContainText('Schwab token expiring');
+    await expect(pill).not.toContainText('Schwab calls failing');
+  });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.15.2",
-        "next": "16.2.4",
+        "next": "16.2.6",
         "next-auth": "^5.0.0-beta.30",
         "plotly.js-finance-dist": "^3.4.0",
         "react": "19.2.3",
@@ -1769,9 +1769,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1785,9 +1785,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1801,9 +1801,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1817,9 +1817,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -1849,9 +1849,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -1865,9 +1865,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -1881,9 +1881,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1897,9 +1897,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -9970,12 +9970,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -9989,14 +9989,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "axios": "^1.15.2",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "next-auth": "^5.0.0-beta.30",
     "plotly.js-finance-dist": "^3.4.0",
     "react": "19.2.3",


### PR DESCRIPTION
## What this release is

Post-v1.0.9 bug bundle. Six small fixes batched after the Axiom logging shipped in v1.0.9 surfaced them (or in the case of #276, surfaced by `gh push` on the v1.0.9 cut). No themed milestone — interleaved cleanup that fits a PATCH per the [versioning policy](https://github.com/ssandy33/regress/wiki/Roadmap#versioning).

Milestone: [V1.0.10 — Bug bundle](https://github.com/ssandy33/regress/milestone/31)

## Closes

| # | Title | Surface |
|---|---|---|
| **#277** | Schwab pill stops lying — payload `status.schwab.valid` downgrades when live Schwab calls actually fail (P1) | backend `dashboard.py`, `schemas.py`; frontend `StatusStrip.jsx` |
| **#278** | `compute_min_cc_strike` log spam silenced (caller-side `shares==0` guard) (P3) | backend `journal.py` |
| **#274** | `/api/health` now exposes a `logging` subsection with Axiom queue depth, capacity, dropped count, last flush time + error (P3 follow-up from #273) | backend `health.py`, `logging_axiom.py` (additive accessors) |
| **#276** | Next.js 16.2.4 → 16.2.6 — closes 13 open Dependabot alerts in one mechanical bump (P1) | frontend `package.json`, `package-lock.json` |
| **#164** | Double-space in `large_loser` action subject fixed (P4) | backend `action_engine.py` |
| **#172** | KPI zero-state renders spec `$0` instead of `+$0.00` (P3 spec-divergence) | frontend `KpiRow.jsx` |

## Parallel-execution DAG

```
feat/v1.0.10 (off main)
├── W1  feat/v1.0.10-w1-schwab-pill   (#277)
├── W2  feat/v1.0.10-w2-backend-cleanup (#278 #274 #164)
├── W3  feat/v1.0.10-w3-kpi-zero-state (#172)
└── W4  feat/v1.0.10-w4-next-bump      (#276)  ← merged last (lockfile churn)
```

Plan: `backend/design-specs/v1.0.10-plan.md` (untracked per CLAUDE.md). Open questions resolved during planning are documented in the milestone-level comment on issue #277.

## Test plan

- [x] Backend: 1311 passed, 9 skipped on the integrated tip (full suite)
- [x] Frontend: lint clean (0 errors)
- [x] Frontend smoke: 120 Playwright tests pass under `health|dashboard` grep
- [x] Next.js 16.2.6 build green (Turbopack, all routes)
- [ ] CI on integration branch (this PR) — will validate
- [ ] Post-merge: Axiom dataset confirms Schwab pill state changes when token refresh fails (#277 acceptance)

## Not in this release

- The 14 → 13 Dependabot alert delta won't close until v1.0.10 lands on `main`. Expected post-merge: 13 → 0.
- Frontend log shipping to Axiom (separate concern).
- Vector container-log sidecar (out of scope, separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)