### PR TITLE
v1.1.0 — Per-position Stock Research page (closes #280)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -168,7 +168,6 @@ app.include_router(positions.router, dependencies=[Depends(get_current_user)])
 app.include_router(research.router, dependencies=[Depends(get_current_user)])
 app.include_router(legs.router, dependencies=[Depends(get_current_user)])
 app.include_router(covered_call.router, dependencies=[Depends(get_current_user)])
-app.include_router(research.router, dependencies=[Depends(get_current_user)])
 
 
 # --- Exception handlers ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.config import settings as app_settings
 from app.logging_config import setup_logging
 from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
-from app.routers import assets, covered_call, dashboard, data, health, journal, legs, options, positions, regression, sessions, settings
+from app.routers import assets, covered_call, dashboard, data, health, journal, legs, options, positions, regression, research, sessions, settings
 from app.services.backup import create_backup
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher, DataFetchError, InvalidTickerError, DataAlignmentError
@@ -167,6 +167,7 @@ app.include_router(dashboard.router, dependencies=[Depends(get_current_user)])
 app.include_router(positions.router, dependencies=[Depends(get_current_user)])
 app.include_router(legs.router, dependencies=[Depends(get_current_user)])
 app.include_router(covered_call.router, dependencies=[Depends(get_current_user)])
+app.include_router(research.router, dependencies=[Depends(get_current_user)])
 
 
 # --- Exception handlers ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.config import settings as app_settings
 from app.logging_config import setup_logging
 from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
-from app.routers import assets, covered_call, dashboard, data, health, journal, legs, options, positions, regression, sessions, settings
+from app.routers import assets, covered_call, dashboard, data, health, journal, legs, options, positions, regression, research, sessions, settings
 from app.services.backup import create_backup
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher, DataFetchError, InvalidTickerError, DataAlignmentError
@@ -165,6 +165,7 @@ app.include_router(options.router, dependencies=[Depends(get_current_user)])
 app.include_router(journal.router, dependencies=[Depends(get_current_user)])
 app.include_router(dashboard.router, dependencies=[Depends(get_current_user)])
 app.include_router(positions.router, dependencies=[Depends(get_current_user)])
+app.include_router(research.router, dependencies=[Depends(get_current_user)])
 app.include_router(legs.router, dependencies=[Depends(get_current_user)])
 app.include_router(covered_call.router, dependencies=[Depends(get_current_user)])
 

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -79,6 +79,39 @@ class Trade(Base):
     position = relationship("Position", back_populates="trades")
 
 
+class PositionNote(Base):
+    """Freeform research thesis attached to a single position (issue #280).
+
+    One row per position (``UNIQUE`` on ``position_id``). The ``version``
+    column increments on every successful PUT so the frontend can surface
+    optimistic-lock style "edited in another tab" warnings; the column
+    exists for future use even though v1 does not expose version history.
+
+    Schema frozen in the issue #280 implementation plan §3.2 / §4.3.
+
+    The project has no Alembic — the table is picked up by the existing
+    ``Base.metadata.create_all(bind=engine)`` call in :func:`init_db` and
+    ``create_all`` is idempotent, so an existing deployment grows the new
+    table on next startup without migration overhead. Rollback path is a
+    manual ``DROP TABLE position_notes``.
+    """
+
+    __tablename__ = "position_notes"
+
+    id = Column(String, primary_key=True)  # UUID4
+    position_id = Column(
+        String,
+        ForeignKey("positions.id"),
+        nullable=False,
+        index=True,
+        unique=True,
+    )
+    body = Column(Text, nullable=False, default="")  # max 4000 chars enforced at API
+    version = Column(Integer, nullable=False, default=1)  # increments on each PUT
+    updated_at = Column(String, nullable=False)  # ISO datetime
+    updated_by = Column(String, nullable=True)  # nullable in single-user mode
+
+
 engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1191,3 +1191,40 @@ class CoveredCallView(BaseModel):
     )
     applicability: COVERED_CALL_APPLICABILITY
     disclaimer: Optional[str] = None
+
+
+# --- Research (#280) ---
+
+
+# Maximum thesis body length per the issue #280 plan §4.3 (locked decision 4
+# from the user). Enforced both via the Pydantic field constraint on the PUT
+# request and on the response-shaping path so the cap is never side-stepped.
+THESIS_MAX_BODY_LENGTH: int = 4000
+
+
+class ThesisPutRequest(BaseModel):
+    """Request body for ``PUT /api/positions/{id}/research/thesis``.
+
+    ``thesis`` is the freeform note body. Empty strings are explicitly
+    allowed (they clear the note) — the plan does not forbid empty bodies.
+    Pydantic enforces the 4000-character ceiling at request validation
+    time; oversize bodies return ``422`` automatically. The router layer
+    re-validates server-side for defence in depth, so callers that bypass
+    the model still get a sanitized 422.
+    """
+
+    thesis: str = Field(default="", max_length=THESIS_MAX_BODY_LENGTH)
+
+
+class ThesisResponse(BaseModel):
+    """Response shape for thesis GET + PUT (issue #280 PRD §F).
+
+    When no row exists yet the endpoint returns ``thesis=None``,
+    ``updated_at=None``, and ``version=0`` — the spec calls for an
+    empty-state shape rather than a 404 so the frontend can render the
+    editor immediately.
+    """
+
+    thesis: Optional[str] = None
+    updated_at: Optional[str] = None
+    version: int = 0

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1228,3 +1228,58 @@ class ThesisResponse(BaseModel):
     thesis: Optional[str] = None
     updated_at: Optional[str] = None
     version: int = 0
+
+class BusinessResponse(BaseModel):
+    """Response shape for ``GET /api/positions/{id}/research/business``.
+
+    The payload is composed by :func:`app.services.research_business.
+    build_business_payload`. Every yfinance field is ``Optional`` because the
+    upstream is known for missing keys on foreign listings / newly-listed
+    tickers (plan §8 risk #1). The router never propagates a yfinance error
+    string — see :class:`app.services.research_business.
+    ResearchSourceUnavailable` for the sanitized 502 detail.
+    """
+
+    ticker: str
+    name: Optional[str] = None
+    summary: Optional[str] = None
+    sector: Optional[str] = None
+    industry: Optional[str] = None
+    market_cap: Optional[float] = None
+    employees: Optional[int] = None
+    source: str
+    fetched_at: str
+
+
+class FinancialQuarter(BaseModel):
+    """One quarter of normalized fundamentals on the Section D scorecard.
+
+    Margins (``gross_margin`` / ``operating_margin``) are derived ratios in
+    [0, 1]; ``revenue`` and ``eps`` flow through verbatim from the upstream.
+    Any individual field can be ``None`` when the source omits the underlying
+    value — the frontend renders ``—`` rather than fabricating a zero
+    (per :func:`app.services.research_financials._safe_float`).
+    """
+
+    period_end: Optional[str] = None
+    revenue: Optional[float] = None
+    eps: Optional[float] = None
+    gross_margin: Optional[float] = None
+    operating_margin: Optional[float] = None
+
+
+class FinancialsResponse(BaseModel):
+    """Response shape for ``GET /api/positions/{id}/research/financials``.
+
+    ``source`` is ``"alphavantage"`` on the primary path and ``"yfinance"``
+    on the fallback path. The frontend renders provenance via Section D's
+    source caption ("Source: alphavantage · refreshed …" or "Source:
+    yfinance (alphavantage rate-limited) · refreshed …"). Up to 8 quarters
+    are returned, newest first — see plan §4.2.
+    """
+
+    ticker: str
+    quarters: list[FinancialQuarter] = Field(default_factory=list)
+    source: str
+    fetched_at: str
+

--- a/backend/app/routers/research.py
+++ b/backend/app/routers/research.py
@@ -137,13 +137,12 @@ def get_price_history(
             status_code=502,
             content={"detail": "Price source unavailable"},
         )
-    except Exception as exc:  # noqa: BLE001 — generic 500 per CLAUDE.md
-        logger.error(
-            "Research price-history composition failed for position=%s "
-            "window=%s: %s",
-            position_id,
-            window,
-            exc,
+    except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        # logger.exception preserves the traceback (CR #1); extra={} feeds
+        # Axiom indexed fields per NFR-6 (Phase 5 S2).
+        logger.exception(
+            "Research price-history composition failed",
+            extra={"position_id": position_id, "window": window},
         )
         return JSONResponse(
             status_code=500,
@@ -185,7 +184,10 @@ def read_thesis(
     except HTTPException:
         raise
     except Exception:
-        logger.exception("Unexpected error reading thesis for %s", position_id)
+        logger.exception(
+            "Unexpected error reading thesis",
+            extra={"position_id": position_id},
+        )
         raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)
 
 
@@ -219,7 +221,10 @@ def write_thesis(
     except HTTPException:
         raise
     except Exception:
-        logger.exception("Unexpected error writing thesis for %s", position_id)
+        logger.exception(
+            "Unexpected error writing thesis",
+            extra={"position_id": position_id},
+        )
         raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)
 
 
@@ -284,14 +289,17 @@ def research_regression(
             status_code=422,
             content={"detail": "Insufficient data for regression"},
         )
-    except RegressionSourceUnavailableError:
+    except RegressionSourceUnavailableError as exc:
+        # exc.detail is pre-sanitized at the service layer — no
+        # str(original_exc) leaks here per CLAUDE.md (CR #4).
         return JSONResponse(
             status_code=502,
-            content={"detail": "Source unavailable for regression"},
+            content={"detail": exc.detail},
         )
     except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
         logger.exception(
-            "Unexpected error composing regression for position %s", position_id
+            "Unexpected error composing regression",
+            extra={"position_id": position_id, "window": window},
         )
         return JSONResponse(
             status_code=500,
@@ -348,8 +356,11 @@ def get_business(
         )
     except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
         logger.exception(
-            "Unexpected error composing business snapshot for position %s",
-            position_id,
+            "Unexpected error composing business snapshot",
+            extra={
+                "position_id": position_id,
+                "ticker": position.get("ticker"),
+            },
         )
         return JSONResponse(
             status_code=500,
@@ -400,8 +411,11 @@ def get_financials(
         )
     except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
         logger.exception(
-            "Unexpected error composing financials for position %s",
-            position_id,
+            "Unexpected error composing financials",
+            extra={
+                "position_id": position_id,
+                "ticker": position.get("ticker"),
+            },
         )
         return JSONResponse(
             status_code=500,

--- a/backend/app/routers/research.py
+++ b/backend/app/routers/research.py
@@ -1,0 +1,99 @@
+"""Research router — per-position stock research page (issue #280).
+
+This file is shared across the four backend workers in the v1.1.0
+fan-out (A: business + financials, B: price history + earnings,
+D: regression, F: thesis). Each worker appends its own endpoints
+here without modifying its siblings'. Worker W performs the final
+wire-up in :mod:`app.main` after all sibling workers merge.
+
+Worker F (this commit) owns the thesis endpoints:
+
+- ``GET  /api/positions/{position_id}/research/thesis``
+- ``PUT  /api/positions/{position_id}/research/thesis``
+
+Both error contracts follow CLAUDE.md: never leak ``str(e)`` — sanitized
+``{"detail": "..."}`` payloads only.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import get_db
+from app.models.schemas import ThesisPutRequest, ThesisResponse
+from app.services.research_thesis import (
+    PositionNotFoundError,
+    ThesisTooLongError,
+    get_thesis,
+    put_thesis,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/positions", tags=["research"])
+
+
+# Generic 500 detail per CLAUDE.md — never leak ``str(e)``.
+_GENERIC_500_DETAIL = "Failed to load research data. Please try again."
+
+
+@router.get(
+    "/{position_id}/research/thesis",
+    response_model=ThesisResponse,
+)
+def read_thesis(
+    position_id: str, db: DBSession = Depends(get_db)
+) -> ThesisResponse:
+    """Return the saved thesis for a position or the empty-state shape.
+
+    Empty state (``thesis=None``, ``version=0``) is returned when the
+    position exists but no thesis has been written yet — the frontend
+    renders the editor immediately rather than a 404. A truly missing
+    position id still returns ``404`` with a sanitized message.
+    """
+    try:
+        return get_thesis(db, position_id)
+    except PositionNotFoundError:
+        raise HTTPException(status_code=404, detail="Position not found")
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unexpected error reading thesis for %s", position_id)
+        raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)
+
+
+@router.put(
+    "/{position_id}/research/thesis",
+    response_model=ThesisResponse,
+)
+def write_thesis(
+    position_id: str,
+    payload: ThesisPutRequest,
+    db: DBSession = Depends(get_db),
+) -> ThesisResponse:
+    """Upsert the thesis body and return the new row.
+
+    Version is incremented on every successful write. Pydantic enforces
+    the 4000-character cap on the request model; the service layer
+    re-validates and the router translates the overflow to ``422``.
+    Position-not-found maps to ``404``.
+    """
+    try:
+        return put_thesis(db, position_id, payload.thesis)
+    except PositionNotFoundError:
+        raise HTTPException(status_code=404, detail="Position not found")
+    except ThesisTooLongError:
+        # Sanitized — never leak str(e). The cap is part of the public
+        # contract; surfacing it in the detail message is intentional.
+        raise HTTPException(
+            status_code=422,
+            detail="Thesis exceeds 4000 character limit",
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Unexpected error writing thesis for %s", position_id)
+        raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)

--- a/backend/app/routers/research.py
+++ b/backend/app/routers/research.py
@@ -27,10 +27,20 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import get_db
-from app.models.schemas import ThesisPutRequest, ThesisResponse
+from app.models.schemas import (
+    BusinessResponse,
+    FinancialsResponse,
+    ThesisPutRequest,
+    ThesisResponse,
+)
 from app.services import journal
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher
+from app.services.research_business import (
+    ResearchSourceUnavailable,
+    build_business_payload,
+)
+from app.services.research_financials import build_financials_payload
 from app.services.research_price_history import (
     DEFAULT_WINDOW,
     SUPPORTED_WINDOWS,
@@ -292,12 +302,108 @@ def research_regression(
 
 
 # ---------------------------------------------------------------------------
-# Section A — Business snapshot (Worker A — issue #280)
+# Section A — Business snapshot (issue #280, Worker W bridges A's service)
 # ---------------------------------------------------------------------------
-# Section D — Financial scorecard (Worker A — issue #280)
+
+
+@router.get(
+    "/{position_id}/research/business",
+    response_model=BusinessResponse,
+)
+def get_business(
+    position_id: str, db: DBSession = Depends(get_db)
+):
+    """Return the Section A business snapshot for a position's ticker.
+
+    Resolves the position's ticker from the journal layer, then delegates to
+    :func:`app.services.research_business.build_business_payload` (which
+    handles the two-tier 24h cache). The yfinance upstream is the only
+    failure mode at the service layer; we translate
+    :class:`ResearchSourceUnavailable` into a sanitized ``502`` per
+    CLAUDE.md and plan §4.5.
+
+    Status codes:
+
+    - ``200`` — payload returned
+    - ``404`` — ``position_id`` is unknown
+    - ``502`` — yfinance returned no data and neither cache tier had a
+      fresh entry
+    - ``500`` — unexpected internal error (generic detail, sanitized log)
+    """
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Position not found"},
+        )
+
+    try:
+        return build_business_payload(db, position["ticker"])
+    except ResearchSourceUnavailable as exc:
+        # ``exc.detail`` is pre-sanitized at the service layer — no
+        # str(original_exc) leaks here per CLAUDE.md.
+        return JSONResponse(
+            status_code=502,
+            content={"detail": exc.detail},
+        )
+    except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.exception(
+            "Unexpected error composing business snapshot for position %s",
+            position_id,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": _GENERIC_500_DETAIL},
+        )
+
+
 # ---------------------------------------------------------------------------
-#
-# Worker A landed service modules (research_business / research_financials)
-# in this release without router shells. Worker W is responsible for adding
-# the matching ``GET /research/business`` and ``GET /research/financials``
-# endpoints that wire those services to the prefix above.
+# Section D — Financial scorecard (issue #280, Worker W bridges A's service)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{position_id}/research/financials",
+    response_model=FinancialsResponse,
+)
+def get_financials(
+    position_id: str, db: DBSession = Depends(get_db)
+):
+    """Return up to 8 quarters of fundamentals for a position's ticker.
+
+    Delegates to
+    :func:`app.services.research_financials.build_financials_payload`, which
+    tries Alpha Vantage's ``INCOME_STATEMENT`` first and falls back to
+    yfinance when AV returns ``None``. Both sources failing surfaces a
+    sanitized ``502`` (``ResearchSourceUnavailable`` carries the detail).
+
+    Status codes:
+
+    - ``200`` — payload returned (``source`` field discloses the upstream)
+    - ``404`` — ``position_id`` is unknown
+    - ``502`` — both AV and yfinance were unavailable
+    - ``500`` — unexpected internal error (generic detail, sanitized log)
+    """
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Position not found"},
+        )
+
+    try:
+        return build_financials_payload(db, position["ticker"])
+    except ResearchSourceUnavailable as exc:
+        return JSONResponse(
+            status_code=502,
+            content={"detail": exc.detail},
+        )
+    except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.exception(
+            "Unexpected error composing financials for position %s",
+            position_id,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": _GENERIC_500_DETAIL},
+        )

--- a/backend/app/routers/research.py
+++ b/backend/app/routers/research.py
@@ -1,0 +1,125 @@
+"""Per-position research router (issue #280).
+
+Hosts the ``/api/positions/{position_id}/research/...`` endpoints for the
+new Stock Research page. Workers A/B/D/F contribute one endpoint each
+(disjoint by section). This file is a multi-worker landing zone — each
+worker appends its endpoint at the position locked by the implementation
+plan. Worker W reconciles the response models into ``schemas.py`` at the
+end of the fan-out.
+
+Section ownership (plan §5):
+
+- Section A (business)         → Worker A
+- Section B+C (price history)  → Worker B
+- Section D (financials)       → Worker A
+- Section E (regression)       → Worker D  ← this file's contribution
+- Section F (thesis)           → Worker F
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import get_db
+from app.services import journal
+from app.services.cache import CacheService
+from app.services.data_fetcher import DataFetcher
+from app.services.research_regression import (
+    DEFAULT_WINDOW,
+    InsufficientRegressionDataError,
+    RegressionSourceUnavailableError,
+    ResearchRegressionResponse,
+    get_regression_for_position,
+    validate_window,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/positions", tags=["research"])
+
+
+def _get_fetcher(db: DBSession = Depends(get_db)) -> DataFetcher:
+    """Construct a :class:`DataFetcher` bound to this request's DB session."""
+    return DataFetcher(CacheService(db))
+
+
+# --- Section E — regression decomposition (Worker D) ----------------------
+
+
+@router.get(
+    "/{position_id}/research/regression",
+    response_model=ResearchRegressionResponse,
+)
+def research_regression(
+    position_id: str,
+    window: str = Query(default=DEFAULT_WINDOW),
+    db: DBSession = Depends(get_db),
+    fetcher: DataFetcher = Depends(_get_fetcher),
+):
+    """Compose the regression decomposition for a single position.
+
+    Pulls 1-year daily prices for the position's ticker, SPY, the position's
+    sector ETF (if mappable), and the FRED 10-year yield, then runs the
+    existing multi-factor OLS engine and returns the factor betas, p-values,
+    variance shares, R², and a plain-English summary string.
+
+    Status codes:
+
+    - ``200`` — success
+    - ``404`` — position not found
+    - ``422`` — ``window`` invalid OR fewer than 60 aligned trading days
+    - ``502`` — an upstream price/yield source was unavailable
+    - ``500`` — unexpected internal error (sanitized message per CLAUDE.md)
+    """
+    # Validate the window query param first — produces a 422 with a
+    # sanitized message rather than a 500 if a caller passes garbage.
+    try:
+        validate_window(window)
+    except ValueError:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": "Unsupported window value"},
+        )
+
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Position not found"},
+        )
+
+    ticker = position["ticker"]
+
+    try:
+        response = get_regression_for_position(
+            position_id=position_id,
+            ticker=ticker,
+            window=window,
+            fetcher=fetcher,
+        )
+    except InsufficientRegressionDataError:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": "Insufficient data for regression"},
+        )
+    except RegressionSourceUnavailableError:
+        return JSONResponse(
+            status_code=502,
+            content={"detail": "Source unavailable for regression"},
+        )
+    except Exception:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.exception(
+            "Unexpected error composing regression for position %s", position_id
+        )
+        return JSONResponse(
+            status_code=500,
+            content={
+                "detail": "Failed to load research data. Please try again."
+            },
+        )
+
+    return response

--- a/backend/app/routers/research.py
+++ b/backend/app/routers/research.py
@@ -1,0 +1,137 @@
+"""Research router — per-position stock research endpoints (issue #280).
+
+Shared prefix ``/api/positions/{position_id}/research/...``. This file
+houses the five GET endpoints + one PUT endpoint that compose Sections
+A–F of the research page (PRD #282 / CTO plan
+``backend/design-specs/issue-280-stock-research-plan.md``).
+
+**Worker DAG convention.** v1.1.0 fans the page out across four parallel
+backend workers (A/B/D/F) plus a bridging worker (W). Each worker
+appends *its own* endpoint(s) at end-of-file in the order the CTO plan
+freezes — A first, then B, D, F, then W's reconciliation pass. The
+top-of-file imports stay alphabetized; the ``router`` object is shared.
+
+Per CLAUDE.md every endpoint returns ``{"detail": "<sanitized message>"}``
+on non-2xx and never propagates ``str(e)``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import get_db
+from app.services.research_price_history import (
+    DEFAULT_WINDOW,
+    SUPPORTED_WINDOWS,
+    InvalidWindowError,
+    PriceHistoryResponse,
+    PriceSourceUnavailableError,
+    build_price_history,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/positions", tags=["research"])
+
+
+# Generic 500 detail per CLAUDE.md — never leak ``str(e)``.
+_GENERIC_500_DETAIL = "Failed to load research data. Please try again."
+
+
+# ---------------------------------------------------------------------------
+# Section B + C — Price history with basis lines + trade markers + earnings
+# (Worker B — issue #280)
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/{position_id}/research/price-history",
+    response_model=PriceHistoryResponse,
+)
+def get_price_history(
+    position_id: str,
+    window: str = Query(
+        DEFAULT_WINDOW,
+        description=(
+            "Lookback window. v1 only renders 1Y; 6M and 2Y are accepted for "
+            "forwards-compatibility with the deferred picker."
+        ),
+    ),
+    db: DBSession = Depends(get_db),
+):
+    """Compose the research price-history payload for one position.
+
+    Combines four sources into a single payload (see CTO plan §3.5):
+
+    - Daily close prices over the window from the existing data fetcher
+    - Broker + adjusted basis lines from the Position row + journal recompute
+    - User-recorded trade events from the position's ledger
+    - Past earnings reporting dates from Alpha Vantage's ``EARNINGS`` function
+
+    Cached in-process for 15 minutes (NFR-7).
+
+    Error mapping:
+
+    - ``404`` — position not found
+    - ``422`` — unsupported ``window`` value
+    - ``502`` — price source (Schwab/yfinance) unavailable
+    - ``500`` — unexpected internal error (generic detail, sanitized log)
+    """
+    try:
+        response = build_price_history(db, position_id, window)
+    except InvalidWindowError:
+        # Detail intentionally lists the supported set so the frontend
+        # (and curl users) can self-correct without reading server logs.
+        return JSONResponse(
+            status_code=422,
+            content={
+                "detail": (
+                    f"Unsupported window. Supported values: "
+                    f"{sorted(SUPPORTED_WINDOWS)}"
+                )
+            },
+        )
+    except PriceSourceUnavailableError:
+        # The service layer logged the underlying cause at WARNING.
+        return JSONResponse(
+            status_code=502,
+            content={"detail": "Price source unavailable"},
+        )
+    except Exception as exc:  # noqa: BLE001 — generic 500 per CLAUDE.md
+        logger.error(
+            "Research price-history composition failed for position=%s "
+            "window=%s: %s",
+            position_id,
+            window,
+            exc,
+        )
+        return JSONResponse(
+            status_code=500,
+            content={"detail": _GENERIC_500_DETAIL},
+        )
+
+    if response is None:
+        return JSONResponse(
+            status_code=404,
+            content={"detail": "Position not found"},
+        )
+
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Section A — Business snapshot (Worker A — issue #280)
+# ---------------------------------------------------------------------------
+# Section D — Financial scorecard (Worker A — issue #280)
+# ---------------------------------------------------------------------------
+# Section E — Regression decomposition (Worker D — issue #280)
+# ---------------------------------------------------------------------------
+# Section F — Thesis note (Worker F — issue #280)
+# ---------------------------------------------------------------------------
+#
+# Sibling workers append their endpoints below in the order shown above.
+# Top-of-file imports stay alphabetized.

--- a/backend/app/services/alpha_vantage_client.py
+++ b/backend/app/services/alpha_vantage_client.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 import logging
 from datetime import datetime, timezone, timedelta
 from typing import Optional
@@ -203,3 +204,188 @@ def get_cached_next_earnings_date(symbol: str) -> Optional[str]:
 def clear_cache() -> None:
     """Clear the in-memory earnings cache (for testing)."""
     _cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# INCOME_STATEMENT (issue #280, plan §3.1 + §4.6)
+# ---------------------------------------------------------------------------
+#
+# The financial-scorecard endpoint uses Alpha Vantage's ``INCOME_STATEMENT``
+# function as its primary source, with yfinance as a fallback when AV
+# rate-limits or errors. This block mirrors the two-tier cache pattern
+# above (in-memory hot cache + ``app_settings`` durable cache) so a
+# server restart does not burn the 25-calls/day free-tier quota. Cache
+# key prefix: ``av_financials:`` (frozen in plan §4.6).
+#
+# Append-only per the W-A worker contract — existing earnings functions
+# above are untouched.
+
+_income_cache: dict[str, tuple[Optional[list[dict]], datetime]] = {}
+_INCOME_DB_KEY_PREFIX = "av_financials:"
+
+# Error signals returned by Alpha Vantage as HTTP-200 JSON bodies. Mirrors
+# the set ``alpha_vantage_client`` already filters on the EARNINGS_CALENDAR
+# path so the rate-limit semantics are identical across the two endpoints.
+_AV_ERROR_KEYS = ("Error Message", "Note", "Information")
+
+
+def _read_income_db_cache(
+    symbol: str,
+) -> Optional[tuple[Optional[list[dict]], datetime]]:
+    """Read cached quarterly income statement from SQLite. ``None`` on miss."""
+    try:
+        from app.models.database import SessionLocal, AppSetting
+        db = SessionLocal()
+        try:
+            entry = db.query(AppSetting).filter(
+                AppSetting.key == f"{_INCOME_DB_KEY_PREFIX}{symbol}"
+            ).first()
+            if entry:
+                # Payload format: ``<iso>|<json-payload>``. ``json-payload``
+                # is either a JSON list of quarter dicts, or the literal
+                # ``null`` for a known-empty/upstream-fail cached result.
+                ts_part, _, json_part = entry.value.partition("|")
+                fetched_at = datetime.fromisoformat(ts_part)
+                payload = json.loads(json_part) if json_part else None
+                return (payload, fetched_at)
+        finally:
+            db.close()
+    except (ImportError, SQLAlchemyError, ValueError) as e:
+        logger.debug(
+            "Failed to read AV income cache from DB for %s: %s", symbol, e
+        )
+    return None
+
+
+def _write_income_db_cache(
+    symbol: str, payload: Optional[list[dict]], fetched_at: datetime
+) -> None:
+    """Persist cached quarterly income statement to SQLite."""
+    try:
+        from app.models.database import SessionLocal, AppSetting
+        db = SessionLocal()
+        try:
+            key = f"{_INCOME_DB_KEY_PREFIX}{symbol}"
+            value = f"{fetched_at.isoformat()}|{json.dumps(payload)}"
+            entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+            if entry:
+                entry.value = value
+            else:
+                db.add(AppSetting(key=key, value=value))
+            db.commit()
+        finally:
+            db.close()
+    except (ImportError, SQLAlchemyError) as e:
+        logger.debug(
+            "Failed to write AV income cache to DB for %s: %s", symbol, e
+        )
+
+
+def get_income_statement(symbol: str, n: int = 8) -> Optional[list[dict]]:
+    """Fetch the most recent ``n`` quarters of income statement data.
+
+    Mirrors :func:`get_next_earnings_date` two-tier cache pattern (in-
+    memory hot + SQLite durable; 24h TTL). Returns:
+
+    - ``list[dict]`` (length up to ``n``, newest first) on success — each
+      dict contains the raw AV fields the caller needs to compute
+      gross_margin and operating_margin: ``fiscalDateEnding``,
+      ``totalRevenue``, ``grossProfit``, ``operatingIncome``,
+      ``netIncome``, ``reportedEPS`` (best-effort).
+    - ``None`` on any of: missing API key, AV rate-limit / error response,
+      network failure, malformed JSON. The caller is expected to fall
+      back to yfinance per plan §3.1.
+
+    Cache key: ``av_financials:{symbol}`` per plan §4.6 (frozen).
+    """
+    now = datetime.now(timezone.utc)
+
+    # Tier 1: in-memory hot cache
+    if symbol in _income_cache:
+        cached, fetched_at = _income_cache[symbol]
+        if now - fetched_at < _CACHE_TTL:
+            return cached
+
+    # Tier 2: SQLite durable cache
+    db_entry = _read_income_db_cache(symbol)
+    if db_entry:
+        cached, fetched_at = db_entry
+        if now - fetched_at < _CACHE_TTL:
+            _income_cache[symbol] = (cached, fetched_at)
+            return cached
+
+    api_key = get_alpha_vantage_api_key()
+    if not api_key:
+        logger.warning(
+            "Alpha Vantage API key not configured; "
+            "skipping income statement lookup for %s",
+            symbol,
+        )
+        return None
+
+    try:
+        resp = requests.get(
+            "https://www.alphavantage.co/query",
+            params={
+                "function": "INCOME_STATEMENT",
+                "symbol": symbol,
+                "apikey": api_key,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+
+        try:
+            body = resp.json()
+        except ValueError:
+            logger.warning(
+                "Alpha Vantage returned non-JSON income statement for %s",
+                symbol,
+            )
+            return None
+
+        # The documented rate-limit / error envelope
+        for key in _AV_ERROR_KEYS:
+            if key in body:
+                logger.warning(
+                    "Alpha Vantage INCOME_STATEMENT %s for %s: %s",
+                    key,
+                    symbol,
+                    body.get(key),
+                )
+                # Do NOT cache rate-limit responses — caller falls back
+                # to yfinance and we want a fresh attempt on the next
+                # request after the rate-limit window has passed.
+                return None
+
+        quarterly = body.get("quarterlyReports")
+        if not isinstance(quarterly, list) or not quarterly:
+            logger.warning(
+                "Alpha Vantage INCOME_STATEMENT missing quarterlyReports "
+                "for %s",
+                symbol,
+            )
+            return None
+
+        # AV returns quarters newest-first; trust the order but slice
+        # defensively to ``n``.
+        result = quarterly[:n]
+
+        # Cache successful result in both tiers
+        _income_cache[symbol] = (result, now)
+        _write_income_db_cache(symbol, result, now)
+        return result
+
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Alpha Vantage income statement lookup failed for %s: %s",
+            symbol,
+            e,
+        )
+        # Don't cache transient failures — allow retry on next call
+        return None
+
+
+def clear_income_cache() -> None:
+    """Clear the in-memory income statement cache (for testing)."""
+    _income_cache.clear()

--- a/backend/app/services/alpha_vantage_client.py
+++ b/backend/app/services/alpha_vantage_client.py
@@ -201,5 +201,229 @@ def get_cached_next_earnings_date(symbol: str) -> Optional[str]:
 
 
 def clear_cache() -> None:
-    """Clear the in-memory earnings cache (for testing)."""
+    """Clear the in-memory earnings caches (for testing).
+
+    Clears both the next-earnings hot cache and the historical-earnings
+    hot cache (see :func:`get_historical_earnings`).
+    """
     _cache.clear()
+    _earnings_history_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Historical earnings (issue #280 / v1.1.0 — Worker B)
+#
+# The forward-looking ``EARNINGS_CALENDAR`` endpoint above answers "when is
+# the *next* earnings event?" — the research price-history endpoint
+# (``/api/positions/{id}/research/price-history``) needs the complement:
+# the *past* earnings dates within a charting window so Section C can
+# annotate them on the price line.
+#
+# Alpha Vantage exposes this via the ``EARNINGS`` function (JSON) which
+# returns both ``annualEarnings`` and ``quarterlyEarnings``. We only use
+# the quarterly array; each row carries ``reportedDate`` (the date the
+# report was released — the date that actually shows up as a vertical
+# line on the price chart) and ``fiscalDateEnding`` (the quarter end).
+# The two are often, but not always, the same.
+#
+# Two-tier cache mirrors :func:`get_next_earnings_date` exactly: in-memory
+# hot cache keyed by symbol, with SQLite ``AppSetting`` durable backing
+# under the ``av_earnings_history:`` prefix.
+# ---------------------------------------------------------------------------
+
+_EARNINGS_HISTORY_DB_KEY_PREFIX = "av_earnings_history:"
+
+# In-memory hot cache: {symbol: (list[ISO date strings], fetched_at_utc)}
+_earnings_history_cache: dict[str, tuple[list[str], datetime]] = {}
+
+
+def _read_earnings_history_db_cache(
+    symbol: str,
+) -> Optional[tuple[list[str], datetime]]:
+    """Read cached historical earnings dates from SQLite.
+
+    Returns ``(dates, fetched_at)`` on cache hit; ``None`` on miss or
+    on any persistence error (callers fall through to a fresh fetch).
+    """
+    try:
+        import json as _json
+
+        from app.models.database import SessionLocal, AppSetting
+        db = SessionLocal()
+        try:
+            entry = db.query(AppSetting).filter(
+                AppSetting.key == f"{_EARNINGS_HISTORY_DB_KEY_PREFIX}{symbol}"
+            ).first()
+            if entry:
+                parts = entry.value.split("|", 1)
+                fetched_at = datetime.fromisoformat(parts[0])
+                payload = parts[1] if len(parts) > 1 and parts[1] else "[]"
+                dates: list[str] = _json.loads(payload)
+                return (dates, fetched_at)
+        finally:
+            db.close()
+    except (ImportError, SQLAlchemyError, ValueError) as e:
+        logger.debug(
+            "Failed to read earnings-history cache from DB for %s: %s", symbol, e
+        )
+    return None
+
+
+def _write_earnings_history_db_cache(
+    symbol: str, dates: list[str], fetched_at: datetime
+) -> None:
+    """Persist cached historical earnings dates to SQLite."""
+    try:
+        import json as _json
+
+        from app.models.database import SessionLocal, AppSetting
+        db = SessionLocal()
+        try:
+            key = f"{_EARNINGS_HISTORY_DB_KEY_PREFIX}{symbol}"
+            value = f"{fetched_at.isoformat()}|{_json.dumps(dates)}"
+            entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+            if entry:
+                entry.value = value
+            else:
+                db.add(AppSetting(key=key, value=value))
+            db.commit()
+        finally:
+            db.close()
+    except (ImportError, SQLAlchemyError) as e:
+        logger.debug(
+            "Failed to write earnings-history cache to DB for %s: %s", symbol, e
+        )
+
+
+def get_historical_earnings(symbol: str, since: Optional[str] = None) -> list[str]:
+    """Fetch historical earnings reporting dates for a symbol via Alpha Vantage.
+
+    Calls Alpha Vantage's ``EARNINGS`` function (JSON) and returns the
+    ``reportedDate`` of each quarterly earnings row, sorted ascending.
+    When ``since`` (ISO ``YYYY-MM-DD``) is provided, dates strictly older
+    than ``since`` are dropped so callers can request a windowed slice.
+
+    Two-tier cache (24h TTL) mirrors :func:`get_next_earnings_date`:
+    in-memory hot cache backed by SQLite ``AppSetting`` rows under the
+    ``av_earnings_history:`` key prefix.
+
+    On any failure (network error, AV rate-limit signature, malformed
+    JSON, missing API key) returns ``[]`` and logs at WARNING. The
+    research/price-history endpoint depends on this: an AV outage must
+    degrade to an empty ``earnings_events`` list, not fail the whole
+    payload (NFR-3).
+    """
+    now = datetime.now(timezone.utc)
+
+    # Tier 1: in-memory hot cache
+    if symbol in _earnings_history_cache:
+        cached_dates, fetched_at = _earnings_history_cache[symbol]
+        if now - fetched_at < _CACHE_TTL:
+            return _filter_since(cached_dates, since)
+
+    # Tier 2: SQLite durable cache
+    db_entry = _read_earnings_history_db_cache(symbol)
+    if db_entry:
+        cached_dates, fetched_at = db_entry
+        if now - fetched_at < _CACHE_TTL:
+            _earnings_history_cache[symbol] = (cached_dates, fetched_at)
+            return _filter_since(cached_dates, since)
+
+    api_key = get_alpha_vantage_api_key()
+    if not api_key:
+        logger.warning(
+            "Alpha Vantage API key not configured; "
+            "skipping earnings-history lookup for %s",
+            symbol,
+        )
+        return []
+
+    try:
+        resp = requests.get(
+            "https://www.alphavantage.co/query",
+            params={
+                "function": "EARNINGS",
+                "symbol": symbol,
+                "apikey": api_key,
+            },
+            timeout=10,
+        )
+        resp.raise_for_status()
+
+        try:
+            body = resp.json()
+        except ValueError:
+            logger.warning(
+                "Alpha Vantage EARNINGS returned non-JSON body for %s", symbol
+            )
+            return []
+
+        error_msg = (
+            body.get("Error Message")
+            or body.get("Note")
+            or body.get("Information")
+        )
+        if error_msg:
+            logger.warning(
+                "Alpha Vantage EARNINGS returned error for %s: %s",
+                symbol,
+                error_msg,
+            )
+            return []
+
+        quarterly = body.get("quarterlyEarnings") or []
+        if not isinstance(quarterly, list):
+            logger.warning(
+                "Alpha Vantage EARNINGS payload missing quarterlyEarnings for %s",
+                symbol,
+            )
+            return []
+
+        dates: list[str] = []
+        for row in quarterly:
+            if not isinstance(row, dict):
+                continue
+            # Prefer reportedDate (the release date — that's what plots on
+            # the price chart). Fall back to fiscalDateEnding because some
+            # thinly-covered tickers omit reportedDate.
+            raw = row.get("reportedDate") or row.get("fiscalDateEnding")
+            if not raw:
+                continue
+            try:
+                datetime.strptime(raw, "%Y-%m-%d")
+            except ValueError:
+                continue
+            dates.append(raw)
+
+        dates.sort()
+        _earnings_history_cache[symbol] = (dates, now)
+        _write_earnings_history_db_cache(symbol, dates, now)
+        return _filter_since(dates, since)
+
+    except Exception as e:  # noqa: BLE001 — network errors degrade to []
+        logger.warning(
+            "Alpha Vantage EARNINGS lookup failed for %s: %s", symbol, e
+        )
+        return []
+
+
+def _filter_since(dates: list[str], since: Optional[str]) -> list[str]:
+    """Return ``dates`` filtered to entries on or after ``since``.
+
+    ``since`` is an ISO ``YYYY-MM-DD`` string. When falsy or invalid the
+    input is returned unchanged so callers don't double-validate.
+    """
+    if not since:
+        return list(dates)
+    try:
+        cutoff = datetime.strptime(since, "%Y-%m-%d").date()
+    except ValueError:
+        return list(dates)
+    out: list[str] = []
+    for d in dates:
+        try:
+            if datetime.strptime(d, "%Y-%m-%d").date() >= cutoff:
+                out.append(d)
+        except ValueError:
+            continue
+    return out

--- a/backend/app/services/alpha_vantage_client.py
+++ b/backend/app/services/alpha_vantage_client.py
@@ -309,19 +309,21 @@ def get_income_statement(symbol: str, n: int = 8) -> Optional[list[dict]]:
     """
     now = datetime.now(timezone.utc)
 
-    # Tier 1: in-memory hot cache
+    # Tier 1: in-memory hot cache. We cache the FULL upstream payload (not
+    # the [:n] slice) and re-slice on read so a prior small-n call never
+    # poisons a later larger-n call (CR #2).
     if symbol in _income_cache:
         cached, fetched_at = _income_cache[symbol]
         if now - fetched_at < _CACHE_TTL:
-            return cached
+            return cached[:n] if cached is not None else None
 
-    # Tier 2: SQLite durable cache
+    # Tier 2: SQLite durable cache (also stores the full payload).
     db_entry = _read_income_db_cache(symbol)
     if db_entry:
         cached, fetched_at = db_entry
         if now - fetched_at < _CACHE_TTL:
             _income_cache[symbol] = (cached, fetched_at)
-            return cached
+            return cached[:n] if cached is not None else None
 
     api_key = get_alpha_vantage_api_key()
     if not api_key:
@@ -376,14 +378,12 @@ def get_income_statement(symbol: str, n: int = 8) -> Optional[list[dict]]:
             )
             return None
 
-        # AV returns quarters newest-first; trust the order but slice
-        # defensively to ``n``.
-        result = quarterly[:n]
-
-        # Cache successful result in both tiers
-        _income_cache[symbol] = (result, now)
-        _write_income_db_cache(symbol, result, now)
-        return result
+        # AV returns quarters newest-first. Cache the FULL list (not the
+        # [:n] slice) so a later request with a larger ``n`` can still
+        # satisfy from cache without re-fetching (CR #2).
+        _income_cache[symbol] = (quarterly, now)
+        _write_income_db_cache(symbol, quarterly, now)
+        return quarterly[:n]
 
     except Exception as e:  # noqa: BLE001
         logger.warning(

--- a/backend/app/services/regression_summary.py
+++ b/backend/app/services/regression_summary.py
@@ -1,0 +1,265 @@
+"""Plain-English summary generator for regression decomposition.
+
+Implements the four-rule set from issue #280 design spec §4 Section E. The
+output is a single sentence rendered verbatim by the frontend, kept under
+the 120-character cap from the implementation plan §4.9.
+
+The four rules (verbatim from the spec):
+
+1. Identify the dominant factor (largest absolute contribution).
+2. If dominant > 0.50: lead with "Mostly {factor}-driven".
+   Else if dominant > 0.30: "Primarily {factor}-driven".
+   Else: "Diversified driver mix".
+3. Flag any factor with p < 0.05 AND |beta| > 0.5 AND contribution > 0.10
+   as "meaningful". List the top 2 meaningful factors after the lead,
+   with sign-aware language:
+     - Negative beta on rates → "rate exposure is meaningful and negative"
+     - Positive beta on sector → "sector exposure adds positively"
+4. Append R² as a closing fact: "R²=0.83 over 252 trading days".
+
+Author notes (ambiguities resolved by the implementer for parity with the
+spec's four worked examples):
+
+- The biotech example renders as "Mostly idiosyncratic — {pct}% of variance
+  unexplained by market/sector/rates" — a distinct form from the other
+  three when the dominant share is the unexplained residual. Handled as a
+  special branch.
+- The TLT example mentions a NON-meaningful secondary factor ("market
+  exposure is minor"). Rule 3 only describes meaningful factors; the
+  "minor" phrase is interpreted as a fallback when no other meaningful
+  factor exists and the dominant factor is overwhelming — surface the
+  next-biggest with a "minor" qualifier so the sentence has content beyond
+  the lead.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+
+# --- Public types -----------------------------------------------------------
+
+
+class SummaryFactor(TypedDict):
+    """Structured factor input for the summary generator.
+
+    ``name`` is one of ``"market"``, ``"sector"``, ``"rates"``, or
+    ``"idiosyncratic"``. ``beta`` and ``p_value`` are ``None`` for the
+    idiosyncratic residual. ``contribution`` is the share of explained
+    variance (sums with idiosyncratic to ~1.0).
+    """
+
+    name: Literal["market", "sector", "rates", "idiosyncratic"]
+    beta: float | None
+    p_value: float | None
+    contribution: float
+
+
+# --- Thresholds (from spec §4 Section E rule set) ---------------------------
+
+_DOMINANT_MOSTLY = 0.50
+_DOMINANT_PRIMARILY = 0.30
+_MEANINGFUL_P_MAX = 0.05
+_MEANINGFUL_ABS_BETA_MIN = 0.5
+_MEANINGFUL_CONTRIBUTION_MIN = 0.10
+_MAX_MEANINGFUL_AFTER_LEAD = 2
+
+
+# --- Phrase builders --------------------------------------------------------
+
+
+def _factor_label(name: str) -> str:
+    """Return the lead-phrase noun for a factor name."""
+    return {
+        "market": "market",
+        "sector": "sector",
+        "rates": "rate",
+        "idiosyncratic": "idiosyncratic",
+    }.get(name, name)
+
+
+def _meaningful_clause(factor: SummaryFactor) -> str:
+    """Build the sign-aware "meaningful factor" clause.
+
+    Mirrors the spec's worked examples:
+    - rates, negative beta → ``"rate exposure is meaningful and negative"``
+    - rates, positive beta → ``"rate exposure is meaningful and positive"``
+    - sector, positive beta → ``"sector exposure adds positively"``
+    - sector, negative beta → ``"sector exposure detracts"``
+    - market, negative beta → ``"market exposure is meaningful and negative"``
+    - market, positive beta → ``"market exposure is meaningful and positive"``
+    """
+    beta = factor["beta"] or 0.0
+    sign_positive = beta >= 0
+    name = factor["name"]
+
+    if name == "rates":
+        return (
+            "rate exposure is meaningful and positive"
+            if sign_positive
+            else "rate exposure is meaningful and negative"
+        )
+    if name == "sector":
+        return (
+            "sector exposure adds positively"
+            if sign_positive
+            else "sector exposure detracts"
+        )
+    # Default ("market" or anything else): use the meaningful-and-{sign} phrasing.
+    label = _factor_label(name)
+    return (
+        f"{label} exposure is meaningful and positive"
+        if sign_positive
+        else f"{label} exposure is meaningful and negative"
+    )
+
+
+def _is_meaningful(factor: SummaryFactor) -> bool:
+    """Apply the rule-3 meaningful-factor predicate.
+
+    Idiosyncratic is never "meaningful" in this sense — it has no beta or
+    p-value, and is handled by the dominant-factor branch instead.
+    """
+    if factor["name"] == "idiosyncratic":
+        return False
+    if factor["beta"] is None or factor["p_value"] is None:
+        return False
+    return (
+        factor["p_value"] < _MEANINGFUL_P_MAX
+        and abs(factor["beta"]) > _MEANINGFUL_ABS_BETA_MIN
+        and factor["contribution"] > _MEANINGFUL_CONTRIBUTION_MIN
+    )
+
+
+def _lead_phrase(dominant: SummaryFactor) -> str:
+    """Build the rule-2 lead phrase from the dominant factor's contribution."""
+    share = dominant["contribution"]
+    label = _factor_label(dominant["name"])
+    if share > _DOMINANT_MOSTLY:
+        return f"Mostly {label}-driven"
+    if share > _DOMINANT_PRIMARILY:
+        return f"Primarily {label}-driven"
+    return "Diversified driver mix"
+
+
+def _r_squared_clause(r_squared: float, sample_size: int) -> str:
+    """Format the rule-4 closing R²/sample-size clause."""
+    return f"R²={r_squared:.2f} over {sample_size} trading days"
+
+
+def _format_pct(value: float) -> str:
+    """Format a 0-1 share as an integer percent (e.g. 0.60 → ``'60%'``)."""
+    return f"{round(value * 100)}%"
+
+
+# --- Idiosyncratic-dominant special case -----------------------------------
+
+
+def _idiosyncratic_lead(factor: SummaryFactor, sector_omitted: bool) -> str:
+    """Lead phrase when idiosyncratic is the dominant share.
+
+    Spec example: ``"Mostly idiosyncratic — 60% of variance unexplained by
+    market/sector/rates"``. When the sector factor was omitted (no sector
+    mapping for the underlying), the basket-list term drops "sector".
+    """
+    basket = "market/rates" if sector_omitted else "market/sector/rates"
+    return (
+        f"Mostly idiosyncratic — {_format_pct(factor['contribution'])} "
+        f"of variance unexplained by {basket}"
+    )
+
+
+# --- Main entrypoint --------------------------------------------------------
+
+
+def build_regression_summary(
+    factors: list[SummaryFactor],
+    r_squared: float,
+    sample_size: int,
+    sector_omitted: bool = False,
+) -> str:
+    """Compose a one-sentence plain-English summary of a regression decomposition.
+
+    See module docstring for the four-rule set the output follows. The
+    returned string is capped at 120 characters per the plan §4.9 contract;
+    if the rule output would exceed the cap, the secondary clauses are
+    trimmed (R² is preserved as the closing fact).
+
+    Parameters
+    ----------
+    factors:
+        Per-factor decomposition, including the idiosyncratic residual.
+    r_squared:
+        Coefficient of determination from the levels regression (0.0-1.0).
+    sample_size:
+        Number of observations used in the regression.
+    sector_omitted:
+        ``True`` when no sector factor was included (unmapped/missing
+        sector); the summary then skips any sector clause.
+    """
+    if not factors:
+        # Defensive: no factors means we have nothing to summarize.
+        return f"Insufficient data — {_r_squared_clause(r_squared, sample_size)}."
+
+    # Rule 1: identify the dominant factor by absolute contribution.
+    dominant = max(factors, key=lambda f: abs(f["contribution"]))
+
+    # Idiosyncratic-dominant special form (spec example 4).
+    if dominant["name"] == "idiosyncratic":
+        lead = _idiosyncratic_lead(dominant, sector_omitted)
+        closing = _r_squared_clause(r_squared, sample_size)
+        return f"{lead}. {closing}."
+
+    # Rule 2: lead phrase.
+    lead = _lead_phrase(dominant)
+
+    # Rule 3: meaningful factors after the lead (excluding the dominant
+    # itself and, if applicable, the omitted sector).
+    candidates = [
+        f
+        for f in factors
+        if f["name"] != dominant["name"]
+        and f["name"] != "idiosyncratic"
+        and not (sector_omitted and f["name"] == "sector")
+        and _is_meaningful(f)
+    ]
+    # Order by contribution descending and cap at the spec's top-2.
+    candidates.sort(key=lambda f: f["contribution"], reverse=True)
+    meaningful = candidates[:_MAX_MEANINGFUL_AFTER_LEAD]
+
+    clauses: list[str] = [lead]
+    if meaningful:
+        clauses.extend(_meaningful_clause(f) for f in meaningful)
+    else:
+        # Fallback (TLT example): if dominant overwhelmingly leads and no
+        # other meaningful factor exists, surface the next-largest factor
+        # with a "minor" qualifier so the sentence carries content beyond
+        # the lead phrase.
+        non_dominant = [
+            f
+            for f in factors
+            if f["name"] != dominant["name"]
+            and f["name"] != "idiosyncratic"
+            and not (sector_omitted and f["name"] == "sector")
+        ]
+        if non_dominant and dominant["contribution"] > _DOMINANT_PRIMARILY:
+            next_biggest = max(non_dominant, key=lambda f: f["contribution"])
+            label = _factor_label(next_biggest["name"])
+            clauses.append(f"{label} exposure is minor")
+
+    # Assemble: "lead; clause1; clause2. R²=…"
+    body = "; ".join(clauses)
+    closing = _r_squared_clause(r_squared, sample_size)
+    summary = f"{body}. {closing}."
+
+    # 120-char cap (plan §4.9). If we are over the cap, trim secondary
+    # clauses one at a time from the tail while keeping the closing R²
+    # fact intact.
+    if len(summary) > 120 and len(clauses) > 1:
+        for cut in range(len(clauses) - 1, 0, -1):
+            trimmed = "; ".join(clauses[:cut])
+            summary = f"{trimmed}. {closing}."
+            if len(summary) <= 120:
+                break
+
+    return summary

--- a/backend/app/services/research_business.py
+++ b/backend/app/services/research_business.py
@@ -1,0 +1,182 @@
+"""Section A — Business snapshot service (issue #280, W-A).
+
+Composes the ``/api/positions/{id}/research/business`` response payload
+per the PRD §"API Contracts → A" frozen contract:
+
+    {
+      "ticker":     "SOFI",
+      "name":       "SoFi Technologies, Inc.",
+      "summary":    "<longBusinessSummary>",
+      "sector":     "Financial Services",
+      "industry":   "Credit Services",
+      "market_cap": 18230000000,
+      "employees":  4900,
+      "source":     "yfinance",
+      "fetched_at": "2026-05-22T17:30:00Z"
+    }
+
+Caching (plan §3.5 + §4.6 — frozen)
+-----------------------------------
+
+Two tiers, both keyed by ticker (positions that hold the same ticker
+share the cache hit):
+
+1. **In-memory** via :mod:`app.services.research_cache` (24 h TTL). The
+   ``research_cache`` key is ``yf_business:{ticker}``.
+2. **Durable** via ``app_settings`` keyed by ``yf_business:{ticker}`` —
+   mirrors the two-tier pattern in :mod:`app.services.alpha_vantage_client`
+   so a server restart does not re-burn the yfinance fetch latency for
+   every position on the dashboard.
+
+Error semantics (plan §4.5 + CLAUDE.md)
+---------------------------------------
+
+The router maps :class:`ResearchSourceUnavailable` to a 502 with the
+sanitized detail string carried by the exception. We never propagate
+``str(e)`` for the underlying yfinance/requests exception — every
+upstream failure is logged at WARNING and surfaced as the same generic
+"Source unavailable" message.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.services import research_cache, yfinance_client
+
+logger = logging.getLogger(__name__)
+
+# Per plan §3.5 — 24h hard TTL for the business snapshot.
+BUSINESS_CACHE_TTL = timedelta(hours=24)
+
+# Cache key formats frozen in plan §4.6.
+_MEMORY_CACHE_KEY = "yf_business:{ticker}"
+_APP_SETTING_KEY = "yf_business:{ticker}"
+
+# Sanitized 502 detail string. Mirrors PRD "→ 502 {detail: ...}".
+_SOURCE_UNAVAILABLE_DETAIL = "Source unavailable"
+
+
+class ResearchSourceUnavailable(RuntimeError):
+    """Raised when every upstream for a research section is unreachable.
+
+    Carries a pre-sanitized detail string (never ``str(original_exc)``) so
+    the router can map directly to a 502 ``{"detail": ...}`` body without
+    further sanitization. Per CLAUDE.md.
+    """
+
+    def __init__(self, detail: str = _SOURCE_UNAVAILABLE_DETAIL) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _read_app_setting(db: Session, key: str) -> Optional[tuple[dict, datetime]]:
+    """Return ``(payload, fetched_at)`` from ``app_settings`` or ``None``."""
+    try:
+        from app.models.database import AppSetting
+
+        entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+        if entry is None:
+            return None
+        ts_part, _, json_part = entry.value.partition("|")
+        if not ts_part or not json_part:
+            return None
+        fetched_at = datetime.fromisoformat(ts_part)
+        payload = json.loads(json_part)
+        if not isinstance(payload, dict):
+            return None
+        return payload, fetched_at
+    except (SQLAlchemyError, ValueError) as exc:
+        logger.debug("Failed to read %s from app_settings: %s", key, exc)
+        return None
+
+
+def _write_app_setting(
+    db: Session, key: str, payload: dict, fetched_at: datetime
+) -> None:
+    """Upsert ``payload`` (JSON-serialized) into ``app_settings`` under ``key``."""
+    try:
+        from app.models.database import AppSetting
+
+        value = f"{fetched_at.isoformat()}|{json.dumps(payload)}"
+        entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+        if entry is None:
+            db.add(AppSetting(key=key, value=value))
+        else:
+            entry.value = value
+        db.commit()
+    except (SQLAlchemyError, ValueError) as exc:
+        logger.debug("Failed to write %s to app_settings: %s", key, exc)
+        try:
+            db.rollback()
+        except SQLAlchemyError:
+            pass
+
+
+# Injectable fetcher hook — tests override this without monkey-patching
+# the yfinance import path. Production code always uses the default.
+_BusinessFetcher = Callable[[str], Optional[dict[str, Any]]]
+
+
+def build_business_payload(
+    db: Session,
+    ticker: str,
+    *,
+    fetcher: _BusinessFetcher | None = None,
+) -> dict[str, Any]:
+    """Build the Section A payload for ``ticker``.
+
+    Reads through the two-tier cache before calling yfinance. Raises
+    :class:`ResearchSourceUnavailable` when yfinance itself fails AND
+    neither cache tier has a fresh entry.
+
+    The optional ``fetcher`` parameter is for test injection — production
+    callers should leave it ``None`` and the default
+    :func:`yfinance_client.fetch_business_info` is used.
+    """
+    ticker_norm = ticker.upper()
+    memory_key = _MEMORY_CACHE_KEY.format(ticker=ticker_norm)
+    app_setting_key = _APP_SETTING_KEY.format(ticker=ticker_norm)
+
+    # Tier 1 — in-memory
+    hit = research_cache.get(memory_key, BUSINESS_CACHE_TTL)
+    if isinstance(hit, dict):
+        return hit
+
+    # Tier 2 — durable app_settings
+    db_hit = _read_app_setting(db, app_setting_key)
+    if db_hit is not None:
+        payload, fetched_at = db_hit
+        if datetime.now(timezone.utc) - fetched_at < BUSINESS_CACHE_TTL:
+            research_cache.set(memory_key, payload)
+            return payload
+
+    # Cache miss / stale — go upstream
+    fetch_impl = fetcher or yfinance_client.fetch_business_info
+    info = fetch_impl(ticker_norm)
+    if info is None:
+        logger.warning("Business snapshot upstream returned no data for %s", ticker_norm)
+        raise ResearchSourceUnavailable(_SOURCE_UNAVAILABLE_DETAIL)
+
+    fetched_at = datetime.now(timezone.utc)
+    payload: dict[str, Any] = {
+        "ticker": ticker_norm,
+        "name": info.get("name"),
+        "summary": info.get("long_business_summary"),
+        "sector": info.get("sector"),
+        "industry": info.get("industry"),
+        "market_cap": info.get("market_cap"),
+        "employees": info.get("employees"),
+        "source": "yfinance",
+        "fetched_at": fetched_at.isoformat().replace("+00:00", "Z"),
+    }
+
+    research_cache.set(memory_key, payload)
+    _write_app_setting(db, app_setting_key, payload, fetched_at)
+    return payload

--- a/backend/app/services/research_business.py
+++ b/backend/app/services/research_business.py
@@ -93,7 +93,10 @@ def _read_app_setting(db: Session, key: str) -> Optional[tuple[dict, datetime]]:
             return None
         return payload, fetched_at
     except (SQLAlchemyError, ValueError) as exc:
-        logger.debug("Failed to read %s from app_settings: %s", key, exc)
+        logger.debug(
+            "Failed to read app_setting",
+            extra={"app_setting_key": key, "error": str(exc)},
+        )
         return None
 
 
@@ -112,7 +115,10 @@ def _write_app_setting(
             entry.value = value
         db.commit()
     except (SQLAlchemyError, ValueError) as exc:
-        logger.debug("Failed to write %s to app_settings: %s", key, exc)
+        logger.debug(
+            "Failed to write app_setting",
+            extra={"app_setting_key": key, "error": str(exc)},
+        )
         try:
             db.rollback()
         except SQLAlchemyError:
@@ -161,7 +167,10 @@ def build_business_payload(
     fetch_impl = fetcher or yfinance_client.fetch_business_info
     info = fetch_impl(ticker_norm)
     if info is None:
-        logger.warning("Business snapshot upstream returned no data for %s", ticker_norm)
+        logger.warning(
+            "Business snapshot upstream returned no data",
+            extra={"ticker": ticker_norm, "source": "yfinance"},
+        )
         raise ResearchSourceUnavailable(_SOURCE_UNAVAILABLE_DETAIL)
 
     fetched_at = datetime.now(timezone.utc)

--- a/backend/app/services/research_cache.py
+++ b/backend/app/services/research_cache.py
@@ -1,0 +1,71 @@
+"""In-memory TTL cache helper for the research endpoints (issue #280).
+
+A small, dependency-free, process-local cache used by every
+``/api/positions/{id}/research/*`` endpoint per the V1 contract freeze in
+``backend/design-specs/issue-280-stock-research-plan.md`` §3.5.
+
+Design notes
+------------
+
+- This is *only* the in-memory tier. The 24h-TTL endpoints (business,
+  financials) ALSO persist to ``app_settings`` keyed by ticker; that
+  durable tier is implemented inline in the per-endpoint services so a
+  server restart does not burn the Alpha Vantage daily quota. The 15min
+  (price-history) and 5min (regression) caches are in-memory only — a
+  restart evicts them harmlessly.
+- The cache stores arbitrary Python objects (typically the already-built
+  response payload as a ``dict``). Each entry carries the timestamp it was
+  written; ``get(key, ttl)`` returns ``None`` when the entry is missing or
+  has aged out.
+- Not thread-safe by design — FastAPI's default worker model is a single
+  event loop per process, and the only writes happen on the request path.
+  If we ever switch to a multi-threaded worker we can wrap the dict in a
+  lock; the public API does not have to change.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+# Module-level store: ``{cache_key: (value, written_at_utc)}``. Keys follow
+# the formats frozen in the plan §4.6 (e.g. ``yf_business:AAPL``).
+_store: dict[str, tuple[Any, datetime]] = {}
+
+
+def get(key: str, ttl: timedelta) -> Any | None:
+    """Return the cached value for ``key`` when still fresh, else ``None``.
+
+    A "fresh" entry is one whose age (now − written_at) is strictly less
+    than ``ttl``. Expired entries are NOT proactively evicted by this
+    function — callers either overwrite them via :func:`set` or the entry
+    is silently superseded on the next successful upstream fetch. This
+    keeps the read path lock-free and predictable.
+    """
+    entry = _store.get(key)
+    if entry is None:
+        return None
+    value, written_at = entry
+    if datetime.now(timezone.utc) - written_at < ttl:
+        return value
+    return None
+
+
+def set(key: str, value: Any) -> None:  # noqa: A001 — mirrors dict API
+    """Write ``value`` into the cache under ``key`` with the current UTC time.
+
+    Overwrites any existing entry. ``value`` is stored by reference, so
+    callers should pass an already-built immutable payload (typically a
+    ``dict`` they no longer mutate).
+    """
+    _store[key] = (value, datetime.now(timezone.utc))
+
+
+def invalidate(key: str) -> None:
+    """Remove ``key`` from the cache. No-op when the key is absent."""
+    _store.pop(key, None)
+
+
+def clear() -> None:
+    """Drop every entry. Test-only — never called on the request path."""
+    _store.clear()

--- a/backend/app/services/research_financials.py
+++ b/backend/app/services/research_financials.py
@@ -1,0 +1,282 @@
+"""Section D — Financial scorecard service (issue #280, W-A).
+
+Composes the ``/api/positions/{id}/research/financials`` response payload
+per the PRD §"API Contracts → D" frozen contract:
+
+    {
+      "ticker": "SOFI",
+      "quarters": [
+        { "period_end": "2025-03-31",
+          "revenue": 645000000,
+          "eps": 0.02,
+          "gross_margin": 0.43,
+          "operating_margin": 0.04 },
+        ...   // up to 8 quarters, newest first
+      ],
+      "source": "alphavantage",   // or "yfinance" if AV failed
+      "fetched_at": "2026-05-22T17:30:00Z"
+    }
+
+Source strategy (plan §3.1, frozen)
+-----------------------------------
+
+1. Alpha Vantage ``INCOME_STATEMENT`` is the primary source. The
+   :func:`app.services.alpha_vantage_client.get_income_statement` helper
+   already implements the two-tier cache and AV's documented rate-limit
+   error filtering (any of ``Error Message`` / ``Note`` / ``Information``
+   in the JSON body → returns ``None`` from the helper, which we treat
+   as "fall back to yfinance").
+2. yfinance ``Ticker.quarterly_income_stmt`` is the fallback when AV
+   returns ``None``. The fallback payload sets ``"source": "yfinance"``
+   so the frontend can render the provenance caption per the spec
+   ("Source: yfinance (alphavantage rate-limited) · refreshed …").
+3. Both upstreams returning ``None`` → 502 with sanitized detail
+   ``"Financials source unavailable"`` per plan §4.5.
+
+Caching
+-------
+
+The AV upstream has its own two-tier cache (in :mod:`alpha_vantage_client`)
+keyed by ``av_financials:{ticker}``. The composed response payload is
+also stored in the in-memory :mod:`research_cache` under
+``av_financials:{ticker}`` / ``yf_financials:{ticker}`` so a second
+request inside the 24h TTL skips both the AV/yfinance call AND the
+margin recomputation. The durable ``yf_financials:{ticker}`` AppSetting
+backs the yfinance fallback path so a server restart does not re-burn
+the (slower, less rate-limited but still costly) yfinance call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Optional
+
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from app.services import alpha_vantage_client, research_cache, yfinance_client
+from app.services.research_business import ResearchSourceUnavailable
+
+logger = logging.getLogger(__name__)
+
+# Per plan §3.5 — 24h hard TTL for the financial scorecard.
+FINANCIALS_CACHE_TTL = timedelta(hours=24)
+QUARTERS = 8
+
+# Cache key formats frozen in plan §4.6.
+_AV_MEMORY_KEY = "av_financials:{ticker}"
+_YF_MEMORY_KEY = "yf_financials:{ticker}"
+_YF_APP_SETTING_KEY = "yf_financials:{ticker}"
+
+_SOURCE_UNAVAILABLE_DETAIL = "Financials source unavailable"
+
+# Hook types for test injection — production code uses the defaults.
+_AVFetcher = Callable[[str, int], Optional[list[dict]]]
+_YFFetcher = Callable[[str, int], Optional[list[dict]]]
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    """Convert ``value`` to ``float``; return ``None`` on any failure.
+
+    AV returns numbers as strings (``"645000000"``); yfinance returns
+    floats / ``NaN``. Either can be missing entirely (``"None"`` string
+    from AV when a quarter has no reported value). This helper normalizes
+    both to ``Optional[float]``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        v = value.strip()
+        if not v or v.lower() in ("none", "null", "n/a", "nan", "-"):
+            return None
+        try:
+            return float(v)
+        except ValueError:
+            return None
+    if isinstance(value, (int, float)):
+        f = float(value)
+        # NaN check — ``f != f`` is the canonical Python NaN test
+        if f != f:
+            return None
+        return f
+    return None
+
+
+def _safe_div(numerator: Any, denominator: Any) -> Optional[float]:
+    """Return ``num / denom`` or ``None`` when either is missing or denom is 0."""
+    num = _safe_float(numerator)
+    denom = _safe_float(denominator)
+    if num is None or denom is None or denom == 0:
+        return None
+    return num / denom
+
+
+def _project_av_quarter(raw: dict) -> dict[str, Any]:
+    """Project one AV ``quarterlyReports`` entry into the response shape.
+
+    AV's fields use camelCase strings: ``fiscalDateEnding``,
+    ``totalRevenue``, ``grossProfit``, ``operatingIncome``,
+    ``reportedEPS``. We compute ``gross_margin`` and ``operating_margin``
+    from the raw numerator/denominator pair; either is ``None`` when a
+    needed field is missing (so the frontend can render a `—` cell
+    instead of a fabricated 0).
+    """
+    return {
+        "period_end": raw.get("fiscalDateEnding"),
+        "revenue": _safe_float(raw.get("totalRevenue")),
+        "eps": _safe_float(raw.get("reportedEPS")),
+        "gross_margin": _safe_div(
+            raw.get("grossProfit"), raw.get("totalRevenue")
+        ),
+        "operating_margin": _safe_div(
+            raw.get("operatingIncome"), raw.get("totalRevenue")
+        ),
+    }
+
+
+def _project_yf_quarter(raw: dict) -> dict[str, Any]:
+    """Project one yfinance-shaped quarter into the response shape.
+
+    yfinance gives us the same set of fundamentals under snake_case keys
+    (the :mod:`yfinance_client` normalization layer), so the margin math
+    is identical — we just rename for the public payload.
+    """
+    return {
+        "period_end": raw.get("fiscal_date_ending"),
+        "revenue": _safe_float(raw.get("total_revenue")),
+        "eps": _safe_float(raw.get("diluted_eps")),
+        "gross_margin": _safe_div(
+            raw.get("gross_profit"), raw.get("total_revenue")
+        ),
+        "operating_margin": _safe_div(
+            raw.get("operating_income"), raw.get("total_revenue")
+        ),
+    }
+
+
+def _read_app_setting(
+    db: Session, key: str
+) -> Optional[tuple[dict, datetime]]:
+    """Return ``(payload, fetched_at)`` from ``app_settings`` or ``None``."""
+    try:
+        from app.models.database import AppSetting
+
+        entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+        if entry is None:
+            return None
+        ts_part, _, json_part = entry.value.partition("|")
+        if not ts_part or not json_part:
+            return None
+        fetched_at = datetime.fromisoformat(ts_part)
+        payload = json.loads(json_part)
+        if not isinstance(payload, dict):
+            return None
+        return payload, fetched_at
+    except (SQLAlchemyError, ValueError) as exc:
+        logger.debug("Failed to read %s from app_settings: %s", key, exc)
+        return None
+
+
+def _write_app_setting(
+    db: Session, key: str, payload: dict, fetched_at: datetime
+) -> None:
+    """Upsert ``payload`` into ``app_settings`` under ``key``."""
+    try:
+        from app.models.database import AppSetting
+
+        value = f"{fetched_at.isoformat()}|{json.dumps(payload)}"
+        entry = db.query(AppSetting).filter(AppSetting.key == key).first()
+        if entry is None:
+            db.add(AppSetting(key=key, value=value))
+        else:
+            entry.value = value
+        db.commit()
+    except (SQLAlchemyError, ValueError) as exc:
+        logger.debug("Failed to write %s to app_settings: %s", key, exc)
+        try:
+            db.rollback()
+        except SQLAlchemyError:
+            pass
+
+
+def build_financials_payload(
+    db: Session,
+    ticker: str,
+    *,
+    av_fetcher: _AVFetcher | None = None,
+    yf_fetcher: _YFFetcher | None = None,
+) -> dict[str, Any]:
+    """Build the Section D payload for ``ticker``.
+
+    Source order: in-memory cache (AV or YF) → AV upstream → yfinance
+    fallback → ``app_settings`` durable cache (yfinance fallback only —
+    AV has its own durable cache inside :mod:`alpha_vantage_client`) →
+    :class:`ResearchSourceUnavailable`.
+
+    The ``av_fetcher`` / ``yf_fetcher`` parameters are for test injection
+    — production callers leave both ``None`` and the defaults are used.
+    """
+    ticker_norm = ticker.upper()
+    av_memory_key = _AV_MEMORY_KEY.format(ticker=ticker_norm)
+    yf_memory_key = _YF_MEMORY_KEY.format(ticker=ticker_norm)
+    yf_app_key = _YF_APP_SETTING_KEY.format(ticker=ticker_norm)
+
+    # Tier 1 — in-memory hot cache (composed payload, either source)
+    for key in (av_memory_key, yf_memory_key):
+        hit = research_cache.get(key, FINANCIALS_CACHE_TTL)
+        if isinstance(hit, dict):
+            return hit
+
+    # Try AV primary
+    av_impl = av_fetcher or alpha_vantage_client.get_income_statement
+    av_raw = av_impl(ticker_norm, QUARTERS)
+    if av_raw is not None:
+        quarters = [_project_av_quarter(q) for q in av_raw[:QUARTERS]]
+        fetched_at = datetime.now(timezone.utc)
+        payload: dict[str, Any] = {
+            "ticker": ticker_norm,
+            "quarters": quarters,
+            "source": "alphavantage",
+            "fetched_at": fetched_at.isoformat().replace("+00:00", "Z"),
+        }
+        research_cache.set(av_memory_key, payload)
+        # AV's own durable cache (av_financials key prefix) is written
+        # inside ``alpha_vantage_client.get_income_statement`` — we do
+        # NOT write again here to avoid two AppSetting rows for the same
+        # ticker.
+        return payload
+
+    # Fall back to yfinance
+    # First check the durable yf cache so a server restart with AV down
+    # still serves a fresh-enough payload.
+    yf_db_hit = _read_app_setting(db, yf_app_key)
+    if yf_db_hit is not None:
+        payload, fetched_at = yf_db_hit
+        if datetime.now(timezone.utc) - fetched_at < FINANCIALS_CACHE_TTL:
+            research_cache.set(yf_memory_key, payload)
+            return payload
+
+    yf_impl = yf_fetcher or yfinance_client.fetch_quarterly_income_stmt
+    yf_raw = yf_impl(ticker_norm, QUARTERS)
+    if yf_raw is None:
+        logger.warning(
+            "Both AV and yfinance returned no income statement for %s",
+            ticker_norm,
+        )
+        raise ResearchSourceUnavailable(_SOURCE_UNAVAILABLE_DETAIL)
+
+    quarters = [_project_yf_quarter(q) for q in yf_raw[:QUARTERS]]
+    fetched_at = datetime.now(timezone.utc)
+    payload = {
+        "ticker": ticker_norm,
+        "quarters": quarters,
+        "source": "yfinance",
+        "fetched_at": fetched_at.isoformat().replace("+00:00", "Z"),
+    }
+    research_cache.set(yf_memory_key, payload)
+    _write_app_setting(db, yf_app_key, payload, fetched_at)
+    return payload

--- a/backend/app/services/research_financials.py
+++ b/backend/app/services/research_financials.py
@@ -177,7 +177,10 @@ def _read_app_setting(
             return None
         return payload, fetched_at
     except (SQLAlchemyError, ValueError) as exc:
-        logger.debug("Failed to read %s from app_settings: %s", key, exc)
+        logger.debug(
+            "Failed to read app_setting",
+            extra={"app_setting_key": key, "error": str(exc)},
+        )
         return None
 
 
@@ -196,7 +199,10 @@ def _write_app_setting(
             entry.value = value
         db.commit()
     except (SQLAlchemyError, ValueError) as exc:
-        logger.debug("Failed to write %s to app_settings: %s", key, exc)
+        logger.debug(
+            "Failed to write app_setting",
+            extra={"app_setting_key": key, "error": str(exc)},
+        )
         try:
             db.rollback()
         except SQLAlchemyError:
@@ -264,8 +270,8 @@ def build_financials_payload(
     yf_raw = yf_impl(ticker_norm, QUARTERS)
     if yf_raw is None:
         logger.warning(
-            "Both AV and yfinance returned no income statement for %s",
-            ticker_norm,
+            "Both AV and yfinance returned no income statement",
+            extra={"ticker": ticker_norm, "source": "alphavantage+yfinance"},
         )
         raise ResearchSourceUnavailable(_SOURCE_UNAVAILABLE_DETAIL)
 

--- a/backend/app/services/research_price_history.py
+++ b/backend/app/services/research_price_history.py
@@ -1,0 +1,396 @@
+"""Research price-history composition (issue #280 / v1.1.0 — Worker B).
+
+Composes the payload for ``GET /api/positions/{id}/research/price-history``:
+
+1. **Prices** — daily closes from the existing :class:`DataFetcher` over the
+   requested window (default ``1Y``).
+2. **Basis lines** — broker basis from the Position row, adjusted basis from
+   the journal recomputation (premiums-net-of-assignment).
+3. **Trade events** — the position's own ledger, mapped to chart markers
+   with the v1 frozen vocabulary (``sell_put``, ``sell_call``, ``assignment``,
+   ``called_away``, ``expired``, ``buy_close``).
+4. **Earnings events** — past reporting dates within the window from
+   Alpha Vantage's ``EARNINGS`` function. Degrades gracefully to ``[]``
+   when AV is unavailable — the price line is the primary signal.
+
+Per the v1 contract freeze the only accepted ``window`` value is ``"1Y"``,
+but ``6M`` and ``2Y`` are accepted too so the API surface is forwards-
+compatible with the deferred window picker (CTO plan §4.1). Anything else
+raises :class:`InvalidWindowError`.
+
+The endpoint is cached in-process for 15 minutes (NFR-7) keyed on
+``research:price-history:{position_id}:{window}``. The cache is intentionally
+in-memory-only — restarts evict harmlessly, the daily quotes have already
+been cached at the :class:`DataFetcher` layer, and the trade ledger lives
+in SQLite. See CTO plan §3.5.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pandas as pd
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.orm import Session as DBSession
+
+from app.services import journal
+from app.services.alpha_vantage_client import get_historical_earnings
+from app.services.cache import CacheService
+from app.services.data_fetcher import DataFetcher
+
+logger = logging.getLogger(__name__)
+
+
+# --- v1 contract: accepted windows -----------------------------------------
+
+# Order matters only for documentation — the dict's values are the lookback
+# in calendar days used when slicing the price DataFrame.
+SUPPORTED_WINDOWS: dict[str, int] = {
+    "6M": 183,
+    "1Y": 365,
+    "2Y": 730,
+}
+DEFAULT_WINDOW: str = "1Y"
+
+# Trade-marker vocabulary frozen at design-spec §4 Section B. The router
+# returns the raw enum value as ``type``; the frontend reads
+# ``tradeMarkerVocabulary.js`` to render symbol + color. Some legacy
+# ``trade_type`` strings on existing rows need normalization (e.g.
+# ``buy_put_close`` and ``buy_call_close`` both render as ``buy_close``).
+_TRADE_TYPE_NORMALIZE: dict[str, str] = {
+    "sell_put": "sell_put",
+    "sell_call": "sell_call",
+    "assignment": "assignment",
+    "called_away": "called_away",
+    "expired": "expired",
+    "buy_put_close": "buy_close",
+    "buy_call_close": "buy_close",
+}
+
+# 15-minute in-memory cache for the composed payload (CTO plan §3.5).
+#
+# Implemented inline rather than via ``research_cache.py`` (Worker A's file)
+# so this PR is fully independent. When Worker A's ``research_cache`` module
+# lands, this module's cache helpers can be replaced one-for-one without
+# touching the public functions. See worker report for the deviation note.
+_CACHE_TTL = timedelta(minutes=15)
+_payload_cache: dict[str, tuple[dict[str, Any], datetime]] = {}
+
+
+# --- Pydantic response models ----------------------------------------------
+#
+# The CTO plan §5 Worker W reconciles all five endpoint models into
+# ``schemas.py`` under a single ``# --- Research (#280) ---`` divider. Until
+# Worker W's pass, the models live here so this worker's PR is self-contained.
+
+
+class PriceHistoryPoint(BaseModel):
+    """A single date + close-price tuple on the price line."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    date: str
+    close: float
+
+
+class BasisLines(BaseModel):
+    """The two horizontal basis lines plotted on the chart.
+
+    ``broker`` is the IRS/Schwab basis (strike × shares − net premium of the
+    matched short put). ``adjusted`` subtracts the *additional* premiums
+    collected on the position after the assignment that established the
+    position — the "real" basis the wheel trader trades against. See
+    :func:`app.services.journal.compute_adjusted_basis` for the math.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    broker: float
+    adjusted: float
+
+
+class TradeEvent(BaseModel):
+    """A user-recorded trade plotted as a chart marker.
+
+    ``type`` is one of the six v1 marker vocabulary values frozen at design
+    spec §4 Section B: ``sell_put``, ``sell_call``, ``assignment``,
+    ``called_away``, ``expired``, ``buy_close``. ``strike`` is omitted for
+    rows where it would be misleading (no current trade type omits it, but
+    the field is ``Optional`` for forwards-compatibility).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    date: str
+    type: str
+    strike: float | None = None
+
+
+class EarningsEvent(BaseModel):
+    """A historical earnings release date annotated on the chart."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    date: str
+    label: str
+
+
+class PriceHistoryResponse(BaseModel):
+    """Composed payload for the research price-history endpoint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ticker: str
+    window: str
+    prices: list[PriceHistoryPoint]
+    basis: BasisLines
+    trade_events: list[TradeEvent]
+    earnings_events: list[EarningsEvent]
+
+
+# --- Errors ---------------------------------------------------------------
+
+
+class InvalidWindowError(ValueError):
+    """Raised when the caller passes an unsupported ``window`` value."""
+
+
+class PriceSourceUnavailableError(RuntimeError):
+    """Raised when the price source (Schwab/yfinance) fails hard.
+
+    The router maps this to a sanitized 502 — never propagate the
+    underlying exception's ``str()`` per CLAUDE.md.
+    """
+
+
+# --- Cache helpers --------------------------------------------------------
+
+
+def _cache_get(key: str) -> dict[str, Any] | None:
+    """Read the 15-min in-memory payload cache; ``None`` on miss or expiry."""
+    entry = _payload_cache.get(key)
+    if entry is None:
+        return None
+    value, fetched_at = entry
+    if datetime.now(timezone.utc) - fetched_at < _CACHE_TTL:
+        return value
+    # Lazily evict on access — keeps the dict small without a sweeper task.
+    _payload_cache.pop(key, None)
+    return None
+
+
+def _cache_set(key: str, value: dict[str, Any]) -> None:
+    """Write to the 15-min in-memory payload cache."""
+    _payload_cache[key] = (value, datetime.now(timezone.utc))
+
+
+def clear_cache() -> None:
+    """Clear the price-history payload cache (testing hook)."""
+    _payload_cache.clear()
+
+
+# --- Composition pieces ---------------------------------------------------
+
+
+def _window_dates(window: str) -> tuple[str, str]:
+    """Return ``(start, end)`` ISO date strings for a window keyword."""
+    if window not in SUPPORTED_WINDOWS:
+        raise InvalidWindowError(f"Unsupported window: {window!r}")
+    end = date.today()
+    start = end - timedelta(days=SUPPORTED_WINDOWS[window])
+    return start.isoformat(), end.isoformat()
+
+
+def _fetch_prices(
+    ticker: str, window: str, fetcher: DataFetcher
+) -> list[PriceHistoryPoint]:
+    """Fetch daily closes for ``ticker`` over ``window``.
+
+    Wraps any data-source error in :class:`PriceSourceUnavailableError`
+    with a generic message so the router can return a sanitized 502.
+    """
+    start, end = _window_dates(window)
+    try:
+        df, _meta = fetcher.fetch(ticker, start, end)
+    except Exception as exc:  # noqa: BLE001 — sanitized at the boundary
+        logger.warning(
+            "Price-history fetch failed for %s window=%s: %s",
+            ticker,
+            window,
+            exc,
+        )
+        raise PriceSourceUnavailableError(
+            "Price source unavailable"
+        ) from exc
+
+    points: list[PriceHistoryPoint] = []
+    if df is None or df.empty:
+        return points
+
+    for idx, row in df.iterrows():
+        try:
+            close = float(row["value"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        # The fetcher returns a DatetimeIndex; isoformat the date component.
+        if isinstance(idx, pd.Timestamp):
+            iso = idx.strftime("%Y-%m-%d")
+        else:
+            iso = str(idx)
+        points.append(PriceHistoryPoint(date=iso, close=close))
+
+    return points
+
+
+def _trade_events_from_position(position: dict[str, Any]) -> list[TradeEvent]:
+    """Map the position's trade ledger to v1 chart-marker events.
+
+    Reads the ``trades`` array on the position dict returned by
+    :func:`app.services.journal.get_position`. Each trade's ``opened_at``
+    is the marker date — that's the date the *user took the action* (the
+    one the chart user would recognize). Closed legs are still rendered;
+    the close itself is its own event when ``closed_at`` exists.
+    """
+    events: list[TradeEvent] = []
+    for trade in position.get("trades") or []:
+        raw_type = trade.get("trade_type")
+        if not raw_type:
+            continue
+        normalized = _TRADE_TYPE_NORMALIZE.get(raw_type)
+        if normalized is None:
+            logger.debug(
+                "Skipping trade with unknown trade_type=%s on position=%s",
+                raw_type,
+                position.get("id"),
+            )
+            continue
+        opened = trade.get("opened_at")
+        if not opened:
+            continue
+        # Normalize ``opened_at`` (may be ``YYYY-MM-DD`` or
+        # ``YYYY-MM-DDTHH:MM:SSZ``) down to the date-only form the chart
+        # x-axis expects.
+        date_only = str(opened).split("T", 1)[0]
+        strike = trade.get("strike")
+        try:
+            strike_f: float | None = float(strike) if strike is not None else None
+        except (TypeError, ValueError):
+            strike_f = None
+        events.append(
+            TradeEvent(date=date_only, type=normalized, strike=strike_f)
+        )
+    events.sort(key=lambda e: e.date)
+    return events
+
+
+def _earnings_events_for_window(
+    ticker: str, window: str
+) -> list[EarningsEvent]:
+    """Fetch historical earnings dates for ``ticker`` within the window.
+
+    Returns an empty list when Alpha Vantage is unavailable — the endpoint
+    must degrade gracefully rather than fail the whole payload (NFR-3).
+    The label string is deterministic: ``"Earnings"`` for v1; Section C
+    can enrich it later with quarter labels.
+    """
+    start, _end = _window_dates(window)
+    try:
+        raw_dates = get_historical_earnings(ticker, since=start)
+    except Exception as exc:  # noqa: BLE001 — degrade to []
+        logger.warning(
+            "Historical earnings fetch failed for %s; "
+            "returning empty earnings_events: %s",
+            ticker,
+            exc,
+        )
+        return []
+    return [EarningsEvent(date=d, label="Earnings") for d in raw_dates]
+
+
+# --- Public API -----------------------------------------------------------
+
+
+def build_price_history(
+    db: DBSession,
+    position_id: str,
+    window: str | None,
+    fetcher: DataFetcher | None = None,
+) -> PriceHistoryResponse | None:
+    """Compose the research price-history payload for one position.
+
+    Returns ``None`` when the position does not exist so the router can map
+    that to a 404. Raises :class:`InvalidWindowError` on bad ``window`` and
+    :class:`PriceSourceUnavailableError` on a hard price-source failure;
+    both are sanitized at the router boundary.
+
+    A 15-minute in-process cache short-circuits the composition; the cache
+    key is ``research:price-history:{position_id}:{window}`` per the v1
+    contract freeze (CTO plan §4.6).
+    """
+    resolved_window = (window or DEFAULT_WINDOW).upper()
+    if resolved_window not in SUPPORTED_WINDOWS:
+        raise InvalidWindowError(
+            f"Unsupported window: {window!r}. Supported: "
+            f"{sorted(SUPPORTED_WINDOWS)}"
+        )
+
+    # 1. Position lookup (also drives 404 + ticker + basis values)
+    position = journal.get_position(db, position_id)
+    if position is None:
+        return None
+
+    cache_key = f"research:price-history:{position_id}:{resolved_window}"
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        return PriceHistoryResponse(**cached)
+
+    ticker = str(position.get("ticker") or "").upper()
+
+    # 2. Prices (raises PriceSourceUnavailableError on hard failure)
+    if fetcher is None:
+        fetcher = DataFetcher(CacheService(db))
+    prices = _fetch_prices(ticker, resolved_window, fetcher)
+
+    # 3. Basis lines from the position row (broker) + journal recompute
+    #    (adjusted). Both are floats; the journal layer guarantees they
+    #    are non-negative and well-formed.
+    basis = BasisLines(
+        broker=float(position.get("broker_cost_basis") or 0.0),
+        adjusted=float(position.get("adjusted_cost_basis") or 0.0),
+    )
+
+    # 4. Trade events from the ledger
+    trade_events = _trade_events_from_position(position)
+
+    # 5. Earnings events (degrades to [] on AV failure)
+    earnings_events = _earnings_events_for_window(ticker, resolved_window)
+
+    response = PriceHistoryResponse(
+        ticker=ticker,
+        window=resolved_window,
+        prices=prices,
+        basis=basis,
+        trade_events=trade_events,
+        earnings_events=earnings_events,
+    )
+
+    # Cache the dict form so a hit can rehydrate via ``PriceHistoryResponse(**)``
+    _cache_set(cache_key, response.model_dump())
+    return response
+
+
+__all__ = [
+    "BasisLines",
+    "DEFAULT_WINDOW",
+    "EarningsEvent",
+    "InvalidWindowError",
+    "PriceHistoryPoint",
+    "PriceHistoryResponse",
+    "PriceSourceUnavailableError",
+    "SUPPORTED_WINDOWS",
+    "TradeEvent",
+    "build_price_history",
+    "clear_cache",
+]

--- a/backend/app/services/research_price_history.py
+++ b/backend/app/services/research_price_history.py
@@ -28,14 +28,14 @@ in SQLite. See CTO plan §3.5.
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, timedelta
 from typing import Any
 
 import pandas as pd
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy.orm import Session as DBSession
 
-from app.services import journal
+from app.services import journal, research_cache
 from app.services.alpha_vantage_client import get_historical_earnings
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher
@@ -71,12 +71,11 @@ _TRADE_TYPE_NORMALIZE: dict[str, str] = {
 
 # 15-minute in-memory cache for the composed payload (CTO plan §3.5).
 #
-# Implemented inline rather than via ``research_cache.py`` (Worker A's file)
-# so this PR is fully independent. When Worker A's ``research_cache`` module
-# lands, this module's cache helpers can be replaced one-for-one without
-# touching the public functions. See worker report for the deviation note.
+# Backed by the shared :mod:`app.services.research_cache` helper now that
+# Worker A's module has landed on the integration branch. Earlier worker
+# isolation required this to be inlined; the dedup happened in the
+# v1.1.0 cleanup pass (Phase 5 should-fix S1).
 _CACHE_TTL = timedelta(minutes=15)
-_payload_cache: dict[str, tuple[dict[str, Any], datetime]] = {}
 
 
 # --- Pydantic response models ----------------------------------------------
@@ -170,25 +169,25 @@ class PriceSourceUnavailableError(RuntimeError):
 
 def _cache_get(key: str) -> dict[str, Any] | None:
     """Read the 15-min in-memory payload cache; ``None`` on miss or expiry."""
-    entry = _payload_cache.get(key)
-    if entry is None:
-        return None
-    value, fetched_at = entry
-    if datetime.now(timezone.utc) - fetched_at < _CACHE_TTL:
-        return value
-    # Lazily evict on access — keeps the dict small without a sweeper task.
-    _payload_cache.pop(key, None)
+    hit = research_cache.get(key, _CACHE_TTL)
+    if isinstance(hit, dict):
+        return hit
     return None
 
 
 def _cache_set(key: str, value: dict[str, Any]) -> None:
     """Write to the 15-min in-memory payload cache."""
-    _payload_cache[key] = (value, datetime.now(timezone.utc))
+    research_cache.set(key, value)
 
 
 def clear_cache() -> None:
-    """Clear the price-history payload cache (testing hook)."""
-    _payload_cache.clear()
+    """Clear the price-history payload cache (testing hook).
+
+    Routes through the shared :mod:`research_cache` ``clear()`` so all
+    research caches drop together — the price-history cache used to be a
+    private dict; tests that imported this helper still work unchanged.
+    """
+    research_cache.clear()
 
 
 # --- Composition pieces ---------------------------------------------------
@@ -216,10 +215,12 @@ def _fetch_prices(
         df, _meta = fetcher.fetch(ticker, start, end)
     except Exception as exc:  # noqa: BLE001 — sanitized at the boundary
         logger.warning(
-            "Price-history fetch failed for %s window=%s: %s",
-            ticker,
-            window,
-            exc,
+            "Price-history fetch failed",
+            extra={
+                "ticker": ticker,
+                "window": window,
+                "error": exc.__class__.__name__,
+            },
         )
         raise PriceSourceUnavailableError(
             "Price source unavailable"
@@ -261,9 +262,11 @@ def _trade_events_from_position(position: dict[str, Any]) -> list[TradeEvent]:
         normalized = _TRADE_TYPE_NORMALIZE.get(raw_type)
         if normalized is None:
             logger.debug(
-                "Skipping trade with unknown trade_type=%s on position=%s",
-                raw_type,
-                position.get("id"),
+                "Skipping trade with unknown trade_type",
+                extra={
+                    "trade_type": raw_type,
+                    "position_id": position.get("id"),
+                },
             )
             continue
         opened = trade.get("opened_at")
@@ -300,10 +303,12 @@ def _earnings_events_for_window(
         raw_dates = get_historical_earnings(ticker, since=start)
     except Exception as exc:  # noqa: BLE001 — degrade to []
         logger.warning(
-            "Historical earnings fetch failed for %s; "
-            "returning empty earnings_events: %s",
-            ticker,
-            exc,
+            "Historical earnings fetch failed; returning empty earnings_events",
+            extra={
+                "ticker": ticker,
+                "source": "alphavantage",
+                "error": exc.__class__.__name__,
+            },
         )
         return []
     return [EarningsEvent(date=d, label="Earnings") for d in raw_dates]

--- a/backend/app/services/research_regression.py
+++ b/backend/app/services/research_regression.py
@@ -50,12 +50,30 @@ logger = logging.getLogger(__name__)
 # --- Public errors ---------------------------------------------------------
 
 
+# Sanitized 502 detail string — never include user-visible ticker / position
+# identifiers per CLAUDE.md (CR #4). Mirrors the
+# ``ResearchSourceUnavailable`` pattern in ``research_business.py``.
+_REGRESSION_SOURCE_UNAVAILABLE_DETAIL = "Source unavailable for regression"
+
+
 class InsufficientRegressionDataError(Exception):
     """Raised when fewer than ``MIN_OBSERVATIONS`` aligned trading days exist."""
 
 
 class RegressionSourceUnavailableError(Exception):
-    """Raised when an upstream data source (Schwab / FRED / sector ETF) fails."""
+    """Raised when an upstream data source (Schwab / FRED / sector ETF) fails.
+
+    Carries a pre-sanitized ``detail`` attribute so the router can map
+    directly to a 502 ``{"detail": ...}`` body without further sanitization
+    (CR #4). The default detail string is the same generic message used by
+    every research 502 — callers MUST NOT pass raw identifiers in.
+    """
+
+    def __init__(
+        self, detail: str = _REGRESSION_SOURCE_UNAVAILABLE_DETAIL
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
 
 
 # --- Pydantic response models (frozen per plan §4.2) ----------------------
@@ -159,7 +177,10 @@ def _resolve_sector_for_ticker(ticker: str) -> str | None:
     try:
         info = yfinance_client.fetch_business_info(ticker)  # type: ignore[attr-defined]
     except Exception:  # noqa: BLE001 — defensive: any yfinance error
-        logger.warning("yfinance lookup failed for %s; omitting sector", ticker)
+        logger.warning(
+            "yfinance lookup failed; omitting sector",
+            extra={"ticker": ticker, "source": "yfinance"},
+        )
         return None
     if not info:
         return None
@@ -309,15 +330,22 @@ def compose_regression_response(
         except (InvalidTickerError, DataFetchError, Exception) as exc:
             # Sanitize: never propagate str(e) to the client. Logged for ops.
             logger.warning(
-                "Regression fetch failed for %s: %s", ident, exc.__class__.__name__
+                "Regression fetch failed",
+                extra={
+                    "ticker": ident,
+                    "error": exc.__class__.__name__,
+                },
             )
-            raise RegressionSourceUnavailableError(
-                f"Source unavailable for {ident}"
-            ) from exc
+            # Sanitized message — never include {ident} in the detail because
+            # tickers are user-visible internal data (CR #4). The log above
+            # captures the precise ticker for ops.
+            raise RegressionSourceUnavailableError() from exc
         if "value" not in df.columns or len(df) == 0:
-            raise RegressionSourceUnavailableError(
-                f"Source returned empty data for {ident}"
+            logger.warning(
+                "Regression source returned empty data",
+                extra={"ticker": ident},
             )
+            raise RegressionSourceUnavailableError()
         series_by_ticker[ident] = df["value"]
 
     # Compute log returns for prices (ticker + ETFs). DGS10 is a yield in
@@ -341,7 +369,13 @@ def compose_regression_response(
     try:
         aligned, _ = align_datasets(datasets)
     except Exception as exc:  # noqa: BLE001 — wrap into a typed error
-        logger.warning("Alignment failed for position %s: %s", position_id, exc)
+        logger.warning(
+            "Alignment failed",
+            extra={
+                "position_id": position_id,
+                "error": exc.__class__.__name__,
+            },
+        )
         raise InsufficientRegressionDataError(
             "Insufficient data for regression"
         ) from exc
@@ -357,9 +391,11 @@ def compose_regression_response(
         result = compute_multifactor_ols(dates, y, x_df_dict)
     except Exception as exc:  # noqa: BLE001 — near-singular factor matrix, etc.
         logger.warning(
-            "Regression engine failed for position %s: %s",
-            position_id,
-            exc.__class__.__name__,
+            "Regression engine failed",
+            extra={
+                "position_id": position_id,
+                "error": exc.__class__.__name__,
+            },
         )
         raise InsufficientRegressionDataError(
             "Regression failed: factor matrix could not be fit"

--- a/backend/app/services/research_regression.py
+++ b/backend/app/services/research_regression.py
@@ -1,0 +1,463 @@
+"""Per-position regression decomposition service (issue #280, Section E).
+
+Composes the ``GET /api/positions/{id}/research/regression`` response by:
+
+1. Resolving the position's ticker (and optionally the sector via the
+   yfinance client, if Worker A's wrapper is available).
+2. Selecting a sector ETF for the regression basket via
+   :mod:`app.services.sector_etf_map`. Falls back to a SPY+DGS10-only
+   basket when no sector can be resolved.
+3. Fetching daily price series for the ticker + factors and the FRED 10Y
+   yield (``DGS10``) over the 1Y window using the existing
+   :class:`app.services.data_fetcher.DataFetcher`.
+4. Computing daily log returns, aligning on the common date index, and
+   handing the aligned data to the existing multi-factor OLS engine in
+   :func:`app.services.regression.compute_multifactor_ols`.
+5. Translating the engine's output into the contract-frozen response
+   shape (factors + summary + donut shares) per the plan §4.2.
+
+Cache TTL is 5 minutes per NFR-7 (key ``research:regression:{position_id}:{window}``).
+The cache is process-local: a single in-memory dict guarded by ISO
+timestamps. Server restarts evict the cache harmlessly because each
+response can be rebuilt from fresh data in seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+from pydantic import BaseModel, ConfigDict
+
+from app.services.data_fetcher import (
+    DataAlignmentError,
+    DataFetcher,
+    DataFetchError,
+    InvalidTickerError,
+)
+from app.services.regression import compute_multifactor_ols
+from app.services.regression_summary import SummaryFactor, build_regression_summary
+from app.services.sector_etf_map import lookup_sector_etf
+from app.utils.transforms import align_datasets
+
+logger = logging.getLogger(__name__)
+
+
+# --- Public errors ---------------------------------------------------------
+
+
+class InsufficientRegressionDataError(Exception):
+    """Raised when fewer than ``MIN_OBSERVATIONS`` aligned trading days exist."""
+
+
+class RegressionSourceUnavailableError(Exception):
+    """Raised when an upstream data source (Schwab / FRED / sector ETF) fails."""
+
+
+# --- Pydantic response models (frozen per plan §4.2) ----------------------
+
+
+class RegressionFactorPayload(BaseModel):
+    """Per-factor row in the regression response.
+
+    ``name`` is one of ``"market"``, ``"sector"``, ``"rates"``, or
+    ``"idiosyncratic"``. ``beta`` and ``p_value`` are ``None`` for the
+    idiosyncratic residual. ``contribution`` is the share of variance
+    (factors + idiosyncratic sum to ~1.0).
+    """
+
+    model_config = ConfigDict(strict=True)
+
+    name: Literal["market", "sector", "rates", "idiosyncratic"]
+    ticker: str | None
+    beta: float | None
+    p_value: float | None
+    contribution: float
+
+
+class ResearchRegressionResponse(BaseModel):
+    """``/research/regression`` response payload (issue #280, Section E)."""
+
+    model_config = ConfigDict(strict=True)
+
+    position_id: str
+    ticker: str
+    window: str
+    basket: list[str]
+    sector_omitted: bool
+    factors: list[RegressionFactorPayload]
+    r_squared: float
+    idiosyncratic_share: float
+    sample_size: int
+    summary: str
+    as_of: str
+
+
+# --- Constants -------------------------------------------------------------
+
+
+MIN_OBSERVATIONS = 60
+DEFAULT_WINDOW = "1Y"
+WINDOW_TO_DAYS: dict[str, int] = {"1Y": 365}
+CACHE_TTL_SECONDS = 5 * 60
+SUPPORTED_WINDOWS: frozenset[str] = frozenset({"1Y"})
+
+
+# --- In-memory cache --------------------------------------------------------
+
+
+_cache: dict[str, tuple[float, ResearchRegressionResponse]] = {}
+
+
+def _cache_key(position_id: str, window: str) -> str:
+    """Build the contract-frozen cache key for this endpoint."""
+    return f"research:regression:{position_id}:{window}"
+
+
+def _cache_get(key: str) -> ResearchRegressionResponse | None:
+    """Return a cached response if still fresh; evict if expired."""
+    entry = _cache.get(key)
+    if entry is None:
+        return None
+    timestamp, value = entry
+    if (time.monotonic() - timestamp) > CACHE_TTL_SECONDS:
+        _cache.pop(key, None)
+        return None
+    return value
+
+
+def _cache_set(key: str, value: ResearchRegressionResponse) -> None:
+    """Store a response in the process-local cache."""
+    _cache[key] = (time.monotonic(), value)
+
+
+def clear_cache() -> None:
+    """Evict every cached entry; intended for tests and admin tooling."""
+    _cache.clear()
+
+
+# --- Sector resolution ------------------------------------------------------
+
+
+def _resolve_sector_for_ticker(ticker: str) -> str | None:
+    """Look up the position's sector via Worker A's yfinance wrapper, if present.
+
+    The yfinance client is owned by Worker A in the v1.1.0 fan-out and may
+    not exist on this branch in isolation. The import is intentionally
+    defensive so this worker is testable independently and so the endpoint
+    degrades gracefully (sector-omitted branch) when the wrapper is absent
+    or yfinance itself raises.
+    """
+    try:
+        from app.services import yfinance_client  # type: ignore[attr-defined]
+    except ImportError:
+        return None
+    try:
+        info = yfinance_client.fetch_business_info(ticker)  # type: ignore[attr-defined]
+    except Exception:  # noqa: BLE001 — defensive: any yfinance error
+        logger.warning("yfinance lookup failed for %s; omitting sector", ticker)
+        return None
+    if not info:
+        return None
+    sector = info.get("sector") if isinstance(info, dict) else None
+    if sector is None or not isinstance(sector, str) or not sector.strip():
+        return None
+    return sector.strip()
+
+
+# --- Window helpers ---------------------------------------------------------
+
+
+def _window_date_range(window: str) -> tuple[str, str]:
+    """Return ``(start_date, end_date)`` ISO strings for a regression window."""
+    days = WINDOW_TO_DAYS[window]
+    end = datetime.now(timezone.utc).date()
+    # Pad the start by ~30 days so post-alignment we still have enough
+    # trading days after weekends/holidays are dropped.
+    start = end - timedelta(days=days + 30)
+    return start.isoformat(), end.isoformat()
+
+
+def validate_window(window: str) -> str:
+    """Validate the ``window`` query param.
+
+    Raises :class:`ValueError` with a sanitized message when the value is
+    not in :data:`SUPPORTED_WINDOWS`. Callers should translate this into
+    an HTTP 422.
+    """
+    if window not in SUPPORTED_WINDOWS:
+        raise ValueError("Unsupported window value")
+    return window
+
+
+# --- Returns helpers --------------------------------------------------------
+
+
+def _log_returns(series: pd.Series) -> pd.Series:
+    """Compute daily log returns from a price/level series.
+
+    NaN-safe: an all-zero or non-positive input would generate inf/NaN
+    rows which :func:`align_datasets` drops downstream.
+    """
+    return np.log(series).diff()
+
+
+def _build_factor_payloads(
+    coefficients: dict[str, float],
+    p_values: dict[str, float],
+    contributions: dict[str, float],
+    idiosyncratic_share: float,
+    factor_name_to_ticker: dict[str, str],
+    basket_names: list[str],
+) -> list[RegressionFactorPayload]:
+    """Assemble the ``factors`` array for the response, including the residual."""
+    payloads: list[RegressionFactorPayload] = []
+    # Render factors in a stable, frontend-friendly order: market → sector → rates.
+    canonical_order = ["market", "sector", "rates"]
+    for name in canonical_order:
+        if name not in basket_names:
+            continue
+        ticker = factor_name_to_ticker.get(name)
+        payloads.append(
+            RegressionFactorPayload(
+                name=name,  # type: ignore[arg-type]
+                ticker=ticker,
+                beta=float(coefficients[name]),
+                p_value=float(p_values[name]),
+                contribution=float(contributions[name]),
+            )
+        )
+    payloads.append(
+        RegressionFactorPayload(
+            name="idiosyncratic",
+            ticker=None,
+            beta=None,
+            p_value=None,
+            contribution=float(idiosyncratic_share),
+        )
+    )
+    return payloads
+
+
+def _compute_contributions(
+    coefficients: dict[str, float],
+    factor_returns: pd.DataFrame,
+    r_squared: float,
+) -> dict[str, float]:
+    """Compute each factor's share of the explained variance.
+
+    Uses ``(beta_i * std(x_i))^2`` normalized so the explained shares sum
+    to ``r_squared``. The idiosyncratic share (``1 - r_squared``) is
+    appended by the caller so factors + idiosyncratic sum to ~1.0.
+    """
+    raw: dict[str, float] = {}
+    for name in factor_returns.columns:
+        std = float(factor_returns[name].std(ddof=1))
+        raw[name] = (coefficients[name] * std) ** 2
+    total = sum(raw.values())
+    if total <= 0:
+        # Degenerate fallback: distribute evenly so the donut still renders.
+        n = len(raw)
+        return {name: r_squared / n for name in raw}
+    return {name: (val / total) * r_squared for name, val in raw.items()}
+
+
+# --- Core composition ------------------------------------------------------
+
+
+def compose_regression_response(
+    *,
+    position_id: str,
+    ticker: str,
+    window: str,
+    fetcher: DataFetcher,
+    sector: str | None,
+) -> ResearchRegressionResponse:
+    """Pure composition function: fetch series, run regression, build response.
+
+    Separated from the cache wrapper so tests can exercise the full
+    pipeline with a stubbed ``DataFetcher`` without touching the cache.
+
+    Raises:
+      InsufficientRegressionDataError — fewer than 60 aligned trading days.
+      RegressionSourceUnavailableError — Schwab/FRED/sector ETF failed.
+    """
+    validate_window(window)
+    sector_etf = lookup_sector_etf(sector)
+    sector_omitted = sector_etf is None
+
+    start, end = _window_date_range(window)
+
+    # Build the factor list: SPY always, sector ETF when known, plus DGS10.
+    factor_name_to_ticker: dict[str, str] = {"market": "SPY", "rates": "DGS10"}
+    if sector_etf is not None:
+        factor_name_to_ticker["sector"] = sector_etf
+
+    basket_names = list(factor_name_to_ticker.keys())
+    basket_tickers = [factor_name_to_ticker[n] for n in basket_names]
+
+    # Fetch every series. Any failure → 502 via RegressionSourceUnavailableError.
+    series_by_ticker: dict[str, pd.Series] = {}
+    fetch_order = [ticker, *basket_tickers]
+    for ident in fetch_order:
+        try:
+            df, _ = fetcher.fetch(ident, start, end)
+        except (InvalidTickerError, DataFetchError, Exception) as exc:
+            # Sanitize: never propagate str(e) to the client. Logged for ops.
+            logger.warning(
+                "Regression fetch failed for %s: %s", ident, exc.__class__.__name__
+            )
+            raise RegressionSourceUnavailableError(
+                f"Source unavailable for {ident}"
+            ) from exc
+        if "value" not in df.columns or len(df) == 0:
+            raise RegressionSourceUnavailableError(
+                f"Source returned empty data for {ident}"
+            )
+        series_by_ticker[ident] = df["value"]
+
+    # Compute log returns for prices (ticker + ETFs). DGS10 is a yield in
+    # percent — use first differences so the regression interprets it on
+    # the same "daily change" scale as the equity returns.
+    returns_by_name: dict[str, pd.Series] = {}
+    ticker_returns = _log_returns(series_by_ticker[ticker]).dropna()
+    returns_by_name["__ticker__"] = ticker_returns
+    for factor_name, factor_ticker in factor_name_to_ticker.items():
+        s = series_by_ticker[factor_ticker]
+        if factor_name == "rates":
+            r = s.diff().dropna()
+        else:
+            r = _log_returns(s).dropna()
+        returns_by_name[factor_name] = r
+
+    # Reuse the project's align_datasets helper for inner-join + ffill semantics.
+    datasets: dict[str, pd.DataFrame] = {
+        name: pd.DataFrame({"value": s}) for name, s in returns_by_name.items()
+    }
+    try:
+        aligned, _ = align_datasets(datasets)
+    except Exception as exc:  # noqa: BLE001 — wrap into a typed error
+        logger.warning("Alignment failed for position %s: %s", position_id, exc)
+        raise InsufficientRegressionDataError(
+            "Insufficient data for regression"
+        ) from exc
+
+    if len(aligned) < MIN_OBSERVATIONS:
+        raise InsufficientRegressionDataError("Insufficient data for regression")
+
+    dates = [idx.strftime("%Y-%m-%d") for idx in aligned.index]
+    y = aligned["__ticker__"].tolist()
+    x_df_dict = {name: aligned[name].tolist() for name in basket_names}
+
+    try:
+        result = compute_multifactor_ols(dates, y, x_df_dict)
+    except Exception as exc:  # noqa: BLE001 — near-singular factor matrix, etc.
+        logger.warning(
+            "Regression engine failed for position %s: %s",
+            position_id,
+            exc.__class__.__name__,
+        )
+        raise InsufficientRegressionDataError(
+            "Regression failed: factor matrix could not be fit"
+        ) from exc
+
+    r_squared = float(result["r_squared"])
+    coefficients: dict[str, float] = {k: float(v) for k, v in result["coefficients"].items()}
+    p_values: dict[str, float] = {k: float(v) for k, v in result["p_values"].items()}
+
+    contributions = _compute_contributions(
+        coefficients,
+        aligned[basket_names],
+        r_squared,
+    )
+    idiosyncratic_share = max(0.0, 1.0 - r_squared)
+
+    factors = _build_factor_payloads(
+        coefficients=coefficients,
+        p_values=p_values,
+        contributions=contributions,
+        idiosyncratic_share=idiosyncratic_share,
+        factor_name_to_ticker=factor_name_to_ticker,
+        basket_names=basket_names,
+    )
+
+    summary_factors: list[SummaryFactor] = [
+        {
+            "name": f.name,
+            "beta": f.beta,
+            "p_value": f.p_value,
+            "contribution": f.contribution,
+        }
+        for f in factors
+    ]
+    summary = build_regression_summary(
+        factors=summary_factors,
+        r_squared=r_squared,
+        sample_size=int(result["sample_size"]),
+        sector_omitted=sector_omitted,
+    )
+
+    return ResearchRegressionResponse(
+        position_id=position_id,
+        ticker=ticker,
+        window=window,
+        basket=basket_tickers,
+        sector_omitted=sector_omitted,
+        factors=factors,
+        r_squared=r_squared,
+        idiosyncratic_share=idiosyncratic_share,
+        sample_size=int(result["sample_size"]),
+        summary=summary,
+        as_of=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def get_regression_for_position(
+    *,
+    position_id: str,
+    ticker: str,
+    window: str,
+    fetcher: DataFetcher,
+    sector: str | None = None,
+) -> ResearchRegressionResponse:
+    """Cache-aware wrapper around :func:`compose_regression_response`.
+
+    Looks up the sector via the yfinance wrapper when not provided, then
+    returns either a cached response (TTL :data:`CACHE_TTL_SECONDS`) or a
+    freshly composed one.
+    """
+    key = _cache_key(position_id, window)
+    cached = _cache_get(key)
+    if cached is not None:
+        return cached
+
+    resolved_sector = sector if sector is not None else _resolve_sector_for_ticker(ticker)
+
+    response = compose_regression_response(
+        position_id=position_id,
+        ticker=ticker,
+        window=window,
+        fetcher=fetcher,
+        sector=resolved_sector,
+    )
+    _cache_set(key, response)
+    return response
+
+
+__all__ = [
+    "DEFAULT_WINDOW",
+    "InsufficientRegressionDataError",
+    "MIN_OBSERVATIONS",
+    "RegressionSourceUnavailableError",
+    "RegressionFactorPayload",
+    "ResearchRegressionResponse",
+    "SUPPORTED_WINDOWS",
+    "clear_cache",
+    "compose_regression_response",
+    "get_regression_for_position",
+    "validate_window",
+]

--- a/backend/app/services/research_thesis.py
+++ b/backend/app/services/research_thesis.py
@@ -135,11 +135,15 @@ def put_thesis(db: Session, position_id: str, body: str) -> ThesisResponse:
         db.commit()
     except Exception:
         db.rollback()
-        logger.exception("Failed to upsert thesis for position %s", position_id)
+        logger.exception(
+            "Failed to upsert thesis",
+            extra={"position_id": position_id},
+        )
         raise
 
     db.refresh(note)
     logger.info(
-        "Upserted thesis for position %s (version=%d)", position_id, note.version
+        "Upserted thesis",
+        extra={"position_id": position_id, "version": note.version},
     )
     return _row_to_response(note)

--- a/backend/app/services/research_thesis.py
+++ b/backend/app/services/research_thesis.py
@@ -1,0 +1,145 @@
+"""Thesis note service for the research page (issue #280, Section F).
+
+Two operations, one row per position:
+
+* :func:`get_thesis` — returns the current thesis or the empty-state shape
+  (``thesis=None``, ``version=0``) when no row exists.
+* :func:`put_thesis` — upserts the thesis body, bumps the ``version`` and
+  ``updated_at`` columns on every successful write. Pre-validates the
+  body length (server-side defence in depth — Pydantic already enforces
+  the cap on the request model).
+
+Position-existence is checked against the ``positions`` table; if the
+position is unknown both endpoints raise :class:`PositionNotFoundError`
+which the router translates to ``404``. Body overflows raise
+:class:`ThesisTooLongError` which the router translates to ``422``.
+Neither error class leaks raw exception text — both carry a sanitized
+message per CLAUDE.md.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.database import Position, PositionNote
+from app.models.schemas import THESIS_MAX_BODY_LENGTH, ThesisResponse
+
+logger = logging.getLogger(__name__)
+
+
+class PositionNotFoundError(Exception):
+    """Raised when a position id does not resolve to a known row."""
+
+
+class ThesisTooLongError(Exception):
+    """Raised when a thesis body exceeds :data:`THESIS_MAX_BODY_LENGTH`."""
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC instant in ISO-8601 with a ``Z`` suffix."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _position_exists(db: Session, position_id: str) -> bool:
+    """Lightweight existence check on the ``positions`` table."""
+    return (
+        db.query(Position.id)
+        .filter(Position.id == position_id)
+        .first()
+        is not None
+    )
+
+
+def _empty_response() -> ThesisResponse:
+    """Build the empty-state response (no row yet) per spec §F."""
+    return ThesisResponse(thesis=None, updated_at=None, version=0)
+
+
+def _row_to_response(note: PositionNote) -> ThesisResponse:
+    """Serialize a persisted ``PositionNote`` to the public response shape."""
+    return ThesisResponse(
+        thesis=note.body,
+        updated_at=note.updated_at,
+        version=note.version,
+    )
+
+
+def get_thesis(db: Session, position_id: str) -> ThesisResponse:
+    """Return the thesis row for ``position_id`` or the empty-state shape.
+
+    Raises :class:`PositionNotFoundError` when the position itself does
+    not exist — the router maps that to ``404``. When the position
+    exists but no thesis row is present, returns the empty-state
+    response (``thesis=None``, ``version=0``).
+    """
+    if not _position_exists(db, position_id):
+        raise PositionNotFoundError(position_id)
+
+    note = (
+        db.query(PositionNote)
+        .filter(PositionNote.position_id == position_id)
+        .first()
+    )
+    if note is None:
+        return _empty_response()
+    return _row_to_response(note)
+
+
+def put_thesis(db: Session, position_id: str, body: str) -> ThesisResponse:
+    """Upsert the thesis for ``position_id`` and return the new row.
+
+    On insert: ``version`` starts at 1. On update: ``version`` is
+    incremented and ``updated_at`` refreshed. The body may be empty —
+    empty strings are explicitly allowed and still bump the version
+    (the plan does not forbid clearing the note).
+
+    Raises:
+        :class:`PositionNotFoundError`: position id does not exist.
+        :class:`ThesisTooLongError`: body length exceeds the cap.
+    """
+    if len(body) > THESIS_MAX_BODY_LENGTH:
+        raise ThesisTooLongError(
+            f"Thesis exceeds {THESIS_MAX_BODY_LENGTH} character limit"
+        )
+
+    if not _position_exists(db, position_id):
+        raise PositionNotFoundError(position_id)
+
+    note = (
+        db.query(PositionNote)
+        .filter(PositionNote.position_id == position_id)
+        .first()
+    )
+    now_iso = _utc_now_iso()
+
+    if note is None:
+        note = PositionNote(
+            id=str(uuid.uuid4()),
+            position_id=position_id,
+            body=body,
+            version=1,
+            updated_at=now_iso,
+            updated_by=None,
+        )
+        db.add(note)
+    else:
+        note.body = body
+        note.version = note.version + 1
+        note.updated_at = now_iso
+
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Failed to upsert thesis for position %s", position_id)
+        raise
+
+    db.refresh(note)
+    logger.info(
+        "Upserted thesis for position %s (version=%d)", position_id, note.version
+    )
+    return _row_to_response(note)

--- a/backend/app/services/sector_etf_map.py
+++ b/backend/app/services/sector_etf_map.py
@@ -1,0 +1,47 @@
+"""GICS-sector → SPDR-sector-ETF mapping (issue #280, plan §3.3 / §4.4).
+
+Hardcoded constants module used by the regression endpoint
+(``/api/positions/{id}/research/regression``) to pick the sector factor
+for the multifactor decomposition. yfinance returns the 11 GICS sector
+strings verbatim in ``Ticker.info["sector"]``; this module maps each one
+to the matching SPDR sector-ETF ticker.
+
+If yfinance returns a sector string we have not mapped (rare — GICS
+reclassifies sectors a handful of times per decade), or if the field is
+missing entirely (some foreign listings), :func:`resolve_sector_etf`
+returns ``None`` and the regression service falls back to a 2-factor
+basket (SPY + DGS10) per plan §3.3.
+"""
+
+from __future__ import annotations
+
+# Eleven GICS sectors. yfinance returns these strings verbatim; the map
+# is keyed by the exact spelling and casing.
+SECTOR_ETF_MAP: dict[str, str] = {
+    "Financial Services": "XLF",
+    "Technology": "XLK",
+    "Healthcare": "XLV",
+    "Energy": "XLE",
+    "Consumer Defensive": "XLP",
+    "Consumer Cyclical": "XLY",
+    "Industrials": "XLI",
+    "Basic Materials": "XLB",
+    "Utilities": "XLU",
+    "Real Estate": "XLRE",
+    "Communication Services": "XLC",
+}
+
+
+def resolve_sector_etf(sector: str | None) -> str | None:
+    """Return the SPDR sector ETF ticker for ``sector`` or ``None``.
+
+    ``None`` is returned when the input is falsy (``None``, empty string)
+    or when the sector string is not in :data:`SECTOR_ETF_MAP`. The lookup
+    is case-sensitive on purpose: yfinance is consistent, so a casing
+    mismatch is a real signal that the upstream string format has drifted
+    and the caller should fall back to a sector-less basket rather than
+    silently misclassify the position.
+    """
+    if not sector:
+        return None
+    return SECTOR_ETF_MAP.get(sector)

--- a/backend/app/services/sector_etf_map.py
+++ b/backend/app/services/sector_etf_map.py
@@ -1,0 +1,45 @@
+"""GICS sector → SPDR sector ETF mapping.
+
+Module-level constant mapping the 11 GICS sectors yfinance returns verbatim
+in ``Ticker.info["sector"]`` to their corresponding SPDR sector ETF tickers.
+Used by the per-position regression decomposition (issue #280) to pick a
+sector factor when the position's underlying has a known GICS sector.
+
+Frozen by issue #280 plan §3.3 / §4.4. If a sector is missing or unmapped,
+:func:`lookup_sector_etf` returns ``None`` and the caller is expected to
+run the regression with ``SPY + DGS10`` only (sector factor omitted).
+"""
+
+from __future__ import annotations
+
+SECTOR_ETF_MAP: dict[str, str] = {
+    "Financial Services": "XLF",
+    "Technology": "XLK",
+    "Healthcare": "XLV",
+    "Energy": "XLE",
+    "Consumer Defensive": "XLP",
+    "Consumer Cyclical": "XLY",
+    "Industrials": "XLI",
+    "Basic Materials": "XLB",
+    "Utilities": "XLU",
+    "Real Estate": "XLRE",
+    "Communication Services": "XLC",
+}
+
+
+def lookup_sector_etf(sector: str | None) -> str | None:
+    """Return the SPDR sector ETF ticker for a GICS sector string.
+
+    Lookup is case-sensitive against the exact yfinance strings (see
+    ``SECTOR_ETF_MAP``). Returns ``None`` when the sector is ``None``,
+    an empty/whitespace-only string, or not present in the map — the
+    caller must handle the sector-omitted branch.
+    """
+    if sector is None:
+        return None
+    if not isinstance(sector, str):
+        return None
+    key = sector.strip()
+    if not key:
+        return None
+    return SECTOR_ETF_MAP.get(key)

--- a/backend/app/services/yfinance_client.py
+++ b/backend/app/services/yfinance_client.py
@@ -1,0 +1,191 @@
+"""Thin defensive wrapper around yfinance for the research endpoints (#280).
+
+Two public functions:
+
+- :func:`fetch_business_info` — pulls the Section A payload from
+  ``yfinance.Ticker.info``. Returns the picked fields as a dict, or
+  ``None`` on any failure.
+- :func:`fetch_quarterly_income_stmt` — pulls the Section D fallback
+  payload from ``yfinance.Ticker.quarterly_income_stmt``. Returns up to
+  ``n`` quarters as a list of dicts (newest first), or ``None``.
+
+Defensive design (plan §4.11 + §8 Risk 1)
+-----------------------------------------
+
+- Every field access uses ``.get(name, default)`` — never bracket indexing.
+- Every yfinance call is wrapped in a broad ``except`` that logs at
+  WARNING and returns ``None``. Per CLAUDE.md, the API surface that
+  consumes these functions converts ``None`` to a sanitized 502 detail —
+  we never leak ``str(e)``.
+- yfinance is imported lazily inside the functions so importing this
+  module is cheap and does not pull yfinance's curl/protobuf transitive
+  deps into the FastAPI worker until a research endpoint is actually hit.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _coerce_optional_str(value: Any) -> str | None:
+    """Return a non-empty string or ``None``.
+
+    yfinance occasionally returns ``""`` or ``NaN`` instead of omitting a
+    field; both should be normalized to ``None`` so downstream callers
+    can branch cleanly.
+    """
+    if value is None:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if isinstance(value, str):
+        return value if value.strip() else None
+    return str(value)
+
+
+def _coerce_optional_number(value: Any) -> float | int | None:
+    """Coerce a yfinance numeric field, dropping NaNs and unconvertibles."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and math.isnan(value):
+            return None
+        return value
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def fetch_business_info(ticker: str) -> dict[str, Any] | None:
+    """Pull the Section A business-snapshot payload for ``ticker``.
+
+    Returns a dict with keys ``long_business_summary``, ``sector``,
+    ``industry``, ``market_cap``, ``employees`` — each value may be
+    ``None`` when yfinance omits the field (foreign listings often skip
+    ``sector``; private companies in the dataset skip employees). Returns
+    ``None`` only when yfinance itself raises or returns an empty info
+    payload, signalling a hard upstream failure.
+    """
+    try:
+        import yfinance  # local import to keep module import cheap
+    except ImportError:  # pragma: no cover — declared in requirements.txt
+        logger.warning("yfinance not installed; business lookup unavailable")
+        return None
+
+    try:
+        info = yfinance.Ticker(ticker).info or {}
+    except Exception as exc:  # noqa: BLE001 — defensive per plan §4.11
+        logger.warning("yfinance Ticker.info failed for %s: %s", ticker, exc)
+        return None
+
+    # An empty info dict means yfinance returned nothing useful — treat
+    # the call as a hard failure so the caller surfaces a 502.
+    if not isinstance(info, dict) or not info:
+        logger.warning("yfinance Ticker.info empty for %s", ticker)
+        return None
+
+    # Company name: prefer ``longName`` (e.g. "SoFi Technologies, Inc.");
+    # fall back to ``shortName`` (e.g. "SoFi Technologies Inc"). Both
+    # may be missing on some foreign listings; the API contract surfaces
+    # ``None`` in that case.
+    name = _coerce_optional_str(info.get("longName")) or _coerce_optional_str(
+        info.get("shortName")
+    )
+    return {
+        "name": name,
+        "long_business_summary": _coerce_optional_str(
+            info.get("longBusinessSummary")
+        ),
+        "sector": _coerce_optional_str(info.get("sector")),
+        "industry": _coerce_optional_str(info.get("industry")),
+        "market_cap": _coerce_optional_number(info.get("marketCap")),
+        "employees": _coerce_optional_number(info.get("fullTimeEmployees")),
+    }
+
+
+def fetch_quarterly_income_stmt(
+    ticker: str, n: int = 8
+) -> list[dict[str, Any]] | None:
+    """Pull up to ``n`` quarters of income-statement data for ``ticker``.
+
+    Used as the Section D fallback path when Alpha Vantage rate-limits.
+    Returns a list of per-quarter dicts (newest first) with normalized
+    keys ``fiscal_date_ending``, ``total_revenue``, ``gross_profit``,
+    ``operating_income``, ``net_income``, ``diluted_eps``. Missing fields
+    are surfaced as ``None`` (the API surface converts to JSON null);
+    callers compute derived metrics (gross_margin, operating_margin) from
+    the raw fields and surface ``None`` when a numerator or denominator
+    is missing.
+
+    Returns ``None`` only on a hard yfinance failure (call raised, empty
+    DataFrame, or library not installed).
+    """
+    try:
+        import pandas as pd
+        import yfinance
+    except ImportError:  # pragma: no cover — declared in requirements.txt
+        logger.warning("yfinance not installed; financials fallback unavailable")
+        return None
+
+    try:
+        ticker_obj = yfinance.Ticker(ticker)
+        statement = ticker_obj.quarterly_income_stmt
+    except Exception as exc:  # noqa: BLE001 — defensive per plan §4.11
+        logger.warning(
+            "yfinance quarterly_income_stmt failed for %s: %s", ticker, exc
+        )
+        return None
+
+    if statement is None or not isinstance(statement, pd.DataFrame):
+        logger.warning("yfinance returned non-DataFrame for %s", ticker)
+        return None
+    if statement.empty:
+        logger.warning("yfinance quarterly_income_stmt empty for %s", ticker)
+        return None
+
+    # yfinance returns columns = quarter-end Timestamps (most-recent first
+    # in 1.3.x, but order is documented as not guaranteed — sort to be
+    # safe), and rows = field names like "Total Revenue", "Gross Profit".
+    columns = sorted(statement.columns, reverse=True)[:n]
+
+    field_map = {
+        "total_revenue": ("Total Revenue", "TotalRevenue"),
+        "gross_profit": ("Gross Profit", "GrossProfit"),
+        "operating_income": ("Operating Income", "OperatingIncome"),
+        "net_income": ("Net Income", "NetIncome"),
+        "diluted_eps": ("Diluted EPS", "DilutedEPS", "Basic EPS"),
+    }
+
+    def _row_value(field_aliases: tuple[str, ...], column: Any) -> Any:
+        for alias in field_aliases:
+            if alias in statement.index:
+                raw = statement.at[alias, column]
+                return _coerce_optional_number(raw)
+        return None
+
+    quarters: list[dict[str, Any]] = []
+    for column in columns:
+        try:
+            fiscal_date = column.strftime("%Y-%m-%d")
+        except AttributeError:
+            fiscal_date = str(column)
+        quarters.append(
+            {
+                "fiscal_date_ending": fiscal_date,
+                "total_revenue": _row_value(field_map["total_revenue"], column),
+                "gross_profit": _row_value(field_map["gross_profit"], column),
+                "operating_income": _row_value(
+                    field_map["operating_income"], column
+                ),
+                "net_income": _row_value(field_map["net_income"], column),
+                "diluted_eps": _row_value(field_map["diluted_eps"], column),
+            }
+        )
+    return quarters

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,3 +21,4 @@ scipy==1.14.1
 PyJWT==2.12.0
 cryptography==46.0.7
 PyYAML==6.0.2
+yfinance>=0.2.50

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,4 +21,4 @@ scipy==1.14.1
 PyJWT==2.12.0
 cryptography==46.0.7
 PyYAML==6.0.2
-yfinance>=0.2.50
+yfinance==0.2.50

--- a/backend/tests/test_acceptance_phase4.py
+++ b/backend/tests/test_acceptance_phase4.py
@@ -191,9 +191,32 @@ class TestAC3_ScannerCompletesWhenAlphaVantageReturnsNone:
         assert len(result["recommendations"]) >= 1
 
 
-class TestAC4_YfinanceRemovedFromRequirements:
-    """AC: yfinance fully removed from requirements.txt."""
+# NOTE (issue #280 / v1.1.0): the original Phase-4 milestone removed
+# yfinance from the *earnings-date* path and replaced it with Alpha
+# Vantage. That goal is preserved — see ``test_alpha_vantage_client.py``
+# and ``app/services/alpha_vantage_client.py``. The v1.1.0 PRD
+# (Discussion #282, "Technical Decisions (Resolved)" §1 and §"API
+# Contracts → A") authorizes re-introducing yfinance for the per-position
+# research surface (``app/services/yfinance_client.py``). The two test
+# classes below pinned the *blanket* yfinance ban from the old milestone
+# and are now superseded by the narrower invariant ("yfinance must not
+# be used for earnings dates", which is tested directly via the AV
+# earnings client suite). They are skipped here for the audit trail.
 
+
+class TestAC4_YfinanceRemovedFromRequirements:
+    """AC (superseded): yfinance fully removed from requirements.txt.
+
+    Superseded by issue #280 — yfinance is the v1 source for the
+    research/business endpoint (PRD §"API Contracts → A").
+    """
+
+    @pytest.mark.skip(
+        reason="Superseded by #280 / v1.1.0 PRD — yfinance is the v1 "
+        "source for /api/positions/{id}/research/business. The "
+        "Phase-4 invariant (no yfinance for earnings dates) is "
+        "preserved and tested via the AV earnings client suite."
+    )
     def test_requirements_has_no_yfinance(self):
         requirements_path = BACKEND_ROOT / "requirements.txt"
         content = requirements_path.read_text()
@@ -201,8 +224,15 @@ class TestAC4_YfinanceRemovedFromRequirements:
 
 
 class TestAC5_NoYfinanceImportsInAnyFile:
-    """AC: No remaining yfinance imports in any file (verified by CI)."""
+    """AC (superseded): No remaining yfinance imports in any file.
 
+    Superseded by issue #280 — :mod:`app.services.yfinance_client` is the
+    new, scoped yfinance integration for the research surface.
+    """
+
+    @pytest.mark.skip(
+        reason="Superseded by #280 / v1.1.0 — see class docstring."
+    )
     def test_no_yfinance_imports_in_any_python_file(self):
         """Walk all .py files under backend/app/ and assert no yfinance imports."""
         violations = []
@@ -223,6 +253,9 @@ class TestAC5_NoYfinanceImportsInAnyFile:
 
         assert violations == [], "yfinance imports found:\n" + "\n".join(violations)
 
+    @pytest.mark.skip(
+        reason="Superseded by #280 / v1.1.0 — see class docstring."
+    )
     def test_no_yf_name_references_in_source(self):
         """No 'yf.' usage pattern in any source file."""
         violations = []

--- a/backend/tests/test_alpha_vantage_client.py
+++ b/backend/tests/test_alpha_vantage_client.py
@@ -265,3 +265,74 @@ class TestGetCachedNextEarningsDate:
                 result = get_cached_next_earnings_date("AAPL")
         assert result == "2026-07-01"
         mock_get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression: cache by-symbol must store the full payload so a small-``n``
+# request never poisons a later larger-``n`` request (CR #2, PR #283).
+# Appended per the v1.1.0 worker convention — does not modify existing tests.
+# ---------------------------------------------------------------------------
+
+
+class TestGetIncomeStatementCacheNPoisoning:
+    """The in-memory and DB caches must not cap entries to the first n quarters.
+
+    Repro: first caller asks for ``n=2``; later caller asks for ``n=8`` and
+    needs the same symbol — before CR #2 the cache stored the 2-element
+    slice and the second caller got only 2 quarters back instead of 8.
+    """
+
+    def _make_quarterly_body(self, k: int) -> dict:
+        """Build an AV ``INCOME_STATEMENT`` JSON body with ``k`` quarters."""
+        return {
+            "symbol": "SOFI",
+            "quarterlyReports": [
+                {
+                    "fiscalDateEnding": f"2024-{(12 - i):02d}-31",
+                    "totalRevenue": str(645000000 + i * 1000000),
+                    "reportedEPS": "0.02",
+                    "grossProfit": "277350000",
+                    "operatingIncome": "25800000",
+                }
+                for i in range(k)
+            ],
+        }
+
+    @patch(
+        "app.services.alpha_vantage_client._write_income_db_cache",
+        new=MagicMock(),
+    )
+    @patch(
+        "app.services.alpha_vantage_client._read_income_db_cache",
+        new=MagicMock(return_value=None),
+    )
+    @patch("app.services.alpha_vantage_client.get_alpha_vantage_api_key")
+    @patch("app.services.alpha_vantage_client.requests.get")
+    def test_small_n_then_large_n_returns_full_payload(self, mock_get, mock_key):
+        from app.services.alpha_vantage_client import (
+            get_income_statement,
+            clear_income_cache,
+        )
+
+        clear_income_cache()
+        mock_key.return_value = "test_key"
+
+        body = self._make_quarterly_body(8)
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = body
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+
+        # First call asks for 2; before CR #2 the cache kept only 2.
+        first = get_income_statement("SOFI", n=2)
+        assert first is not None
+        assert len(first) == 2
+
+        # Second call asks for 8 — must NOT re-fetch, must return 8 from cache.
+        second = get_income_statement("SOFI", n=8)
+        assert second is not None
+        assert len(second) == 8
+        # Exactly one upstream request — the second call was a cache hit.
+        assert mock_get.call_count == 1
+        clear_income_cache()

--- a/backend/tests/test_position_notes_model.py
+++ b/backend/tests/test_position_notes_model.py
@@ -1,0 +1,221 @@
+"""Migration + integrity tests for the ``position_notes`` table (issue #280).
+
+The project has no Alembic — ``init_db()`` simply calls
+``Base.metadata.create_all(bind=engine)`` and SQLAlchemy is idempotent.
+These tests assert the table appears on a fresh DB, that the FK + UNIQUE
+constraints hold, and that the "down" path (manual ``DROP TABLE``)
+cleanly removes the table without disturbing siblings. This stands in
+for the missing Alembic ``downgrade`` step the implementation plan
+explicitly documents as a manual operation.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, event, inspect, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import Base, Position, PositionNote
+
+
+def _make_engine():
+    """Build an isolated in-memory SQLite engine with FK enforcement on."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    # SQLite has FK support off by default — enable it so the FK column
+    # on position_notes actually rejects orphans.
+    @event.listens_for(engine, "connect")
+    def _fk_on(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    return engine
+
+
+def _seed_position(session, position_id: str | None = None) -> str:
+    """Insert a minimal Position and return its id."""
+    pid = position_id or str(uuid.uuid4())
+    session.add(
+        Position(
+            id=pid,
+            ticker="AAPL",
+            shares=100,
+            broker_cost_basis=15000.0,
+            status="open",
+            strategy="csp",
+            opened_at="2026-01-01T00:00:00Z",
+        )
+    )
+    session.commit()
+    return pid
+
+
+# --- Migration up: table appears via create_all ---
+
+
+def test_create_all_creates_position_notes_table():
+    """``Base.metadata.create_all`` materializes the new table."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    inspector = inspect(engine)
+    assert "position_notes" in inspector.get_table_names()
+
+
+def test_position_notes_columns_match_plan():
+    """Frozen column set per plan §3.2 / §4.3."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    inspector = inspect(engine)
+    cols = {c["name"]: c for c in inspector.get_columns("position_notes")}
+    assert set(cols.keys()) == {
+        "id",
+        "position_id",
+        "body",
+        "version",
+        "updated_at",
+        "updated_by",
+    }
+    # ``body`` is the column name the API and frontend round-trip on —
+    # rename-here would break the contract.
+    assert "body" in cols
+
+
+def test_position_notes_position_id_indexed():
+    """``position_id`` is indexed (frequent lookup column)."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    inspector = inspect(engine)
+    indexes = inspector.get_indexes("position_notes")
+    indexed_cols = {col for idx in indexes for col in idx["column_names"]}
+    assert "position_id" in indexed_cols
+
+
+# --- Migration down: explicit DROP TABLE cleans up ---
+
+
+def test_drop_table_removes_position_notes_without_touching_positions():
+    """The documented manual rollback path removes only the new table."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    inspector = inspect(engine)
+    assert "position_notes" in inspector.get_table_names()
+    assert "positions" in inspector.get_table_names()
+
+    with engine.begin() as conn:
+        conn.execute(text("DROP TABLE position_notes"))
+
+    # Re-introspect with a fresh inspector — SQLAlchemy caches tables.
+    inspector = inspect(engine)
+    assert "position_notes" not in inspector.get_table_names()
+    assert "positions" in inspector.get_table_names()
+
+
+def test_create_all_is_idempotent():
+    """Calling ``create_all`` twice on an existing DB is a no-op."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    # Second call must not raise even though the table already exists.
+    Base.metadata.create_all(bind=engine)
+    inspector = inspect(engine)
+    assert "position_notes" in inspector.get_table_names()
+
+
+# --- Constraint enforcement ---
+
+
+def test_unique_constraint_on_position_id():
+    """A single position can hold only one note row."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        pid = _seed_position(session)
+
+        session.add(
+            PositionNote(
+                id=str(uuid.uuid4()),
+                position_id=pid,
+                body="first",
+                version=1,
+                updated_at="2026-01-01T00:00:00Z",
+            )
+        )
+        session.commit()
+
+        session.add(
+            PositionNote(
+                id=str(uuid.uuid4()),
+                position_id=pid,
+                body="second",
+                version=1,
+                updated_at="2026-01-01T00:00:00Z",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+    finally:
+        session.close()
+
+
+def test_fk_rejects_orphan_position_id():
+    """A note pointing at a non-existent position is rejected."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        session.add(
+            PositionNote(
+                id=str(uuid.uuid4()),
+                position_id="does-not-exist",
+                body="orphan",
+                version=1,
+                updated_at="2026-01-01T00:00:00Z",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            session.commit()
+        session.rollback()
+    finally:
+        session.close()
+
+
+def test_body_roundtrips_unchanged():
+    """``body`` is the column name and the text survives a round-trip."""
+    engine = _make_engine()
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        pid = _seed_position(session)
+        original = "Long thesis with newlines\n\nand unicode — café —."
+        session.add(
+            PositionNote(
+                id=str(uuid.uuid4()),
+                position_id=pid,
+                body=original,
+                version=1,
+                updated_at="2026-01-01T00:00:00Z",
+            )
+        )
+        session.commit()
+
+        fetched = (
+            session.query(PositionNote)
+            .filter(PositionNote.position_id == pid)
+            .one()
+        )
+        assert fetched.body == original
+    finally:
+        session.close()

--- a/backend/tests/test_regression_summary.py
+++ b/backend/tests/test_regression_summary.py
@@ -1,0 +1,329 @@
+"""Tests for the plain-English regression summary generator (issue #280).
+
+Covers the four worked examples from frontend/design-specs/issue-280-stock-research.md
+§4 Section E (SOFI, AAPL, TLT, idiosyncratic biotech) plus the rule-3 sign-aware
+phrasing branches and the sector-omitted special handling.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.regression_summary import (
+    SummaryFactor,
+    build_regression_summary,
+)
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+def _factor(
+    name: str,
+    *,
+    beta: float | None,
+    p_value: float | None,
+    contribution: float,
+) -> SummaryFactor:
+    """Convenience constructor for SummaryFactor TypedDict instances."""
+    return {  # type: ignore[return-value]
+        "name": name,  # type: ignore[typeddict-item]
+        "beta": beta,
+        "p_value": p_value,
+        "contribution": contribution,
+    }
+
+
+# --- Spec example fixtures -------------------------------------------------
+
+
+SOFI_FACTORS: list[SummaryFactor] = [
+    _factor("market", beta=1.42, p_value=0.001, contribution=0.60),
+    # Sector contribution below the 0.10 threshold so only rates surfaces
+    # as a meaningful secondary, matching the spec example string.
+    _factor("sector", beta=0.78, p_value=0.04, contribution=0.08),
+    _factor("rates", beta=-0.61, p_value=0.02, contribution=0.15),
+    _factor("idiosyncratic", beta=None, p_value=None, contribution=0.17),
+]
+
+
+AAPL_FACTORS: list[SummaryFactor] = [
+    _factor("market", beta=1.10, p_value=0.001, contribution=0.55),
+    _factor("sector", beta=0.62, p_value=0.03, contribution=0.18),
+    # Rates beta below the |beta|>0.5 threshold → not meaningful.
+    _factor("rates", beta=-0.12, p_value=0.40, contribution=0.05),
+    _factor("idiosyncratic", beta=None, p_value=None, contribution=0.22),
+]
+
+
+TLT_FACTORS: list[SummaryFactor] = [
+    # Rates dominate (0.30 < contribution <= 0.50 → "Primarily"); the
+    # remaining factors are non-meaningful so the fallback "market exposure
+    # is minor" clause fires.
+    _factor("market", beta=0.20, p_value=0.30, contribution=0.20),
+    _factor("sector", beta=0.10, p_value=0.20, contribution=0.15),
+    _factor("rates", beta=-1.80, p_value=0.001, contribution=0.40),
+    _factor("idiosyncratic", beta=None, p_value=None, contribution=0.25),
+]
+
+
+BIOTECH_FACTORS: list[SummaryFactor] = [
+    # Binary-event biotech: most of variance is unexplained.
+    _factor("market", beta=0.4, p_value=0.20, contribution=0.18),
+    _factor("sector", beta=0.3, p_value=0.20, contribution=0.12),
+    _factor("rates", beta=-0.10, p_value=0.50, contribution=0.10),
+    _factor("idiosyncratic", beta=None, p_value=None, contribution=0.60),
+]
+
+
+# --- Spec example tests ----------------------------------------------------
+
+
+def test_spec_example_sofi_rate_sensitive_financial() -> None:
+    """SOFI: dominant market, secondary rate exposure (negative)."""
+    out = build_regression_summary(
+        factors=SOFI_FACTORS,
+        r_squared=0.83,
+        sample_size=252,
+        sector_omitted=False,
+    )
+    assert out == (
+        "Mostly market-driven; rate exposure is meaningful and negative. "
+        "R²=0.83 over 252 trading days."
+    )
+
+
+def test_spec_example_aapl_low_rates_tech_heavy() -> None:
+    """AAPL: dominant market, secondary sector adds positively."""
+    out = build_regression_summary(
+        factors=AAPL_FACTORS,
+        r_squared=0.78,
+        sample_size=252,
+        sector_omitted=False,
+    )
+    assert out == (
+        "Mostly market-driven; sector exposure adds positively. "
+        "R²=0.78 over 252 trading days."
+    )
+
+
+def test_spec_example_tlt_rate_tracker() -> None:
+    """TLT: dominant rates, market exposure is minor (non-meaningful fallback)."""
+    out = build_regression_summary(
+        factors=TLT_FACTORS,
+        r_squared=0.91,
+        sample_size=252,
+        sector_omitted=False,
+    )
+    assert out == (
+        "Primarily rate-driven; market exposure is minor. "
+        "R²=0.91 over 252 trading days."
+    )
+
+
+def test_spec_example_idiosyncratic_biotech() -> None:
+    """Biotech: idiosyncratic-dominant special form."""
+    out = build_regression_summary(
+        factors=BIOTECH_FACTORS,
+        r_squared=0.40,
+        sample_size=252,
+        sector_omitted=False,
+    )
+    assert out == (
+        "Mostly idiosyncratic — 60% of variance unexplained by "
+        "market/sector/rates. R²=0.40 over 252 trading days."
+    )
+
+
+# --- Rule branch coverage --------------------------------------------------
+
+
+def test_rule_2_primarily_when_dominant_between_30_and_50_pct() -> None:
+    """Rule 2: ``Primarily`` label kicks in for 0.30 < dominant <= 0.50."""
+    factors = [
+        _factor("market", beta=1.0, p_value=0.001, contribution=0.40),
+        _factor("sector", beta=0.2, p_value=0.30, contribution=0.20),
+        _factor("rates", beta=-0.1, p_value=0.40, contribution=0.10),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.30),
+    ]
+    out = build_regression_summary(
+        factors=factors, r_squared=0.70, sample_size=252
+    )
+    assert out.startswith("Primarily market-driven")
+
+
+def test_rule_2_diversified_when_no_factor_above_30_pct() -> None:
+    """Rule 2: ``Diversified driver mix`` when no factor dominates."""
+    factors = [
+        _factor("market", beta=0.4, p_value=0.10, contribution=0.25),
+        _factor("sector", beta=0.3, p_value=0.10, contribution=0.25),
+        _factor("rates", beta=-0.2, p_value=0.10, contribution=0.20),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.30),
+    ]
+    out = build_regression_summary(
+        factors=factors, r_squared=0.70, sample_size=252
+    )
+    # Idiosyncratic is dominant here at 0.30 — wait, that ties rule 2 too.
+    # We want the canonical "Diversified" output, so bump market to 0.31
+    # so it dominates without crossing 0.30 strictly.
+    factors2 = [
+        _factor("market", beta=0.4, p_value=0.10, contribution=0.30),
+        _factor("sector", beta=0.3, p_value=0.10, contribution=0.25),
+        _factor("rates", beta=-0.2, p_value=0.10, contribution=0.20),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.25),
+    ]
+    out2 = build_regression_summary(
+        factors=factors2, r_squared=0.70, sample_size=252
+    )
+    # market.contribution = 0.30, not strictly > 0.30, so "Diversified" wins.
+    assert out2.startswith("Diversified driver mix")
+    # First call's dominant is idiosyncratic at 0.30 (still tied with market);
+    # since max() takes the first occurrence of equal values among the
+    # iteration order, idiosyncratic wins here only if it appears first.
+    # We don't assert on `out`; the second case is the deterministic one.
+    del out
+
+
+def test_rule_3_positive_beta_on_rates_renders_meaningful_and_positive() -> None:
+    """Sign-aware: positive rate beta produces ``...and positive``."""
+    factors = [
+        _factor("market", beta=1.0, p_value=0.001, contribution=0.55),
+        _factor("rates", beta=0.7, p_value=0.01, contribution=0.20),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.25),
+    ]
+    out = build_regression_summary(
+        factors=factors, r_squared=0.75, sample_size=252
+    )
+    assert "rate exposure is meaningful and positive" in out
+
+
+def test_rule_3_negative_beta_on_sector_renders_detracts() -> None:
+    """Sign-aware: negative sector beta produces ``sector exposure detracts``."""
+    factors = [
+        _factor("market", beta=1.0, p_value=0.001, contribution=0.60),
+        _factor("sector", beta=-0.65, p_value=0.04, contribution=0.18),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.22),
+    ]
+    out = build_regression_summary(
+        factors=factors, r_squared=0.78, sample_size=252
+    )
+    assert "sector exposure detracts" in out
+
+
+def test_rule_3_non_meaningful_factor_is_excluded() -> None:
+    """A factor with p>0.05 is dropped from the meaningful list."""
+    factors = [
+        _factor("market", beta=1.0, p_value=0.001, contribution=0.60),
+        _factor("sector", beta=0.7, p_value=0.50, contribution=0.15),  # p too high
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.25),
+    ]
+    out = build_regression_summary(
+        factors=factors, r_squared=0.75, sample_size=252
+    )
+    # No qualifying meaningful factor → fallback "market exposure is minor"?
+    # No — market is dominant. The non-dominant non-meaningful sector falls
+    # through to the "minor" fallback because dominant > 0.50.
+    assert out == (
+        "Mostly market-driven; sector exposure is minor. "
+        "R²=0.75 over 252 trading days."
+    )
+
+
+# --- Sector-omitted branch -------------------------------------------------
+
+
+def test_sector_omitted_skips_sector_clause() -> None:
+    """When the sector factor is omitted, the rules skip any sector clause."""
+    factors = [
+        _factor("market", beta=1.2, p_value=0.001, contribution=0.65),
+        _factor("rates", beta=-0.7, p_value=0.02, contribution=0.20),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.15),
+    ]
+    out = build_regression_summary(
+        factors=factors,
+        r_squared=0.85,
+        sample_size=252,
+        sector_omitted=True,
+    )
+    assert "sector" not in out.lower()
+    assert "rate exposure is meaningful and negative" in out
+
+
+def test_sector_omitted_idiosyncratic_uses_two_factor_basket_phrase() -> None:
+    """Idiosyncratic-dominant + sector-omitted lists market/rates only."""
+    factors = [
+        _factor("market", beta=0.3, p_value=0.30, contribution=0.20),
+        _factor("rates", beta=-0.1, p_value=0.40, contribution=0.10),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.70),
+    ]
+    out = build_regression_summary(
+        factors=factors,
+        r_squared=0.30,
+        sample_size=252,
+        sector_omitted=True,
+    )
+    assert "market/rates" in out
+    assert "market/sector/rates" not in out
+
+
+# --- Format / cap coverage -------------------------------------------------
+
+
+def test_r_squared_is_two_decimals() -> None:
+    """R² renders with two decimals (matches spec examples)."""
+    factors = [
+        _factor("market", beta=1.0, p_value=0.01, contribution=0.55),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.45),
+    ]
+    out = build_regression_summary(factors=factors, r_squared=0.123456, sample_size=200)
+    assert "R²=0.12 over 200 trading days" in out
+
+
+def test_summary_is_at_most_120_characters_under_normal_conditions() -> None:
+    """All four spec examples + the rule-branch tests stay under 120 chars."""
+    cases = [SOFI_FACTORS, AAPL_FACTORS, TLT_FACTORS, BIOTECH_FACTORS]
+    for c in cases:
+        out = build_regression_summary(factors=c, r_squared=0.80, sample_size=252)
+        assert len(out) <= 120, f"summary exceeds 120 chars: {out!r}"
+
+
+def test_empty_factors_returns_safe_fallback() -> None:
+    """Defensive: empty factor list still returns a deterministic string."""
+    out = build_regression_summary(
+        factors=[], r_squared=0.0, sample_size=0, sector_omitted=False
+    )
+    assert "Insufficient data" in out
+    assert "R²=0.00 over 0 trading days" in out
+
+
+@pytest.mark.parametrize(
+    "p_value, abs_beta, contribution, expected_meaningful",
+    [
+        (0.04, 0.6, 0.15, True),
+        (0.06, 0.6, 0.15, False),  # p too high
+        (0.04, 0.4, 0.15, False),  # |beta| too low
+        (0.04, 0.6, 0.05, False),  # contribution too low
+    ],
+)
+def test_rule_3_predicate_thresholds(
+    p_value: float, abs_beta: float, contribution: float, expected_meaningful: bool
+) -> None:
+    """Rule 3 predicate is strict on all three thresholds."""
+    factors = [
+        _factor("market", beta=1.0, p_value=0.001, contribution=0.60),
+        _factor(
+            "rates",
+            beta=-abs_beta,
+            p_value=p_value,
+            contribution=contribution,
+        ),
+        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.20),
+    ]
+    out = build_regression_summary(
+        factors=factors, r_squared=0.78, sample_size=252
+    )
+    if expected_meaningful:
+        assert "rate exposure is meaningful and negative" in out
+    else:
+        # Non-meaningful → either no rate clause or "minor" fallback.
+        assert "rate exposure is meaningful and negative" not in out

--- a/backend/tests/test_regression_summary.py
+++ b/backend/tests/test_regression_summary.py
@@ -153,35 +153,21 @@ def test_rule_2_primarily_when_dominant_between_30_and_50_pct() -> None:
 
 
 def test_rule_2_diversified_when_no_factor_above_30_pct() -> None:
-    """Rule 2: ``Diversified driver mix`` when no factor dominates."""
+    """Rule 2: ``Diversified driver mix`` when no factor dominates.
+
+    Boundary case: dominant contribution at exactly 0.30 should still
+    produce the diversified label (>0.30 is required to escape it).
+    """
     factors = [
-        _factor("market", beta=0.4, p_value=0.10, contribution=0.25),
-        _factor("sector", beta=0.3, p_value=0.10, contribution=0.25),
-        _factor("rates", beta=-0.2, p_value=0.10, contribution=0.20),
-        _factor("idiosyncratic", beta=None, p_value=None, contribution=0.30),
-    ]
-    out = build_regression_summary(
-        factors=factors, r_squared=0.70, sample_size=252
-    )
-    # Idiosyncratic is dominant here at 0.30 — wait, that ties rule 2 too.
-    # We want the canonical "Diversified" output, so bump market to 0.31
-    # so it dominates without crossing 0.30 strictly.
-    factors2 = [
         _factor("market", beta=0.4, p_value=0.10, contribution=0.30),
         _factor("sector", beta=0.3, p_value=0.10, contribution=0.25),
         _factor("rates", beta=-0.2, p_value=0.10, contribution=0.20),
         _factor("idiosyncratic", beta=None, p_value=None, contribution=0.25),
     ]
-    out2 = build_regression_summary(
-        factors=factors2, r_squared=0.70, sample_size=252
+    out = build_regression_summary(
+        factors=factors, r_squared=0.70, sample_size=252
     )
-    # market.contribution = 0.30, not strictly > 0.30, so "Diversified" wins.
-    assert out2.startswith("Diversified driver mix")
-    # First call's dominant is idiosyncratic at 0.30 (still tied with market);
-    # since max() takes the first occurrence of equal values among the
-    # iteration order, idiosyncratic wins here only if it appears first.
-    # We don't assert on `out`; the second case is the deterministic one.
-    del out
+    assert out.startswith("Diversified driver mix")
 
 
 def test_rule_3_positive_beta_on_rates_renders_meaningful_and_positive() -> None:

--- a/backend/tests/test_research_business.py
+++ b/backend/tests/test_research_business.py
@@ -1,0 +1,269 @@
+"""Tests for Section A — Business snapshot service (issue #280, W-A).
+
+Covers :func:`app.services.research_business.build_business_payload` plus
+the two-tier cache and the sanitized-502 error path. The yfinance call
+is always patched via the ``fetcher`` injection hook on the service
+function — no real Yahoo Finance traffic in tests.
+
+These tests are service-level (not HTTP). The HTTP wiring lives in
+``backend/app/routers/research.py`` (owned by Worker W); when that router
+lands, it will map :class:`ResearchSourceUnavailable` to a 502 with the
+same sanitized detail the service exposes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.database import AppSetting
+from app.services import research_business, research_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_research_cache():
+    """Drop the in-memory research cache between tests."""
+    research_cache.clear()
+    yield
+    research_cache.clear()
+
+
+def _seed_position(client, *, ticker: str = "SOFI", pos_id: str = "p-1") -> str:
+    """Insert a position so the future router has something to look up."""
+    from app.main import app
+    from app.models.database import Position, get_db
+
+    override = app.dependency_overrides[get_db]
+    db = next(override())
+    try:
+        pos = Position(
+            id=pos_id,
+            ticker=ticker,
+            shares=100,
+            broker_cost_basis=2856.0,
+            status="open",
+            strategy="csp",
+            opened_at="2024-01-01",
+        )
+        db.add(pos)
+        db.commit()
+    finally:
+        db.close()
+    return pos_id
+
+
+def _db_session(client):
+    """Pull a session bound to the in-memory test DB."""
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    return next(override())
+
+
+def _fake_info(**overrides: Any) -> dict[str, Any]:
+    """Build a yfinance-shaped business info dict for fixtures."""
+    base = {
+        "name": "SoFi Technologies, Inc.",
+        "long_business_summary": "SoFi is a personal finance company.",
+        "sector": "Financial Services",
+        "industry": "Credit Services",
+        "market_cap": 18230000000,
+        "employees": 4900,
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+def test_build_business_payload_success_returns_payload(client):
+    """yfinance returns full info → payload matches PRD contract verbatim."""
+    _seed_position(client)
+    db = _db_session(client)
+    fetcher = MagicMock(return_value=_fake_info())
+
+    payload = research_business.build_business_payload(
+        db, "SOFI", fetcher=fetcher
+    )
+
+    assert payload["ticker"] == "SOFI"
+    assert payload["name"] == "SoFi Technologies, Inc."
+    assert payload["summary"].startswith("SoFi is")
+    assert payload["sector"] == "Financial Services"
+    assert payload["industry"] == "Credit Services"
+    assert payload["market_cap"] == 18230000000
+    assert payload["employees"] == 4900
+    assert payload["source"] == "yfinance"
+    # ISO-8601 with trailing Z per PRD example
+    assert payload["fetched_at"].endswith("Z")
+    fetcher.assert_called_once_with("SOFI")
+
+
+def test_build_business_payload_normalizes_ticker_to_upper(client):
+    """Lowercase ticker is uppercased before the fetch and in the payload."""
+    _seed_position(client, ticker="sofi")
+    db = _db_session(client)
+    fetcher = MagicMock(return_value=_fake_info())
+
+    payload = research_business.build_business_payload(
+        db, "sofi", fetcher=fetcher
+    )
+
+    assert payload["ticker"] == "SOFI"
+    fetcher.assert_called_once_with("SOFI")
+
+
+def test_build_business_payload_surfaces_partial_fields_as_none(client):
+    """yfinance omitted fields → JSON null, not fabricated values."""
+    _seed_position(client)
+    db = _db_session(client)
+    fetcher = MagicMock(
+        return_value=_fake_info(
+            employees=None,
+            market_cap=None,
+            industry=None,
+        )
+    )
+
+    payload = research_business.build_business_payload(
+        db, "SOFI", fetcher=fetcher
+    )
+
+    assert payload["employees"] is None
+    assert payload["market_cap"] is None
+    assert payload["industry"] is None
+    # Other fields untouched
+    assert payload["sector"] == "Financial Services"
+
+
+# ---------------------------------------------------------------------------
+# Upstream failure → 502 (sanitized)
+# ---------------------------------------------------------------------------
+
+
+def test_build_business_payload_raises_when_yfinance_returns_none(client):
+    """yfinance hard fail → ResearchSourceUnavailable with sanitized detail."""
+    _seed_position(client)
+    db = _db_session(client)
+    fetcher = MagicMock(return_value=None)
+
+    with pytest.raises(research_business.ResearchSourceUnavailable) as exc:
+        research_business.build_business_payload(db, "SOFI", fetcher=fetcher)
+
+    # CLAUDE.md compliance: the detail string is the generic
+    # "Source unavailable" message, never an inner exception's str().
+    assert exc.value.detail == "Source unavailable"
+    assert str(exc.value) == "Source unavailable"
+
+
+# ---------------------------------------------------------------------------
+# Cache hit — in-memory tier
+# ---------------------------------------------------------------------------
+
+
+def test_in_memory_cache_hit_skips_yfinance_on_second_call(client):
+    """Second call inside TTL serves from research_cache — no fetcher call."""
+    _seed_position(client)
+    db = _db_session(client)
+    fetcher = MagicMock(return_value=_fake_info())
+
+    first = research_business.build_business_payload(
+        db, "SOFI", fetcher=fetcher
+    )
+    second = research_business.build_business_payload(
+        db, "SOFI", fetcher=fetcher
+    )
+
+    assert first == second
+    assert fetcher.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Cache hit — durable app_settings tier
+# ---------------------------------------------------------------------------
+
+
+def test_app_setting_cache_hit_skips_yfinance_after_in_memory_eviction(
+    client,
+):
+    """Pre-seed app_settings → call serves the row without hitting yfinance."""
+    _seed_position(client)
+    db = _db_session(client)
+
+    fixture_payload = {
+        "ticker": "SOFI",
+        "name": "SoFi Technologies, Inc.",
+        "summary": "Pre-seeded.",
+        "sector": "Financial Services",
+        "industry": "Credit Services",
+        "market_cap": 18230000000,
+        "employees": 4900,
+        "source": "yfinance",
+        "fetched_at": "2026-05-22T17:30:00Z",
+    }
+    import json
+
+    fetched_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    db.add(
+        AppSetting(
+            key="yf_business:SOFI",
+            value=f"{fetched_at.isoformat()}|{json.dumps(fixture_payload)}",
+        )
+    )
+    db.commit()
+
+    # In-memory tier is empty (autouse fixture) — only the app_settings
+    # row should resolve this call.
+    fetcher = MagicMock(return_value=_fake_info(name="WRONG"))
+    payload = research_business.build_business_payload(
+        db, "SOFI", fetcher=fetcher
+    )
+
+    fetcher.assert_not_called()
+    assert payload["name"] == "SoFi Technologies, Inc."
+    assert payload["summary"] == "Pre-seeded."
+
+
+def test_stale_app_setting_falls_through_to_yfinance(client):
+    """app_settings row older than 24h → yfinance is called again."""
+    _seed_position(client)
+    db = _db_session(client)
+
+    stale_payload = {
+        "ticker": "SOFI",
+        "name": "STALE",
+        "summary": "Stale.",
+        "sector": "Financial Services",
+        "industry": "Credit Services",
+        "market_cap": 1,
+        "employees": 1,
+        "source": "yfinance",
+        "fetched_at": "2025-01-01T00:00:00Z",
+    }
+    import json
+
+    fetched_at = datetime.now(timezone.utc) - timedelta(hours=48)
+    db.add(
+        AppSetting(
+            key="yf_business:SOFI",
+            value=f"{fetched_at.isoformat()}|{json.dumps(stale_payload)}",
+        )
+    )
+    db.commit()
+
+    fetcher = MagicMock(return_value=_fake_info(name="FRESH"))
+    payload = research_business.build_business_payload(
+        db, "SOFI", fetcher=fetcher
+    )
+
+    fetcher.assert_called_once_with("SOFI")
+    # Fresh fetcher value is surfaced, not the stale app_settings row
+    assert payload["name"] == "FRESH"
+    assert payload["name"] != "STALE"

--- a/backend/tests/test_research_business_router.py
+++ b/backend/tests/test_research_business_router.py
@@ -1,0 +1,122 @@
+"""Router-shell tests for ``GET /api/positions/{id}/research/business`` (#280, W).
+
+The service layer (:mod:`app.services.research_business`) is already covered
+exhaustively in ``tests/test_research_business.py``. This module covers only
+the HTTP wiring Worker W added:
+
+- Position not found → 404 with sanitized detail
+- Service raises :class:`ResearchSourceUnavailable` → 502 with sanitized detail
+- Happy path → 200 + payload that conforms to :class:`BusinessResponse`
+- Unexpected exception → 500 with the generic CLAUDE.md detail
+
+yfinance is never hit. We patch the service-level upstream by injecting a
+test ``fetcher`` via :func:`app.services.research_business.build_business_payload`
+through a tiny monkey-patch on the module-global default — the same hook
+the service tests use.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services import research_cache, yfinance_client
+
+
+@pytest.fixture(autouse=True)
+def _clear_research_cache():
+    """Drop the in-memory research cache between tests (mirrors service tests)."""
+    research_cache.clear()
+    yield
+    research_cache.clear()
+
+
+def _create_position(client, ticker: str = "SOFI") -> str:
+    """POST a minimal position and return its id."""
+    resp = client.post(
+        "/api/journal/positions",
+        json={
+            "ticker": ticker,
+            "shares": 100,
+            "broker_cost_basis": 2856.0,
+            "opened_at": "2026-01-15T10:00:00Z",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _fake_info() -> dict:
+    """Build a yfinance-shaped business info dict (mirrors service-test fixture)."""
+    return {
+        "name": "SoFi Technologies, Inc.",
+        "long_business_summary": "SoFi is a personal finance company.",
+        "sector": "Financial Services",
+        "industry": "Credit Services",
+        "market_cap": 18230000000,
+        "employees": 4900,
+    }
+
+
+def test_get_business_404_for_missing_position(client):
+    """Unknown ``position_id`` → 404 with sanitized detail (never str(e))."""
+    resp = client.get("/api/positions/does-not-exist/research/business")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Position not found"}
+
+
+def test_get_business_200_returns_payload(client):
+    """yfinance returns full info → 200 with the BusinessResponse shape."""
+    pid = _create_position(client)
+    with patch.object(yfinance_client, "fetch_business_info", return_value=_fake_info()):
+        resp = client.get(f"/api/positions/{pid}/research/business")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ticker"] == "SOFI"
+    assert body["name"] == "SoFi Technologies, Inc."
+    assert body["summary"].startswith("SoFi is")
+    assert body["sector"] == "Financial Services"
+    assert body["industry"] == "Credit Services"
+    assert body["market_cap"] == 18230000000
+    assert body["employees"] == 4900
+    assert body["source"] == "yfinance"
+    # ISO-8601 with trailing Z per PRD example
+    assert isinstance(body["fetched_at"], str)
+    assert body["fetched_at"].endswith("Z")
+
+
+def test_get_business_502_on_source_unavailable(client):
+    """yfinance hard-fail + empty cache → 502 with sanitized detail."""
+    pid = _create_position(client)
+    # When the service raises ResearchSourceUnavailable the router maps to 502.
+    with patch.object(yfinance_client, "fetch_business_info", return_value=None):
+        resp = client.get(f"/api/positions/{pid}/research/business")
+
+    assert resp.status_code == 502
+    # The detail string is the pre-sanitized service-layer value — never
+    # the underlying yfinance exception's str().
+    assert resp.json() == {"detail": "Source unavailable"}
+
+
+def test_get_business_500_on_unexpected_exception(client):
+    """Unexpected service exception → 500 with the generic CLAUDE.md detail."""
+    pid = _create_position(client)
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("internal explosion that must NOT leak to clients")
+
+    # The router imports ``build_business_payload`` by name into its own
+    # namespace; patch the binding in the router module (not the service
+    # module) so the substitution is visible from the request path.
+    with patch(
+        "app.routers.research.build_business_payload", side_effect=_boom
+    ):
+        resp = client.get(f"/api/positions/{pid}/research/business")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    # Generic detail per CLAUDE.md — must NOT contain the original exception text.
+    assert body == {"detail": "Failed to load research data. Please try again."}
+    assert "explosion" not in body["detail"]

--- a/backend/tests/test_research_financials.py
+++ b/backend/tests/test_research_financials.py
@@ -1,0 +1,331 @@
+"""Tests for Section D — Financial scorecard service (issue #280, W-A).
+
+Covers :func:`app.services.research_financials.build_financials_payload`
+including the AV-primary success path, the AV-rate-limit → yfinance
+fallback path, the both-fail → sanitized 502 path, the 8-quarter
+projection / margin math, source attribution, and the cache-hit path.
+
+No real Alpha Vantage or yfinance traffic — both upstreams are patched
+via the explicit fetcher hooks on the service function.
+
+The "position not found → 404" acceptance criterion in the worker brief
+is HTTP-layer behavior that lives on the router (owned by Worker W).
+That test belongs alongside the router code; see the skipped placeholder
+at the bottom of this file for the audit trail.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.models.database import AppSetting
+from app.services import (
+    alpha_vantage_client,
+    research_cache,
+    research_financials,
+)
+from app.services.research_business import ResearchSourceUnavailable
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    """Drop both the research cache and the AV client's hot caches."""
+    research_cache.clear()
+    alpha_vantage_client.clear_cache()
+    alpha_vantage_client.clear_income_cache()
+    yield
+    research_cache.clear()
+    alpha_vantage_client.clear_cache()
+    alpha_vantage_client.clear_income_cache()
+
+
+def _db_session(client):
+    """Pull a session bound to the in-memory test DB."""
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    return next(override())
+
+
+def _av_quarter(
+    *,
+    period: str,
+    revenue: str = "645000000",
+    gross_profit: str = "277350000",
+    operating_income: str = "25800000",
+    net_income: str = "10000000",
+    eps: str = "0.02",
+) -> dict[str, Any]:
+    """Build one AV ``quarterlyReports`` entry in the wire format."""
+    return {
+        "fiscalDateEnding": period,
+        "totalRevenue": revenue,
+        "grossProfit": gross_profit,
+        "operatingIncome": operating_income,
+        "netIncome": net_income,
+        "reportedEPS": eps,
+    }
+
+
+def _yf_quarter(
+    *,
+    period: str,
+    revenue: float = 645000000.0,
+    gross_profit: float = 277350000.0,
+    operating_income: float = 25800000.0,
+    net_income: float = 10000000.0,
+    eps: float = 0.02,
+) -> dict[str, Any]:
+    """Build one yfinance-shaped quarter (snake_case normalized keys)."""
+    return {
+        "fiscal_date_ending": period,
+        "total_revenue": revenue,
+        "gross_profit": gross_profit,
+        "operating_income": operating_income,
+        "net_income": net_income,
+        "diluted_eps": eps,
+    }
+
+
+def _ten_av_quarters() -> list[dict[str, Any]]:
+    """Return 10 AV quarters newest-first so the 8-quarter slice is tested."""
+    quarters = []
+    for i in range(10):
+        # 2025-03-31, 2024-12-31, 2024-09-30, ...
+        year = 2025 - (i // 4)
+        month_day = ["03-31", "12-31", "09-30", "06-30"][i % 4]
+        quarters.append(_av_quarter(period=f"{year}-{month_day}"))
+    return quarters
+
+
+# ---------------------------------------------------------------------------
+# Success path — Alpha Vantage primary
+# ---------------------------------------------------------------------------
+
+
+def test_build_financials_payload_av_primary_success(client):
+    """AV returns 10 quarters → response carries 8, source=alphavantage."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(return_value=_ten_av_quarters())
+    yf_fetcher = MagicMock(return_value=None)
+
+    payload = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+    )
+
+    assert payload["ticker"] == "SOFI"
+    assert payload["source"] == "alphavantage"
+    assert len(payload["quarters"]) == 8
+    # Sliced to 8 newest-first; yfinance never invoked
+    av_fetcher.assert_called_once_with("SOFI", 8)
+    yf_fetcher.assert_not_called()
+
+
+def test_av_quarter_projection_computes_margins(client):
+    """gross_margin = gross_profit / total_revenue; operating_margin same shape."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(
+        return_value=[
+            _av_quarter(
+                period="2025-03-31",
+                revenue="1000",
+                gross_profit="430",
+                operating_income="40",
+                eps="0.02",
+            )
+        ]
+    )
+
+    payload = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=MagicMock()
+    )
+
+    q = payload["quarters"][0]
+    assert q["period_end"] == "2025-03-31"
+    assert q["revenue"] == 1000.0
+    assert q["eps"] == 0.02
+    assert q["gross_margin"] == pytest.approx(0.43)
+    assert q["operating_margin"] == pytest.approx(0.04)
+
+
+def test_av_quarter_with_missing_fields_surfaces_none_margins(client):
+    """Missing numerator/denominator → margins are JSON null, not 0."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(
+        return_value=[
+            {
+                "fiscalDateEnding": "2025-03-31",
+                "totalRevenue": "None",  # AV stringifies "None"
+                "grossProfit": "100",
+                "operatingIncome": "10",
+                "reportedEPS": "0.02",
+            }
+        ]
+    )
+
+    payload = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=MagicMock()
+    )
+
+    q = payload["quarters"][0]
+    assert q["revenue"] is None
+    assert q["gross_margin"] is None
+    assert q["operating_margin"] is None
+    # EPS still surfaces — independent field
+    assert q["eps"] == 0.02
+
+
+# ---------------------------------------------------------------------------
+# AV rate-limit → yfinance fallback
+# ---------------------------------------------------------------------------
+
+
+def test_av_rate_limited_falls_back_to_yfinance(client):
+    """AV returns None → yfinance is called; source attribution flips."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(return_value=None)
+    yf_fetcher = MagicMock(
+        return_value=[
+            _yf_quarter(period="2025-03-31"),
+            _yf_quarter(period="2024-12-31"),
+        ]
+    )
+
+    payload = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+    )
+
+    av_fetcher.assert_called_once_with("SOFI", 8)
+    yf_fetcher.assert_called_once_with("SOFI", 8)
+    assert payload["source"] == "yfinance"
+    assert len(payload["quarters"]) == 2
+    assert payload["quarters"][0]["period_end"] == "2025-03-31"
+
+
+def test_yfinance_fallback_payload_is_persisted_to_app_settings(client):
+    """yfinance fallback writes a durable yf_financials:{ticker} row."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(return_value=None)
+    yf_fetcher = MagicMock(
+        return_value=[_yf_quarter(period="2025-03-31")]
+    )
+
+    research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+    )
+
+    row = (
+        db.query(AppSetting)
+        .filter(AppSetting.key == "yf_financials:SOFI")
+        .first()
+    )
+    assert row is not None
+    _, _, json_part = row.value.partition("|")
+    persisted = json.loads(json_part)
+    assert persisted["source"] == "yfinance"
+    assert persisted["quarters"][0]["period_end"] == "2025-03-31"
+
+
+# ---------------------------------------------------------------------------
+# Both sources fail → sanitized 502
+# ---------------------------------------------------------------------------
+
+
+def test_both_sources_fail_raises_sanitized_error(client):
+    """AV None + yfinance None → ResearchSourceUnavailable; no str(e) leak."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(return_value=None)
+    yf_fetcher = MagicMock(return_value=None)
+
+    with pytest.raises(ResearchSourceUnavailable) as exc:
+        research_financials.build_financials_payload(
+            db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+        )
+
+    # CLAUDE.md: sanitized, generic; specific to the financials path
+    assert exc.value.detail == "Financials source unavailable"
+    assert "Exception" not in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Cache hit (in-memory)
+# ---------------------------------------------------------------------------
+
+
+def test_cache_hit_skips_both_upstreams_on_second_call(client):
+    """Second call within TTL serves the composed payload from research_cache."""
+    db = _db_session(client)
+    av_fetcher = MagicMock(return_value=_ten_av_quarters())
+    yf_fetcher = MagicMock(return_value=None)
+
+    first = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+    )
+    second = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+    )
+
+    assert first == second
+    # Only the first call touched the AV upstream
+    assert av_fetcher.call_count == 1
+
+
+def test_durable_yf_cache_serves_after_in_memory_eviction(client):
+    """Pre-seeded yf_financials app_setting served when AV is unavailable."""
+    db = _db_session(client)
+
+    fixture_payload = {
+        "ticker": "SOFI",
+        "quarters": [
+            {
+                "period_end": "2025-03-31",
+                "revenue": 645000000,
+                "eps": 0.02,
+                "gross_margin": 0.43,
+                "operating_margin": 0.04,
+            }
+        ],
+        "source": "yfinance",
+        "fetched_at": "2026-05-22T17:30:00Z",
+    }
+    fetched_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    db.add(
+        AppSetting(
+            key="yf_financials:SOFI",
+            value=f"{fetched_at.isoformat()}|{json.dumps(fixture_payload)}",
+        )
+    )
+    db.commit()
+
+    av_fetcher = MagicMock(return_value=None)
+    yf_fetcher = MagicMock(return_value=None)
+
+    payload = research_financials.build_financials_payload(
+        db, "SOFI", av_fetcher=av_fetcher, yf_fetcher=yf_fetcher
+    )
+
+    # Durable cache served the row; yfinance not invoked again
+    yf_fetcher.assert_not_called()
+    assert payload["source"] == "yfinance"
+    assert payload["quarters"][0]["period_end"] == "2025-03-31"
+
+
+# ---------------------------------------------------------------------------
+# Position not found — router-layer test placeholder
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skip(
+    reason="Position-not-found returns 404 at the HTTP router layer; "
+    "that test belongs alongside backend/app/routers/research.py "
+    "(Worker W). The service layer never sees a position id — it "
+    "only takes a ticker."
+)
+def test_position_not_found_returns_404_via_router():
+    """See routers/research.py + test_research_router.py (Worker W)."""

--- a/backend/tests/test_research_financials_router.py
+++ b/backend/tests/test_research_financials_router.py
@@ -69,7 +69,19 @@ def test_get_financials_404_for_missing_position(client):
 def test_get_financials_200_returns_av_payload(client):
     """AV primary returns data → 200 with ``source=alphavantage``."""
     pid = _create_position(client)
-    av_quarters = [_av_quarter(f"2025-0{i + 1}-30") for i in range(8)]
+    # Use real quarter-end dates so the fixture does not contain invalid
+    # calendar dates (CR #7 — 2025-02-30 was producing impossible dates).
+    quarter_ends = [
+        "2025-03-31",
+        "2024-12-31",
+        "2024-09-30",
+        "2024-06-30",
+        "2024-03-31",
+        "2023-12-31",
+        "2023-09-30",
+        "2023-06-30",
+    ]
+    av_quarters = [_av_quarter(d) for d in quarter_ends]
 
     with patch.object(
         alpha_vantage_client, "get_income_statement", return_value=av_quarters

--- a/backend/tests/test_research_financials_router.py
+++ b/backend/tests/test_research_financials_router.py
@@ -1,0 +1,163 @@
+"""Router-shell tests for ``GET /api/positions/{id}/research/financials`` (#280, W).
+
+Service-layer coverage lives in ``tests/test_research_financials.py``. This
+module covers only the HTTP wiring Worker W added:
+
+- Position not found → 404 with sanitized detail
+- Service raises :class:`ResearchSourceUnavailable` → 502 with sanitized detail
+- Happy path → 200 + payload that conforms to :class:`FinancialsResponse`
+- Unexpected exception → 500 with the generic CLAUDE.md detail
+
+Alpha Vantage and yfinance are never hit — both upstreams are patched at
+the service-import seam.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app.services import (
+    alpha_vantage_client,
+    research_cache,
+    yfinance_client,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_research_cache():
+    """Drop the in-memory research cache between tests."""
+    research_cache.clear()
+    yield
+    research_cache.clear()
+
+
+def _create_position(client, ticker: str = "SOFI") -> str:
+    """POST a minimal position and return its id."""
+    resp = client.post(
+        "/api/journal/positions",
+        json={
+            "ticker": ticker,
+            "shares": 100,
+            "broker_cost_basis": 2856.0,
+            "opened_at": "2026-01-15T10:00:00Z",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _av_quarter(period: str = "2025-03-31") -> dict:
+    """Build an Alpha Vantage ``quarterlyReports`` row (camelCase keys)."""
+    return {
+        "fiscalDateEnding": period,
+        "totalRevenue": "645000000",
+        "reportedEPS": "0.02",
+        "grossProfit": "277350000",  # 43% of revenue
+        "operatingIncome": "25800000",  # ~4% of revenue
+    }
+
+
+def test_get_financials_404_for_missing_position(client):
+    """Unknown ``position_id`` → 404 with sanitized detail."""
+    resp = client.get("/api/positions/does-not-exist/research/financials")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Position not found"}
+
+
+def test_get_financials_200_returns_av_payload(client):
+    """AV primary returns data → 200 with ``source=alphavantage``."""
+    pid = _create_position(client)
+    av_quarters = [_av_quarter(f"2025-0{i + 1}-30") for i in range(8)]
+
+    with patch.object(
+        alpha_vantage_client, "get_income_statement", return_value=av_quarters
+    ):
+        resp = client.get(f"/api/positions/{pid}/research/financials")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ticker"] == "SOFI"
+    assert body["source"] == "alphavantage"
+    assert isinstance(body["quarters"], list)
+    assert len(body["quarters"]) == 8
+    # Schema sanity — each quarter has the keys defined on FinancialQuarter.
+    expected_keys = {
+        "period_end",
+        "revenue",
+        "eps",
+        "gross_margin",
+        "operating_margin",
+    }
+    assert set(body["quarters"][0].keys()) == expected_keys
+    # Derived margins computed from the AV quarter fixture.
+    first = body["quarters"][0]
+    assert first["revenue"] == 645000000.0
+    assert first["eps"] == 0.02
+    assert first["gross_margin"] is not None
+    assert 0.42 < first["gross_margin"] < 0.44
+
+
+def test_get_financials_200_falls_back_to_yfinance(client):
+    """AV down + yfinance up → 200 with ``source=yfinance``."""
+    pid = _create_position(client)
+    yf_quarters = [
+        {
+            "fiscal_date_ending": "2025-03-31",
+            "total_revenue": 645000000,
+            "diluted_eps": 0.02,
+            "gross_profit": 277350000,
+            "operating_income": 25800000,
+        }
+    ]
+
+    with (
+        patch.object(alpha_vantage_client, "get_income_statement", return_value=None),
+        patch.object(
+            yfinance_client, "fetch_quarterly_income_stmt", return_value=yf_quarters
+        ),
+    ):
+        resp = client.get(f"/api/positions/{pid}/research/financials")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source"] == "yfinance"
+    assert len(body["quarters"]) == 1
+
+
+def test_get_financials_502_when_both_sources_unavailable(client):
+    """AV ``None`` + yfinance ``None`` → 502 with sanitized detail."""
+    pid = _create_position(client)
+
+    with (
+        patch.object(alpha_vantage_client, "get_income_statement", return_value=None),
+        patch.object(
+            yfinance_client, "fetch_quarterly_income_stmt", return_value=None
+        ),
+    ):
+        resp = client.get(f"/api/positions/{pid}/research/financials")
+
+    assert resp.status_code == 502
+    assert resp.json() == {"detail": "Financials source unavailable"}
+
+
+def test_get_financials_500_on_unexpected_exception(client):
+    """Unexpected service exception → 500 with the generic CLAUDE.md detail."""
+    pid = _create_position(client)
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("internal explosion that must NOT leak to clients")
+
+    # Patch the router's bound name (the service function was imported
+    # into the router namespace, so the service-module attribute is no
+    # longer the live reference).
+    with patch(
+        "app.routers.research.build_financials_payload", side_effect=_boom
+    ):
+        resp = client.get(f"/api/positions/{pid}/research/financials")
+
+    assert resp.status_code == 500
+    body = resp.json()
+    assert body == {"detail": "Failed to load research data. Please try again."}
+    assert "explosion" not in body["detail"]

--- a/backend/tests/test_research_price_history.py
+++ b/backend/tests/test_research_price_history.py
@@ -1,0 +1,468 @@
+"""Integration + unit tests for the research price-history endpoint.
+
+Covers ``GET /api/positions/{id}/research/price-history`` (issue #280 /
+v1.1.0 — Worker B).
+
+Test plan (from the CTO plan §6.1 and the worker prompt):
+
+- Success path with mocked Schwab + mocked AV + fixture trades
+- AV-down → empty earnings_events with 200 (graceful degradation)
+- Schwab-down → 502
+- Cache-hit on second call (15-minute TTL — no second fetch)
+- Position not found → 404
+- Empty position (no trades) → 200 with basis but empty trade_events
+- Window param parsing: default ``1Y``; ``6M``, ``2Y`` accepted; other → 422
+
+Pattern: integration tests use the in-memory SQLite ``client`` fixture
+from ``conftest.py`` and patch the *named* dependencies of the service
+module (``DataFetcher.fetch`` for prices, ``get_historical_earnings``
+for AV). Unit tests for the trade-event mapper exercise the
+private helper directly.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from app.models.database import Position, Trade
+from app.models.schemas import DataMeta, DateRange
+from app.services import research_price_history as svc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + seeders
+# ---------------------------------------------------------------------------
+
+_POS_ID = "pos-sofi"
+_TICKER = "SOFI"
+_BROKER_BASIS = 2856.0  # 100 shares @ 28.56
+_SHARES = 100
+
+# Time-relative trade timestamps so DTE-style assertions don't rot when the
+# suite is run on a different day (matches the BTC detail tests' approach).
+_OPEN_DATE = (date.today() - timedelta(days=120)).isoformat()
+_CLOSE_DATE = (date.today() - timedelta(days=60)).isoformat()
+
+
+def _db(client):
+    """Pull a DB session from the FastAPI override."""
+    from app.main import app
+    from app.models.database import get_db
+
+    override = app.dependency_overrides[get_db]
+    return next(override())
+
+
+def _seed_position_with_trades(
+    client,
+    *,
+    pos_id: str = _POS_ID,
+    ticker: str = _TICKER,
+    shares: int = _SHARES,
+    broker_basis: float = _BROKER_BASIS,
+    with_trades: bool = True,
+) -> str:
+    """Seed one open position with two representative trades.
+
+    The trades produce one ``sell_put`` event and one ``buy_close`` event
+    (the latter exercises the legacy ``buy_put_close`` → ``buy_close``
+    normalization). Skipped when ``with_trades=False`` so callers can
+    test the "no trades" edge case.
+    """
+    db = _db(client)
+    try:
+        db.add(
+            Position(
+                id=pos_id,
+                ticker=ticker,
+                shares=shares,
+                broker_cost_basis=broker_basis,
+                status="open",
+                strategy="csp",
+                opened_at=_OPEN_DATE,
+            )
+        )
+        if with_trades:
+            # Premium 0.50 collected when sell_put opened; closed for 0.10
+            # (net +0.40 → adjusted basis goes down).
+            db.add(
+                Trade(
+                    id=f"{pos_id}-sp1",
+                    position_id=pos_id,
+                    trade_type="sell_put",
+                    strike=28.0,
+                    expiration=(date.today() - timedelta(days=80)).isoformat(),
+                    premium=0.50,
+                    fees=0.0,
+                    quantity=1,
+                    opened_at=_OPEN_DATE,
+                    closed_at=_CLOSE_DATE,
+                    close_reason="closed_early",
+                )
+            )
+            db.add(
+                Trade(
+                    id=f"{pos_id}-bp1",
+                    position_id=pos_id,
+                    trade_type="buy_put_close",
+                    strike=28.0,
+                    expiration=(date.today() - timedelta(days=80)).isoformat(),
+                    premium=-0.10,
+                    fees=0.0,
+                    quantity=1,
+                    opened_at=_CLOSE_DATE,
+                )
+            )
+        db.commit()
+    finally:
+        db.close()
+    return pos_id
+
+
+def _price_df(n: int = 60, base: float = 25.0) -> pd.DataFrame:
+    """Build a minimal daily-close DataFrame in DataFetcher's contract.
+
+    The fetcher returns a ``DatetimeIndex`` + a ``value`` column; the
+    composition layer iterates rows in order and emits ``{date, close}``.
+    """
+    today = date.today()
+    idx = pd.date_range(end=today, periods=n, freq="D")
+    values = [base + i * 0.05 for i in range(n)]
+    df = pd.DataFrame({"value": values}, index=idx)
+    df.index.name = "date"
+    return df
+
+
+def _price_meta(n: int = 60) -> DataMeta:
+    today = date.today()
+    return DataMeta(
+        source="schwab",
+        frequency="daily",
+        fetched_at=today.isoformat() + "T00:00:00+00:00",
+        is_stale=False,
+        record_count=n,
+        date_range=DateRange(
+            start=(today - timedelta(days=n)).isoformat(),
+            end=today.isoformat(),
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_price_history_cache():
+    """The composition cache is process-global; isolate each test."""
+    svc.clear_cache()
+    yield
+    svc.clear_cache()
+
+
+# ---------------------------------------------------------------------------
+# Service-layer unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTradeEventMapping:
+    """:func:`_trade_events_from_position` correctly normalizes legacy types."""
+
+    def test_normalizes_buy_put_close_to_buy_close(self):
+        events = svc._trade_events_from_position(
+            {
+                "id": "p",
+                "trades": [
+                    {
+                        "trade_type": "buy_put_close",
+                        "strike": 26.0,
+                        "opened_at": "2025-02-15T10:00:00Z",
+                    }
+                ],
+            }
+        )
+        assert len(events) == 1
+        assert events[0].type == "buy_close"
+        assert events[0].date == "2025-02-15"
+        assert events[0].strike == 26.0
+
+    def test_normalizes_buy_call_close_to_buy_close(self):
+        events = svc._trade_events_from_position(
+            {
+                "id": "p",
+                "trades": [
+                    {
+                        "trade_type": "buy_call_close",
+                        "strike": 30.0,
+                        "opened_at": "2025-03-15",
+                    }
+                ],
+            }
+        )
+        assert events[0].type == "buy_close"
+
+    def test_passes_through_v1_vocabulary_unchanged(self):
+        for raw in ("sell_put", "sell_call", "assignment", "called_away", "expired"):
+            events = svc._trade_events_from_position(
+                {
+                    "id": "p",
+                    "trades": [
+                        {
+                            "trade_type": raw,
+                            "strike": 10.0,
+                            "opened_at": "2025-01-01",
+                        }
+                    ],
+                }
+            )
+            assert events and events[0].type == raw, raw
+
+    def test_skips_unknown_trade_types(self):
+        events = svc._trade_events_from_position(
+            {
+                "id": "p",
+                "trades": [
+                    {
+                        "trade_type": "mystery",
+                        "strike": 10.0,
+                        "opened_at": "2025-01-01",
+                    },
+                    {
+                        "trade_type": "sell_put",
+                        "strike": 10.0,
+                        "opened_at": "2025-01-02",
+                    },
+                ],
+            }
+        )
+        assert [e.type for e in events] == ["sell_put"]
+
+    def test_skips_rows_without_opened_at(self):
+        events = svc._trade_events_from_position(
+            {
+                "id": "p",
+                "trades": [{"trade_type": "sell_put", "strike": 10.0}],
+            }
+        )
+        assert events == []
+
+    def test_sorts_events_by_date(self):
+        events = svc._trade_events_from_position(
+            {
+                "id": "p",
+                "trades": [
+                    {"trade_type": "sell_put", "strike": 10.0, "opened_at": "2025-03-01"},
+                    {"trade_type": "sell_call", "strike": 12.0, "opened_at": "2025-01-15"},
+                    {"trade_type": "expired", "strike": 12.0, "opened_at": "2025-02-15"},
+                ],
+            }
+        )
+        assert [e.date for e in events] == ["2025-01-15", "2025-02-15", "2025-03-01"]
+
+
+class TestWindowResolution:
+    """:func:`_window_dates` returns a sensible (start, end) range."""
+
+    def test_default_window_is_one_year(self):
+        start, end = svc._window_dates("1Y")
+        # The window is 365 days; allow ±1 day for the day-boundary edge.
+        delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
+        assert 364 <= delta <= 366
+
+    @pytest.mark.parametrize("window,min_days,max_days", [
+        ("6M", 182, 184),
+        ("1Y", 364, 366),
+        ("2Y", 729, 731),
+    ])
+    def test_supported_windows_have_correct_lookback(self, window, min_days, max_days):
+        start, end = svc._window_dates(window)
+        delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
+        assert min_days <= delta <= max_days
+
+    def test_unsupported_window_raises(self):
+        with pytest.raises(svc.InvalidWindowError):
+            svc._window_dates("3D")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — full endpoint behavior
+# ---------------------------------------------------------------------------
+
+
+# Patch targets — keep them in one place so a refactor finds them all.
+_FETCH_PATCH = "app.services.research_price_history.DataFetcher.fetch"
+_AV_PATCH = "app.services.research_price_history.get_historical_earnings"
+
+
+class TestPriceHistoryEndpoint:
+    """End-to-end behavior of ``GET /research/price-history``."""
+
+    def test_success_path_with_trades_and_earnings(self, client):
+        _seed_position_with_trades(client)
+        earnings = [
+            (date.today() - timedelta(days=90)).isoformat(),
+            (date.today() - timedelta(days=10)).isoformat(),
+        ]
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=earnings):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert payload["ticker"] == _TICKER
+        assert payload["window"] == "1Y"
+        # Prices: 60 daily rows from the fixture
+        assert len(payload["prices"]) == 60
+        assert all("date" in p and "close" in p for p in payload["prices"])
+        # Basis lines present, broker matches seed
+        assert payload["basis"]["broker"] == _BROKER_BASIS
+        # adjusted_cost_basis is journal-computed (broker - premiums after
+        # netting); we only assert the field is present and a float here —
+        # the journal's own tests own the exact-value coverage.
+        assert isinstance(payload["basis"]["adjusted"], (int, float))
+        # Trade events from two seeded trades
+        trade_types = [e["type"] for e in payload["trade_events"]]
+        assert "sell_put" in trade_types
+        assert "buy_close" in trade_types
+        # Earnings events came from the mocked AV
+        assert {e["date"] for e in payload["earnings_events"]} == set(earnings)
+        for e in payload["earnings_events"]:
+            assert e["label"] == "Earnings"
+
+    def test_empty_position_returns_basis_and_empty_trade_events(self, client):
+        _seed_position_with_trades(client, with_trades=False)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["trade_events"] == []
+        assert payload["basis"]["broker"] == _BROKER_BASIS
+        # No trades → adjusted basis equals broker basis (no premium offset).
+        assert payload["basis"]["adjusted"] == _BROKER_BASIS
+
+    def test_av_failure_degrades_to_empty_earnings_with_200(self, client):
+        """AV unavailable must NOT fail the whole payload (NFR-3)."""
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["earnings_events"] == []
+        assert len(payload["prices"]) > 0  # primary signal still rendered
+
+    def test_av_raises_unexpected_exception_still_degrades_to_empty(self, client):
+        """Even if the AV client raises, the endpoint must stay 200."""
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, side_effect=RuntimeError("AV exploded")):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert resp.status_code == 200
+        assert resp.json()["earnings_events"] == []
+
+    def test_price_source_failure_returns_502(self, client):
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, side_effect=RuntimeError("schwab kaboom")), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert resp.status_code == 502
+        body = resp.json()
+        assert body["detail"] == "Price source unavailable"
+        # CLAUDE.md: no raw exception messages in API responses.
+        assert "kaboom" not in body["detail"]
+
+    def test_position_not_found_returns_404(self, client):
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                "/api/positions/does-not-exist/research/price-history"
+            )
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Position not found"
+
+    def test_default_window_is_one_year(self, client):
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert resp.status_code == 200
+        assert resp.json()["window"] == "1Y"
+
+    @pytest.mark.parametrize("window", ["6M", "1Y", "2Y"])
+    def test_supported_windows_accepted(self, client, window):
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history?window={window}"
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["window"] == window
+
+    def test_lowercase_window_accepted(self, client):
+        """The service uppercases ``window`` before validating."""
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history?window=1y"
+            )
+        assert resp.status_code == 200
+        assert resp.json()["window"] == "1Y"
+
+    def test_unsupported_window_returns_422(self, client):
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
+             patch(_AV_PATCH, return_value=[]):
+            resp = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history?window=3D"
+            )
+        assert resp.status_code == 422
+        # Detail must enumerate the supported set so callers can self-correct.
+        detail = resp.json()["detail"]
+        for w in ("6M", "1Y", "2Y"):
+            assert w in detail
+
+    def test_cache_hit_skips_second_fetch_within_ttl(self, client):
+        """Second call within 15 min should NOT re-fetch prices or earnings."""
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())) as fetch_mock, \
+             patch(_AV_PATCH, return_value=[]) as av_mock:
+            r1 = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+            r2 = client.get(
+                f"/api/positions/{_POS_ID}/research/price-history"
+            )
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r1.json() == r2.json()
+        # Each upstream is called exactly once over the two HTTP requests.
+        assert fetch_mock.call_count == 1
+        assert av_mock.call_count == 1
+
+    def test_cache_key_is_per_window(self, client):
+        """Different window params get separate cache entries."""
+        _seed_position_with_trades(client)
+        with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())) as fetch_mock, \
+             patch(_AV_PATCH, return_value=[]):
+            client.get(
+                f"/api/positions/{_POS_ID}/research/price-history?window=1Y"
+            )
+            client.get(
+                f"/api/positions/{_POS_ID}/research/price-history?window=6M"
+            )
+        # Two distinct windows → two upstream fetches.
+        assert fetch_mock.call_count == 2

--- a/backend/tests/test_research_regression.py
+++ b/backend/tests/test_research_regression.py
@@ -1,0 +1,337 @@
+"""Integration tests for ``GET /api/positions/{id}/research/regression`` (issue #280).
+
+Covers Worker D's contract: success path with all 3 factors, sector-omitted
+branch, insufficient-data 422, upstream-failure 502, and the 5-minute cache.
+The existing multi-factor OLS engine is exercised end-to-end with synthetic
+return series; the upstream fetchers are mocked so tests are hermetic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.models.schemas import DataMeta, DateRange
+from app.services import research_regression
+from app.services.data_fetcher import DataFetcher, DataFetchError
+
+
+# --- Fixtures --------------------------------------------------------------
+
+
+def _meta(n: int = 260) -> DataMeta:
+    """Build a stub DataMeta with realistic counts."""
+    return DataMeta(
+        source="schwab",
+        frequency="daily",
+        fetched_at="2024-06-01T00:00:00+00:00",
+        is_stale=False,
+        record_count=n,
+        date_range=DateRange(start="2023-01-01", end="2023-12-31"),
+    )
+
+
+def _price_series(n: int, seed: int, drift: float = 0.0005, vol: float = 0.015) -> pd.DataFrame:
+    """Generate a synthetic daily-close price series as a single-column DataFrame."""
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range("2024-01-02", periods=n, freq="B")
+    returns = rng.normal(drift, vol, n)
+    prices = 100.0 * np.cumprod(1 + returns)
+    df = pd.DataFrame({"value": prices}, index=dates)
+    df.index.name = "date"
+    return df
+
+
+def _yield_series(n: int, seed: int) -> pd.DataFrame:
+    """Generate a synthetic DGS10 yield series (percent levels)."""
+    rng = np.random.default_rng(seed)
+    dates = pd.date_range("2024-01-02", periods=n, freq="B")
+    yields = 4.0 + np.cumsum(rng.normal(0.0, 0.02, n))
+    df = pd.DataFrame({"value": yields}, index=dates)
+    df.index.name = "date"
+    return df
+
+
+def _create_position(client, ticker: str = "AAPL") -> str:
+    """POST a position via the journal API; return the new position id."""
+    resp = client.post(
+        "/api/journal/positions",
+        json={
+            "ticker": ticker,
+            "shares": 100,
+            "broker_cost_basis": 5000.0,
+            "opened_at": "2024-01-15T10:00:00Z",
+        },
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return resp.json()["id"]
+
+
+def _three_factor_fetch_side_effect(
+    ticker: str,
+    *,
+    n: int = 252,
+    correlated_factors: bool = False,
+):
+    """Build a DataFetcher.fetch side-effect that returns 4 distinct series.
+
+    The 4 series mimic ticker + SPY + sector ETF + DGS10. Schwab/FRED-style
+    returns are emulated with synthetic random walks. By default the four
+    series are statistically independent; ``correlated_factors=True`` makes
+    SPY and the sector ETF nearly identical (VIF blow-up scenario).
+    """
+    spy = _price_series(n, seed=1)
+    sector = spy.copy() if correlated_factors else _price_series(n, seed=2)
+    target = _price_series(n, seed=3, drift=0.0007)
+    dgs10 = _yield_series(n, seed=4)
+    rates_map = {
+        ticker: target,
+        "SPY": spy,
+        "DGS10": dgs10,
+    }
+    sector_etfs = {"XLF", "XLK", "XLV", "XLE", "XLP", "XLY", "XLI", "XLB", "XLU", "XLRE", "XLC"}
+
+    def _side_effect(identifier: str, start: str, end: str):
+        if identifier == ticker:
+            return target, _meta(n)
+        if identifier == "SPY":
+            return spy, _meta(n)
+        if identifier == "DGS10":
+            return dgs10, _meta(n)
+        if identifier in sector_etfs:
+            return sector, _meta(n)
+        raise AssertionError(f"Unexpected fetch identifier: {identifier}")
+
+    return _side_effect
+
+
+@pytest.fixture(autouse=True)
+def _clear_regression_cache():
+    """Clear the process-local response cache between tests."""
+    research_regression.clear_cache()
+    yield
+    research_regression.clear_cache()
+
+
+# --- Success path with all 3 factors --------------------------------------
+
+
+def test_success_with_all_three_factors(client):
+    """Financial Services position → basket includes SPY + XLF + DGS10."""
+    position_id = _create_position(client, ticker="JPM")
+
+    with patch.object(
+        research_regression,
+        "_resolve_sector_for_ticker",
+        return_value="Financial Services",
+    ), patch.object(
+        DataFetcher,
+        "fetch",
+        side_effect=_three_factor_fetch_side_effect("JPM"),
+    ):
+        resp = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["position_id"] == position_id
+    assert body["ticker"] == "JPM"
+    assert body["window"] == "1Y"
+    assert body["sector_omitted"] is False
+    assert set(body["basket"]) == {"SPY", "XLF", "DGS10"}
+
+    factor_names = [f["name"] for f in body["factors"]]
+    assert factor_names == ["market", "sector", "rates", "idiosyncratic"]
+
+    # Idiosyncratic has no beta/p-value; explicit None in payload.
+    idio = [f for f in body["factors"] if f["name"] == "idiosyncratic"][0]
+    assert idio["beta"] is None
+    assert idio["p_value"] is None
+
+    # Variance shares (factors + idio) should sum to ~1.0.
+    total = sum(f["contribution"] for f in body["factors"])
+    assert total == pytest.approx(1.0, abs=0.05)
+
+    # Summary is a single short sentence — frozen 120-char cap.
+    assert isinstance(body["summary"], str)
+    assert body["summary"].endswith("trading days.")
+    assert len(body["summary"]) <= 120
+
+
+# --- Sector-omitted branch -------------------------------------------------
+
+
+def test_sector_unknown_drops_to_two_factor_basket(client):
+    """Unmapped sector → basket is SPY + DGS10 only and sector_omitted=True."""
+    position_id = _create_position(client, ticker="ZZZX")
+
+    with patch.object(
+        research_regression,
+        "_resolve_sector_for_ticker",
+        return_value=None,  # unmapped / missing sector
+    ), patch.object(
+        DataFetcher,
+        "fetch",
+        side_effect=_three_factor_fetch_side_effect("ZZZX"),
+    ):
+        resp = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["sector_omitted"] is True
+    assert body["basket"] == ["SPY", "DGS10"]
+
+    factor_names = [f["name"] for f in body["factors"]]
+    assert factor_names == ["market", "rates", "idiosyncratic"]
+    assert all(f["name"] != "sector" for f in body["factors"])
+
+
+# --- Insufficient-data branch ---------------------------------------------
+
+
+def test_insufficient_sample_size_returns_422(client):
+    """Fewer than 60 aligned trading days → 422 with sanitized message."""
+    position_id = _create_position(client, ticker="AAPL")
+
+    short_series = _price_series(n=30, seed=10)
+    short_yield = _yield_series(n=30, seed=11)
+
+    def _short_side_effect(identifier: str, start: str, end: str):
+        if identifier == "DGS10":
+            return short_yield, _meta(30)
+        return short_series, _meta(30)
+
+    with patch.object(
+        research_regression,
+        "_resolve_sector_for_ticker",
+        return_value="Technology",
+    ), patch.object(DataFetcher, "fetch", side_effect=_short_side_effect):
+        resp = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"] == "Insufficient data for regression"
+    # Sanitized — never contains raw exception text or stack frames.
+    assert "Traceback" not in body["detail"]
+
+
+# --- Upstream-source failure ----------------------------------------------
+
+
+def test_upstream_fetch_failure_returns_502(client):
+    """Any upstream fetch raising → 502 with generic source message."""
+    position_id = _create_position(client, ticker="AAPL")
+
+    def _failing_fetch(identifier: str, start: str, end: str):
+        raise DataFetchError("internal Schwab error with secret details")
+
+    with patch.object(
+        research_regression,
+        "_resolve_sector_for_ticker",
+        return_value="Technology",
+    ), patch.object(DataFetcher, "fetch", side_effect=_failing_fetch):
+        resp = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["detail"] == "Source unavailable for regression"
+    # CLAUDE.md: never leak str(e) to the client.
+    assert "secret" not in body["detail"]
+
+
+# --- Position not found ---------------------------------------------------
+
+
+def test_unknown_position_returns_404(client):
+    """A position id that does not exist → 404."""
+    resp = client.get(
+        "/api/positions/does-not-exist/research/regression"
+    )
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Position not found"
+
+
+# --- Window validation -----------------------------------------------------
+
+
+def test_invalid_window_returns_422(client):
+    """Any ``window`` value other than ``1Y`` → 422."""
+    position_id = _create_position(client, ticker="AAPL")
+    resp = client.get(
+        f"/api/positions/{position_id}/research/regression?window=5Y"
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Unsupported window value"
+
+
+# --- Cache behavior --------------------------------------------------------
+
+
+def test_cache_hit_on_second_call_within_ttl(client):
+    """Second call within TTL serves the cached response without fetching."""
+    position_id = _create_position(client, ticker="JPM")
+    side_effect = _three_factor_fetch_side_effect("JPM")
+    call_log: list[str] = []
+
+    def _logging_side_effect(identifier: str, start: str, end: str):
+        call_log.append(identifier)
+        return side_effect(identifier, start, end)
+
+    with patch.object(
+        research_regression,
+        "_resolve_sector_for_ticker",
+        return_value="Financial Services",
+    ), patch.object(DataFetcher, "fetch", side_effect=_logging_side_effect):
+        first = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+        calls_after_first = len(call_log)
+        second = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    # Second call must not touch the fetcher at all.
+    assert calls_after_first > 0
+    assert len(call_log) == calls_after_first
+    # Both responses are byte-identical (deterministic from the cache).
+    assert first.json() == second.json()
+
+
+# --- Factor variance share normalization ----------------------------------
+
+
+def test_factor_contributions_sum_to_approximately_one(client):
+    """Sanity check: factor + idiosyncratic shares sum to ~1.0 (donut-ready)."""
+    position_id = _create_position(client, ticker="JPM")
+
+    with patch.object(
+        research_regression,
+        "_resolve_sector_for_ticker",
+        return_value="Financial Services",
+    ), patch.object(
+        DataFetcher,
+        "fetch",
+        side_effect=_three_factor_fetch_side_effect("JPM"),
+    ):
+        resp = client.get(
+            f"/api/positions/{position_id}/research/regression"
+        )
+
+    body: dict[str, Any] = resp.json()
+    total = sum(f["contribution"] for f in body["factors"])
+    assert 0.95 <= total <= 1.05
+    assert 0.0 <= body["r_squared"] <= 1.0
+    assert 0.0 <= body["idiosyncratic_share"] <= 1.0

--- a/backend/tests/test_research_thesis.py
+++ b/backend/tests/test_research_thesis.py
@@ -1,0 +1,209 @@
+"""API tests for the thesis endpoints (issue #280, Worker F).
+
+Covers the eight required scenarios from the worker brief:
+
+1. GET with no note → empty-state shape (``thesis=null``, ``version=0``).
+2. PUT creates a row, GET returns it with ``version=1``.
+3. PUT updates an existing note — ``version`` increments,
+   ``updated_at`` refreshes, body changes.
+4. PUT with > 4000 chars → 422 with sanitized detail.
+5. PUT with empty string → allowed, version increments.
+6. GET on a non-existent position → 404 with sanitized detail.
+7. PUT on a non-existent position → 404 with sanitized detail.
+8. ``body`` is the column name and the text round-trips cleanly.
+"""
+
+from __future__ import annotations
+
+
+def _create_position(client, ticker: str = "AAPL") -> str:
+    """POST a minimal position and return its id."""
+    resp = client.post(
+        "/api/journal/positions",
+        json={
+            "ticker": ticker,
+            "shares": 100,
+            "broker_cost_basis": 15000.0,
+            "opened_at": "2026-01-15T10:00:00Z",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+# --- GET ---
+
+
+def test_get_thesis_empty_state_when_no_row(client):
+    """Position exists but no thesis row → empty-state shape (NOT 404)."""
+    pid = _create_position(client)
+    resp = client.get(f"/api/positions/{pid}/research/thesis")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"thesis": None, "updated_at": None, "version": 0}
+
+
+def test_get_thesis_404_for_missing_position(client):
+    """A missing position id returns sanitized 404."""
+    resp = client.get("/api/positions/does-not-exist/research/thesis")
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Position not found"}
+
+
+# --- PUT create ---
+
+
+def test_put_creates_row_version_one(client):
+    """First PUT creates the row at version 1; GET returns it."""
+    pid = _create_position(client)
+    put_resp = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": "Initial thesis on the company"},
+    )
+    assert put_resp.status_code == 200
+    payload = put_resp.json()
+    assert payload["thesis"] == "Initial thesis on the company"
+    assert payload["version"] == 1
+    assert payload["updated_at"] is not None
+
+    # GET reflects the same row.
+    get_resp = client.get(f"/api/positions/{pid}/research/thesis")
+    assert get_resp.status_code == 200
+    assert get_resp.json() == payload
+
+
+def test_put_404_for_missing_position(client):
+    """PUT on a missing position id returns sanitized 404."""
+    resp = client.put(
+        "/api/positions/does-not-exist/research/thesis",
+        json={"thesis": "anything"},
+    )
+    assert resp.status_code == 404
+    assert resp.json() == {"detail": "Position not found"}
+
+
+# --- PUT update / versioning ---
+
+
+def test_put_update_increments_version_and_refreshes_updated_at(client):
+    """Second PUT bumps version, refreshes updated_at, replaces body."""
+    pid = _create_position(client)
+    first = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": "v1 body"},
+    ).json()
+    assert first["version"] == 1
+
+    second = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": "v2 body, revised after earnings"},
+    ).json()
+    assert second["version"] == 2
+    assert second["thesis"] == "v2 body, revised after earnings"
+    # updated_at advances monotonically (or stays equal at the ISO
+    # millisecond floor — accept >= to keep the test robust on fast
+    # in-memory DBs).
+    assert second["updated_at"] >= first["updated_at"]
+
+
+def test_put_three_times_increments_version_each_call(client):
+    """Three sequential PUTs land at versions 1, 2, 3 in order."""
+    pid = _create_position(client)
+    versions = []
+    for n in range(1, 4):
+        resp = client.put(
+            f"/api/positions/{pid}/research/thesis",
+            json={"thesis": f"v{n}"},
+        )
+        assert resp.status_code == 200
+        versions.append(resp.json()["version"])
+    assert versions == [1, 2, 3]
+
+
+# --- PUT validation ---
+
+
+def test_put_rejects_over_4000_chars(client):
+    """Bodies longer than the cap return 422 with a sanitized message."""
+    pid = _create_position(client)
+    too_long = "x" * 4001
+    resp = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": too_long},
+    )
+    assert resp.status_code == 422
+    # Pydantic surfaces its own detail on validation; we only assert the
+    # response is sanitized (no ``str(e)`` traceback leaks). The body
+    # text MUST NOT contain "Traceback" or sensitive markers.
+    text = resp.text
+    assert "Traceback" not in text
+    # The router fallback message and the Pydantic message both mention
+    # the cap in human-readable form; either is acceptable.
+    assert "4000" in text or "limit" in text.lower() or "length" in text.lower()
+
+
+def test_put_accepts_exactly_4000_chars(client):
+    """Exactly 4000 characters is within the cap (boundary)."""
+    pid = _create_position(client)
+    boundary = "y" * 4000
+    resp = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": boundary},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["thesis"] == boundary
+
+
+def test_put_empty_string_is_allowed_and_bumps_version(client):
+    """Empty body clears the note but still increments the version."""
+    pid = _create_position(client)
+    first = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": "something to clear"},
+    ).json()
+    cleared = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": ""},
+    )
+    assert cleared.status_code == 200
+    body = cleared.json()
+    assert body["thesis"] == ""
+    assert body["version"] == first["version"] + 1
+
+
+# --- Round-trip / sanity ---
+
+
+def test_body_column_round_trips_complex_text(client):
+    """``body`` round-trips newlines, unicode, and punctuation losslessly."""
+    pid = _create_position(client)
+    original = "Line 1\n\nLine 2 — café — and a 中文 character."
+    put_resp = client.put(
+        f"/api/positions/{pid}/research/thesis",
+        json={"thesis": original},
+    )
+    assert put_resp.status_code == 200
+    assert put_resp.json()["thesis"] == original
+
+    get_resp = client.get(f"/api/positions/{pid}/research/thesis")
+    assert get_resp.json()["thesis"] == original
+
+
+def test_two_positions_have_independent_notes(client):
+    """Each position has its own thesis — no cross-pollination."""
+    pid_a = _create_position(client, ticker="AAPL")
+    pid_b = _create_position(client, ticker="MSFT")
+
+    client.put(
+        f"/api/positions/{pid_a}/research/thesis",
+        json={"thesis": "thesis A"},
+    )
+    client.put(
+        f"/api/positions/{pid_b}/research/thesis",
+        json={"thesis": "thesis B"},
+    )
+
+    a = client.get(f"/api/positions/{pid_a}/research/thesis").json()
+    b = client.get(f"/api/positions/{pid_b}/research/thesis").json()
+    assert a["thesis"] == "thesis A"
+    assert b["thesis"] == "thesis B"

--- a/backend/tests/test_sector_etf_map.py
+++ b/backend/tests/test_sector_etf_map.py
@@ -1,0 +1,73 @@
+"""Tests for the GICS sector → SPDR sector ETF mapping (issue #280)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.sector_etf_map import SECTOR_ETF_MAP, lookup_sector_etf
+
+
+@pytest.mark.parametrize(
+    "sector, expected_etf",
+    [
+        ("Financial Services", "XLF"),
+        ("Technology", "XLK"),
+        ("Healthcare", "XLV"),
+        ("Energy", "XLE"),
+        ("Consumer Defensive", "XLP"),
+        ("Consumer Cyclical", "XLY"),
+        ("Industrials", "XLI"),
+        ("Basic Materials", "XLB"),
+        ("Utilities", "XLU"),
+        ("Real Estate", "XLRE"),
+        ("Communication Services", "XLC"),
+    ],
+)
+def test_all_eleven_gics_sectors_map_to_spdr_etfs(sector: str, expected_etf: str) -> None:
+    """Every yfinance GICS sector returns the corresponding SPDR ticker."""
+    assert lookup_sector_etf(sector) == expected_etf
+
+
+def test_map_has_exactly_eleven_entries() -> None:
+    """The map covers all 11 GICS sectors — no extras, no omissions."""
+    assert len(SECTOR_ETF_MAP) == 11
+
+
+def test_unknown_sector_returns_none() -> None:
+    """An unmapped sector string returns ``None`` (sector-omitted branch)."""
+    assert lookup_sector_etf("Telecommunications") is None
+    assert lookup_sector_etf("Crypto") is None
+
+
+def test_none_returns_none() -> None:
+    """``None`` input (missing sector) returns ``None``."""
+    assert lookup_sector_etf(None) is None
+
+
+def test_empty_string_returns_none() -> None:
+    """Empty / whitespace-only sector strings return ``None``."""
+    assert lookup_sector_etf("") is None
+    assert lookup_sector_etf("   ") is None
+
+
+def test_lookup_is_case_sensitive() -> None:
+    """yfinance returns canonical-cased strings; we don't lower-case lookups."""
+    assert lookup_sector_etf("financial services") is None
+    assert lookup_sector_etf("FINANCIAL SERVICES") is None
+
+
+def test_surrounding_whitespace_is_tolerated() -> None:
+    """Defensive: a stray space around a known sector still resolves."""
+    assert lookup_sector_etf("  Technology  ") == "XLK"
+
+
+def test_non_string_input_returns_none() -> None:
+    """Non-string inputs (e.g. a yfinance None-coerced int) return None."""
+    assert lookup_sector_etf(123) is None  # type: ignore[arg-type]
+    assert lookup_sector_etf(["Technology"]) is None  # type: ignore[arg-type]
+
+
+def test_all_etf_values_are_xl_prefixed() -> None:
+    """All values follow the SPDR ``XL*`` naming convention."""
+    for etf in SECTOR_ETF_MAP.values():
+        assert etf.startswith("XL"), f"{etf} does not look like a SPDR sector ETF"

--- a/backend/tests/test_sector_etf_map.py
+++ b/backend/tests/test_sector_etf_map.py
@@ -1,0 +1,62 @@
+"""Tests for the GICS-sector → SPDR sector ETF map (issue #280, W-A).
+
+The map is a hardcoded module-level constant per plan §3.3 / §4.4. These
+tests pin the 11-entry contract so a typo or accidental key rename is
+caught at the unit-test layer rather than surfacing as a silent
+regression-without-sector branch in production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.sector_etf_map import SECTOR_ETF_MAP, resolve_sector_etf
+
+
+# Frozen 11 entries — case-sensitive, verbatim from plan §3.3.
+_EXPECTED: dict[str, str] = {
+    "Financial Services": "XLF",
+    "Technology": "XLK",
+    "Healthcare": "XLV",
+    "Energy": "XLE",
+    "Consumer Defensive": "XLP",
+    "Consumer Cyclical": "XLY",
+    "Industrials": "XLI",
+    "Basic Materials": "XLB",
+    "Utilities": "XLU",
+    "Real Estate": "XLRE",
+    "Communication Services": "XLC",
+}
+
+
+def test_sector_etf_map_has_eleven_entries():
+    assert len(SECTOR_ETF_MAP) == 11
+
+
+def test_sector_etf_map_matches_frozen_contract():
+    """Every plan-§3.3 entry maps to the frozen ticker. No extra entries."""
+    assert SECTOR_ETF_MAP == _EXPECTED
+
+
+@pytest.mark.parametrize("sector,etf", list(_EXPECTED.items()))
+def test_resolve_sector_etf_returns_etf_for_each_known_sector(
+    sector: str, etf: str
+):
+    assert resolve_sector_etf(sector) == etf
+
+
+def test_resolve_sector_etf_returns_none_for_unmapped_sector():
+    """Unknown GICS sector → None so the regression service drops the factor."""
+    assert resolve_sector_etf("Magical Cryptocurrencies") is None
+
+
+def test_resolve_sector_etf_returns_none_for_missing_sector():
+    """yfinance sometimes omits ``info.sector`` entirely → None propagates."""
+    assert resolve_sector_etf(None) is None
+    assert resolve_sector_etf("") is None
+
+
+def test_resolve_sector_etf_is_case_sensitive():
+    """Casing drift should NOT silently misclassify — caller falls back instead."""
+    assert resolve_sector_etf("financial services") is None
+    assert resolve_sector_etf("TECHNOLOGY") is None

--- a/backend/tests/test_sector_etf_map.py
+++ b/backend/tests/test_sector_etf_map.py
@@ -52,7 +52,7 @@ def test_sector_etf_map_matches_frozen_contract():
     assert SECTOR_ETF_MAP == _EXPECTED
 
 
-@pytest.mark.parametrize("sector,etf", list(_EXPECTED.items()))
+@pytest.mark.parametrize(("sector", "etf"), list(_EXPECTED.items()))
 def test_resolve_sector_etf_returns_etf_for_each_known_sector(
     sector: str, etf: str
 ):
@@ -82,7 +82,7 @@ def test_resolve_sector_etf_is_case_sensitive():
 
 
 @pytest.mark.parametrize(
-    "sector, expected_etf",
+    ("sector", "expected_etf"),
     [
         ("Financial Services", "XLF"),
         ("Technology", "XLK"),

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -400,4 +400,57 @@ export async function getCoveredCallView(positionId) {
   return data;
 }
 
+
+// --- Stock Research page (v1.1.0, issue #280) ---
+//
+// Five GET endpoints + one PUT for the per-position `/positions/{id}/review`
+// screen. Sections A, B+C, D, E, F all hang off this prefix; the page hook
+// fans them out with `Promise.allSettled` so a single endpoint failure
+// degrades to a per-section tile instead of failing the whole page (NFR-3).
+
+export async function getResearchBusiness(positionId) {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}/research/business`,
+  );
+  return data;
+}
+
+export async function getResearchPriceHistory(positionId, window = '1Y') {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}/research/price-history`,
+    { params: { window } },
+  );
+  return data;
+}
+
+export async function getResearchFinancials(positionId) {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}/research/financials`,
+  );
+  return data;
+}
+
+export async function getResearchRegression(positionId, window = '1Y') {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}/research/regression`,
+    { params: { window } },
+  );
+  return data;
+}
+
+export async function getResearchThesis(positionId) {
+  const { data } = await api.get(
+    `/api/positions/${encodeURIComponent(positionId)}/research/thesis`,
+  );
+  return data;
+}
+
+export async function putResearchThesis(positionId, thesis) {
+  const { data } = await api.put(
+    `/api/positions/${encodeURIComponent(positionId)}/research/thesis`,
+    { thesis },
+  );
+  return data;
+}
+
 export default api;

--- a/frontend/app/positions/[id]/review/page.jsx
+++ b/frontend/app/positions/[id]/review/page.jsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { use } from 'react';
+import dynamic from 'next/dynamic';
+import LoadingSkeleton from '@/components/layout/LoadingSkeleton';
+
+// Route shell for /positions/[id]/review — the per-position Stock Research
+// page (issue #280). The dashboard Positions card's per-row "Review" CTA
+// routes here (replacing the legacy /journal?position={id} target).
+const StockResearchPage = dynamic(
+  () => import('@/components/research/StockResearchPage'),
+  {
+    loading: () => (
+      <div className="h-screen flex items-center justify-center bg-slate-100 dark:bg-slate-900">
+        <LoadingSkeleton />
+      </div>
+    ),
+    ssr: false,
+  },
+);
+
+export default function PositionReview({ params }) {
+  // Next 16: route params are delivered as a Promise; `use()` unwraps it.
+  const { id } = use(params);
+  return <StockResearchPage positionId={id} />;
+}

--- a/frontend/components/dashboard/DashboardPositionsCard.jsx
+++ b/frontend/components/dashboard/DashboardPositionsCard.jsx
@@ -67,8 +67,15 @@ function nextActionCta(action, ticker, positionId) {
         label: 'Cover',
         href: `/options?ticker=${encodeURIComponent(ticker)}`,
       };
-    case 'Roll':
     case 'Review':
+      // Issue #280: Review CTA routes to the per-position Stock Research
+      // page, not the journal. The other two actions in this branch
+      // continue to land in the ledger.
+      return {
+        label: action,
+        href: `/positions/${encodeURIComponent(positionId)}/review`,
+      };
+    case 'Roll':
     case 'Manage':
       return {
         label: action,

--- a/frontend/components/research/BusinessSnapshotCard.jsx
+++ b/frontend/components/research/BusinessSnapshotCard.jsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+
+/**
+ * Section A — Business snapshot card (issue #280, design spec §4 Section A).
+ *
+ * - Long-summary paragraph truncated at ~280 chars; a "Show more" toggle
+ *   reveals the full body. State is component-local — toggling does NOT
+ *   persist across navigations (spec §4 Section A).
+ * - 4-up KV strip (Sector / Industry / Market cap / Employees). 2-up on
+ *   mobile.
+ * - Per-section failure tile when the upstream returns nothing —
+ *   amber-warning iconography (not rose) because the page still works.
+ *
+ * The card frame stays visible even in the failure state so the user can
+ * still see "this is Section A". Loading skeleton mirrors the populated
+ * layout to keep the cumulative-layout-shift score honest.
+ */
+
+const SUMMARY_TRUNCATE_AT = 280;
+
+function FailureTile({ source, onRetry }) {
+  return (
+    <div data-testid="research-a-error" className="text-sm">
+      <p className="text-amber-600 dark:text-amber-400">
+        <span aria-hidden="true">⚠</span> We couldn&apos;t load this — retry
+      </p>
+      <p className="text-slate-500 dark:text-slate-400 mt-1">
+        Source unavailable: {source || 'yfinance'}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-sm font-medium hover:bg-slate-200 dark:hover:bg-slate-600"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div
+      data-testid="research-a-skeleton"
+      className="space-y-3"
+      aria-busy="true"
+    >
+      <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse w-11/12" />
+      <div className="h-3 rounded bg-slate-200 dark:bg-slate-700 animate-pulse w-10/12" />
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-14 rounded bg-slate-200 dark:bg-slate-700 animate-pulse"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function formatMarketCap(value) {
+  if (value === null || value === undefined) return '—';
+  const abs = Math.abs(value);
+  if (abs >= 1e12) return `$${(value / 1e12).toFixed(1)}T`;
+  if (abs >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
+  if (abs >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function formatEmployees(value) {
+  if (value === null || value === undefined) return '—';
+  return value.toLocaleString();
+}
+
+function KvTile({ testId, label, value }) {
+  return (
+    <div
+      data-testid={testId}
+      className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 p-3"
+    >
+      <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+      <div className="mt-1 text-sm font-medium text-slate-900 dark:text-white tabular-nums">
+        {value ?? '—'}
+      </div>
+    </div>
+  );
+}
+
+export default function BusinessSnapshotCard({ data, loading, error, onRetry }) {
+  const [expanded, setExpanded] = useState(false);
+  const summary = data?.summary || '';
+  const truncated =
+    summary.length > SUMMARY_TRUNCATE_AT
+      ? `${summary.slice(0, SUMMARY_TRUNCATE_AT)}…`
+      : summary;
+  const showToggle = summary.length > SUMMARY_TRUNCATE_AT;
+
+  return (
+    <section
+      data-testid="research-a"
+      aria-labelledby="research-a-heading"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <h2
+        id="research-a-heading"
+        className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+      >
+        A · Business snapshot
+      </h2>
+
+      {loading && !data ? (
+        <div className="mt-4">
+          <Skeleton />
+        </div>
+      ) : error && !data ? (
+        <div className="mt-4">
+          <FailureTile source="yfinance" onRetry={onRetry} />
+        </div>
+      ) : data ? (
+        <>
+          <p
+            data-testid="research-a-business-summary"
+            className="mt-3 text-sm text-slate-700 dark:text-slate-200 leading-relaxed"
+          >
+            {expanded ? summary : truncated || '—'}
+          </p>
+          {showToggle && (
+            <button
+              type="button"
+              data-testid="research-a-show-more"
+              onClick={() => setExpanded((v) => !v)}
+              className="mt-2 text-sm text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              {expanded ? 'Show less' : 'Show more'}
+            </button>
+          )}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-5">
+            <KvTile
+              testId="research-a-kv-sector"
+              label="Sector"
+              value={data.sector}
+            />
+            <KvTile
+              testId="research-a-kv-industry"
+              label="Industry"
+              value={data.industry}
+            />
+            <KvTile
+              testId="research-a-kv-market-cap"
+              label="Market cap"
+              value={formatMarketCap(data.market_cap)}
+            />
+            <KvTile
+              testId="research-a-kv-employees"
+              label="Employees"
+              value={formatEmployees(data.employees)}
+            />
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/components/research/DataCaveatsFooter.jsx
+++ b/frontend/components/research/DataCaveatsFooter.jsx
@@ -1,0 +1,59 @@
+/**
+ * Data caveats footer (issue #280, design spec §2 + §5).
+ *
+ * Single tile at the bottom of the page listing the aggregate sources +
+ * the latest refresh timestamp + the not-investment-advice disclaimer.
+ * Source pills are aggregated here (NOT surfaced per-section) per the
+ * design spec recommendation.
+ */
+function uniqueSources(sections) {
+  const set = new Set();
+  sections.forEach((s) => {
+    if (s?.source) set.add(s.source);
+  });
+  return Array.from(set);
+}
+
+function latestRefresh(sections) {
+  const stamps = sections
+    .map((s) => s?.fetched_at)
+    .filter(Boolean)
+    .sort();
+  if (!stamps.length) return null;
+  return stamps[stamps.length - 1];
+}
+
+export default function DataCaveatsFooter({ business, financials, regression }) {
+  const sources = uniqueSources([business, financials, regression]);
+  const refresh = latestRefresh([business, financials, regression]);
+  const sourceLine = sources.length
+    ? `${sources.join(' · ')} · FRED · your trades.`
+    : 'yfinance · alphavantage · FRED · your trades.';
+
+  return (
+    <section className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        Data &amp; caveats
+      </h3>
+      <p
+        data-testid="research-footer-sources"
+        className="mt-2 text-sm text-slate-700 dark:text-slate-200"
+      >
+        Sources: {sourceLine}
+      </p>
+      <p
+        data-testid="research-footer-refreshed"
+        className="mt-1 text-xs text-slate-500 dark:text-slate-400"
+      >
+        Last refresh: {refresh || 'unknown'}
+      </p>
+      <p
+        data-testid="research-footer-disclaimer"
+        className="mt-2 text-xs text-slate-500 dark:text-slate-400"
+      >
+        Not investment advice. Cached per Source pill on each section. The
+        regression decomposes recent price behavior — it is not a prediction.
+      </p>
+    </section>
+  );
+}

--- a/frontend/components/research/FinancialScorecard.jsx
+++ b/frontend/components/research/FinancialScorecard.jsx
@@ -1,0 +1,289 @@
+/**
+ * Section D — Financial scorecard (issue #280, design spec §4 Section D).
+ *
+ * Renders a 2×2 grid of stat tiles, each with a sparkline + QoQ and YoY
+ * delta pills. Sparklines are native SVG (no Plotly) — 8 points per tile
+ * is too small to warrant a charting library.
+ *
+ * Per design spec the missing-quarter and missing-metric cases each have
+ * their own visual treatment:
+ *   - Fewer than 4 quarters → render available points + show QoQ only;
+ *     YoY renders as "—" with the rationale exposed via `title` attribute.
+ *   - A specific metric absent for the latest quarter → tile renders at
+ *     `opacity-60` with "Not reported" copy.
+ */
+
+function FailureTile({ source, onRetry }) {
+  return (
+    <div data-testid="research-d-error" className="text-sm">
+      <p className="text-amber-600 dark:text-amber-400">
+        <span aria-hidden="true">⚠</span> We couldn&apos;t load this — retry
+      </p>
+      <p className="text-slate-500 dark:text-slate-400 mt-1">
+        Source unavailable: {source || 'financials'}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-sm font-medium hover:bg-slate-200 dark:hover:bg-slate-600"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div
+      data-testid="research-d-skeleton"
+      className="grid grid-cols-1 sm:grid-cols-2 gap-4"
+      aria-busy="true"
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className="h-32 rounded-lg bg-slate-200 dark:bg-slate-700 animate-pulse"
+        />
+      ))}
+    </div>
+  );
+}
+
+function Sparkline({ points }) {
+  // points: numeric array, oldest → newest.
+  const series = points.filter((v) => v !== null && v !== undefined);
+  if (series.length < 2) {
+    return (
+      <svg
+        className="w-full h-12"
+        viewBox="0 0 100 30"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <line
+          x1="0"
+          y1="15"
+          x2="100"
+          y2="15"
+          stroke="rgb(148 163 184)"
+          strokeDasharray="2 2"
+        />
+      </svg>
+    );
+  }
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const range = max - min || 1;
+  const stepX = 100 / (series.length - 1);
+  const yFor = (v) => 28 - ((v - min) / range) * 24;
+  const path = series
+    .map((v, i) => `${i === 0 ? 'M' : 'L'} ${i * stepX} ${yFor(v)}`)
+    .join(' ');
+  const lastX = (series.length - 1) * stepX;
+  const lastY = yFor(series[series.length - 1]);
+
+  return (
+    <svg
+      className="w-full h-12"
+      viewBox="0 0 100 30"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+    >
+      <path d={path} fill="none" stroke="rgb(59 130 246)" strokeWidth="1.5" />
+      <circle cx={lastX} cy={lastY} r="1.8" fill="rgb(59 130 246)" />
+    </svg>
+  );
+}
+
+function deltaClass(value) {
+  if (value === null || value === undefined) return 'text-slate-400';
+  if (value > 0) return 'text-emerald-600 dark:text-emerald-400';
+  if (value < 0) return 'text-rose-600 dark:text-rose-400';
+  return 'text-slate-400';
+}
+
+function formatPct(value) {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '▲ ' : value < 0 ? '▼ ' : '';
+  return `${sign}${Math.abs(value * 100).toFixed(1)}%`;
+}
+
+function formatPctPoints(value) {
+  if (value === null || value === undefined) return '—';
+  const sign = value > 0 ? '▲ ' : value < 0 ? '▼ ' : '';
+  return `${sign}${Math.abs(value * 100).toFixed(1)}pp`;
+}
+
+function formatRevenue(value) {
+  if (value === null || value === undefined) return '—';
+  if (Math.abs(value) >= 1e9) return `$${(value / 1e9).toFixed(2)}B`;
+  if (Math.abs(value) >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  return `$${Math.round(value).toLocaleString()}`;
+}
+
+function formatEps(value) {
+  if (value === null || value === undefined) return '—';
+  const sign = value < 0 ? '−' : '';
+  return `${sign}$${Math.abs(value).toFixed(2)}`;
+}
+
+function formatMargin(value) {
+  if (value === null || value === undefined) return '—';
+  return `${(value * 100).toFixed(0)}%`;
+}
+
+function computeQoQ(values) {
+  // values: oldest → newest
+  if (values.length < 2) return null;
+  const last = values[values.length - 1];
+  const prev = values[values.length - 2];
+  if (last === null || last === undefined || prev === null || prev === undefined) {
+    return null;
+  }
+  if (prev === 0) return null;
+  return (last - prev) / Math.abs(prev);
+}
+
+function computeYoY(values) {
+  if (values.length < 5) return null;
+  const last = values[values.length - 1];
+  const yearAgo = values[values.length - 5];
+  if (last === null || last === undefined || yearAgo === null || yearAgo === undefined) {
+    return null;
+  }
+  if (yearAgo === 0) return null;
+  return (last - yearAgo) / Math.abs(yearAgo);
+}
+
+function ScoreTile({
+  testId,
+  label,
+  values,
+  formatValue,
+  formatDelta = formatPct,
+  ariaLabel,
+}) {
+  // values: ordered oldest → newest. The payload from the backend comes
+  // newest-first; the page reverses before passing in here.
+  const last = values[values.length - 1];
+  const qoq = computeQoQ(values);
+  const yoy = computeYoY(values);
+  const missing = last === null || last === undefined;
+
+  return (
+    <div
+      data-testid={testId}
+      aria-label={ariaLabel}
+      className={`rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 p-4 ${
+        missing ? 'opacity-60' : ''
+      }`}
+    >
+      <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+      <div className="mt-1 flex items-center justify-between">
+        <span className="text-2xl font-semibold tabular-nums text-slate-900 dark:text-white">
+          {formatValue(last)}
+        </span>
+        <span className={`text-xs tabular-nums ${deltaClass(qoq)}`}>
+          {qoq === null ? '—' : `${formatDelta(qoq)} QoQ`}
+        </span>
+      </div>
+      <div className="mt-2">
+        <Sparkline points={values} />
+      </div>
+      <div className={`mt-1 text-xs tabular-nums ${deltaClass(yoy)}`}>
+        {yoy === null ? (
+          <span title="Need 4+ quarters for YoY">— YoY</span>
+        ) : (
+          `${formatDelta(yoy)} YoY`
+        )}
+      </div>
+      {missing && (
+        <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+          Not reported
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FinancialScorecard({ data, loading, error, onRetry }) {
+  let body;
+  if (loading && !data) {
+    body = <Skeleton />;
+  } else if (error && !data) {
+    body = <FailureTile source="alphavantage" onRetry={onRetry} />;
+  } else if (data) {
+    // The backend ships newest-first; sparklines want oldest-first.
+    const quarters = [...(data.quarters || [])].reverse();
+    const revenue = quarters.map((q) => q.revenue);
+    const eps = quarters.map((q) => q.eps);
+    const grossMargin = quarters.map((q) => q.gross_margin);
+    const opMargin = quarters.map((q) => q.operating_margin);
+    body = (
+      <>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <ScoreTile
+            testId="research-d-tile-revenue"
+            label="Revenue"
+            ariaLabel="Revenue trend over last 8 quarters"
+            values={revenue}
+            formatValue={formatRevenue}
+          />
+          <ScoreTile
+            testId="research-d-tile-eps"
+            label="EPS"
+            ariaLabel="Earnings per share trend over last 8 quarters"
+            values={eps}
+            formatValue={formatEps}
+          />
+          <ScoreTile
+            testId="research-d-tile-gross-margin"
+            label="Gross margin"
+            ariaLabel="Gross margin trend over last 8 quarters"
+            values={grossMargin}
+            formatValue={formatMargin}
+            formatDelta={formatPctPoints}
+          />
+          <ScoreTile
+            testId="research-d-tile-operating-margin"
+            label="Operating margin"
+            ariaLabel="Operating margin trend over last 8 quarters"
+            values={opMargin}
+            formatValue={formatMargin}
+            formatDelta={formatPctPoints}
+          />
+        </div>
+        <div
+          data-testid="research-d-source-caption"
+          className="mt-3 text-xs text-slate-500 dark:text-slate-400"
+        >
+          {data.source === 'yfinance'
+            ? `Source: yfinance (alphavantage rate-limited)`
+            : `Source: ${data.source || 'alphavantage'}`}
+          {data.fetched_at ? ` · refreshed ${data.fetched_at}` : ''}
+        </div>
+      </>
+    );
+  } else {
+    body = null;
+  }
+
+  return (
+    <section
+      data-testid="research-d"
+      aria-labelledby="research-d-heading"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <h2
+        id="research-d-heading"
+        className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+      >
+        D · Financial scorecard (last 8 quarters)
+      </h2>
+      <div className="mt-3">{body}</div>
+    </section>
+  );
+}

--- a/frontend/components/research/PositionHeader.jsx
+++ b/frontend/components/research/PositionHeader.jsx
@@ -1,0 +1,106 @@
+import Link from 'next/link';
+
+/**
+ * Position header (issue #280, design spec §3).
+ *
+ * Renders the ticker, name, sector pill, basis metadata, and the three
+ * link-out pills (Recovery / Scan CCs / Trade ledger). The link-outs are
+ * intentionally styled as **secondary outline pills** — they are
+ * navigation, not primary actions, per spec §3.
+ *
+ * Sticky behavior: the header does not stick on scroll. Spec §1 calls
+ * this out — link-outs are not primary actions and shouldn't pin to the
+ * viewport.
+ */
+
+function formatBasis(value) {
+  if (value === null || value === undefined) return null;
+  return `$${Number(value).toFixed(2)}`;
+}
+
+function formatDate(value) {
+  if (!value) return null;
+  // The journal returns ISO 8601 — slice to YYYY-MM-DD.
+  return String(value).slice(0, 10);
+}
+
+function LinkPill({ href, testId, label }) {
+  return (
+    <Link
+      href={href}
+      data-testid={testId}
+      className="inline-flex items-center px-3 py-1.5 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-sm font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700"
+    >
+      {label}
+      <span aria-hidden="true">&nbsp;→</span>
+    </Link>
+  );
+}
+
+export default function PositionHeader({ position, business }) {
+  if (!position) return null;
+  const id = position.id;
+  const ticker = position.ticker;
+  const name = business?.name || '';
+  const sector = business?.sector || position.sector || null;
+  const broker = formatBasis(position.broker_cost_basis);
+  const adjusted = formatBasis(position.adjusted_cost_basis);
+  const openedAt = formatDate(position.opened_at);
+  const shares = position.shares ?? 0;
+
+  return (
+    <div
+      data-testid="research-header"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4"
+    >
+      <div className="flex items-baseline gap-3 flex-wrap">
+        <h1
+          data-testid="research-header-ticker"
+          className="text-2xl font-semibold text-slate-900 dark:text-white"
+        >
+          {ticker}
+        </h1>
+        <span
+          data-testid="research-header-name"
+          className="text-base text-slate-500 dark:text-slate-400"
+        >
+          {name}
+        </span>
+        {sector && (
+          <span
+            data-testid="research-header-sector-pill"
+            className="inline-block px-2 py-0.5 text-xs rounded-full bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200"
+          >
+            {sector}
+          </span>
+        )}
+      </div>
+      <p
+        data-testid="research-header-basis"
+        className="mt-1 text-sm text-slate-500 dark:text-slate-400"
+      >
+        {`${shares} sh`}
+        {adjusted ? ` · basis ${adjusted} (adj)` : ''}
+        {broker ? ` · ${broker} (broker)` : ''}
+        {openedAt ? ` · open since ${openedAt}` : ''}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <LinkPill
+          testId="research-header-recovery-link"
+          href={`/positions/${encodeURIComponent(id)}/recovery`}
+          label="Recovery plan"
+        />
+        <LinkPill
+          testId="research-header-scanner-link"
+          href={`/options?ticker=${encodeURIComponent(ticker)}`}
+          label="Scan CCs"
+        />
+        <LinkPill
+          testId="research-header-journal-link"
+          href={`/journal?position=${encodeURIComponent(id)}`}
+          label="Trade ledger"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/research/RegressionInsightCard.jsx
+++ b/frontend/components/research/RegressionInsightCard.jsx
@@ -1,0 +1,355 @@
+/**
+ * Section E — Regression decomposition card (issue #280, design spec §4 Section E).
+ *
+ * Three blocks side-by-side:
+ *   1. Plain-English summary (verbatim from the backend payload)
+ *   2. Donut chart (native SVG — 4 wedges in fixed colors)
+ *   3. Beta table (factor / beta / p-value / share-of-variance)
+ *
+ * The summary is rendered verbatim from `data.summary`; the rule set
+ * lives in `backend/app/services/regression_summary.py`. The page never
+ * runs its own NLG over the regression numbers.
+ *
+ * Donut color map (frozen — spec §4 Section E):
+ *   - Market (SPY)  → blue-500
+ *   - Sector (XL*)  → emerald-500
+ *   - Rates (DGS10) → amber-500
+ *   - Idiosyncratic → slate-400
+ */
+
+const FACTOR_COLOR = {
+  market: '#3b82f6',
+  sector: '#10b981',
+  rates: '#f59e0b',
+  idiosyncratic: '#94a3b8',
+};
+
+const FACTOR_BORDER = {
+  market: 'border-blue-500',
+  sector: 'border-emerald-500',
+  rates: 'border-amber-500',
+  idiosyncratic: 'border-slate-400',
+};
+
+function FailureTile({ source, onRetry }) {
+  return (
+    <div data-testid="research-e-error" className="text-sm">
+      <p className="text-amber-600 dark:text-amber-400">
+        <span aria-hidden="true">⚠</span> We couldn&apos;t load this — retry
+      </p>
+      <p className="text-slate-500 dark:text-slate-400 mt-1">
+        Source unavailable: {source || 'regression'}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-sm font-medium hover:bg-slate-200 dark:hover:bg-slate-600"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div
+      data-testid="research-e-skeleton"
+      className="space-y-3"
+      aria-busy="true"
+    >
+      <div className="h-4 rounded bg-slate-200 dark:bg-slate-700 animate-pulse w-3/4" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-3">
+        <div className="h-44 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+        <div className="h-44 rounded bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      </div>
+    </div>
+  );
+}
+
+function Donut({ wedges, size = 180 }) {
+  // wedges: [{ name, share, color }] — share ∈ [0,1]
+  const total = wedges.reduce((sum, w) => sum + (w.share || 0), 0) || 1;
+  const radius = size / 2;
+  const strokeWidth = 28;
+  const inner = radius - strokeWidth;
+  const circumference = 2 * Math.PI * (radius - strokeWidth / 2);
+
+  // Pre-compute each wedge's dash offset via a fold so we don't mutate
+  // a closure variable across the .map callbacks (react-hooks/immutability).
+  const wedgeArcs = wedges.reduce((acc, w) => {
+    const length = (w.share / total) * circumference;
+    const offset = acc.length
+      ? acc[acc.length - 1].offset + acc[acc.length - 1].length
+      : 0;
+    acc.push({ ...w, length, offset });
+    return acc;
+  }, []);
+
+  const srLabel = wedges
+    .map((w) => `${w.name} ${(w.share * 100).toFixed(0)}%`)
+    .join(', ');
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      role="img"
+      aria-label={srLabel}
+      data-testid="research-e-donut"
+    >
+      <circle
+        cx={radius}
+        cy={radius}
+        r={radius - strokeWidth / 2}
+        fill="none"
+        stroke="rgb(226 232 240)"
+        strokeWidth={strokeWidth}
+      />
+      <g transform={`rotate(-90 ${radius} ${radius})`}>
+        {wedgeArcs.map((w) => {
+          const dash = `${w.length} ${circumference - w.length}`;
+          return (
+            <circle
+              key={w.name}
+              cx={radius}
+              cy={radius}
+              r={radius - strokeWidth / 2}
+              fill="none"
+              stroke={w.color}
+              strokeWidth={strokeWidth}
+              strokeDasharray={dash}
+              strokeDashoffset={-w.offset}
+            />
+          );
+        })}
+      </g>
+      <circle
+        cx={radius}
+        cy={radius}
+        r={inner}
+        fill="white"
+        className="dark:fill-slate-800"
+      />
+    </svg>
+  );
+}
+
+function formatBeta(value) {
+  if (value === null || value === undefined) return '—';
+  const sign = value < 0 ? '−' : '';
+  return `${sign}${Math.abs(value).toFixed(2)}`;
+}
+
+function formatPValue(value) {
+  if (value === null || value === undefined) return '—';
+  if (value > 0.05) {
+    return (
+      <span className="italic text-slate-400" title="Not statistically significant (p > 0.05)">
+        n.s.
+      </span>
+    );
+  }
+  return value.toFixed(3);
+}
+
+function formatShare(value) {
+  if (value === null || value === undefined) return '—';
+  return `${Math.round(value * 100)}%`;
+}
+
+function BetaRow({ rowId, color, name, label, beta, pValue, share, omitted }) {
+  return (
+    <tr
+      data-testid={rowId}
+      className={`border-l-4 ${color} bg-white dark:bg-slate-800`}
+    >
+      <td className="py-1.5 px-2 text-sm text-slate-700 dark:text-slate-200">
+        {name}
+        {label ? (
+          <span className="ml-1 text-slate-500 dark:text-slate-400 text-xs">
+            ({label})
+          </span>
+        ) : null}
+        {omitted ? (
+          <span className="ml-1 italic text-slate-400 text-xs">
+            (omitted: sector unmapped)
+          </span>
+        ) : null}
+      </td>
+      <td className="py-1.5 px-2 text-sm tabular-nums text-slate-700 dark:text-slate-200">
+        {omitted ? '—' : formatBeta(beta)}
+      </td>
+      <td className="py-1.5 px-2 text-sm tabular-nums text-slate-700 dark:text-slate-200">
+        {omitted ? '—' : formatPValue(pValue)}
+      </td>
+      <td className="py-1.5 px-2 text-sm tabular-nums text-right text-slate-700 dark:text-slate-200">
+        {formatShare(share)}
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * Map a backend `factor` row to the {key,label,name} we render under.
+ * The backend names factors by ticker (e.g. "SPY", "XLF", "DGS10"); the
+ * frontend groups them under the four canonical buckets per the spec.
+ */
+function categorizeFactor(factor) {
+  const name = (factor?.name || '').toUpperCase();
+  if (name === 'SPY' || name === '^GSPC') {
+    return { key: 'market', label: name, displayName: 'Market' };
+  }
+  if (name === 'DGS10' || name.endsWith('YIELD')) {
+    return { key: 'rates', label: name, displayName: 'Rates' };
+  }
+  if (name.startsWith('XL') || factor?.role === 'sector') {
+    return { key: 'sector', label: name, displayName: 'Sector' };
+  }
+  return { key: 'sector', label: name, displayName: 'Sector' };
+}
+
+export default function RegressionInsightCard({ data, loading, error, onRetry }) {
+  let body;
+  if (loading && !data) {
+    body = <Skeleton />;
+  } else if (error && !data) {
+    body = <FailureTile source="regression" onRetry={onRetry} />;
+  } else if (data) {
+    const factors = data.factors || [];
+    const idioShare = data.idiosyncratic_share ?? Math.max(0, 1 - (data.r_squared ?? 0));
+    const sectorOmitted = !!data.sector_omitted;
+
+    // Bucket factors by category so each row in the table maps to a wedge.
+    const categorized = factors.map((f) => ({ ...categorizeFactor(f), raw: f }));
+    const find = (key) => categorized.find((c) => c.key === key);
+    const market = find('market');
+    const sector = find('sector');
+    const rates = find('rates');
+
+    const wedges = [
+      {
+        name: 'market',
+        share: market?.raw?.share ?? 0,
+        color: FACTOR_COLOR.market,
+      },
+      ...(sectorOmitted || !sector
+        ? []
+        : [
+            {
+              name: 'sector',
+              share: sector.raw?.share ?? 0,
+              color: FACTOR_COLOR.sector,
+            },
+          ]),
+      {
+        name: 'rates',
+        share: rates?.raw?.share ?? 0,
+        color: FACTOR_COLOR.rates,
+      },
+      {
+        name: 'idiosyncratic',
+        share: idioShare,
+        color: FACTOR_COLOR.idiosyncratic,
+      },
+    ];
+
+    const basket = (data.basket || []).join(' + ');
+    body = (
+      <>
+        <p
+          data-testid="research-e-summary"
+          className="text-sm text-slate-700 dark:text-slate-200"
+        >
+          {data.summary || '—'}
+        </p>
+        <div className="mt-4 grid grid-cols-1 md:grid-cols-[auto_1fr] items-center gap-6">
+          <div className="flex justify-center">
+            <Donut wedges={wedges} />
+          </div>
+          <div className="overflow-x-auto">
+            <table
+              data-testid="research-e-beta-table"
+              className="w-full text-sm border-separate border-spacing-y-1"
+            >
+              <thead className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                <tr>
+                  <th className="text-left px-2">Factor</th>
+                  <th className="text-left px-2">Beta</th>
+                  <th className="text-left px-2">p-value</th>
+                  <th className="text-right px-2">Share</th>
+                </tr>
+              </thead>
+              <tbody>
+                <BetaRow
+                  rowId="research-e-row-market"
+                  color={FACTOR_BORDER.market}
+                  name="Market"
+                  label={market?.label}
+                  beta={market?.raw?.beta}
+                  pValue={market?.raw?.p_value}
+                  share={market?.raw?.share}
+                />
+                <BetaRow
+                  rowId="research-e-row-sector"
+                  color={FACTOR_BORDER.sector}
+                  name="Sector"
+                  label={sectorOmitted ? '—' : sector?.label}
+                  beta={sector?.raw?.beta}
+                  pValue={sector?.raw?.p_value}
+                  share={sector?.raw?.share}
+                  omitted={sectorOmitted}
+                />
+                <BetaRow
+                  rowId="research-e-row-rates"
+                  color={FACTOR_BORDER.rates}
+                  name="Rates"
+                  label={rates?.label || 'DGS10'}
+                  beta={rates?.raw?.beta}
+                  pValue={rates?.raw?.p_value}
+                  share={rates?.raw?.share}
+                />
+                <BetaRow
+                  rowId="research-e-row-idiosyncratic"
+                  color={FACTOR_BORDER.idiosyncratic}
+                  name="Idiosyncratic"
+                  label={null}
+                  beta={null}
+                  pValue={null}
+                  share={idioShare}
+                />
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <p
+          data-testid="research-e-basket-caption"
+          className="mt-3 text-xs text-slate-500 dark:text-slate-400"
+        >
+          {basket ? `Basket: ${basket} · ` : ''}
+          {data.window || '1Y'} daily · n={data.sample_size ?? '—'} · R²=
+          {data.r_squared !== null && data.r_squared !== undefined
+            ? data.r_squared.toFixed(2)
+            : '—'}
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <section
+      data-testid="research-e"
+      aria-labelledby="research-e-heading"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <h2
+        id="research-e-heading"
+        className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+      >
+        E · What drives this stock?
+      </h2>
+      <div className="mt-3">{body}</div>
+    </section>
+  );
+}

--- a/frontend/components/research/ResearchPriceChart.jsx
+++ b/frontend/components/research/ResearchPriceChart.jsx
@@ -1,0 +1,306 @@
+import dynamic from 'next/dynamic';
+import { TRADE_MARKER_VOCAB } from './tradeMarkerVocabulary';
+
+// Plotly is heavy + browser-only. Dynamic-import so the page shell
+// renders the skeleton before the chart bundle arrives.
+const Plot = dynamic(() => import('../charts/PlotlyChart'), { ssr: false });
+
+/**
+ * Section B + C — Price chart with basis lines, trade markers, and
+ * earnings annotations (issue #280, design spec §4 Section B + C).
+ *
+ * Sections B and C share one chart by design:
+ *   - Layer 1: daily close prices (slate line)
+ *   - Layer 2: broker basis (blue, dotted) + adjusted basis (emerald, solid)
+ *              — shape lines at fixed y-values
+ *   - Layer 3: trade markers per `TRADE_MARKER_VOCAB`
+ *   - Layer 4: earnings annotations (rose `E` glyphs at chart top with a
+ *              dashed vertical line down to the price)
+ *
+ * Accessibility: a visually-hidden table below the chart (`research-b-sr-table`)
+ * lists every trade and earnings event in chronological order, with the
+ * date/type/detail columns the design spec §8 calls for. Screen readers
+ * announce this; the chart wrapper has an explanatory `aria-label`.
+ */
+
+function FailureTile({ source, onRetry }) {
+  return (
+    <div data-testid="research-b-error" className="text-sm">
+      <p className="text-amber-600 dark:text-amber-400">
+        <span aria-hidden="true">⚠</span> We couldn&apos;t load this — retry
+      </p>
+      <p className="text-slate-500 dark:text-slate-400 mt-1">
+        Source unavailable: {source || 'price source'}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-sm font-medium hover:bg-slate-200 dark:hover:bg-slate-600"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div
+      data-testid="research-b-skeleton"
+      className="h-[360px] rounded-lg bg-slate-200 dark:bg-slate-700 animate-pulse"
+      aria-busy="true"
+    />
+  );
+}
+
+function PlotlyImpl({ data }) {
+  const prices = data?.prices || [];
+  const dates = prices.map((p) => p.date);
+  const closes = prices.map((p) => p.close);
+  const broker = data?.basis?.broker ?? null;
+  const adjusted = data?.basis?.adjusted ?? null;
+  const tradeEvents = data?.trade_events || [];
+  const earningsEvents = data?.earnings_events || [];
+
+  const colorFor = (token) => {
+    switch (token) {
+      case 'text-emerald-500':
+        return '#10b981';
+      case 'text-rose-500':
+        return '#f43f5e';
+      case 'text-slate-400':
+        return '#94a3b8';
+      case 'text-amber-500':
+        return '#f59e0b';
+      default:
+        return '#64748b';
+    }
+  };
+
+  const tradesByType = tradeEvents.reduce((acc, ev) => {
+    const key = ev.type;
+    if (!acc[key]) acc[key] = [];
+    acc[key].push(ev);
+    return acc;
+  }, {});
+
+  const priceByDate = Object.fromEntries(prices.map((p) => [p.date, p.close]));
+
+  const tradeTraces = Object.entries(tradesByType).map(([type, events]) => {
+    const vocab = TRADE_MARKER_VOCAB[type];
+    if (!vocab) return null;
+    return {
+      x: events.map((e) => e.date),
+      y: events.map((e) => priceByDate[e.date] ?? null),
+      type: 'scatter',
+      mode: 'markers',
+      name: type,
+      marker: {
+        symbol: vocab.symbol,
+        size: 10,
+        color: colorFor(vocab.color),
+      },
+      hoverinfo: 'x+name',
+    };
+  }).filter(Boolean);
+
+  const traces = [
+    {
+      x: dates,
+      y: closes,
+      type: 'scatter',
+      mode: 'lines',
+      name: 'Close',
+      line: { color: '#94a3b8', width: 1.5 },
+      hovertemplate: '%{x|%Y-%m-%d} · $%{y:.2f}<extra></extra>',
+    },
+    ...tradeTraces,
+  ];
+
+  const shapes = [];
+  if (broker !== null && broker !== undefined) {
+    shapes.push({
+      type: 'line',
+      xref: 'paper',
+      x0: 0,
+      x1: 1,
+      y0: broker,
+      y1: broker,
+      line: { color: '#3b82f6', width: 1, dash: 'dot' },
+    });
+  }
+  if (adjusted !== null && adjusted !== undefined) {
+    shapes.push({
+      type: 'line',
+      xref: 'paper',
+      x0: 0,
+      x1: 1,
+      y0: adjusted,
+      y1: adjusted,
+      line: { color: '#10b981', width: 1.5 },
+    });
+  }
+  // Earnings vertical dashes
+  earningsEvents.forEach((ev) => {
+    shapes.push({
+      type: 'line',
+      x0: ev.date,
+      x1: ev.date,
+      y0: 0,
+      y1: 1,
+      yref: 'paper',
+      line: { color: '#fb7185', width: 1, dash: 'dash' },
+    });
+  });
+
+  const annotations = earningsEvents.map((ev) => ({
+    x: ev.date,
+    y: 1,
+    yref: 'paper',
+    text: 'E',
+    showarrow: false,
+    font: { size: 11, color: '#fb7185', weight: 'bold' },
+    yanchor: 'bottom',
+  }));
+
+  const layout = {
+    paper_bgcolor: 'transparent',
+    plot_bgcolor: 'transparent',
+    margin: { l: 50, r: 16, t: 32, b: 36 },
+    height: 360,
+    hovermode: 'closest',
+    showlegend: false,
+    xaxis: {
+      gridcolor: 'rgba(148,163,184,0.2)',
+    },
+    yaxis: {
+      gridcolor: 'rgba(148,163,184,0.2)',
+    },
+    shapes,
+    annotations,
+  };
+
+  return (
+    <Plot
+      data={traces}
+      layout={layout}
+      config={{ displayModeBar: false, responsive: true }}
+      style={{ width: '100%', height: '360px' }}
+    />
+  );
+}
+
+function ScreenReaderTable({ data }) {
+  const trades = data?.trade_events || [];
+  const earnings = data?.earnings_events || [];
+  const rows = [
+    ...trades.map((t) => ({
+      date: t.date,
+      type: t.type,
+      detail: `Strike ${t.strike ?? '—'}`,
+    })),
+    ...earnings.map((e) => ({
+      date: e.date,
+      type: 'earnings',
+      detail: e.label || 'Quarterly earnings',
+    })),
+  ].sort((a, b) => (a.date < b.date ? -1 : 1));
+
+  return (
+    <table data-testid="research-b-sr-table" className="sr-only">
+      <caption>Trade and earnings events on the price chart</caption>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Event type</th>
+          <th>Detail</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr key={`${r.date}-${r.type}-${i}`}>
+            <td>{r.date}</td>
+            <td>{r.type}</td>
+            <td>{r.detail}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function Legend() {
+  const entries = [
+    { type: 'sell_put', label: 'Sell put' },
+    { type: 'sell_call', label: 'Sell call' },
+    { type: 'assignment', label: 'Assignment' },
+    { type: 'expired', label: 'Expired' },
+    { type: 'buy_close', label: 'Buy to close' },
+  ];
+  return (
+    <div
+      data-testid="research-b-legend"
+      className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500 dark:text-slate-400"
+    >
+      {entries.map((e) => {
+        const v = TRADE_MARKER_VOCAB[e.type];
+        if (!v) return null;
+        return (
+          <span key={e.type} className={`inline-flex items-center ${v.color}`}>
+            <span aria-hidden="true">{v.glyph}</span>
+            <span className="ml-1">{e.label}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+export default function ResearchPriceChart({ data, loading, error, onRetry }) {
+  return (
+    <section
+      data-testid="research-b"
+      aria-labelledby="research-b-heading"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <div className="flex items-center justify-between">
+        <h2
+          id="research-b-heading"
+          className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+        >
+          B · Price chart with basis &amp; events
+        </h2>
+        <button
+          type="button"
+          data-testid="research-b-window-selector"
+          disabled
+          title="Window picker coming soon"
+          className="text-xs px-2 py-1 rounded border border-slate-200 dark:border-slate-700 text-slate-400 dark:text-slate-500 opacity-50 cursor-not-allowed"
+        >
+          1Y ▾
+        </button>
+      </div>
+
+      <div className="mt-3">
+        {loading && !data ? (
+          <Skeleton />
+        ) : error && !data ? (
+          <FailureTile source="price source" onRetry={onRetry} />
+        ) : data ? (
+          <>
+            <div
+              data-testid="research-b-chart"
+              aria-label={`Price chart for ${data.ticker || ''} with basis lines and ${
+                (data.trade_events || []).length
+              } trade events.`}
+            >
+              <PlotlyImpl data={data} />
+            </div>
+            <Legend />
+            <ScreenReaderTable data={data} />
+          </>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/research/StockResearchPage.jsx
+++ b/frontend/components/research/StockResearchPage.jsx
@@ -1,0 +1,174 @@
+"use client";
+
+import Link from 'next/link';
+import Header from '../layout/Header';
+import { useStockResearch } from '../../hooks/useStockResearch';
+import BusinessSnapshotCard from './BusinessSnapshotCard';
+import ResearchPriceChart from './ResearchPriceChart';
+import FinancialScorecard from './FinancialScorecard';
+import RegressionInsightCard from './RegressionInsightCard';
+import ThesisNoteEditor from './ThesisNoteEditor';
+import PositionHeader from './PositionHeader';
+import DataCaveatsFooter from './DataCaveatsFooter';
+
+/**
+ * StockResearchPage — top-level state machine for /positions/[id]/review
+ * (issue #280).
+ *
+ * Mirrors the recovery / BTC page-state contract:
+ *
+ *   loading   → page skeleton (mirrors the populated layout for CLS-stability)
+ *   not-found → centered EmptyState (full-page 404)
+ *   error     → red retry banner (transient backend failures)
+ *   populated → header + 6 sections + footer
+ *
+ * Per-section failures are handled INSIDE each section component (NFR-3 /
+ * design spec §7) — only a hard-fail on the *position* itself collapses
+ * the page to the full-page error/404 state.
+ */
+
+function FullPageError({ message, onRetry }) {
+  return (
+    <div
+      data-testid="research-error"
+      className="rounded-xl bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-4 text-sm text-red-700 dark:text-red-300 flex items-center justify-between gap-4"
+    >
+      <span>{message || "Couldn't load this position."}</span>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="px-3 py-1.5 rounded-lg bg-red-600 text-white text-sm font-medium hover:bg-red-700 shrink-0"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function NotFound() {
+  return (
+    <div
+      data-testid="research-not-found"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-6 text-center"
+    >
+      <h2 className="text-base font-semibold text-slate-900 dark:text-white">
+        That position isn&apos;t on file
+      </h2>
+      <p className="text-sm text-slate-500 dark:text-slate-400 mt-2 max-w-prose mx-auto">
+        It may have been deleted or never existed.
+      </p>
+      <Link
+        href="/dashboard"
+        className="inline-block mt-4 text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+      >
+        ← Back to dashboard
+      </Link>
+    </div>
+  );
+}
+
+function FullPageSkeleton() {
+  return (
+    <div data-testid="research-loading" className="space-y-6">
+      <div className="h-20 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      <div className="h-40 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      <div className="h-72 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      <div className="h-48 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      <div className="h-60 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+      <div className="h-48 rounded-xl bg-slate-200 dark:bg-slate-700 animate-pulse" />
+    </div>
+  );
+}
+
+export default function StockResearchPage({ positionId }) {
+  const {
+    position,
+    business,
+    priceHistory,
+    financials,
+    regression,
+    thesis,
+    refetchSection,
+    refetchAll,
+  } = useStockResearch(positionId);
+
+  const positionData = position.data;
+  const positionStatus = position.status;
+  const positionLoading = position.loading;
+  const positionError = position.error;
+
+  return (
+    <div
+      data-testid="research-page"
+      className="min-h-screen flex flex-col bg-slate-100 dark:bg-slate-900"
+    >
+      <Header sessions={[]} onLoadSession={() => {}} />
+      <main className="flex-1 max-w-4xl w-full mx-auto px-6 py-8 space-y-6">
+        <Link
+          href="/dashboard"
+          data-testid="research-back-to-dashboard"
+          className="inline-block text-sm font-medium text-blue-700 dark:text-blue-300 hover:underline"
+        >
+          ← Back to dashboard
+        </Link>
+
+        {positionLoading && !positionData && <FullPageSkeleton />}
+
+        {!positionLoading && positionStatus === 404 && <NotFound />}
+
+        {!positionLoading && positionError && positionStatus !== 404 && (
+          <FullPageError message={positionError} onRetry={refetchAll} />
+        )}
+
+        {positionData && (
+          <>
+            <PositionHeader position={positionData} business={business.data} />
+
+            <BusinessSnapshotCard
+              data={business.data}
+              loading={business.loading}
+              error={business.error}
+              onRetry={() => refetchSection('business')}
+            />
+
+            <ResearchPriceChart
+              data={priceHistory.data}
+              loading={priceHistory.loading}
+              error={priceHistory.error}
+              onRetry={() => refetchSection('priceHistory')}
+            />
+
+            <FinancialScorecard
+              data={financials.data}
+              loading={financials.loading}
+              error={financials.error}
+              onRetry={() => refetchSection('financials')}
+            />
+
+            <RegressionInsightCard
+              data={regression.data}
+              loading={regression.loading}
+              error={regression.error}
+              onRetry={() => refetchSection('regression')}
+            />
+
+            <ThesisNoteEditor
+              ticker={positionData.ticker}
+              data={thesis.data}
+              loading={thesis.loading}
+              error={thesis.error}
+              onRetry={() => refetchSection('thesis')}
+              saveThesis={thesis.save}
+            />
+
+            <DataCaveatsFooter
+              business={business.data}
+              financials={financials.data}
+              regression={regression.data}
+            />
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/components/research/ThesisNoteEditor.jsx
+++ b/frontend/components/research/ThesisNoteEditor.jsx
@@ -86,6 +86,9 @@ export default function ThesisNoteEditor({
   // render" pattern — preferred over useEffect+setState for hydration.
   const [hydratedFrom, setHydratedFrom] = useState(null);
   const debounceTimer = useRef(null);
+  // Last-saved body snapshot — used by handleBlur (CR #10) to skip the
+  // redundant PUT when the user clicks away without editing.
+  const lastSavedBodyRef = useRef('');
 
   // Render-phase hydration from the GET payload. Runs exactly once per
   // distinct server payload identity (object reference comparison) —
@@ -98,6 +101,15 @@ export default function ThesisNoteEditor({
     setExpectedVersion(data.version ?? 0);
   }
 
+  // Mirror the hydrated body into the last-saved snapshot. Done in an
+  // effect (not render-phase) so the react-hooks/refs linter is happy
+  // — refs must not be written during render.
+  useEffect(() => {
+    if (data && hydratedFrom === data) {
+      lastSavedBodyRef.current = data.thesis || '';
+    }
+  }, [data, hydratedFrom]);
+
   const flush = useCallback(
     async (current) => {
       const trimmed = (current ?? '').slice(0, THESIS_MAX);
@@ -107,6 +119,9 @@ export default function ThesisNoteEditor({
       const result = await saveThesis(trimmed);
       if (result?.ok) {
         setLastSavedAt(result.updatedAt || new Date().toISOString());
+        // Remember what we just persisted so the next blur can skip a
+        // redundant PUT (CR #10).
+        lastSavedBodyRef.current = trimmed;
         // If the server jumped more than +1 version since our last write,
         // another tab beat us — flag the conflict per spec §4 Section F.
         if (
@@ -163,8 +178,15 @@ export default function ThesisNoteEditor({
       window.clearTimeout(debounceTimer.current);
       debounceTimer.current = null;
     }
-    // Only flush if there's pending input vs the last-saved server state.
-    if (status === STATUS_SAVING || status === STATUS_IDLE) {
+    // Only flush when we have pending input the server doesn't already
+    // have (CR #10). A debounce cancel is fine — the next render will
+    // re-queue if needed.
+    if (status === STATUS_SAVING) {
+      // An in-flight debounce was already cleared above; force the flush.
+      flush(body);
+      return;
+    }
+    if (status === STATUS_IDLE && body !== lastSavedBodyRef.current) {
       flush(body);
     }
   };

--- a/frontend/components/research/ThesisNoteEditor.jsx
+++ b/frontend/components/research/ThesisNoteEditor.jsx
@@ -1,0 +1,290 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Section F — Thesis editor (issue #280, design spec §4 Section F).
+ *
+ * Plain-text autosave with four visible lifecycle states:
+ *
+ *   idle    → mounted, no edits yet OR no recent edits
+ *   saving  → 500ms after the last keystroke, a PUT is in flight
+ *   saved   → 200 from the PUT, < ~2s ago — transitions back to idle
+ *   failed  → non-2xx, network error, OR a cross-tab version conflict
+ *
+ * Save-on-blur is layered on top of the debounce so unsaved work is
+ * flushed when the user navigates away. The hard cap (4000 chars) is
+ * enforced both client-side (`maxLength` on the textarea) and server-side
+ * (the router returns 422 if the body squeaks past somehow).
+ *
+ * The save function is injected by the parent so this component does not
+ * own its own axios client. The function returns
+ * `{ ok, version, updatedAt, error?, status? }`.
+ */
+
+const THESIS_MAX = 4000;
+const DEBOUNCE_MS = 500;
+
+const STATUS_IDLE = 'idle';
+const STATUS_SAVING = 'saving';
+const STATUS_SAVED = 'saved';
+const STATUS_FAILED = 'failed';
+
+function formatRelative(ts) {
+  if (!ts) return '';
+  const updated = new Date(ts);
+  if (Number.isNaN(updated.getTime())) return '';
+  const seconds = Math.max(1, Math.round((Date.now() - updated.getTime()) / 1000));
+  if (seconds < 60) return `Saved ${seconds} seconds ago`;
+  if (seconds < 3600) return `Saved ${Math.round(seconds / 60)} minutes ago`;
+  return `Saved ${updated.toISOString().slice(0, 16).replace('T', ' ')}`;
+}
+
+function FailureTile({ onRetry }) {
+  return (
+    <div data-testid="research-f-error" className="text-sm">
+      <p className="text-amber-600 dark:text-amber-400">
+        <span aria-hidden="true">⚠</span> We couldn&apos;t load your thesis — retry
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-3 px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-sm font-medium hover:bg-slate-200 dark:hover:bg-slate-600"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div
+      data-testid="research-f-skeleton"
+      className="h-56 rounded-lg bg-slate-200 dark:bg-slate-700 animate-pulse"
+      aria-busy="true"
+    />
+  );
+}
+
+export default function ThesisNoteEditor({
+  ticker,
+  data,
+  loading,
+  error,
+  onRetry,
+  saveThesis,
+}) {
+  const [body, setBody] = useState('');
+  const [status, setStatus] = useState(STATUS_IDLE);
+  const [lastSavedAt, setLastSavedAt] = useState(null);
+  const [conflictMessage, setConflictMessage] = useState(null);
+  // The version we expect on the server. State (not ref) so the
+  // render-phase hydration below can update it without violating the
+  // react-hooks/refs rule.
+  const [expectedVersion, setExpectedVersion] = useState(0);
+  // Tracks the most recent server payload we've reflected into local state.
+  // This is the React-recommended "store previous prop to derive state during
+  // render" pattern — preferred over useEffect+setState for hydration.
+  const [hydratedFrom, setHydratedFrom] = useState(null);
+  const debounceTimer = useRef(null);
+
+  // Render-phase hydration from the GET payload. Runs exactly once per
+  // distinct server payload identity (object reference comparison) —
+  // subsequent server-side echoes (e.g., from our own saves) update
+  // `data` but the editor's local body is already in sync.
+  if (data && !loading && hydratedFrom !== data) {
+    setHydratedFrom(data);
+    setBody(data.thesis || '');
+    setLastSavedAt(data.updated_at || null);
+    setExpectedVersion(data.version ?? 0);
+  }
+
+  const flush = useCallback(
+    async (current) => {
+      const trimmed = (current ?? '').slice(0, THESIS_MAX);
+      setStatus(STATUS_SAVING);
+      setConflictMessage(null);
+      const expected = expectedVersion;
+      const result = await saveThesis(trimmed);
+      if (result?.ok) {
+        setLastSavedAt(result.updatedAt || new Date().toISOString());
+        // If the server jumped more than +1 version since our last write,
+        // another tab beat us — flag the conflict per spec §4 Section F.
+        if (
+          typeof result.version === 'number' &&
+          result.version > expected + 1
+        ) {
+          setStatus(STATUS_FAILED);
+          setConflictMessage(
+            'Your thesis was edited in another tab · Reload to see the latest',
+          );
+        } else {
+          setStatus(STATUS_SAVED);
+          // Transition back to idle after the "saved just now" window
+          // lapses (spec §4 Section F autosave lifecycle table).
+          window.setTimeout(() => {
+            setStatus((s) => (s === STATUS_SAVED ? STATUS_IDLE : s));
+          }, 2000);
+        }
+        if (typeof result.version === 'number') {
+          setExpectedVersion(result.version);
+        }
+      } else {
+        setStatus(STATUS_FAILED);
+        setConflictMessage(null);
+      }
+    },
+    [expectedVersion, saveThesis],
+  );
+
+  const queueSave = useCallback(
+    (next) => {
+      if (debounceTimer.current) {
+        window.clearTimeout(debounceTimer.current);
+      }
+      debounceTimer.current = window.setTimeout(() => {
+        debounceTimer.current = null;
+        flush(next);
+      }, DEBOUNCE_MS);
+    },
+    [flush],
+  );
+
+  const handleChange = (e) => {
+    let next = e.target.value;
+    if (next.length > THESIS_MAX) {
+      next = next.slice(0, THESIS_MAX);
+    }
+    setBody(next);
+    queueSave(next);
+  };
+
+  const handleBlur = () => {
+    if (debounceTimer.current) {
+      window.clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+    // Only flush if there's pending input vs the last-saved server state.
+    if (status === STATUS_SAVING || status === STATUS_IDLE) {
+      flush(body);
+    }
+  };
+
+  const handleRetry = () => {
+    flush(body);
+  };
+
+  // Cleanup any pending debounce on unmount.
+  useEffect(() => () => {
+    if (debounceTimer.current) {
+      window.clearTimeout(debounceTimer.current);
+    }
+  }, []);
+
+  const countClass =
+    body.length >= 3900
+      ? 'text-rose-600 dark:text-rose-400'
+      : body.length >= 3600
+        ? 'text-amber-600 dark:text-amber-400'
+        : 'text-slate-500 dark:text-slate-400';
+
+  let statusRow;
+  if (status === STATUS_SAVING) {
+    statusRow = (
+      <span
+        data-testid="research-f-status-saving"
+        className="text-slate-500 dark:text-slate-400"
+      >
+        Saving…
+      </span>
+    );
+  } else if (status === STATUS_SAVED) {
+    statusRow = (
+      <span
+        data-testid="research-f-status-saved"
+        className="text-emerald-600 dark:text-emerald-400"
+      >
+        ✓ Saved just now
+      </span>
+    );
+  } else if (status === STATUS_FAILED) {
+    statusRow = (
+      <span
+        data-testid="research-f-status-failed"
+        className="text-rose-600 dark:text-rose-400"
+      >
+        ⚠ {conflictMessage || "Couldn't save"}
+        {' · '}
+        <button
+          type="button"
+          data-testid="research-f-status-retry"
+          onClick={handleRetry}
+          className="underline"
+        >
+          Retry
+        </button>
+      </span>
+    );
+  } else {
+    statusRow = (
+      <span
+        data-testid="research-f-status-idle"
+        className="text-slate-500 dark:text-slate-400"
+      >
+        {formatRelative(lastSavedAt) || 'No edits yet'}
+      </span>
+    );
+  }
+
+  return (
+    <section
+      data-testid="research-f"
+      aria-labelledby="research-f-heading"
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-5"
+    >
+      <h2
+        id="research-f-heading"
+        className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400"
+      >
+        F · Your thesis
+      </h2>
+      <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+        Why you bought, what would change your mind.
+      </p>
+
+      <div className="mt-3">
+        {loading && !data ? (
+          <Skeleton />
+        ) : error && !data ? (
+          <FailureTile onRetry={onRetry} />
+        ) : (
+          <>
+            <textarea
+              data-testid="research-f-textarea"
+              aria-label={`Your thesis for ${ticker || 'this position'}`}
+              value={body}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              maxLength={THESIS_MAX}
+              rows={12}
+              placeholder={'Bull case: ...\nBear case: ...\nWhat changes my mind: ...'}
+              className="w-full max-w-3xl rounded-lg border border-slate-300 dark:border-slate-600 bg-slate-50 dark:bg-slate-900/40 p-3 text-sm text-slate-900 dark:text-white"
+            />
+            <div
+              aria-live="polite"
+              className="mt-2 flex items-center justify-between text-sm"
+            >
+              {statusRow}
+              <span
+                data-testid="research-f-char-count"
+                aria-live="off"
+                className={`tabular-nums text-xs ${countClass}`}
+              >
+                {body.length} / {THESIS_MAX} chars
+              </span>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/components/research/tradeMarkerVocabulary.js
+++ b/frontend/components/research/tradeMarkerVocabulary.js
@@ -1,0 +1,33 @@
+/**
+ * Trade-marker vocabulary (issue #280, design spec §4 Section B / plan §4.8).
+ *
+ * Each event type maps to one Plotly marker symbol + one Tailwind color
+ * token. The mapping is frozen — the implementer wires this constant
+ * verbatim and never edits keys at the render site. Colors are chosen so
+ * they remain visually distinguishable on the price chart and never
+ * collide with the basis-line hues (blue, emerald) used on the same chart.
+ *
+ * The earnings annotation is rendered separately (rose `E` glyph at the
+ * top of the chart) and intentionally re-uses rose with assignment /
+ * called_away — earnings markers sit on the chart's top edge, trade
+ * markers ride on the price line, so they never occupy the same y-axis
+ * row.
+ */
+export const TRADE_MARKER_VOCAB = {
+  sell_put: { symbol: 'circle', glyph: '●', color: 'text-emerald-500' },
+  sell_call: { symbol: 'triangle-up', glyph: '▲', color: 'text-emerald-500' },
+  assignment: { symbol: 'diamond', glyph: '◆', color: 'text-rose-500' },
+  called_away: { symbol: 'diamond', glyph: '◆', color: 'text-rose-500' },
+  expired: { symbol: 'circle-open', glyph: '○', color: 'text-slate-400' },
+  buy_close: { symbol: 'triangle-down', glyph: '▽', color: 'text-amber-500' },
+};
+
+/**
+ * Resolve a marker descriptor for a trade type, falling back to a
+ * conservative "unknown" pill so the chart never crashes on a new
+ * `trade_type` string the backend introduces in a future release.
+ */
+export function resolveTradeMarker(type) {
+  if (!type) return null;
+  return TRADE_MARKER_VOCAB[type] || null;
+}

--- a/frontend/components/research/tradeMarkerVocabulary.js
+++ b/frontend/components/research/tradeMarkerVocabulary.js
@@ -23,9 +23,11 @@ export const TRADE_MARKER_VOCAB = {
 };
 
 /**
- * Resolve a marker descriptor for a trade type, falling back to a
- * conservative "unknown" pill so the chart never crashes on a new
- * `trade_type` string the backend introduces in a future release.
+ * Resolve a marker descriptor for a trade type. Returns `null` when the
+ * type is missing or not in `TRADE_MARKER_VOCAB`. Callers MUST handle
+ * `null` defensively (skip the marker, or render a generic glyph) so the
+ * chart does not crash on a new `trade_type` string the backend
+ * introduces in a future release.
  */
 export function resolveTradeMarker(type) {
   if (!type) return null;

--- a/frontend/e2e/stock-research.spec.js
+++ b/frontend/e2e/stock-research.spec.js
@@ -1,0 +1,475 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for issue #280 — per-position Stock Research page (/positions/[id]/review).
+ *
+ * Covers the PRD AC list:
+ *   - The dashboard Positions "Review" CTA routes to /positions/{id}/review
+ *     (not /journal?position={id}, which was the legacy destination).
+ *   - The page header link-outs route to recovery / scanner / journal.
+ *   - All six sections render in the populated state.
+ *   - Per-section endpoint failure surfaces the section-level retry tile —
+ *     other sections still render (NFR-3).
+ *   - The full-page error and 404 states render when the position itself
+ *     fails to load.
+ *   - The thesis editor autosaves with the documented lifecycle.
+ *   - The thesis editor enforces the 4000-character client-side cap.
+ *
+ * Every test mocks the backend at the route level. No live backend, no
+ * yfinance / Alpha Vantage / FRED traffic.
+ */
+
+const POSITION_ID = 'pos-sofi';
+
+// --- Fixture builders -------------------------------------------------------
+
+function positionPayload(overrides = {}) {
+  return {
+    id: POSITION_ID,
+    ticker: 'SOFI',
+    shares: 100,
+    broker_cost_basis: 2856.0,
+    adjusted_cost_basis: 2632.0,
+    current_price: 23.76,
+    unrealized_pl: -224.0,
+    pl_pct: -0.078,
+    status: 'open',
+    strategy: 'wheel',
+    opened_at: '2024-09-12T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function businessPayload() {
+  return {
+    ticker: 'SOFI',
+    name: 'SoFi Technologies, Inc.',
+    summary:
+      'SoFi is a personal finance company offering a wide range of financial services and products through its mobile-first platform.',
+    sector: 'Financial Services',
+    industry: 'Credit Services',
+    market_cap: 18230000000,
+    employees: 4900,
+    source: 'yfinance',
+    fetched_at: '2026-05-22T17:30:00Z',
+  };
+}
+
+function priceHistoryPayload() {
+  return {
+    ticker: 'SOFI',
+    window: '1Y',
+    prices: [
+      { date: '2025-06-01', close: 7.8 },
+      { date: '2025-07-01', close: 8.1 },
+      { date: '2025-08-01', close: 9.4 },
+      { date: '2025-09-01', close: 10.6 },
+      { date: '2025-10-01', close: 12.0 },
+      { date: '2025-11-01', close: 14.2 },
+      { date: '2025-12-01', close: 15.5 },
+      { date: '2026-01-01', close: 18.0 },
+      { date: '2026-02-01', close: 20.1 },
+      { date: '2026-03-01', close: 22.8 },
+      { date: '2026-04-01', close: 24.0 },
+      { date: '2026-05-01', close: 23.76 },
+    ],
+    basis: { broker: 28.56, adjusted: 26.32 },
+    trade_events: [
+      { date: '2025-09-15', type: 'sell_put', strike: 8 },
+      { date: '2025-11-15', type: 'sell_call', strike: 12 },
+      { date: '2025-12-15', type: 'assignment', strike: 12 },
+    ],
+    earnings_events: [
+      { date: '2025-08-04', label: 'Q2 earnings' },
+      { date: '2025-11-04', label: 'Q3 earnings' },
+    ],
+    source: 'schwab',
+    fetched_at: '2026-05-22T17:30:00Z',
+  };
+}
+
+function financialsPayload() {
+  // 8 quarters, newest first
+  const base = [
+    { period_end: '2026-03-31', revenue: 645e6, eps: 0.02, gross_margin: 0.43, operating_margin: 0.04 },
+    { period_end: '2025-12-31', revenue: 619e6, eps: 0.01, gross_margin: 0.42, operating_margin: 0.03 },
+    { period_end: '2025-09-30', revenue: 600e6, eps: 0.00, gross_margin: 0.41, operating_margin: 0.02 },
+    { period_end: '2025-06-30', revenue: 570e6, eps: -0.01, gross_margin: 0.40, operating_margin: 0.01 },
+    { period_end: '2025-03-31', revenue: 550e6, eps: -0.02, gross_margin: 0.39, operating_margin: 0.00 },
+    { period_end: '2024-12-31', revenue: 530e6, eps: -0.03, gross_margin: 0.38, operating_margin: -0.01 },
+    { period_end: '2024-09-30', revenue: 510e6, eps: -0.04, gross_margin: 0.37, operating_margin: -0.02 },
+    { period_end: '2024-06-30', revenue: 490e6, eps: -0.05, gross_margin: 0.36, operating_margin: -0.03 },
+  ];
+  return {
+    ticker: 'SOFI',
+    quarters: base,
+    source: 'alphavantage',
+    fetched_at: '2026-05-22T17:30:00Z',
+  };
+}
+
+function regressionPayload() {
+  return {
+    ticker: 'SOFI',
+    window: '1Y',
+    summary:
+      'Mostly market-driven; rate exposure is meaningful and negative. R²=0.83 over 252 trading days.',
+    sector_omitted: false,
+    basket: ['SPY', 'XLF', 'DGS10'],
+    sample_size: 252,
+    r_squared: 0.83,
+    idiosyncratic_share: 0.17,
+    factors: [
+      { name: 'SPY', beta: 1.42, p_value: 0.001, share: 0.55 },
+      { name: 'XLF', beta: 0.78, p_value: 0.04, share: 0.18 },
+      { name: 'DGS10', beta: -0.61, p_value: 0.02, share: 0.1 },
+    ],
+    source: 'composite',
+    fetched_at: '2026-05-22T17:30:00Z',
+  };
+}
+
+function thesisPayload(overrides = {}) {
+  return {
+    thesis: 'Bull case: SoFi grows lending into a maturing student-loan market.',
+    updated_at: '2026-05-22T17:30:00Z',
+    version: 3,
+    ...overrides,
+  };
+}
+
+// --- Mock helpers -----------------------------------------------------------
+
+function mockPosition(page, payload, status = 200) {
+  return page.route(`**/api/journal/positions/${POSITION_ID}`, (route) =>
+    route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+function mockResearchEndpoint(page, suffix, payload, status = 200) {
+  return page.route(`**/api/positions/${POSITION_ID}/research/${suffix}*`, (route) =>
+    route.fulfill({
+      status,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+async function mockAllSectionsHappy(page) {
+  await mockPosition(page, positionPayload());
+  await mockResearchEndpoint(page, 'business', businessPayload());
+  await mockResearchEndpoint(page, 'price-history', priceHistoryPayload());
+  await mockResearchEndpoint(page, 'financials', financialsPayload());
+  await mockResearchEndpoint(page, 'regression', regressionPayload());
+  await mockResearchEndpoint(page, 'thesis', thesisPayload());
+}
+
+async function openResearchPage(page) {
+  await page.goto(`/positions/${POSITION_ID}/review`);
+  await page.waitForLoadState('networkidle');
+}
+
+// --- Tests ------------------------------------------------------------------
+
+test.describe('Stock Research page — populated state', () => {
+  test('renders all six sections + header + footer', async ({ page }) => {
+    await mockAllSectionsHappy(page);
+    await openResearchPage(page);
+
+    await expect(page.getByTestId('research-page')).toBeVisible();
+    await expect(page.getByTestId('research-header')).toBeVisible();
+    await expect(page.getByTestId('research-header-ticker')).toHaveText('SOFI');
+    await expect(page.getByTestId('research-header-sector-pill')).toHaveText(
+      'Financial Services',
+    );
+
+    // All six section cards are present.
+    await expect(page.getByTestId('research-a')).toBeVisible();
+    await expect(page.getByTestId('research-b')).toBeVisible();
+    await expect(page.getByTestId('research-d')).toBeVisible();
+    await expect(page.getByTestId('research-e')).toBeVisible();
+    await expect(page.getByTestId('research-f')).toBeVisible();
+    await expect(page.getByTestId('research-footer-disclaimer')).toBeVisible();
+  });
+
+  test('three header link-outs route to recovery / options / journal', async ({
+    page,
+  }) => {
+    await mockAllSectionsHappy(page);
+    await openResearchPage(page);
+
+    await expect(page.getByTestId('research-header-recovery-link')).toHaveAttribute(
+      'href',
+      `/positions/${POSITION_ID}/recovery`,
+    );
+    await expect(page.getByTestId('research-header-scanner-link')).toHaveAttribute(
+      'href',
+      '/options?ticker=SOFI',
+    );
+    await expect(page.getByTestId('research-header-journal-link')).toHaveAttribute(
+      'href',
+      `/journal?position=${POSITION_ID}`,
+    );
+  });
+
+  test('Section A renders summary + KV strip + show-more toggle', async ({
+    page,
+  }) => {
+    await mockAllSectionsHappy(page);
+    await openResearchPage(page);
+
+    await expect(page.getByTestId('research-a-business-summary')).toContainText(
+      'SoFi is a personal finance',
+    );
+    await expect(page.getByTestId('research-a-kv-sector')).toContainText(
+      'Financial Services',
+    );
+    await expect(page.getByTestId('research-a-kv-industry')).toContainText(
+      'Credit Services',
+    );
+    await expect(page.getByTestId('research-a-kv-market-cap')).toContainText(
+      '$18.2B',
+    );
+    await expect(page.getByTestId('research-a-kv-employees')).toContainText(
+      '4,900',
+    );
+  });
+
+  test('Section E renders the verbatim backend summary + factor rows', async ({
+    page,
+  }) => {
+    await mockAllSectionsHappy(page);
+    await openResearchPage(page);
+
+    await expect(page.getByTestId('research-e-summary')).toContainText(
+      'Mostly market-driven; rate exposure is meaningful and negative.',
+    );
+    await expect(page.getByTestId('research-e-row-market')).toBeVisible();
+    await expect(page.getByTestId('research-e-row-sector')).toBeVisible();
+    await expect(page.getByTestId('research-e-row-rates')).toBeVisible();
+    await expect(page.getByTestId('research-e-row-idiosyncratic')).toBeVisible();
+    await expect(page.getByTestId('research-e-basket-caption')).toContainText(
+      'Basket: SPY + XLF + DGS10',
+    );
+  });
+});
+
+test.describe('Stock Research page — per-section failure', () => {
+  test('Section D 502 surfaces the section error tile while the rest render', async ({
+    page,
+  }) => {
+    await mockPosition(page, positionPayload());
+    await mockResearchEndpoint(page, 'business', businessPayload());
+    await mockResearchEndpoint(page, 'price-history', priceHistoryPayload());
+    await mockResearchEndpoint(
+      page,
+      'financials',
+      { detail: 'Financials source unavailable' },
+      502,
+    );
+    await mockResearchEndpoint(page, 'regression', regressionPayload());
+    await mockResearchEndpoint(page, 'thesis', thesisPayload());
+    await openResearchPage(page);
+
+    // Section D shows the error tile.
+    await expect(page.getByTestId('research-d-error')).toBeVisible();
+    // Other sections still render.
+    await expect(page.getByTestId('research-a-business-summary')).toBeVisible();
+    await expect(page.getByTestId('research-e-summary')).toBeVisible();
+  });
+});
+
+test.describe('Stock Research page — full-page states', () => {
+  test('404 on position renders the not-found EmptyState', async ({ page }) => {
+    await mockPosition(
+      page,
+      { detail: 'Position not found' },
+      404,
+    );
+    await openResearchPage(page);
+
+    await expect(page.getByTestId('research-not-found')).toBeVisible();
+  });
+
+  test('500 on position renders the full-page error retry banner', async ({
+    page,
+  }) => {
+    await mockPosition(
+      page,
+      { detail: 'Failed to load position' },
+      500,
+    );
+    await openResearchPage(page);
+
+    await expect(page.getByTestId('research-error')).toBeVisible();
+  });
+});
+
+test.describe('Stock Research page — thesis editor', () => {
+  test('autosave fires after debounce and transitions through saved state', async ({
+    page,
+  }) => {
+    await mockPosition(page, positionPayload());
+    await mockResearchEndpoint(page, 'business', businessPayload());
+    await mockResearchEndpoint(page, 'price-history', priceHistoryPayload());
+    await mockResearchEndpoint(page, 'financials', financialsPayload());
+    await mockResearchEndpoint(page, 'regression', regressionPayload());
+    await mockResearchEndpoint(
+      page,
+      'thesis',
+      thesisPayload({ thesis: '', version: 0, updated_at: null }),
+    );
+
+    // Capture the PUT and respond with version: 1.
+    const putRequests = [];
+    await page.route(
+      `**/api/positions/${POSITION_ID}/research/thesis`,
+      async (route) => {
+        const req = route.request();
+        if (req.method() === 'PUT') {
+          const body = JSON.parse(req.postData() || '{}');
+          putRequests.push(body);
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              thesis: body.thesis,
+              updated_at: '2026-05-22T18:00:00Z',
+              version: 1,
+            }),
+          });
+        }
+        // GET — empty initial state
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ thesis: '', updated_at: null, version: 0 }),
+        });
+      },
+    );
+
+    await openResearchPage(page);
+
+    const textarea = page.getByTestId('research-f-textarea');
+    await textarea.fill('Bull case: rates falling boost SoFi.');
+
+    // The status row transitions through saving → saved (or directly to saved
+    // if the network mock resolves before we check). Either way, a saved
+    // state should appear and the PUT should have fired exactly once.
+    await expect(page.getByTestId('research-f-status-saved')).toBeVisible({
+      timeout: 5000,
+    });
+    expect(putRequests).toHaveLength(1);
+    expect(putRequests[0].thesis).toBe('Bull case: rates falling boost SoFi.');
+  });
+
+  test('enforces the 4000-character client-side cap', async ({ page }) => {
+    await mockAllSectionsHappy(page);
+    await openResearchPage(page);
+
+    const big = 'a'.repeat(4500);
+    const textarea = page.getByTestId('research-f-textarea');
+    await textarea.fill(big);
+
+    const value = await textarea.inputValue();
+    expect(value.length).toBe(4000);
+
+    await expect(page.getByTestId('research-f-char-count')).toContainText(
+      '4000 / 4000',
+    );
+  });
+});
+
+// --- Dashboard CTA wire-up (issue #280 §9) ----------------------------------
+
+test.describe('Dashboard Positions Card — Review CTA', () => {
+  function dashboardPayload() {
+    // Mirror the shape used by existing dashboard-* e2e specs so the
+    // /dashboard surface renders without crashing.
+    return {
+      generated_at: '2026-05-22T13:42:00+00:00',
+      status: {
+        schwab: {
+          configured: true,
+          valid: true,
+          expires_at: '2026-08-01T00:00:00+00:00',
+        },
+        fred: { configured: true, valid: true },
+        cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+        journal: { positions_count: 1 },
+      },
+      kpis: {
+        open_positions: 1,
+        open_positions_breakdown: { stock: 1, csp: 0, cc: 0, wheel: 0, holding: 0 },
+        notional_value: 2376,
+        notional_change_pct: 0,
+        open_legs: 0,
+        open_legs_breakdown: { puts: 0, calls: 0 },
+        unrealized_pl: -224,
+        unrealized_pl_pct: -0.078,
+        largest_risk: null,
+        premium_collected_total: 0,
+        premium_collected_trades: 0,
+        premium_collected_ytd: 0,
+        realized_pl: 0,
+        realized_pl_pct: null,
+        largest_loser: null,
+      },
+      positions: [
+        {
+          id: POSITION_ID,
+          ticker: 'SOFI',
+          shares: 100,
+          strategy: 'wheel',
+          broker_cost_basis: 2856.0,
+          adjusted_cost_basis: 2632.0,
+          current_price: 23.76,
+          notional: 2376.0,
+          unrealized_pl: -224.0,
+          pl_pct: -0.078,
+          open_legs_count: 0,
+          wheel_status: 'Holding',
+          next_suggested_action: 'Review',
+        },
+      ],
+      open_legs: [],
+      recent_activity: [],
+      data_meta: {
+        is_stale: false,
+        fetched_at: '2026-05-22T13:42:00+00:00',
+        sources_unavailable: [],
+      },
+      next_actions: [],
+    };
+  }
+
+  test('Review action routes to /positions/{id}/review (not /journal)', async ({
+    page,
+  }) => {
+    await page.route('**/api/dashboard', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(dashboardPayload()),
+      }),
+    );
+
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const review = page.getByTestId('dashboard-position-next-action');
+    await expect(review).toHaveAttribute(
+      'href',
+      `/positions/${POSITION_ID}/review`,
+    );
+    await expect(review).not.toHaveAttribute(
+      'href',
+      `/journal?position=${POSITION_ID}`,
+    );
+  });
+});

--- a/frontend/hooks/useStockResearch.js
+++ b/frontend/hooks/useStockResearch.js
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   getPosition,
   getResearchBusiness,
@@ -65,21 +65,30 @@ export function useStockResearch(positionId) {
     status: null,
   });
   const [sections, setSections] = useState(() => initialSectionsState());
+  // Monotonic request token (CR #12). Every refetchAll bumps this; every
+  // in-flight fetchSection captures the token at call time and discards
+  // its result if the token no longer matches when the await resolves.
+  // This prevents stale section data from clobbering fresh state when
+  // positionId changes mid-flight or refetchAll is called concurrently.
+  const requestSeqRef = useRef(0);
 
   const fetchSection = useCallback(
-    async (name) => {
+    async (name, requestSeq) => {
       if (!positionId) return;
+      const seq = requestSeq ?? requestSeqRef.current;
       setSections((prev) => ({
         ...prev,
         [name]: { ...prev[name], loading: true, error: null },
       }));
       try {
         const data = await SECTION_FETCHERS[name](positionId);
+        if (seq !== requestSeqRef.current) return;
         setSections((prev) => ({
           ...prev,
           [name]: { data, loading: false, error: null },
         }));
       } catch (e) {
+        if (seq !== requestSeqRef.current) return;
         setSections((prev) => ({
           ...prev,
           [name]: {
@@ -94,6 +103,9 @@ export function useStockResearch(positionId) {
   );
 
   const refetchAll = useCallback(async () => {
+    // Bump the token so any in-flight fetch from a prior refetchAll
+    // discards its result on resolution (CR #12).
+    const seq = ++requestSeqRef.current;
     if (!positionId) {
       setPosition({ data: null, loading: false, error: null, status: null });
       setSections(initialSectionsState());
@@ -104,6 +116,7 @@ export function useStockResearch(positionId) {
     setSections(initialSectionsState());
     try {
       const positionPayload = await getPosition(positionId);
+      if (seq !== requestSeqRef.current) return;
       setPosition({
         data: positionPayload,
         loading: false,
@@ -111,6 +124,7 @@ export function useStockResearch(positionId) {
         status: 200,
       });
     } catch (e) {
+      if (seq !== requestSeqRef.current) return;
       const status = e?.response?.status ?? null;
       setPosition({
         data: null,
@@ -130,7 +144,9 @@ export function useStockResearch(positionId) {
       return;
     }
     // Position resolved — fan the five section fetches out in parallel.
-    await Promise.allSettled(SECTIONS.map((name) => fetchSection(name)));
+    await Promise.allSettled(
+      SECTIONS.map((name) => fetchSection(name, seq)),
+    );
   }, [positionId, fetchSection]);
 
   useEffect(() => {
@@ -144,12 +160,17 @@ export function useStockResearch(positionId) {
       if (!positionId) {
         return { ok: false, error: 'No position id' };
       }
+      const seq = requestSeqRef.current;
       try {
         const updated = await putResearchThesis(positionId, body ?? '');
-        setSections((prev) => ({
-          ...prev,
-          thesis: { data: updated, loading: false, error: null },
-        }));
+        // If positionId changed mid-save, drop the optimistic update — the
+        // new positionId already triggered its own refetchAll (CR #12).
+        if (seq === requestSeqRef.current) {
+          setSections((prev) => ({
+            ...prev,
+            thesis: { data: updated, loading: false, error: null },
+          }));
+        }
         return {
           ok: true,
           version: updated.version,

--- a/frontend/hooks/useStockResearch.js
+++ b/frontend/hooks/useStockResearch.js
@@ -1,0 +1,179 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getPosition,
+  getResearchBusiness,
+  getResearchFinancials,
+  getResearchPriceHistory,
+  getResearchRegression,
+  getResearchThesis,
+  putResearchThesis,
+} from '../api/client';
+
+/**
+ * useStockResearch — fetch all six sections of the research page in parallel.
+ *
+ * Returns:
+ *
+ * ```
+ * {
+ *   position: { data, loading, error, status },  // 404 if position missing
+ *   business: { data, loading, error },
+ *   priceHistory: { data, loading, error },
+ *   financials: { data, loading, error },
+ *   regression: { data, loading, error },
+ *   thesis: {
+ *     data, loading, error,
+ *     save: (body) => Promise<{ ok, version, updatedAt, error? }>,
+ *   },
+ *   refetchSection: (name) => void,   // re-runs a single section's fetch
+ *   refetchAll: () => void,
+ * }
+ * ```
+ *
+ * The position fetch is awaited first because it gates the entire page —
+ * a 404 on the position skips every section fetch (we render the
+ * `research-not-found` empty state). When the position resolves, the five
+ * section fetches fire in parallel via `Promise.allSettled` so a single
+ * section failure does NOT poison the others (NFR-3, design spec §7).
+ */
+
+const SECTIONS = ['business', 'priceHistory', 'financials', 'regression', 'thesis'];
+
+const SECTION_FETCHERS = {
+  business: getResearchBusiness,
+  priceHistory: (positionId) => getResearchPriceHistory(positionId, '1Y'),
+  financials: getResearchFinancials,
+  regression: (positionId) => getResearchRegression(positionId, '1Y'),
+  thesis: getResearchThesis,
+};
+
+function extractDetail(e, fallback) {
+  return e?.response?.data?.detail || fallback;
+}
+
+function initialSectionsState() {
+  return Object.fromEntries(
+    SECTIONS.map((name) => [name, { data: null, loading: true, error: null }]),
+  );
+}
+
+export function useStockResearch(positionId) {
+  const [position, setPosition] = useState({
+    data: null,
+    loading: true,
+    error: null,
+    status: null,
+  });
+  const [sections, setSections] = useState(() => initialSectionsState());
+
+  const fetchSection = useCallback(
+    async (name) => {
+      if (!positionId) return;
+      setSections((prev) => ({
+        ...prev,
+        [name]: { ...prev[name], loading: true, error: null },
+      }));
+      try {
+        const data = await SECTION_FETCHERS[name](positionId);
+        setSections((prev) => ({
+          ...prev,
+          [name]: { data, loading: false, error: null },
+        }));
+      } catch (e) {
+        setSections((prev) => ({
+          ...prev,
+          [name]: {
+            data: null,
+            loading: false,
+            error: extractDetail(e, 'Section unavailable'),
+          },
+        }));
+      }
+    },
+    [positionId],
+  );
+
+  const refetchAll = useCallback(async () => {
+    if (!positionId) {
+      setPosition({ data: null, loading: false, error: null, status: null });
+      setSections(initialSectionsState());
+      return;
+    }
+    // Reset the position gate; section state resets via Promise.allSettled below.
+    setPosition({ data: null, loading: true, error: null, status: null });
+    setSections(initialSectionsState());
+    try {
+      const positionPayload = await getPosition(positionId);
+      setPosition({
+        data: positionPayload,
+        loading: false,
+        error: null,
+        status: 200,
+      });
+    } catch (e) {
+      const status = e?.response?.status ?? null;
+      setPosition({
+        data: null,
+        loading: false,
+        error: extractDetail(e, 'Failed to load position'),
+        status,
+      });
+      // Position fetch failed — short-circuit sections so the UI doesn't spin forever.
+      setSections(
+        Object.fromEntries(
+          SECTIONS.map((name) => [
+            name,
+            { data: null, loading: false, error: null },
+          ]),
+        ),
+      );
+      return;
+    }
+    // Position resolved — fan the five section fetches out in parallel.
+    await Promise.allSettled(SECTIONS.map((name) => fetchSection(name)));
+  }, [positionId, fetchSection]);
+
+  useEffect(() => {
+    refetchAll();
+  }, [refetchAll]);
+
+  // Thesis writes — owned by the hook so the editor doesn't reimplement
+  // optimistic-locking + status reducer.
+  const saveThesis = useCallback(
+    async (body) => {
+      if (!positionId) {
+        return { ok: false, error: 'No position id' };
+      }
+      try {
+        const updated = await putResearchThesis(positionId, body ?? '');
+        setSections((prev) => ({
+          ...prev,
+          thesis: { data: updated, loading: false, error: null },
+        }));
+        return {
+          ok: true,
+          version: updated.version,
+          updatedAt: updated.updated_at,
+        };
+      } catch (e) {
+        return {
+          ok: false,
+          error: extractDetail(e, 'Failed to save thesis'),
+          status: e?.response?.status ?? null,
+        };
+      }
+    },
+    [positionId],
+  );
+
+  return {
+    position,
+    business: sections.business,
+    priceHistory: sections.priceHistory,
+    financials: sections.financials,
+    regression: sections.regression,
+    thesis: { ...sections.thesis, save: saveThesis },
+    refetchSection: fetchSection,
+    refetchAll,
+  };
+}


### PR DESCRIPTION
## What this release is

**v1.1.0 — MINOR bump.** New per-position research surface — answers "what do I own?" rather than "what trades did I make?" — replaces the dashboard's per-row `Review →` CTA destination from the trade journal to a purpose-built research page.

Closes: **#280**
PRD: [Discussion #282](https://github.com/ssandy33/regress/discussions/282)
Milestone: TBD (CPO assigns at release time)

## Design lineage

- **#280** — feature issue
- **PRD #282** — full product spec (Discussion, per memory convention)
- **Designer spec + mock** (untracked, local)
- **CTO plan** at `backend/design-specs/issue-280-stock-research-plan.md` (untracked) — 5-worker parallel DAG

## The page (`/positions/{id}/review`)

Six sections in render order, pure research, no tactical garnish:

| # | Section | Purpose | Source |
|---|---|---|---|
| **A** | Business snapshot | What the company does, segments, market cap | yfinance `Ticker.info` |
| **B** | Price chart w/ your basis + trade markers | Where you are relative to break-even, visualized | existing `/api/data` + Position.trades |
| **C** | Why did this move? | Earnings annotations on the same chart | AV `EARNINGS` (cached) |
| **D** | Financial scorecard | Revenue / EPS / margins last 8 quarters | AV `INCOME_STATEMENT`, yfinance fallback |
| **E** | Regression decomposition | Multi-factor: SPY + sector ETF + DGS10. Plain-English summary headline + donut + beta table. | existing regression engine + FRED |
| **F** | Your thesis (freeform note, persistent) | Why you bought, what would change your mind | new `position_notes` table |

Header link-outs (navigation only, not content): `Recovery plan →`, `Scan covered calls →`, `Trade ledger →`.

## Parallel-execution worker DAG

```
feat/v1.1.0 (off main)
├── W-A  feat/v1.1.0-w-a-business-financials   (Section A + D services + yfinance + sector map)
├── W-B  feat/v1.1.0-w-b-price-history         (Section B + C endpoint + AV historical earnings)
├── W-D  feat/v1.1.0-w-d-regression            (Section E endpoint + summary rules)
├── W-F  feat/v1.1.0-w-f-thesis-notes          (Section F endpoint + new position_notes table)
└── W    feat/v1.1.0-w-bridge                  (frontend + 2 missing endpoint shells + Review CTA)
```

Merge order: W-F → W-A → W-B → W-D → W. Two text-conflicts during W-B and W-D merges (`research.py`, `alpha_vantage_client.py`, `sector_etf_map.py`, `test_sector_etf_map.py`) — all resolved by superset/union, no semantic loss.

## What changed

- **5 new backend endpoints** under `/api/positions/{id}/research/{business|price-history|financials|regression|thesis}` (GET + PUT for thesis).
- **New `position_notes` table** for thesis persistence (single-row, version-counter; idempotent migration via existing `Base.metadata.create_all` pattern).
- **New `yfinance>=0.2.50` backend dep** (first yfinance dep in the codebase — explicitly authorized by maintainer; full sub-deps list documented in W-A's worker report).
- **Sector → ETF map** module with 11 GICS sectors → SPDR ETFs (XLF, XLK, XLV, XLE, XLP, XLY, XLI, XLB, XLU, XLRE, XLC).
- **Plain-English regression summary** generator implementing design spec §4 rules verbatim (backend-generated, NOT frontend-rules, per locked decision).
- **AV client extensions** (append-only): `get_income_statement`, `get_historical_earnings`, `_filter_since`, new caches.
- **13 new frontend files**: route shell, top-level page, 6 section components + header + caveats footer + trade-marker vocab + hook + Playwright e2e.
- **Dashboard Review CTA rewired**: `nextActionCta()` now routes `Review` → `/positions/{id}/review` (was `/journal?position={id}`).
- **3 superseded acceptance tests** in `test_acceptance_phase4.py` marked skip with rationale — they enforced a blanket yfinance ban that the PRD explicitly authorizes overriding for the research surface.

## Test plan

- [x] Backend: **1438 passed, 13 skipped** on integrated tip (full suite, includes 120+ new tests across the 4 backend workers)
- [x] Frontend: ESLint clean (0 errors), `next build` succeeds
- [x] Frontend smoke: **10/10 Playwright tests pass** in `stock-research.spec.js`
- [x] Dashboard regression check: existing `dashboard-positions-triage` and `dashboard-rule-monitor` specs still pass
- [ ] CI on integration branch (this PR) — will validate
- [ ] Post-merge: verify in prod by clicking Review on a real position

## Locked design decisions (PRD-resolved, not re-litigated)

1. Route: `/positions/{id}/review` (position-scoped)
2. Section C news markers: **deferred to v2** (earnings only in v1)
3. Section E regression basket: **fixed preset** (SPY + sector ETF + DGS10)
4. Section F storage: **separate `position_notes` table** with version counter

Plus 6 designer-flagged minor decisions (window picker hidden in v1, 8 quarters in Section D, backend-generated summary, 4000-char thesis cap, non-sticky header, no logo in Section A) all baked in.

## Out of scope (intentional, follow-ons)

- News-event markers (Alpha Vantage NEWS_SENTIMENT) — separate v1.2/v1.1.x follow-on
- Window picker UI — endpoints accept `window` param but UI is fixed at 1Y
- Inline regression basket configurability — `/analysis` remains the deep-dive
- Vector container-log shipping (sibling to v1.0.9 Axiom logging) — separate
- Thesis history UI (version field exists, but only the latest is rendered in v1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)