### PR TITLE
Quality v1 Wave 1: TDD test pyramid foundation (closes #265 #266 #267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ permissions:
   contents: read
 
 jobs:
-  backend-tests:
+  # Quality v1 — Wave 1 (#267): backend test pyramid split into independent jobs.
+  # Each backend job runs ONE marker tier (unit OR integration) and emits its
+  # own coverage XML. Coverage will be reunified in Wave 3 (#270); here it's
+  # left split per job so a flaky integration run doesn't hide a unit regression.
+  backend-unit:
+    name: Backend tests (unit)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -29,10 +34,49 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run tests
-        run: pytest tests/ -v --tb=short --cov=app --cov-report=term-missing
+      - name: Run unit tests
+        run: pytest tests/ -v --tb=short -m unit --cov=app --cov-report=term-missing --cov-report=xml:coverage-unit.xml
+
+      - name: Upload unit coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-unit
+          path: backend/coverage-unit.xml
+          if-no-files-found: ignore
+
+  backend-integration:
+    name: Backend tests (integration)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run integration tests
+        run: pytest tests/ -v --tb=short -m integration --cov=app --cov-report=term-missing --cov-report=xml:coverage-integration.xml
+
+      - name: Upload integration coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-integration
+          path: backend/coverage-integration.xml
+          if-no-files-found: ignore
 
   frontend-checks:
+    name: Frontend checks (lint + build)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -55,3 +99,42 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  # Quality v1 — Wave 1 (#267): Playwright job closes the E2E gap from #231.
+  # Shakedown period until 2026-05-25. After 48h of green runs, flip
+  # continue-on-error: false. Owner: orchestrator + manual flip.
+  frontend-playwright:
+    name: Frontend Playwright (shakedown)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            frontend/playwright-report
+            frontend/test-results
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,27 @@
 - No unused imports, variables, or dead code.
 - Keep PRs focused — one issue per PR (or, for parallel-execution releases, one PR per integration branch — see Release Model).
 
+## Observability
+
+All new logging code MUST follow the conventions in [ADR Discussion #292](https://github.com/ssandy33/regress/discussions/292):
+
+- **Event names** — `<noun>.<lifecycle_phase>` (e.g., `refresh_job.complete`) or single `<noun>` (e.g., `provider_call`). snake_case, dot-separated, 1–3 segments.
+- **Structured fields via `extra={}`** — canonical vocabulary: `event`, `request_id`, `outcome`, `duration_ms`, `error_class`, `ticker`, `position_id`, `data_class`, `provider`, `endpoint`, `status_code`, `latency_ms`, `cache_hit`. Use these field names exactly — don't invent local variants.
+- **Lifecycle events** always carry `outcome` (`success` / `failed` / `throttled` / `no_data` / `degraded`); `.complete` and `.failed` always carry `duration_ms`.
+- **Sanitization** (hard): never log raw upstream API response bodies, Schwab/Axiom tokens, encryption keys, user secrets, or full request bodies for authenticated endpoints. See #292 for the full NEVER / OK lists.
+- **Phase 5 reviewers** check observability conformance during code review, alongside the no-raw-exception-messages and test-coverage checks.
+
+## API Contract
+
+The full API-contract architecture is specified in [**PRD #262 — Contract v1: OpenAPI as Source of Truth**](https://github.com/ssandy33/regress/discussions/262) — committed `openapi.json` snapshot artifact, CI drift detection, Schemathesis contract tests, and `openapi-typescript` frontend type generation. Contract v1 lands as a Platform-lane milestone (#28); first-wave issues are filed just-in-time when the milestone activates.
+
+While Contract v1 is in draft, the following interim disciplines apply to all new endpoints:
+
+- **`response_model` is required on every route** — `@router.get("/path", response_model=SomeSchema)`. This is the minimum-viable contract discipline; PRD #262 builds on this with Schemathesis + drift detection when it activates.
+- **Pydantic model location** — define new response shapes in `backend/app/models/schemas.py` under the appropriate `# --- <domain> ---` section divider. No inline orphan models on routes.
+- **Stability tiers** — every endpoint is **Internal** (UI-only, ships in lockstep, no deprecation cycle) unless explicitly promoted to **Public**. All endpoints are Internal today; reserve `/api/v1/...` for future Public per PRD #262's authoring direction.
+- **Phase 5 reviewers** check API-contract conformance during code review (every new endpoint has `response_model` + every new response shape is in `schemas.py`).
+
 ## Issue Management
 
 - When creating an issue, determine its priority (critical, high, medium, low) and add a comment explaining the rationale for the chosen priority level.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,22 @@
+[pytest]
+# Quality v1 — Wave 1 (#265): pytest markers + classifier foundation.
+#
+# Three classifier markers form the test pyramid for the backend suite.
+# Every backend test_* function must carry exactly one of these markers;
+# the partition is enforced by ``backend/scripts/classify_tests.py``
+# (run locally and in CI; see Quality v1 PRD #261).
+#
+# Playwright owns the ``e2e`` tier — no pytest marker is registered for it.
+markers =
+    unit: Pure-Python unit test — no FastAPI app, no TestClient, no DB session, no network.
+    integration: Full backend stack — FastAPI TestClient + in-memory SQLite + routers + services + ORM.
+    tdd_red: In-flight Red test (deliberately failing because impl is not written yet). Excluded by default.
+
+# ``--strict-markers`` turns unregistered ``@pytest.mark.<name>`` decorators
+# into errors instead of warnings. This is safe because the existing suite
+# only uses pytest built-ins (``parametrize``, ``skip``) and the three
+# markers registered above.
+#
+# ``-m "not tdd_red"`` excludes deliberately-failing Red tests from the
+# default invocation. Run ``pytest -m tdd_red`` to exercise them explicitly.
+addopts = --strict-markers -m "not tdd_red"

--- a/backend/scripts/classify_tests.py
+++ b/backend/scripts/classify_tests.py
@@ -1,0 +1,482 @@
+"""Quality v1 — pytest marker classifier (issue #265).
+
+Walks ``backend/tests/`` and enforces the test-pyramid partition agreed
+in Quality v1 PRD #261:
+
+- Every ``test_*`` function MUST carry exactly one of:
+    * ``@pytest.mark.unit``        — pure-Python, no app, no TestClient, no DB.
+    * ``@pytest.mark.integration`` — FastAPI TestClient + in-memory SQLite + routers.
+    * ``@pytest.mark.tdd_red``     — deliberately failing Red test (skipped by default).
+- ``pytest.mark.parametrize`` / ``pytest.mark.skip`` are NOT classifiers
+  and are ignored by this script.
+
+Two modes:
+
+    python -m scripts.classify_tests              # CHECK mode (default)
+    python -m scripts.classify_tests --check      # explicit CHECK mode
+    python -m scripts.classify_tests --report PATH  # write a heuristic report
+                                                    # of suggested classifications
+                                                    # (humans apply tags by hand)
+
+CHECK mode exit codes:
+    0  every test in ``backend/tests/`` carries exactly one classifier marker.
+    1  one or more tests are unclassified or double-classified — details printed.
+
+REPORT mode never modifies any test file. It is a read-only advisory pass:
+it scans imports + fixture usage with the heuristics below and writes
+``markdown`` summarising the suggested tier per test. Humans then add
+the actual ``@pytest.mark.<tier>`` decorators by hand (Wave 1 issue
+#265's PF-Q1 sample + Wave 2's full tagging pass).
+
+Heuristics (REPORT mode only — never decides for CHECK mode):
+
+- A test is suggested **integration** when ANY of:
+    * The file imports ``fastapi.testclient.TestClient`` directly.
+    * A test function takes the ``client`` fixture parameter (the
+      conftest-provided TestClient) — even transitively through another
+      fixture that consumes ``client``.
+    * The file imports ``app.main.app`` for direct mounting.
+- Otherwise the test is suggested **unit**.
+
+This is deliberately conservative: tests that drive in-memory SQLite
+*without* the FastAPI app (e.g. ``test_rules_config.py``'s ``db`` fixture
+that builds its own engine) stay **unit** because the marker definition
+says integration = full backend stack (TestClient + routers + services + ORM).
+
+The classifier is intentionally pytest + stdlib only; no third-party deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import logging
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# The three classifier markers. Order is the canonical report order.
+CLASSIFIER_MARKERS: tuple[str, ...] = ("unit", "integration", "tdd_red")
+
+# Markers we ignore (pytest built-ins or non-classifier marks).
+NON_CLASSIFIER_MARKERS: frozenset[str] = frozenset(
+    {"parametrize", "skip", "skipif", "xfail", "usefixtures", "filterwarnings"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TestRecord:
+    """A single discovered ``test_*`` function with its classifier markers."""
+
+    file: Path
+    qualname: str  # e.g. "TestCanonicalShape.test_returns_four_paths"
+    lineno: int
+    markers: tuple[str, ...]  # only classifier markers, in source order
+    suggested_tier: str  # heuristic suggestion for REPORT mode
+
+
+@dataclass
+class FileScan:
+    """Result of scanning one test_*.py file."""
+
+    path: Path
+    has_testclient_import: bool = False
+    has_app_main_import: bool = False
+    fixtures_using_client: set[str] = field(default_factory=set)
+    tests: list[TestRecord] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _decorator_marker_name(node: ast.expr) -> str | None:
+    """Return the marker name for a ``@pytest.mark.<name>`` decorator, else None.
+
+    Handles both bare (``@pytest.mark.unit``) and called
+    (``@pytest.mark.parametrize(...)``) forms.
+    """
+    # The called form: ``@pytest.mark.parametrize(...)`` -> Call(func=Attribute(...))
+    target = node.func if isinstance(node, ast.Call) else node
+    if not isinstance(target, ast.Attribute):
+        return None
+    # We want ``pytest.mark.<name>`` shape: Attribute(value=Attribute(value=Name('pytest'), attr='mark'), attr='<name>')
+    parent = target.value
+    if not isinstance(parent, ast.Attribute):
+        return None
+    if parent.attr != "mark":
+        return None
+    grandparent = parent.value
+    if not isinstance(grandparent, ast.Name) or grandparent.id != "pytest":
+        return None
+    return target.attr
+
+
+def _classifier_markers(decorators: list[ast.expr]) -> list[str]:
+    """Return the classifier markers (in source order) from a decorator list."""
+    out: list[str] = []
+    for deco in decorators:
+        name = _decorator_marker_name(deco)
+        if name in CLASSIFIER_MARKERS:
+            out.append(name)
+    return out
+
+
+def _imports_testclient(tree: ast.Module) -> bool:
+    """True iff the module imports ``fastapi.testclient.TestClient``."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module == "fastapi.testclient":
+                if any(alias.name == "TestClient" for alias in node.names):
+                    return True
+    return False
+
+
+def _imports_app_main(tree: ast.Module) -> bool:
+    """True iff the module imports ``app.main`` (the FastAPI app object)."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module in {"app.main", "main"}:
+                return True
+        if isinstance(node, ast.Import):
+            if any(alias.name in {"app.main"} for alias in node.names):
+                return True
+    return False
+
+
+def _fixture_consumes_client(func: ast.FunctionDef, known_client_fixtures: set[str]) -> bool:
+    """True iff this fixture takes a parameter named ``client`` or a known transitive."""
+    for arg in func.args.args:
+        if arg.arg in known_client_fixtures:
+            return True
+    return False
+
+
+def _is_pytest_fixture(decorators: list[ast.expr]) -> bool:
+    """True iff any decorator looks like ``@pytest.fixture`` (bare or called)."""
+    for deco in decorators:
+        target = deco.func if isinstance(deco, ast.Call) else deco
+        if isinstance(target, ast.Attribute):
+            if target.attr == "fixture":
+                parent = target.value
+                if isinstance(parent, ast.Name) and parent.id == "pytest":
+                    return True
+    return False
+
+
+def _walk_test_functions(tree: ast.Module):
+    """Yield ``(qualname, FunctionDef)`` pairs for every ``test_*`` def.
+
+    Recurses into top-level classes (``class Test...:``) so class-scoped
+    test methods are surfaced with their ``ClassName.method`` qualname.
+    """
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name.startswith("test_"):
+                yield node.name, node
+        elif isinstance(node, ast.ClassDef):
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if sub.name.startswith("test_"):
+                        yield f"{node.name}.{sub.name}", sub
+
+
+# ---------------------------------------------------------------------------
+# Core scan
+# ---------------------------------------------------------------------------
+
+
+def scan_file(path: Path) -> FileScan:
+    """Parse ``path`` and return a :class:`FileScan` describing every test in it.
+
+    Never raises on syntactically broken files — broken files surface as a
+    ``FileScan`` with zero tests and the broken-file path so the caller can
+    surface them in CHECK mode.
+    """
+    source = path.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        logger.warning(
+            "classify_tests: failed to parse %s — skipping",
+            path,
+            extra={"event": "classify.parse_error", "file": str(path)},
+        )
+        return FileScan(path=path)
+
+    scan = FileScan(path=path)
+    scan.has_testclient_import = _imports_testclient(tree)
+    scan.has_app_main_import = _imports_app_main(tree)
+
+    # First pass: discover ``client``-consuming fixtures so we know that a
+    # test taking that fixture is effectively integration.
+    known_client_fixtures: set[str] = {"client"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            if _is_pytest_fixture(node.decorator_list):
+                if _fixture_consumes_client(node, known_client_fixtures):
+                    known_client_fixtures.add(node.name)
+    scan.fixtures_using_client = known_client_fixtures - {"client"}
+
+    # Second pass: collect every test_* with its classifier markers.
+    for qualname, func in _walk_test_functions(tree):
+        markers = tuple(_classifier_markers(func.decorator_list))
+        uses_client = any(
+            arg.arg in known_client_fixtures for arg in func.args.args
+        )
+        if scan.has_testclient_import or scan.has_app_main_import or uses_client:
+            suggested = "integration"
+        else:
+            suggested = "unit"
+        scan.tests.append(
+            TestRecord(
+                file=path,
+                qualname=qualname,
+                lineno=func.lineno,
+                markers=markers,
+                suggested_tier=suggested,
+            )
+        )
+    return scan
+
+
+def scan_directory(tests_dir: Path) -> list[FileScan]:
+    """Scan every ``test_*.py`` file in ``tests_dir`` (non-recursive)."""
+    if not tests_dir.is_dir():
+        raise SystemExit(
+            f"classify_tests: tests directory not found: {tests_dir}"
+        )
+    return [
+        scan_file(p)
+        for p in sorted(tests_dir.glob("test_*.py"))
+    ]
+
+
+# ---------------------------------------------------------------------------
+# CHECK mode
+# ---------------------------------------------------------------------------
+
+
+def check(scans: list[FileScan]) -> int:
+    """Enforce: every test has exactly one classifier marker.
+
+    Returns process-style exit code: 0 = clean, 1 = violations.
+    """
+    unclassified: list[TestRecord] = []
+    double_classified: list[TestRecord] = []
+    counts: Counter[str] = Counter()
+
+    for scan in scans:
+        for record in scan.tests:
+            if len(record.markers) == 0:
+                unclassified.append(record)
+            elif len(record.markers) > 1:
+                double_classified.append(record)
+            else:
+                counts[record.markers[0]] += 1
+
+    if unclassified or double_classified:
+        print("classify_tests: FAIL — unclassified or double-classified tests:")
+        for r in unclassified:
+            print(
+                f"  [unclassified] {r.file}:{r.lineno} {r.qualname} "
+                "— no classifier marker. Add one of "
+                "@pytest.mark.unit / @pytest.mark.integration / @pytest.mark.tdd_red "
+                "(see CLAUDE.md Testing Pyramid section)."
+            )
+        for r in double_classified:
+            print(
+                f"  [double-marked] {r.file}:{r.lineno} {r.qualname} "
+                f"— has {len(r.markers)} classifier markers ({', '.join(r.markers)}); "
+                "exactly one is required."
+            )
+        return 1
+
+    parts = ", ".join(f"{m}: {counts.get(m, 0)}" for m in CLASSIFIER_MARKERS)
+    total = sum(counts.values())
+    print(f"classify_tests: OK — {total} tests classified ({parts}).")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# REPORT mode
+# ---------------------------------------------------------------------------
+
+
+def write_report(scans: list[FileScan], out_path: Path) -> None:
+    """Write a human-reviewable markdown report of suggested classifications.
+
+    The report is the PF-Q1 deliverable for issue #265 AC-1.3: humans
+    use it to apply markers by hand to the sample (and, in Wave 2, the
+    full suite).
+    """
+    suggested_counts: Counter[str] = Counter()
+    per_file_counts: list[tuple[Path, Counter[str], FileScan]] = []
+    for scan in scans:
+        c: Counter[str] = Counter()
+        for record in scan.tests:
+            c[record.suggested_tier] += 1
+            suggested_counts[record.suggested_tier] += 1
+        per_file_counts.append((scan.path, c, scan))
+
+    lines: list[str] = []
+    lines.append("# Quality v1 — PF-Q1 classifier report")
+    lines.append("")
+    lines.append(
+        "Generated by `backend/scripts/classify_tests.py --report`. "
+        "Heuristic suggestions only — humans apply the actual "
+        "`@pytest.mark.<tier>` decorators per Quality v1 (#261, #265)."
+    )
+    lines.append("")
+    lines.append("## Heuristics")
+    lines.append("")
+    lines.append(
+        "- **integration** if the file imports `fastapi.testclient.TestClient`, "
+        "imports `app.main`, or a test takes the `client` fixture "
+        "(or any fixture transitively consuming `client`)."
+    )
+    lines.append("- **unit** otherwise.")
+    lines.append("")
+    lines.append("## Distribution")
+    lines.append("")
+    total = sum(suggested_counts.values())
+    lines.append(f"- Total tests scanned: **{total}**")
+    for tier in ("unit", "integration"):
+        lines.append(f"- Suggested **{tier}**: {suggested_counts.get(tier, 0)}")
+    lines.append("")
+    lines.append("## Per-file summary")
+    lines.append("")
+    lines.append("| File | unit | integration | TestClient import | app.main import |")
+    lines.append("|---|---:|---:|:---:|:---:|")
+    for path, c, scan in per_file_counts:
+        lines.append(
+            "| `{name}` | {u} | {i} | {tc} | {am} |".format(
+                name=path.name,
+                u=c.get("unit", 0),
+                i=c.get("integration", 0),
+                tc="yes" if scan.has_testclient_import else "no",
+                am="yes" if scan.has_app_main_import else "no",
+            )
+        )
+    lines.append("")
+    lines.append("## PF-Q1 hand-marked sample")
+    lines.append("")
+    lines.append(
+        "Issue #265 AC-1.3 calls for 5 unit + 3 integration tests "
+        "to be hand-marked across these four files:"
+    )
+    lines.append("")
+    pf_q1_files = {
+        "test_recovery_engine.py",
+        "test_rules_config.py",
+        "test_integration_dashboard.py",
+        "test_integration_settings.py",
+    }
+    for path, _c, scan in per_file_counts:
+        if path.name not in pf_q1_files:
+            continue
+        lines.append(f"### `{path.name}`")
+        lines.append("")
+        for r in scan.tests[:8]:
+            marker_str = (
+                ", ".join(f"`{m}`" for m in r.markers) if r.markers else "_none_"
+            )
+            lines.append(
+                f"- L{r.lineno} `{r.qualname}` — suggested **{r.suggested_tier}**, applied: {marker_str}"
+            )
+        lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    logger.info(
+        "wrote classifier report",
+        extra={
+            "event": "classify.report.written",
+            "path": str(out_path),
+            "total_tests": total,
+            "suggested_unit": suggested_counts.get("unit", 0),
+            "suggested_integration": suggested_counts.get("integration", 0),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _default_tests_dir() -> Path:
+    """Locate ``backend/tests/`` relative to this script."""
+    return Path(__file__).resolve().parent.parent / "tests"
+
+
+def _default_report_path() -> Path:
+    """PF-Q1 sample path: lives alongside the design specs (untracked)."""
+    return (
+        Path(__file__).resolve().parent.parent
+        / "design-specs"
+        / "quality-v1-pf-q1-sample.md"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="classify_tests",
+        description=(
+            "Enforce the Quality v1 pytest-marker partition "
+            "(unit / integration / tdd_red). Default mode is --check."
+        ),
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify every test has exactly one classifier marker (default).",
+    )
+    parser.add_argument(
+        "--report",
+        nargs="?",
+        const=str(_default_report_path()),
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write a heuristic suggested-classification report to PATH "
+            "(default: backend/design-specs/quality-v1-pf-q1-sample.md). "
+            "Read-only — never modifies any test file."
+        ),
+    )
+    parser.add_argument(
+        "--tests-dir",
+        type=Path,
+        default=_default_tests_dir(),
+        help="Override the tests directory (default: backend/tests/).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    scans = scan_directory(args.tests_dir)
+
+    if args.report is not None:
+        write_report(scans, Path(args.report))
+        print(f"classify_tests: report written to {args.report}")
+        # Report mode does not enforce — it is read-only.
+        return 0
+
+    # Default: --check
+    return check(scans)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_acceptance_encryption.py
+++ b/backend/tests/test_acceptance_encryption.py
@@ -35,6 +35,7 @@ class TestAC1_SchwabValuesEncryptedAtRest:
     """Verify that writing via _upsert_setting encrypts, and reading via
     _read_setting decrypts, through a real SQLite DB."""
 
+    @pytest.mark.integration
     def test_upsert_stores_encrypted_values_in_db(self, client):
         """Values written via _upsert_setting are encrypted in the raw DB."""
         from app.main import app
@@ -65,6 +66,7 @@ class TestAC1_SchwabValuesEncryptedAtRest:
 
         db.close()
 
+    @pytest.mark.integration
     def test_read_setting_returns_decrypted_values(self, client):
         """Values read via _read_setting are transparently decrypted."""
         from app.main import app
@@ -92,6 +94,7 @@ class TestAC1_SchwabValuesEncryptedAtRest:
 
         db.close()
 
+    @pytest.mark.integration
     def test_non_sensitive_keys_stored_as_plaintext(self, client):
         """Timestamp keys are NOT encrypted."""
         from app.main import app
@@ -117,6 +120,7 @@ class TestAC1_SchwabValuesEncryptedAtRest:
 
         db.close()
 
+    @pytest.mark.integration
     def test_all_four_sensitive_keys_are_covered(self):
         """ENCRYPTED_SETTING_KEYS covers exactly the 4 sensitive schwab_* keys."""
         expected = {
@@ -127,6 +131,7 @@ class TestAC1_SchwabValuesEncryptedAtRest:
         }
         assert ENCRYPTED_SETTING_KEYS == expected
 
+    @pytest.mark.integration
     def test_migration_encrypts_existing_plaintext(self, client):
         """On startup migration, existing plaintext tokens become encrypted."""
         from app.main import app
@@ -167,6 +172,7 @@ class TestAC1_SchwabValuesEncryptedAtRest:
 class TestAC2_FailClosedWithoutEncryptionKey:
     """App must refuse to start when Schwab tokens exist but key is missing."""
 
+    @pytest.mark.integration
     def test_startup_raises_when_tokens_exist_without_key(self):
         """_run_security_checks raises EncryptionKeyMissing when tokens
         exist in DB but SCHWAB_ENCRYPTION_KEY is not set."""
@@ -184,6 +190,7 @@ class TestAC2_FailClosedWithoutEncryptionKey:
             with pytest.raises(EncryptionKeyMissing, match="SCHWAB_ENCRYPTION_KEY"):
                 _run_security_checks()
 
+    @pytest.mark.integration
     def test_startup_ok_when_no_tokens_and_no_key(self):
         """No error when there are no Schwab tokens and no key (fresh install)."""
         from app.main import _run_security_checks
@@ -200,6 +207,7 @@ class TestAC2_FailClosedWithoutEncryptionKey:
             # Should not raise
             _run_security_checks()
 
+    @pytest.mark.integration
     def test_startup_ok_when_tokens_exist_with_key(self):
         """No error when tokens exist and encryption key is set."""
         from app.main import _run_security_checks
@@ -216,6 +224,7 @@ class TestAC2_FailClosedWithoutEncryptionKey:
             # Should not raise
             _run_security_checks()
 
+    @pytest.mark.integration
     def test_schwab_tokens_exist_detects_stored_tokens(self, client):
         """schwab_tokens_exist returns True when tokens are in DB."""
         from app.main import app
@@ -247,6 +256,7 @@ class TestAC2_FailClosedWithoutEncryptionKey:
 class TestAC3_StartupWarnsOnBadDbPermissions:
     """Startup must log a warning when the DB file is group/world readable."""
 
+    @pytest.mark.integration
     def test_warns_on_group_readable_db(self, tmp_path):
         """_run_security_checks logs a warning for group-readable DB file."""
         from app.main import _run_security_checks
@@ -275,6 +285,7 @@ class TestAC3_StartupWarnsOnBadDbPermissions:
                 f"Expected permission warning, got: {warning_calls}"
             )
 
+    @pytest.mark.integration
     def test_warns_on_world_readable_db(self, tmp_path):
         """_run_security_checks logs a warning for world-readable DB file."""
         from app.main import _run_security_checks
@@ -300,6 +311,7 @@ class TestAC3_StartupWarnsOnBadDbPermissions:
             ]
             assert any("chmod 600" in w for w in warning_calls)
 
+    @pytest.mark.integration
     def test_no_warning_on_secure_permissions(self, tmp_path):
         """No permission warning when DB file has 0600."""
         from app.main import _run_security_checks
@@ -334,6 +346,7 @@ class TestAC3_StartupWarnsOnBadDbPermissions:
 class TestAC5_EncryptDecryptRoundtripAndMissingKey:
     """Verify core encrypt/decrypt round-trip and missing-key behavior."""
 
+    @pytest.mark.integration
     def test_encrypt_decrypt_roundtrip_all_sensitive_keys(self):
         """Each sensitive key type encrypts and decrypts correctly."""
         for key_name in ENCRYPTED_SETTING_KEYS:
@@ -342,6 +355,7 @@ class TestAC5_EncryptDecryptRoundtripAndMissingKey:
             assert encrypted != value
             assert decrypt_value(encrypted, key=TEST_KEY) == value
 
+    @pytest.mark.integration
     def test_missing_key_raises_on_encrypt(self):
         """encrypt_value raises EncryptionKeyMissing without a key."""
         with patch("app.services.encryption.settings") as mock_settings:
@@ -349,6 +363,7 @@ class TestAC5_EncryptDecryptRoundtripAndMissingKey:
             with pytest.raises(EncryptionKeyMissing):
                 encrypt_value("secret")
 
+    @pytest.mark.integration
     def test_missing_key_raises_on_decrypt(self):
         """decrypt_value raises EncryptionKeyMissing without a key."""
         ciphertext = encrypt_value("secret", key=TEST_KEY)
@@ -357,6 +372,7 @@ class TestAC5_EncryptDecryptRoundtripAndMissingKey:
             with pytest.raises(EncryptionKeyMissing):
                 decrypt_value(ciphertext)
 
+    @pytest.mark.integration
     def test_health_endpoint_includes_token_expiry(self, client):
         """GET /api/settings/health/schwab returns token_expiry field."""
         from app.services.schwab_auth import SchwabTokenManager
@@ -382,6 +398,7 @@ class TestAC5_EncryptDecryptRoundtripAndMissingKey:
         assert data["token_expiry"]["expired"] is False
         assert "hours_remaining" in data["token_expiry"]
 
+    @pytest.mark.integration
     def test_health_endpoint_token_expiry_null_when_not_configured(self, client):
         """GET /api/settings/health/schwab returns token_expiry=null when unconfigured."""
         from app.services.schwab_auth import SchwabTokenManager

--- a/backend/tests/test_acceptance_phase4.py
+++ b/backend/tests/test_acceptance_phase4.py
@@ -29,6 +29,7 @@ def _clear_av_cache():
 class TestAC1_EarningsDatesResolveViaAlphaVantage:
     """AC: Earnings dates resolve correctly via Alpha Vantage."""
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_parses_csv_and_returns_next_future_date(self, mock_get, mock_settings):
@@ -54,6 +55,7 @@ class TestAC1_EarningsDatesResolveViaAlphaVantage:
         assert kwargs["params"]["function"] == "EARNINGS_CALENDAR"
         assert kwargs["params"]["symbol"] == "AAPL"
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_selects_earliest_future_date_from_multiple(self, mock_get, mock_settings):
@@ -80,6 +82,7 @@ class TestAC1_EarningsDatesResolveViaAlphaVantage:
 class TestAC2_EarningsExclusionWorksInScanner:
     """AC: Earnings exclusion still works in scanner when date is available."""
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date")
     @patch("app.services.options_scanner.SchwabClient")
     def test_scan_excludes_expirations_near_earnings(self, mock_client_cls, mock_earnings):
@@ -145,6 +148,7 @@ class TestAC2_EarningsExclusionWorksInScanner:
 class TestAC3_ScannerCompletesWhenAlphaVantageReturnsNone:
     """AC: Scanner completes successfully when Alpha Vantage returns None."""
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_scan_succeeds_with_none_earnings(self, mock_client_cls, _mock_earnings):
@@ -211,6 +215,7 @@ class TestAC4_YfinanceRemovedFromRequirements:
     research/business endpoint (PRD §"API Contracts → A").
     """
 
+    @pytest.mark.unit
     @pytest.mark.skip(
         reason="Superseded by #280 / v1.1.0 PRD — yfinance is the v1 "
         "source for /api/positions/{id}/research/business. The "
@@ -230,6 +235,7 @@ class TestAC5_NoYfinanceImportsInAnyFile:
     new, scoped yfinance integration for the research surface.
     """
 
+    @pytest.mark.unit
     @pytest.mark.skip(
         reason="Superseded by #280 / v1.1.0 — see class docstring."
     )
@@ -253,6 +259,7 @@ class TestAC5_NoYfinanceImportsInAnyFile:
 
         assert violations == [], "yfinance imports found:\n" + "\n".join(violations)
 
+    @pytest.mark.unit
     @pytest.mark.skip(
         reason="Superseded by #280 / v1.1.0 — see class docstring."
     )
@@ -275,6 +282,7 @@ class TestAC5_NoYfinanceImportsInAnyFile:
 class TestAC6_EnvExampleDocumentsAllVars:
     """AC: .env.example documents all 4 new env vars with setup instructions."""
 
+    @pytest.mark.unit
     def test_env_example_has_required_vars(self):
         env_example_path = BACKEND_ROOT.parent / ".env.example"
         content = env_example_path.read_text()

--- a/backend/tests/test_acceptance_schwab_phase2.py
+++ b/backend/tests/test_acceptance_schwab_phase2.py
@@ -56,6 +56,7 @@ def _mock_cache(has_fresh=False, has_stale=False):
 class TestAC1_RegressionChartsLoadViaSchwab:
     """AC: Regression charts load correctly using Schwab price history."""
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_fetch_routes_stock_through_schwab(self, mock_schwab):
         """DataFetcher.fetch() calls _fetch_schwab for stock tickers."""
@@ -70,6 +71,7 @@ class TestAC1_RegressionChartsLoadViaSchwab:
         assert not meta.is_stale
         assert len(df) == 30
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_fetch_routes_index_through_schwab(self, mock_schwab):
         """Index tickers (^GSPC) also route through Schwab."""
@@ -82,6 +84,7 @@ class TestAC1_RegressionChartsLoadViaSchwab:
         mock_schwab.assert_called_once_with("^GSPC", "2024-01-01", "2024-01-30")
         assert meta.source == "schwab"
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_fetch_routes_commodity_through_schwab(self, mock_schwab):
         """Commodity tickers (GC=F) also route through Schwab."""
@@ -94,6 +97,7 @@ class TestAC1_RegressionChartsLoadViaSchwab:
         mock_schwab.assert_called_once_with("GC=F", "2024-01-01", "2024-01-30")
         assert meta.source == "schwab"
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_returned_dataframe_has_correct_shape(self, mock_schwab):
         """Returned DataFrame has date index and value column (chart-ready)."""
@@ -109,12 +113,14 @@ class TestAC1_RegressionChartsLoadViaSchwab:
         assert meta.date_range.start == df.index[0].strftime("%Y-%m-%d")
         assert meta.date_range.end == df.index[-1].strftime("%Y-%m-%d")
 
+    @pytest.mark.unit
     def test_fred_still_routes_to_fred(self):
         """FRED series must NOT route through Schwab."""
         assert detect_source("FEDFUNDS") == "fred"
         assert detect_source("DGS10") == "fred"
         assert detect_source("UNRATE") == "fred"
 
+    @pytest.mark.unit
     def test_zillow_still_routes_to_zillow(self):
         """Zillow ZIP codes must NOT route through Schwab."""
         assert detect_source("ZIP:10001") == "zillow"
@@ -128,6 +134,7 @@ class TestAC2_CurrentPriceViaSchwab:
     response lacks a price.
     """
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_get_current_price_uses_schwab(self, mock_client_cls):
         """_get_current_price_fallback uses Schwab get_quote."""
@@ -141,6 +148,7 @@ class TestAC2_CurrentPriceViaSchwab:
         assert price == 185.50
         mock_client.get_quote.assert_called_once_with("AAPL")
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_get_current_price_falls_back_to_error(self, mock_client_cls):
         """When Schwab fails, raises OptionScannerError (no yfinance fallback for price)."""
@@ -152,6 +160,7 @@ class TestAC2_CurrentPriceViaSchwab:
         with pytest.raises(OptionScannerError, match="Cannot get current price"):
             scanner._get_current_price_fallback(mock_client, "AAPL")
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_get_current_price_falls_back_on_auth_error(self, mock_client_cls):
         """SchwabAuthError also raises OptionScannerError."""
@@ -171,6 +180,7 @@ class TestAC3_VixDisplaysCorrectly:
     from the chain response underlying quote, not a separate _get_market_context call.
     """
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_vix_from_schwab_quote(self, mock_client_cls):
         """VIX is fetched via Schwab get_quote('^VIX') mapped to $VIX.X."""
@@ -183,6 +193,7 @@ class TestAC3_VixDisplaysCorrectly:
 
         assert vix == 22.35
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_vix_fallback_returns_none(self, mock_client_cls):
         """When Schwab VIX fails, returns None."""
@@ -195,6 +206,7 @@ class TestAC3_VixDisplaysCorrectly:
 
         assert vix is None
 
+    @pytest.mark.unit
     def test_52week_data_from_chain_underlying(self):
         """52-week high/low comes from Schwab chain response underlying quote."""
         # In Phase 3, the scan() method extracts 52-week data from the chain
@@ -221,6 +233,7 @@ class TestAC3_VixDisplaysCorrectly:
 class TestAC4_CacheBehaviorUnchanged:
     """AC: Cache behavior unchanged (TTL rules still apply)."""
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_fresh_cache_prevents_schwab_call(self, mock_schwab):
         """Fresh cache entry should prevent any Schwab API call."""
@@ -233,6 +246,7 @@ class TestAC4_CacheBehaviorUnchanged:
         assert not meta.is_stale
         cache.get.assert_called_once_with("schwab:AAPL")
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_cache_key_uses_schwab_prefix(self, mock_schwab):
         """Cache key for stock tickers is 'schwab:<ticker>'."""
@@ -250,6 +264,7 @@ class TestAC4_CacheBehaviorUnchanged:
         assert args[0][0] == "schwab:AAPL"  # key
         assert args[0][3] == "schwab"  # source
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_stale_cache_fallback_on_schwab_failure(self, mock_schwab):
         """SchwabClientError triggers stale cache fallback."""
@@ -261,6 +276,7 @@ class TestAC4_CacheBehaviorUnchanged:
 
         assert meta.is_stale
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_stale_cache_fallback_on_auth_error(self, mock_schwab):
         """SchwabAuthError also triggers stale cache fallback."""
@@ -272,6 +288,7 @@ class TestAC4_CacheBehaviorUnchanged:
 
         assert meta.is_stale
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_no_cache_no_fallback_raises(self, mock_schwab):
         """When Schwab fails and no cache exists, error propagates."""
@@ -282,6 +299,7 @@ class TestAC4_CacheBehaviorUnchanged:
         with pytest.raises(SchwabClientError):
             fetcher.fetch("AAPL", "2024-01-01", "2024-01-30")
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_index_cache_key_uses_schwab_prefix(self, mock_schwab):
         """Index tickers also use schwab: prefix in cache keys."""
@@ -297,6 +315,7 @@ class TestAC4_CacheBehaviorUnchanged:
 class TestAC5_NoYfinanceInDataFetcher:
     """AC: No remaining yfinance calls in data_fetcher.py."""
 
+    @pytest.mark.unit
     def test_no_yfinance_import(self):
         """data_fetcher.py must not import yfinance."""
         import app.services.data_fetcher as mod
@@ -309,6 +328,7 @@ class TestAC5_NoYfinanceInDataFetcher:
             if isinstance(node, ast.ImportFrom):
                 assert node.module != "yfinance", "data_fetcher.py still imports from yfinance"
 
+    @pytest.mark.unit
     def test_no_yf_references_in_source(self):
         """data_fetcher.py AST must not contain yf or yfinance name/attribute nodes."""
         import app.services.data_fetcher as mod
@@ -321,6 +341,7 @@ class TestAC5_NoYfinanceInDataFetcher:
             if isinstance(node, ast.Attribute):
                 assert node.attr != "yfinance", "data_fetcher.py has 'yfinance' attribute reference"
 
+    @pytest.mark.unit
     def test_detect_source_returns_schwab_not_yfinance(self):
         """detect_source() must return 'schwab' for all non-FRED, non-Zillow tickers."""
         stock_tickers = ["AAPL", "MSFT", "TSLA", "GOOGL"]
@@ -330,6 +351,7 @@ class TestAC5_NoYfinanceInDataFetcher:
         for ticker in stock_tickers + index_tickers + commodity_tickers:
             assert detect_source(ticker) == "schwab", f"detect_source('{ticker}') != 'schwab'"
 
+    @pytest.mark.unit
     def test_asset_registry_uses_schwab_not_yfinance(self):
         """All non-FRED entries in ASSET_REGISTRY must use source='schwab'."""
         for entry in ASSET_REGISTRY:
@@ -343,6 +365,7 @@ class TestAC5_NoYfinanceInDataFetcher:
 class TestAC6_ExistingTestsUpdated:
     """AC: Existing data fetcher tests updated for Schwab response fixtures."""
 
+    @pytest.mark.unit
     def test_mock_cache_uses_schwab_source_name(self):
         """Test fixtures must use 'schwab' as source_name, not 'yfinance'."""
         from tests.test_data_fetcher import _make_mock_cache

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -126,6 +126,7 @@ def _leg(
 
 
 class TestSchwabDisconnectedTrigger:
+    @pytest.mark.unit
     def test_emits_when_not_configured(self):
         actions = compute_next_actions(
             status=_status(schwab_configured=False, schwab_valid=False),
@@ -136,6 +137,7 @@ class TestSchwabDisconnectedTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_disconnected" in ids
 
+    @pytest.mark.unit
     def test_emits_when_invalid(self):
         actions = compute_next_actions(
             status=_status(schwab_configured=True, schwab_valid=False),
@@ -146,6 +148,7 @@ class TestSchwabDisconnectedTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_disconnected" in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_when_healthy(self):
         actions = compute_next_actions(
             status=_status(schwab_configured=True, schwab_valid=True),
@@ -158,6 +161,7 @@ class TestSchwabDisconnectedTrigger:
 
 
 class TestCacheVeryStaleTrigger:
+    @pytest.mark.unit
     def test_emits_when_very_stale_positive(self):
         actions = compute_next_actions(
             status=_status(cache_very_stale=3),
@@ -169,6 +173,7 @@ class TestCacheVeryStaleTrigger:
         assert action["priority"] == "P0"
         assert action["cta"]["kind"] == "inline"
 
+    @pytest.mark.unit
     def test_does_not_emit_when_no_very_stale(self):
         actions = compute_next_actions(
             status=_status(cache_very_stale=0),
@@ -181,6 +186,7 @@ class TestCacheVeryStaleTrigger:
 
 
 class TestSchwabTokenExpiringTrigger:
+    @pytest.mark.unit
     def test_emits_when_within_threshold(self):
         soon = (datetime.now(timezone.utc) + timedelta(hours=12)).isoformat()
         actions = compute_next_actions(
@@ -192,6 +198,7 @@ class TestSchwabTokenExpiringTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_token_expiring" in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_when_far_from_expiry(self):
         far = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
         actions = compute_next_actions(
@@ -203,6 +210,7 @@ class TestSchwabTokenExpiringTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_token_expiring" not in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_immediately_after_fresh_seven_day_grant(self):
         # Regression: Schwab refresh tokens last exactly 7 days. A 7-day
         # threshold here caused the P1 "Renew Schwab token" card to fire
@@ -220,6 +228,7 @@ class TestSchwabTokenExpiringTrigger:
         ids = {a["action_id"] for a in actions}
         assert "data.schwab_token_expiring" not in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_when_disconnected(self):
         # Disconnected case is handled by `data.schwab_disconnected`. No
         # double-emit when both conditions hold.
@@ -235,6 +244,7 @@ class TestSchwabTokenExpiringTrigger:
 
 
 class TestLargeLoserTrigger:
+    @pytest.mark.unit
     def test_emits_at_default_pct_threshold_minus_fifteen_pct(self):
         # Whichever-fires-first: the default loss-review threshold (-15%)
         # trips even when dollars are small. With no `rules` override the
@@ -250,6 +260,7 @@ class TestLargeLoserTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.large_loser" in ids
 
+    @pytest.mark.unit
     def test_emits_at_dollar_threshold_minus_1000(self):
         # Whichever-fires-first: -$1000 trips even at -1% basis. The dollar
         # trigger is a hardcoded heuristic, independent of the rules config.
@@ -264,6 +275,7 @@ class TestLargeLoserTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.large_loser" in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_just_below_thresholds(self):
         # -14.9% and -$999 should NOT trigger under the default -15% rule.
         actions = compute_next_actions(
@@ -277,6 +289,7 @@ class TestLargeLoserTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.large_loser" not in ids
 
+    @pytest.mark.unit
     def test_default_rule_does_not_emit_between_5_and_15_pct(self):
         # Issue #235: the old hardcoded -5% constant is gone. An -8% loser
         # — between the retired -5% and the configured -15% — must NOT flag
@@ -292,6 +305,7 @@ class TestLargeLoserTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.large_loser" not in ids
 
+    @pytest.mark.unit
     def test_largest_loser_honors_configured_loss_review_threshold(self):
         # Issue #235: a stricter-than-default threshold (-5%) flags an -8%
         # loser that the default -15% rule would leave alone — proving the
@@ -319,6 +333,7 @@ class TestLargeLoserTrigger:
             a["action_id"] for a in strict_actions
         }
 
+    @pytest.mark.unit
     def test_reason_copy_reflects_configured_threshold_no_hardcoded_pct(self):
         # Issue #235: the card's `reason` string must report the configured
         # threshold, never a hardcoded "-5%". Here a stored -20% rule.
@@ -337,6 +352,7 @@ class TestLargeLoserTrigger:
         assert "-20%" in loser_card["reason"]
         assert "-5%" not in loser_card["reason"]
 
+    @pytest.mark.unit
     def test_only_single_largest_loser_emitted(self):
         # Three losers — engine surfaces only the worst.
         actions = compute_next_actions(
@@ -353,6 +369,7 @@ class TestLargeLoserTrigger:
         assert len(loser_cards) == 1
         assert loser_cards[0]["subject"]["ticker"] == "BBB"
 
+    @pytest.mark.unit
     def test_cta_href_points_at_recovery_plan_route(self):
         # V0.5.8 (#182): the loser CTA destination flipped from the journal
         # filter page to the Recovery Plan route. Both shipped in the same
@@ -371,6 +388,7 @@ class TestLargeLoserTrigger:
 
 
 class TestItmShortDteTrigger:
+    @pytest.mark.unit
     def test_emits_when_itm_and_short_dte(self):
         actions = compute_next_actions(
             status=_status(),
@@ -381,6 +399,7 @@ class TestItmShortDteTrigger:
         ids = {a["action_id"] for a in actions}
         assert "expiration.itm_short_dte" in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_at_exact_boundary_eight_dte(self):
         # 8 DTE is outside the ≤ 7 window — no per-leg ITM card.
         actions = compute_next_actions(
@@ -392,6 +411,7 @@ class TestItmShortDteTrigger:
         ids = {a["action_id"] for a in actions}
         assert "expiration.itm_short_dte" not in ids
 
+    @pytest.mark.unit
     def test_capped_at_three(self):
         legs = [
             _leg(f"l-{i}", dte=i, moneyness_state="ITM", position_id=f"p-{i}")
@@ -408,6 +428,7 @@ class TestItmShortDteTrigger:
 
 
 class TestShortDteAggregateTrigger:
+    @pytest.mark.unit
     def test_aggregates_one_per_ticker_when_otm(self):
         # Two OTM short-DTE legs on AAPL → one card.
         actions = compute_next_actions(
@@ -424,6 +445,7 @@ class TestShortDteAggregateTrigger:
         # Carries leg count in the subject amount.
         assert "2 legs" in cards[0]["subject"]["amount"]
 
+    @pytest.mark.unit
     def test_does_not_emit_when_itm(self):
         actions = compute_next_actions(
             status=_status(),
@@ -436,6 +458,7 @@ class TestShortDteAggregateTrigger:
 
 
 class TestCcCandidateTrigger:
+    @pytest.mark.unit
     def test_emits_for_position_with_shares_and_no_open_call(self):
         actions = compute_next_actions(
             status=_status(),
@@ -446,6 +469,7 @@ class TestCcCandidateTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.cc_candidate" in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_when_open_call_exists(self):
         actions = compute_next_actions(
             status=_status(),
@@ -456,6 +480,7 @@ class TestCcCandidateTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.cc_candidate" not in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_for_less_than_100_shares(self):
         actions = compute_next_actions(
             status=_status(),
@@ -466,6 +491,7 @@ class TestCcCandidateTrigger:
         ids = {a["action_id"] for a in actions}
         assert "position.cc_candidate" not in ids
 
+    @pytest.mark.unit
     def test_cc_candidate_href_carries_context(self):
         """The CTA href hands off strategy, shares, and cost basis to the scanner."""
         actions = compute_next_actions(
@@ -492,6 +518,7 @@ class TestCcCandidateTrigger:
         # Must never emit the raw total — that breaks the 10% rule downstream.
         assert "cost_basis=17240" not in href
 
+    @pytest.mark.unit
     def test_cc_candidate_href_emits_per_share_basis_canonical_f_case(self):
         """Regression for #186: F at 100 shares with broker_cost_basis=$1,320.66
         must emit cost_basis=13.2066 per-share, not the raw total.
@@ -520,6 +547,7 @@ class TestCcCandidateTrigger:
         assert "13.206600000000002" not in href
         assert "13.20660000000001" not in href
 
+    @pytest.mark.unit
     @pytest.mark.skip(
         reason=(
             "Manual AC from #186: clicking 'Scan F →' on the dashboard yields "
@@ -530,6 +558,7 @@ class TestCcCandidateTrigger:
     def test_manual_ac_cc_candidate_yields_non_rejected_strike(self):
         pass
 
+    @pytest.mark.unit
     def test_cc_candidate_href_omits_cost_basis_when_null(self):
         """Null broker_cost_basis must omit the cost_basis param entirely."""
         actions = compute_next_actions(
@@ -554,6 +583,7 @@ class TestCcCandidateTrigger:
 
 
 class TestNoOpenLegsTrigger:
+    @pytest.mark.unit
     def test_emits_when_zero_open_legs(self):
         actions = compute_next_actions(
             status=_status(),
@@ -564,6 +594,7 @@ class TestNoOpenLegsTrigger:
         ids = {a["action_id"] for a in actions}
         assert "journal.no_open_legs" in ids
 
+    @pytest.mark.unit
     def test_emits_when_positions_exist_but_zero_legs(self):
         # Locked decision: emit even when positions exist but kpis.open_legs == 0.
         actions = compute_next_actions(
@@ -575,6 +606,7 @@ class TestNoOpenLegsTrigger:
         ids = {a["action_id"] for a in actions}
         assert "journal.no_open_legs" in ids
 
+    @pytest.mark.unit
     def test_does_not_emit_when_legs_exist(self):
         actions = compute_next_actions(
             status=_status(),
@@ -592,6 +624,7 @@ class TestNoOpenLegsTrigger:
 
 
 class TestRanking:
+    @pytest.mark.unit
     def test_p0_data_above_p0_position(self):
         # Spec §14.7: within P0, `data.*` outranks `position.*`.
         actions = compute_next_actions(
@@ -604,6 +637,7 @@ class TestRanking:
         first_p0 = next(a for a in actions if a["priority"] == "P0")
         assert first_p0["action_id"] == "data.cache_very_stale"
 
+    @pytest.mark.unit
     def test_p0_above_p1(self):
         actions = compute_next_actions(
             status=_status(schwab_configured=False, schwab_valid=False),
@@ -620,6 +654,7 @@ class TestRanking:
             if seen_p1 and p == "P0":
                 raise AssertionError("P0 found after a P1 — ranking is broken")
 
+    @pytest.mark.unit
     def test_p1_expiration_sorted_by_dte_ascending(self):
         legs = [
             _leg("l-7", dte=7, moneyness_state="ITM", position_id="p-7"),
@@ -636,6 +671,7 @@ class TestRanking:
         leg_ids = [a["id"].split(".")[-1] for a in cards]
         assert leg_ids == ["l-3", "l-5", "l-7"]
 
+    @pytest.mark.unit
     def test_p2_cc_before_scanner(self):
         # Both P2 cards in the same payload — covered call ranks first.
         actions = compute_next_actions(
@@ -649,6 +685,7 @@ class TestRanking:
             "journal.no_open_legs"
         )
 
+    @pytest.mark.unit
     def test_p2_cc_candidates_sorted_alphabetically(self):
         positions = [
             _position("p-tsla", "TSLA", shares=100),
@@ -668,6 +705,7 @@ class TestRanking:
         ]
         assert tickers == ["AAPL", "MSFT", "TSLA"]
 
+    @pytest.mark.unit
     def test_deterministic_across_runs(self):
         # Same inputs → same outputs across 100 runs.
         positions = [
@@ -693,6 +731,7 @@ class TestRanking:
             )
             assert again == first
 
+    @pytest.mark.unit
     def test_capped_at_max(self):
         # Stuff every bucket; ensure the engine truncates at MAX_ACTIONS.
         legs = [
@@ -712,6 +751,7 @@ class TestRanking:
 
 
 class TestActionShape:
+    @pytest.mark.unit
     def test_id_is_action_id_dot_subject_id(self):
         actions = compute_next_actions(
             status=_status(),
@@ -722,6 +762,7 @@ class TestActionShape:
         scanner = next(a for a in actions if a["action_id"] == "journal.no_open_legs")
         assert scanner["id"].startswith("journal.no_open_legs.")
 
+    @pytest.mark.unit
     def test_cta_kind_inline_only_for_cache_refresh(self):
         actions = compute_next_actions(
             status=_status(cache_very_stale=1),
@@ -735,6 +776,7 @@ class TestActionShape:
             else:
                 assert action["cta"]["kind"] == "link"
 
+    @pytest.mark.unit
     def test_priority_is_string_label(self):
         actions = compute_next_actions(
             status=_status(schwab_configured=False, schwab_valid=False),
@@ -834,6 +876,7 @@ def _verdict_leg(
 
 
 class TestProfitTakeReviewCard:
+    @pytest.mark.unit
     def test_emits_when_verdict_is_profit_take_review(self):
         actions = compute_next_actions(
             status=_status(),
@@ -849,6 +892,7 @@ class TestProfitTakeReviewCard:
         assert card["id"] == "leg.profit_take_review.l-1"
         assert card["triggered_rules"]
 
+    @pytest.mark.unit
     def test_card_cta_links_to_btc_detail_route(self):
         # Issue #244 — the CTA repoints from the dead `/dashboard#leg-{id}`
         # hash to the dedicated per-leg buy-to-close detail route.
@@ -861,6 +905,7 @@ class TestProfitTakeReviewCard:
         card = next(a for a in actions if a["action_id"] == "leg.profit_take_review")
         assert card["cta"]["href"] == "/positions/p-1/legs/l-1/btc"
 
+    @pytest.mark.unit
     def test_not_emitted_for_hold_verdict(self):
         actions = compute_next_actions(
             status=_status(),
@@ -871,6 +916,7 @@ class TestProfitTakeReviewCard:
         ids = {a["action_id"] for a in actions}
         assert "leg.profit_take_review" not in ids
 
+    @pytest.mark.unit
     def test_card_title_and_cta_use_buy_to_close_vocabulary(self):
         """Issue #249 — the card title and CTA label name the destination
         screen, not the rule audit sub-section. Locks the vocabulary contract:
@@ -889,6 +935,7 @@ class TestProfitTakeReviewCard:
 
 
 class TestDteReviewCard:
+    @pytest.mark.unit
     def test_emits_when_verdict_is_dte_review(self):
         actions = compute_next_actions(
             status=_status(),
@@ -904,6 +951,7 @@ class TestDteReviewCard:
         assert card.get("tone", "warning") == "warning"
         assert card["id"] == "leg.dte_review.l-1"
 
+    @pytest.mark.unit
     def test_not_emitted_for_profit_take_verdict(self):
         actions = compute_next_actions(
             status=_status(),
@@ -914,6 +962,7 @@ class TestDteReviewCard:
         ids = {a["action_id"] for a in actions}
         assert "leg.dte_review" not in ids
 
+    @pytest.mark.unit
     def test_cta_label_uses_buy_to_close_vocabulary(self):
         """Issue #249 — DTE-review CTA also names the destination. The card
         title (``{N}-day review``) is intentionally retained — it describes
@@ -933,6 +982,7 @@ class TestDteReviewCard:
 
 
 class TestRuleMonitorCardPrecedence:
+    @pytest.mark.unit
     def test_itm_short_dte_leg_emits_only_expiration_card(self):
         # A 5-DTE ITM leg: verdict is "assignment" (the §R6 governing rule).
         # The legacy expiration.itm_short_dte builder still fires on its own
@@ -951,6 +1001,7 @@ class TestRuleMonitorCardPrecedence:
         assert "leg.profit_take_review" not in ids
         assert "leg.dte_review" not in ids
 
+    @pytest.mark.unit
     def test_profit_take_leg_inside_dte_window_emits_only_profit_card(self):
         # 18-DTE leg, 60% captured: profit-take governs (verdict drives it),
         # so no leg.dte_review card despite the 21d window also matching.
@@ -973,6 +1024,7 @@ class TestExpirationCardsUnaffected:
     after the new §R6 builders land (spec §10 cross-cutting AC).
     """
 
+    @pytest.mark.unit
     def test_mixed_leg_set_expiration_cards_unchanged(self):
         legs = [
             # ITM short-DTE → expiration.itm_short_dte
@@ -1006,6 +1058,7 @@ class TestExpirationCardsUnaffected:
 
 
 class TestRuleMonitorCardSort:
+    @pytest.mark.unit
     def test_expiration_card_sorts_before_profit_take_within_p1(self):
         legs = [
             _verdict_leg(
@@ -1028,6 +1081,7 @@ class TestRuleMonitorCardSort:
             "leg.profit_take_review"
         )
 
+    @pytest.mark.unit
     def test_dte_review_card_sorts_in_p2(self):
         legs = [
             _verdict_leg(
@@ -1051,6 +1105,7 @@ class TestProfitTakeCardThreadsManagementThresholds:
     (CodeRabbit fix: ``dte_review_days``/``expiration_warning_days``).
     """
 
+    @pytest.mark.unit
     def test_custom_dte_review_days_flows_into_profit_take_card_reason(
         self, monkeypatch
     ):
@@ -1102,6 +1157,7 @@ class TestLargeLoserSubjectSpacingIssue164:
     cosmetic defect.
     """
 
+    @pytest.mark.unit
     def test_subject_amount_uses_single_space_with_pct(self):
         actions = compute_next_actions(
             status=_status(),
@@ -1122,6 +1178,7 @@ class TestLargeLoserSubjectSpacingIssue164:
             f"subject.amount must not contain a double space: {amount!r}"
         )
 
+    @pytest.mark.unit
     def test_subject_amount_uses_single_space_when_pct_is_none(self):
         # The no-pct branch hits the alternate f-string at L296 — same
         # spacing rule must hold even though the trailing ``({pct})`` is

--- a/backend/tests/test_alpha_vantage_client.py
+++ b/backend/tests/test_alpha_vantage_client.py
@@ -42,6 +42,7 @@ def _mock_resp(text: str) -> MagicMock:
 
 
 class TestGetNextEarningsDate:
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_returns_next_future_date(self, mock_get, mock_settings):
@@ -55,6 +56,7 @@ class TestGetNextEarningsDate:
         result = get_next_earnings_date("AAPL")
         assert result == future_date
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_returns_earliest_future_date(self, mock_get, mock_settings):
@@ -68,6 +70,7 @@ class TestGetNextEarningsDate:
         result = get_next_earnings_date("AAPL")
         assert result == date2
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_returns_none_when_no_future_dates(self, mock_get, mock_settings):
@@ -80,11 +83,13 @@ class TestGetNextEarningsDate:
         result = get_next_earnings_date("AAPL")
         assert result is None
 
+    @pytest.mark.unit
     def test_returns_none_when_api_key_not_set(self):
         with patch("app.services.alpha_vantage_client.get_alpha_vantage_api_key", return_value=""):
             result = get_next_earnings_date("AAPL")
         assert result is None
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_returns_none_on_api_error(self, mock_get, mock_settings):
@@ -94,6 +99,7 @@ class TestGetNextEarningsDate:
         result = get_next_earnings_date("AAPL")
         assert result is None
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_caches_result(self, mock_get, mock_settings):
@@ -108,6 +114,7 @@ class TestGetNextEarningsDate:
         assert result1 == result2 == future_date
         assert mock_get.call_count == 1  # Only called once due to cache
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_returns_none_on_empty_csv(self, mock_get, mock_settings):
@@ -120,6 +127,7 @@ class TestGetNextEarningsDate:
         result = get_next_earnings_date("AAPL")
         assert result is None
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_returns_none_on_missing_report_date_header(self, mock_get, mock_settings):
@@ -135,6 +143,7 @@ class TestGetNextEarningsDate:
         result = get_next_earnings_date("AAPL")
         assert result is None
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_does_not_cache_transient_failures(self, mock_get, mock_settings):
@@ -152,6 +161,7 @@ class TestGetNextEarningsDate:
         result2 = get_next_earnings_date("AAPL")
         assert result2 == future_date
 
+    @pytest.mark.unit
     @patch("app.services.alpha_vantage_client.settings")
     @patch("app.services.alpha_vantage_client.requests.get")
     def test_detects_json_error_in_200_response(self, mock_get, mock_settings):
@@ -175,6 +185,7 @@ class TestNoYfinanceImportsAnywhere:
     These are smoke tests for the key files.
     """
 
+    @pytest.mark.unit
     def test_no_yfinance_in_options_scanner(self):
         import ast
         import inspect
@@ -188,6 +199,7 @@ class TestNoYfinanceImportsAnywhere:
             if isinstance(node, ast.ImportFrom):
                 assert node.module != "yfinance", "options_scanner.py still imports from yfinance"
 
+    @pytest.mark.unit
     def test_no_yfinance_in_regression_router(self):
         import ast
         import inspect
@@ -202,6 +214,7 @@ class TestNoYfinanceImportsAnywhere:
                 if node.module and "yfinance" in node.module:
                     raise AssertionError("regression.py still imports from yfinance")
 
+    @pytest.mark.unit
     def test_no_yfinance_in_health_router(self):
         import ast
         import inspect
@@ -224,6 +237,7 @@ class TestGetCachedNextEarningsDate:
     on this guarantee to avoid blocking the request on Alpha Vantage.
     """
 
+    @pytest.mark.unit
     def test_returns_none_when_cache_miss(self):
         # No in-memory entry; _read_db_cache is stubbed to None via the
         # module-level autouse fixture. The helper MUST NOT call requests.get.
@@ -232,6 +246,7 @@ class TestGetCachedNextEarningsDate:
         assert result is None
         mock_get.assert_not_called()
 
+    @pytest.mark.unit
     def test_returns_value_from_hot_cache(self):
         # Pre-populate the hot cache.
         from app.services import alpha_vantage_client as av
@@ -242,6 +257,7 @@ class TestGetCachedNextEarningsDate:
         assert result == "2026-06-15"
         mock_get.assert_not_called()
 
+    @pytest.mark.unit
     def test_returns_none_when_hot_cache_expired(self):
         from app.services import alpha_vantage_client as av
 
@@ -253,6 +269,7 @@ class TestGetCachedNextEarningsDate:
         assert result is None
         mock_get.assert_not_called()
 
+    @pytest.mark.unit
     def test_falls_back_to_db_cache(self):
         from app.services import alpha_vantage_client as av
 
@@ -298,6 +315,7 @@ class TestGetIncomeStatementCacheNPoisoning:
             ],
         }
 
+    @pytest.mark.unit
     @patch(
         "app.services.alpha_vantage_client._write_income_db_cache",
         new=MagicMock(),

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -10,6 +10,7 @@ Covers acceptance criteria from issue #20 (original auth) and issue #28
 - AC6: github_id and github_secret removed from Settings
 """
 
+import pytest
 import logging
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -71,6 +72,7 @@ def _mock_full_auth(mock_settings, allowed_users=""):
 class TestAC1NoAuthEnvVars:
     """AC1: App works out of the box with no auth env vars set."""
 
+    @pytest.mark.integration
     def test_anonymous_access_when_no_env_vars(self):
         """Protected routes allow anonymous access when no auth env vars are set."""
         app = _make_app()
@@ -84,6 +86,7 @@ class TestAC1NoAuthEnvVars:
         assert resp.json()["user"]["username"] == "anonymous"
         assert resp.json()["user"]["sub"] == "anonymous"
 
+    @pytest.mark.integration
     def test_anonymous_access_without_bearer_token(self):
         """No Authorization header needed when auth is unconfigured."""
         app = _make_app()
@@ -95,18 +98,21 @@ class TestAC1NoAuthEnvVars:
 
         assert resp.status_code == 200
 
+    @pytest.mark.integration
     def test_is_auth_configured_false_when_nothing_set(self):
         """is_auth_configured() returns False when NEXTAUTH_SECRET is not set."""
         with patch("app.auth.settings") as mock_settings:
             _mock_no_auth(mock_settings)
             assert is_auth_configured() is False
 
+    @pytest.mark.integration
     def test_is_auth_configured_false_for_empty_string(self):
         """is_auth_configured() returns False for empty NEXTAUTH_SECRET."""
         with patch("app.auth.settings") as mock_settings:
             mock_settings.nextauth_secret = ""
             assert is_auth_configured() is False
 
+    @pytest.mark.integration
     def test_logs_info_when_unconfigured(self, caplog):
         """Logs an info message when auth is not configured."""
         import app.auth
@@ -133,12 +139,14 @@ class TestAC1NoAuthEnvVars:
 class TestAC2FullAuthEnabled:
     """AC2: Setting NEXTAUTH_SECRET enables full auth (no GitHub secrets needed)."""
 
+    @pytest.mark.integration
     def test_is_auth_configured_true_when_secret_set(self):
         """is_auth_configured() returns True when NEXTAUTH_SECRET is set."""
         with patch("app.auth.settings") as mock_settings:
             _mock_full_auth(mock_settings)
             assert is_auth_configured() is True
 
+    @pytest.mark.integration
     def test_returns_401_when_no_token_provided(self):
         """When auth is configured but no token is sent, return 401."""
         app = _make_app()
@@ -151,6 +159,7 @@ class TestAC2FullAuthEnabled:
         assert resp.status_code == 401
         assert "Authentication required" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_returns_user_for_valid_token(self):
         """A valid HS256 JWT returns the user info."""
         app = _make_app()
@@ -168,6 +177,7 @@ class TestAC2FullAuthEnabled:
         assert data["sub"] == "12345"
         assert data["username"] == "testuser"
 
+    @pytest.mark.integration
     def test_returns_401_for_expired_token(self):
         """An expired JWT returns 401."""
         app = _make_app()
@@ -187,6 +197,7 @@ class TestAC2FullAuthEnabled:
         assert resp.status_code == 401
         assert "expired" in resp.json()["detail"].lower()
 
+    @pytest.mark.integration
     def test_returns_401_for_wrong_secret(self):
         """A JWT signed with a different secret returns 401."""
         app = _make_app()
@@ -202,6 +213,7 @@ class TestAC2FullAuthEnabled:
         assert resp.status_code == 401
         assert "Invalid token" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_returns_401_for_malformed_token(self):
         """A garbage string returns 401."""
         app = _make_app()
@@ -215,6 +227,7 @@ class TestAC2FullAuthEnabled:
 
         assert resp.status_code == 401
 
+    @pytest.mark.integration
     def test_rejects_blank_username(self):
         """A token with an empty username is rejected."""
         app = _make_app()
@@ -239,12 +252,14 @@ class TestAC2FullAuthEnabled:
 class TestAC3PartialConfig:
     """AC3: With single-var auth model, partial config is not possible."""
 
+    @pytest.mark.integration
     def test_no_partial_config_function(self):
         """_is_partially_configured() has been removed as dead code."""
         import app.auth
 
         assert not hasattr(app.auth, "_is_partially_configured")
 
+    @pytest.mark.integration
     def test_anonymous_access_when_secret_not_set(self):
         """Anonymous access works when NEXTAUTH_SECRET is not set."""
         app = _make_app()
@@ -266,6 +281,7 @@ class TestAC3PartialConfig:
 class TestAC4AllowedUsers:
     """AC4: ALLOWED_USERS still restricts access when auth is enabled."""
 
+    @pytest.mark.integration
     def test_rejects_user_not_in_allowlist(self):
         """A valid token for a user not in ALLOWED_USERS is rejected with 403."""
         app = _make_app()
@@ -281,6 +297,7 @@ class TestAC4AllowedUsers:
         assert resp.status_code == 403
         assert "not authorized" in resp.json()["detail"].lower()
 
+    @pytest.mark.integration
     def test_allows_user_in_allowlist(self):
         """A valid token for a user in ALLOWED_USERS succeeds."""
         app = _make_app()
@@ -296,6 +313,7 @@ class TestAC4AllowedUsers:
         assert resp.status_code == 200
         assert resp.json()["user"]["username"] == "Alice"
 
+    @pytest.mark.integration
     def test_case_insensitive_allowlist(self):
         """Allowlist matching is case-insensitive."""
         app = _make_app()
@@ -310,6 +328,7 @@ class TestAC4AllowedUsers:
 
         assert resp.status_code == 200
 
+    @pytest.mark.integration
     def test_empty_allowlist_allows_any_user(self):
         """When ALLOWED_USERS is empty, any authenticated user is allowed."""
         app = _make_app()
@@ -333,12 +352,14 @@ class TestAC4AllowedUsers:
 class TestAC5NoDevBypass:
     """AC5: DEV_AUTH_BYPASS is removed — not needed when unconfigured = open."""
 
+    @pytest.mark.integration
     def test_no_dev_auth_bypass_in_settings(self):
         """The Settings class no longer has a dev_auth_bypass field."""
         from app.config import Settings
 
         assert "dev_auth_bypass" not in Settings.model_fields
 
+    @pytest.mark.integration
     def test_no_dev_auth_bypass_in_env_example(self):
         """DEV_AUTH_BYPASS is not referenced in .env.example."""
         import pathlib
@@ -348,6 +369,7 @@ class TestAC5NoDevBypass:
             content = env_example.read_text()
             assert "DEV_AUTH_BYPASS" not in content
 
+    @pytest.mark.integration
     def test_anonymous_without_bypass_flag(self):
         """Anonymous access works without any bypass flag when auth is unconfigured."""
         app = _make_app()
@@ -369,18 +391,21 @@ class TestAC5NoDevBypass:
 class TestAC6NoGitHubSecretsInBackend:
     """AC6: GITHUB_ID and GITHUB_SECRET are removed from the backend."""
 
+    @pytest.mark.integration
     def test_no_github_id_in_settings(self):
         """The Settings class no longer has a github_id field."""
         from app.config import Settings
 
         assert "github_id" not in Settings.model_fields
 
+    @pytest.mark.integration
     def test_no_github_secret_in_settings(self):
         """The Settings class no longer has a github_secret field."""
         from app.config import Settings
 
         assert "github_secret" not in Settings.model_fields
 
+    @pytest.mark.integration
     def test_auth_works_without_github_secrets(self):
         """Auth is fully functional with only NEXTAUTH_SECRET."""
         app = _make_app()
@@ -396,6 +421,7 @@ class TestAC6NoGitHubSecretsInBackend:
         assert resp.status_code == 200
         assert resp.json()["user"]["username"] == "testuser"
 
+    @pytest.mark.integration
     def test_is_auth_configured_ignores_github_vars(self):
         """is_auth_configured() only checks NEXTAUTH_SECRET, not GitHub vars."""
         with patch("app.auth.settings") as mock_settings:
@@ -412,6 +438,7 @@ class TestAC6NoGitHubSecretsInBackend:
 class TestRouteProtection:
     """Verify health is public and protected routes require auth when configured."""
 
+    @pytest.mark.integration
     def test_health_check_is_public(self):
         """The /api/health endpoint works without auth.
 
@@ -432,6 +459,7 @@ class TestRouteProtection:
         body = resp.json()
         assert body["status"] == "ok"
 
+    @pytest.mark.integration
     def test_protected_route_returns_401_when_auth_enabled(self):
         """A protected endpoint returns 401 without auth when NEXTAUTH_SECRET is set."""
         from app.main import app
@@ -444,6 +472,7 @@ class TestRouteProtection:
 
         assert resp.status_code == 401
 
+    @pytest.mark.integration
     def test_protected_route_allows_anonymous_when_auth_disabled(self):
         """A protected endpoint allows anonymous access when auth is not configured."""
         app = _make_app()
@@ -456,6 +485,7 @@ class TestRouteProtection:
         assert resp.status_code == 200
         assert resp.json()["user"]["username"] == "anonymous"
 
+    @pytest.mark.integration
     def test_protected_route_allows_anonymous_when_secret_not_set(self):
         """A protected endpoint allows anonymous access when NEXTAUTH_SECRET is not set."""
         app = _make_app()

--- a/backend/tests/test_backup.py
+++ b/backend/tests/test_backup.py
@@ -5,12 +5,14 @@ from app.services.backup import ensure_backup_dir, list_backups, BACKUP_DIR
 
 
 class TestBackup:
+    @pytest.mark.unit
     def test_ensure_backup_dir_creates_directory(self):
         """ensure_backup_dir should create the directory and return its path."""
         result = ensure_backup_dir()
         assert result == BACKUP_DIR
         assert BACKUP_DIR.is_dir()
 
+    @pytest.mark.unit
     def test_list_backups_returns_list(self):
         """list_backups should return a list (possibly empty)."""
         result = list_backups()

--- a/backend/tests/test_btc_detail_endpoint.py
+++ b/backend/tests/test_btc_detail_endpoint.py
@@ -18,6 +18,7 @@ Covers:
 """
 
 from __future__ import annotations
+import pytest
 
 from datetime import date, timedelta
 from unittest.mock import patch
@@ -159,6 +160,7 @@ def _patch_schwab(quote_price=15.0, chain=None):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_btc_detail_200_populated_when_profit_take_fired(client):
     """A leg deep in the money for the seller (% captured high) → populated."""
     _seed_position(client)
@@ -178,6 +180,7 @@ def test_btc_detail_200_populated_when_profit_take_fired(client):
     assert payload["disclaimer"]
 
 
+@pytest.mark.integration
 def test_btc_detail_rules_audit_has_all_four_rules(client):
     _seed_position(client)
     _seed_trade(client)
@@ -198,6 +201,7 @@ def test_btc_detail_rules_audit_has_all_four_rules(client):
     assert governing[0]["reasoning"]
 
 
+@pytest.mark.integration
 def test_btc_detail_economics_fields_are_correct(client):
     _seed_position(client)
     # 1 contract, $0.3834 premium → $38.34 credit; $0.1572 mid → $15.72 cost.
@@ -212,6 +216,7 @@ def test_btc_detail_economics_fields_are_correct(client):
     assert econ["pricing_as_of"] is not None
 
 
+@pytest.mark.integration
 def test_btc_detail_captured_pct_agrees_with_profit_signal(client):
     """captured_pct is lifted from the % CAPT signal — agree by construction."""
     _seed_position(client)
@@ -229,6 +234,7 @@ def test_btc_detail_captured_pct_agrees_with_profit_signal(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_btc_detail_no_rule_triggered_for_quiet_leg(client):
     """A far-DTE OTM leg with low capture → verdict hold → no-rule-triggered."""
     _seed_position(client)
@@ -258,6 +264,7 @@ def test_btc_detail_no_rule_triggered_for_quiet_leg(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_btc_detail_pricing_unavailable_when_no_mark(client):
     """No option mark for the contract → pricing fields degrade to null."""
     _seed_position(client)
@@ -281,6 +288,7 @@ def test_btc_detail_pricing_unavailable_when_no_mark(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_btc_detail_404_for_unknown_position(client):
     with _patch_schwab():
         resp = client.get("/api/positions/nope/legs/whatever/btc")
@@ -288,6 +296,7 @@ def test_btc_detail_404_for_unknown_position(client):
     assert resp.json() == {"detail": "Leg not found"}
 
 
+@pytest.mark.integration
 def test_btc_detail_404_for_unknown_leg(client):
     _seed_position(client)
     _seed_trade(client)
@@ -297,6 +306,7 @@ def test_btc_detail_404_for_unknown_leg(client):
     assert resp.json() == {"detail": "Leg not found"}
 
 
+@pytest.mark.integration
 def test_btc_detail_404_for_closed_leg(client):
     _seed_position(client)
     _seed_trade(client, closed_at="2026-05-01T00:00:00Z")
@@ -306,6 +316,7 @@ def test_btc_detail_404_for_closed_leg(client):
     assert resp.json() == {"detail": "Leg not found"}
 
 
+@pytest.mark.integration
 def test_btc_detail_404_for_position_leg_mismatch(client):
     """A leg id that belongs to a different position → 404, no cross-leak."""
     _seed_position(client, pos_id="pos-ford", ticker="F")
@@ -323,6 +334,7 @@ def test_btc_detail_404_for_position_leg_mismatch(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_btc_detail_500_uses_generic_detail_on_quote_failure(client):
     _seed_position(client)
     _seed_trade(client)

--- a/backend/tests/test_btc_detail_service.py
+++ b/backend/tests/test_btc_detail_service.py
@@ -13,6 +13,7 @@ is not re-tested here. The full endpoint flow is covered by
 """
 
 from __future__ import annotations
+import pytest
 
 from app.services.btc_detail import (
     _build_economics,
@@ -22,6 +23,7 @@ from app.services.btc_detail import (
 
 
 class TestBuildEconomics:
+    @pytest.mark.unit
     def test_per_share_premium_scales_to_whole_position_credit(self):
         # A 1-contract $0.3834 per-share premium → $38.34 credit (×1×100).
         leg = {
@@ -35,6 +37,7 @@ class TestBuildEconomics:
         assert econ["cost_to_close"] == 15.72
         assert econ["pricing_source"] == "live"
 
+    @pytest.mark.unit
     def test_credit_scales_by_contract_count(self):
         leg = {
             "premium": 2.25,
@@ -46,6 +49,7 @@ class TestBuildEconomics:
         assert econ["credit_received"] == 675.0  # 2.25 × 3 × 100
         assert econ["cost_to_close"] == 270.0  # 0.90 × 3 × 100
 
+    @pytest.mark.unit
     def test_est_pl_is_signed_credit_minus_cost(self):
         leg = {
             "premium": 2.25,
@@ -57,6 +61,7 @@ class TestBuildEconomics:
         # 225 credit - 90 cost = +135 gain.
         assert econ["est_pl_if_closed"] == 135.0
 
+    @pytest.mark.unit
     def test_est_pl_is_negative_when_cost_exceeds_credit(self):
         leg = {
             "premium": 1.00,
@@ -68,6 +73,7 @@ class TestBuildEconomics:
         # 100 credit - 250 cost = -150 loss.
         assert econ["est_pl_if_closed"] == -150.0
 
+    @pytest.mark.unit
     def test_captured_pct_is_lifted_not_recomputed(self):
         # The economics block lifts captured_pct verbatim from the % CAPT
         # signal so it agrees with the dashboard column by construction.
@@ -80,6 +86,7 @@ class TestBuildEconomics:
         econ = _build_economics(leg)
         assert econ["captured_pct"] == 0.6042
 
+    @pytest.mark.unit
     def test_no_mid_propagates_null_pricing_fields(self):
         # No live mark → cost/captured/est_pl/as_of all None, source unavailable.
         leg = {
@@ -98,6 +105,7 @@ class TestBuildEconomics:
         # credit_received is static — always real even with no live pricing.
         assert econ["credit_received"] == 225.0
 
+    @pytest.mark.unit
     def test_pricing_as_of_is_set_when_mid_available(self):
         leg = {
             "premium": 2.25,
@@ -111,27 +119,33 @@ class TestBuildEconomics:
 
 
 class TestPositionLabel:
+    @pytest.mark.unit
     def test_covered_call_label(self):
         assert _position_label({"ticker": "F", "strategy": "cc"}) == "F covered call"
 
+    @pytest.mark.unit
     def test_cash_secured_put_label(self):
         assert (
             _position_label({"ticker": "SOFI", "strategy": "csp"})
             == "SOFI cash-secured put"
         )
 
+    @pytest.mark.unit
     def test_wheel_label(self):
         assert _position_label({"ticker": "F", "strategy": "wheel"}) == "F wheel"
 
+    @pytest.mark.unit
     def test_unknown_strategy_falls_back_to_position(self):
         assert _position_label({"ticker": "F", "strategy": "mystery"}) == "F position"
 
 
 class TestMoneynessLabel:
+    @pytest.mark.unit
     def test_reports_state_when_present(self):
         assert _moneyness_label({"moneyness": {"state": "ITM"}}) == "ITM"
         assert _moneyness_label({"moneyness": {"state": "OTM"}}) == "OTM"
 
+    @pytest.mark.unit
     def test_unknown_when_no_moneyness(self):
         assert _moneyness_label({"moneyness": None}) == "Unknown"
         assert _moneyness_label({}) == "Unknown"

--- a/backend/tests/test_cache_service.py
+++ b/backend/tests/test_cache_service.py
@@ -55,6 +55,7 @@ def cache_service(db_session):
 class TestSetAndGet:
     """AC: test_set_and_get_cache_entry"""
 
+    @pytest.mark.unit
     def test_round_trip_returns_stored_data(self, cache_service):
         """set() followed by get() returns matching data, source, and frequency."""
         data = json.dumps({"prices": [1, 2, 3]})
@@ -76,10 +77,12 @@ class TestSetAndGet:
 class TestCacheMiss:
     """AC: test_get_returns_none_for_missing_key"""
 
+    @pytest.mark.unit
     def test_get_returns_none_for_missing_key(self, cache_service):
         """get() returns None when no entry exists for the key."""
         assert cache_service.get("nonexistent") is None
 
+    @pytest.mark.unit
     def test_get_stale_returns_none_for_missing_key(self, cache_service):
         """get_stale() also returns None when no entry exists."""
         assert cache_service.get_stale("nonexistent") is None
@@ -93,6 +96,7 @@ class TestCacheMiss:
 class TestExpiration:
     """AC: test_expired_entry_returns_none, test_expired_entry_get_stale_still_returns"""
 
+    @pytest.mark.unit
     def test_expired_daily_entry_returns_none(self, cache_service, db_session):
         """get() returns None when a daily entry has exceeded the TTL."""
         cache_service.set("schwab:AAPL", '{"p":1}', "daily", "schwab")
@@ -106,6 +110,7 @@ class TestExpiration:
 
         assert cache_service.get("schwab:AAPL") is None
 
+    @pytest.mark.unit
     def test_expired_entry_get_stale_still_returns(self, cache_service, db_session):
         """get_stale() returns data even when the entry is expired."""
         cache_service.set("schwab:AAPL", '{"p":1}', "daily", "schwab")
@@ -120,11 +125,13 @@ class TestExpiration:
         assert result is not None
         assert result["data"] == '{"p":1}'
 
+    @pytest.mark.unit
     def test_fresh_daily_entry_within_ttl(self, cache_service):
         """get() returns data for a daily entry still within the TTL window."""
         cache_service.set("schwab:AAPL", '{"p":1}', "daily", "schwab")
         assert cache_service.get("schwab:AAPL") is not None
 
+    @pytest.mark.unit
     def test_monthly_entry_uses_monthly_ttl(self, cache_service, db_session):
         """Monthly frequency uses cache_ttl_monthly_days (7d), not the daily TTL."""
         cache_service.set("fred:GDP", '{"v":100}', "monthly", "fred")
@@ -144,6 +151,7 @@ class TestExpiration:
         db_session.commit()
         assert cache_service.get("fred:GDP") is None
 
+    @pytest.mark.unit
     def test_quarterly_entry_uses_monthly_ttl(self, cache_service, db_session):
         """Quarterly frequency falls into the else branch, using monthly TTL."""
         cache_service.set("fred:GDPQ", '{"v":200}', "quarterly", "fred")
@@ -164,6 +172,7 @@ class TestExpiration:
 class TestUpsert:
     """AC: test_set_overwrites_existing_entry"""
 
+    @pytest.mark.unit
     def test_set_overwrites_existing_entry(self, cache_service):
         """Calling set() twice with the same key updates to the latest data."""
         cache_service.set("schwab:AAPL", '{"v":1}', "daily", "schwab")
@@ -173,6 +182,7 @@ class TestUpsert:
         assert result is not None
         assert result["data"] == '{"v":2}'
 
+    @pytest.mark.unit
     def test_set_overwrites_frequency_and_source(self, cache_service):
         """Upsert also updates frequency and source fields."""
         cache_service.set("schwab:AAPL", '{"v":1}', "daily", "schwab")
@@ -191,6 +201,7 @@ class TestUpsert:
 class TestLargePayload:
     """AC: test_cache_with_large_payload"""
 
+    @pytest.mark.unit
     def test_large_payload_round_trips_without_truncation(self, cache_service):
         """A ~500KB JSON payload stores and retrieves without data loss."""
         large_data = json.dumps({"values": list(range(100000))})
@@ -212,6 +223,7 @@ class TestLargePayload:
 class TestSpecialCharacterKeys:
     """AC: test_cache_with_special_characters_in_key"""
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "key",
         [
@@ -240,6 +252,7 @@ class TestSequentialWrites:
     """AC: test_concurrent_writes_same_key (sequential — true concurrency not
     meaningful with single-threaded in-memory SQLite)."""
 
+    @pytest.mark.unit
     def test_sequential_writes_no_corruption(self, cache_service):
         """Two rapid sequential set() calls leave the entry in a valid state."""
         cache_service.set("schwab:MSFT", '{"v":1}', "daily", "schwab")
@@ -256,6 +269,7 @@ class TestSequentialWrites:
 
 
 class TestFetchedAtFormat:
+    @pytest.mark.unit
     def test_set_stores_valid_iso_format(self, cache_service, db_session):
         """set() writes fetched_at as a parseable ISO 8601 string."""
         cache_service.set("schwab:AAPL", '{"v":1}', "daily", "schwab")
@@ -271,6 +285,7 @@ class TestFetchedAtFormat:
 
 
 class TestNaiveDatetimeHandling:
+    @pytest.mark.unit
     def test_fetched_at_without_timezone_treated_as_utc(
         self, cache_service, db_session
     ):
@@ -291,6 +306,7 @@ class TestNaiveDatetimeHandling:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 @pytest.mark.skip(
     reason="CacheService has no delete() method — AC not applicable (issue #82)"
 )
@@ -298,6 +314,7 @@ def test_delete_cache_entry():
     """AC: test_delete_cache_entry. CacheService does not implement delete()."""
 
 
+@pytest.mark.unit
 @pytest.mark.skip(
     reason="CacheService has no clear_all() method — AC not applicable (issue #82)"
 )
@@ -305,6 +322,7 @@ def test_clear_all_cache():
     """AC: test_clear_all_cache. CacheService does not implement clear_all()."""
 
 
+@pytest.mark.unit
 @pytest.mark.skip(
     reason="CacheService has no key-listing method — AC not applicable (issue #82)"
 )

--- a/backend/tests/test_classify_tests.py
+++ b/backend/tests/test_classify_tests.py
@@ -1,0 +1,479 @@
+"""Tests for ``backend/scripts/classify_tests.py``.
+
+Covers the AC test list in issue #265:
+
+| AC | Test |
+|---|---|
+| AC-1.1 | test_pytest_ini_registers_three_markers |
+| AC-1.1 | test_pytest_ini_addopts_excludes_tdd_red |
+| AC-1.1 | test_pytest_ini_strict_markers_enabled |
+| AC-1.2 | test_classifier_finds_marked_tests |
+| AC-1.2 | test_classifier_rejects_unmarked |
+| AC-1.2 | test_classifier_rejects_double_marked |
+| AC-1.2 | test_classifier_accepts_tdd_red |
+| AC-1.2 | test_classifier_prints_counts |
+| AC-1.2 | test_classifier_exit_code_clean_repo |
+| AC-1.3 | test_report_mode_writes_sample_to_default_path |
+| AC-1.3 | test_report_mode_lists_per_file_distribution |
+| AC-1.4 | test_default_run_excludes_tdd_red (subprocess) |
+| AC-1.5 | test_unit_and_integration_partitions_disjoint (subprocess) |
+
+The classifier is application code, not just a script, so its tests are
+real pytest tests in ``backend/tests/``. They are themselves marked
+``@pytest.mark.unit`` (no FastAPI app, no DB) per the partition they
+enforce.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts import classify_tests
+
+
+REPO_BACKEND = Path(__file__).resolve().parent.parent  # backend/
+PYTEST_INI = REPO_BACKEND / "pytest.ini"
+
+
+# ---------------------------------------------------------------------------
+# AC-1.1 — pytest.ini registers markers, strict-markers, addopts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pytest_ini_registers_three_markers():
+    """pytest.ini declares unit / integration / tdd_red and nothing else as classifier markers."""
+    assert PYTEST_INI.exists(), f"missing {PYTEST_INI}"
+    cfg = configparser.ConfigParser()
+    cfg.read(PYTEST_INI)
+    raw_markers = cfg["pytest"]["markers"]
+    declared = {
+        line.split(":", 1)[0].strip()
+        for line in raw_markers.splitlines()
+        if line.strip() and ":" in line
+    }
+    assert declared == {"unit", "integration", "tdd_red"}, (
+        f"pytest.ini classifier markers mismatch — got {declared}"
+    )
+
+
+@pytest.mark.unit
+def test_pytest_ini_addopts_excludes_tdd_red():
+    """Default pytest invocation must skip tdd_red tests."""
+    cfg = configparser.ConfigParser()
+    cfg.read(PYTEST_INI)
+    addopts = cfg["pytest"]["addopts"]
+    assert "not tdd_red" in addopts, (
+        f"pytest.ini addopts must exclude tdd_red — got {addopts!r}"
+    )
+
+
+@pytest.mark.unit
+def test_pytest_ini_strict_markers_enabled():
+    """`--strict-markers` must be on so unregistered marks become errors."""
+    cfg = configparser.ConfigParser()
+    cfg.read(PYTEST_INI)
+    addopts = cfg["pytest"]["addopts"]
+    assert "--strict-markers" in addopts, (
+        f"pytest.ini addopts must include --strict-markers — got {addopts!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-1.2 — classifier behavior on synthetic input
+# ---------------------------------------------------------------------------
+
+
+def _write_test_file(path: Path, source: str) -> None:
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_classifier_finds_marked_tests(tmp_path):
+    """scan_file returns one record per test_* function with its classifier markers."""
+    f = tmp_path / "test_sample.py"
+    _write_test_file(
+        f,
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_alpha():
+            assert True
+
+        @pytest.mark.integration
+        def test_beta(client):
+            assert client is not None
+
+        class TestGroup:
+            @pytest.mark.unit
+            def test_gamma(self):
+                pass
+        """,
+    )
+    scan = classify_tests.scan_file(f)
+    qualnames = {(r.qualname, r.markers) for r in scan.tests}
+    assert qualnames == {
+        ("test_alpha", ("unit",)),
+        ("test_beta", ("integration",)),
+        ("TestGroup.test_gamma", ("unit",)),
+    }
+
+
+@pytest.mark.unit
+def test_classifier_rejects_unmarked(tmp_path, capsys):
+    """check() exits non-zero and prints the unmarked test's name + line."""
+    f = tmp_path / "test_bad.py"
+    _write_test_file(
+        f,
+        """
+        def test_no_marker():
+            assert True
+        """,
+    )
+    rc = classify_tests.check([classify_tests.scan_file(f)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "unclassified" in out
+    assert "test_no_marker" in out
+    # Actionable hint to CLAUDE.md and the three valid markers.
+    assert "@pytest.mark.unit" in out
+    assert "@pytest.mark.integration" in out
+    assert "@pytest.mark.tdd_red" in out
+
+
+@pytest.mark.unit
+def test_classifier_rejects_double_marked(tmp_path, capsys):
+    """A test with two classifier markers exits non-zero with a double-marked error."""
+    f = tmp_path / "test_double.py"
+    _write_test_file(
+        f,
+        """
+        import pytest
+
+        @pytest.mark.unit
+        @pytest.mark.integration
+        def test_two_marks():
+            assert True
+        """,
+    )
+    rc = classify_tests.check([classify_tests.scan_file(f)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "double-marked" in out
+    assert "test_two_marks" in out
+    assert "unit" in out and "integration" in out
+
+
+@pytest.mark.unit
+def test_classifier_accepts_tdd_red(tmp_path, capsys):
+    """A tdd_red marker is a valid classifier — check() exits 0."""
+    f = tmp_path / "test_red.py"
+    _write_test_file(
+        f,
+        """
+        import pytest
+
+        @pytest.mark.tdd_red
+        def test_not_yet_implemented():
+            assert False  # impl not written yet
+        """,
+    )
+    rc = classify_tests.check([classify_tests.scan_file(f)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "tdd_red: 1" in out
+
+
+@pytest.mark.unit
+def test_classifier_prints_counts(tmp_path, capsys):
+    """On success, classifier prints per-layer counts."""
+    f = tmp_path / "test_counts.py"
+    _write_test_file(
+        f,
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_u1(): pass
+
+        @pytest.mark.unit
+        def test_u2(): pass
+
+        @pytest.mark.integration
+        def test_i1(client): pass
+
+        @pytest.mark.tdd_red
+        def test_r1(): pass
+        """,
+    )
+    rc = classify_tests.check([classify_tests.scan_file(f)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "unit: 2" in out
+    assert "integration: 1" in out
+    assert "tdd_red: 1" in out
+
+
+@pytest.mark.unit
+def test_classifier_ignores_parametrize_and_skip(tmp_path):
+    """pytest.mark.parametrize/skip are not classifier markers — must not satisfy."""
+    f = tmp_path / "test_paramonly.py"
+    _write_test_file(
+        f,
+        """
+        import pytest
+
+        @pytest.mark.parametrize("x", [1, 2])
+        @pytest.mark.skip(reason="wip")
+        def test_only_builtins(x):
+            assert True
+        """,
+    )
+    scan = classify_tests.scan_file(f)
+    assert scan.tests[0].markers == ()  # neither classifier present
+
+
+@pytest.mark.unit
+def test_classifier_exit_code_clean_repo(tmp_path, capsys):
+    """check() against an empty FileScan list exits 0 with zero counts."""
+    rc = classify_tests.check([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "0 tests classified" in out
+
+
+# ---------------------------------------------------------------------------
+# AC-1.3 — REPORT mode (PF-Q1 sample generation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_report_mode_writes_sample_to_default_path(tmp_path, monkeypatch):
+    """--report writes a markdown file at the provided path."""
+    # Build a fake tests dir with one unit + one integration file.
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    _write_test_file(
+        tests_dir / "test_unit_example.py",
+        """
+        def test_pure():
+            assert True
+        """,
+    )
+    _write_test_file(
+        tests_dir / "test_integration_example.py",
+        """
+        from fastapi.testclient import TestClient
+
+        def test_via_client(client):
+            assert client is not None
+        """,
+    )
+    report_path = tmp_path / "report.md"
+    rc = classify_tests.main(
+        ["--report", str(report_path), "--tests-dir", str(tests_dir)]
+    )
+    assert rc == 0
+    assert report_path.exists()
+    body = report_path.read_text(encoding="utf-8")
+    assert "Quality v1 — PF-Q1 classifier report" in body
+    assert "test_unit_example.py" in body
+    assert "test_integration_example.py" in body
+
+
+@pytest.mark.unit
+def test_report_mode_lists_per_file_distribution(tmp_path):
+    """Report contains a per-file table with unit/integration columns."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    _write_test_file(
+        tests_dir / "test_mixed.py",
+        """
+        from fastapi.testclient import TestClient
+
+        def test_a():
+            assert True
+
+        def test_b(client):
+            assert client is not None
+        """,
+    )
+    report_path = tmp_path / "r.md"
+    classify_tests.main(
+        ["--report", str(report_path), "--tests-dir", str(tests_dir)]
+    )
+    body = report_path.read_text(encoding="utf-8")
+    # The file imports TestClient, so the heuristic suggests integration for
+    # every test in the file (suggested = integration when TestClient is imported).
+    assert "test_mixed.py" in body
+    assert "Distribution" in body
+    assert "Per-file summary" in body
+
+
+@pytest.mark.unit
+def test_report_mode_suggests_integration_for_client_fixture(tmp_path):
+    """A test taking the ``client`` fixture is suggested integration even without TestClient import."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    f = tests_dir / "test_client_only.py"
+    _write_test_file(
+        f,
+        """
+        def test_via_client(client):
+            assert client is not None
+        """,
+    )
+    scan = classify_tests.scan_file(f)
+    assert scan.tests[0].suggested_tier == "integration"
+
+
+@pytest.mark.unit
+def test_report_mode_suggests_unit_for_pure_test(tmp_path):
+    """A pure-Python test (no client, no TestClient import) is suggested unit."""
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    f = tests_dir / "test_pure.py"
+    _write_test_file(
+        f,
+        """
+        def test_math():
+            assert 2 + 2 == 4
+        """,
+    )
+    scan = classify_tests.scan_file(f)
+    assert scan.tests[0].suggested_tier == "unit"
+
+
+# ---------------------------------------------------------------------------
+# AC-1.4 / AC-1.5 — End-to-end via subprocess: default run excludes tdd_red,
+# unit and integration partitions are disjoint.
+# ---------------------------------------------------------------------------
+
+
+def _run_pytest(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    """Invoke pytest as a subprocess against ``cwd``."""
+    env = os.environ.copy()
+    # Avoid pytest discovering OUR test in the child run.
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _scaffold_sample_suite(root: Path) -> None:
+    """Build a self-contained pytest project with the three markers."""
+    (root / "pytest.ini").write_text(
+        textwrap.dedent(
+            """
+            [pytest]
+            markers =
+                unit: Pure unit.
+                integration: Stacked.
+                tdd_red: Red.
+            addopts = --strict-markers -m "not tdd_red"
+            """
+        ).lstrip(),
+        encoding="utf-8",
+    )
+    tests = root / "tests"
+    tests.mkdir()
+    (tests / "conftest.py").write_text("", encoding="utf-8")
+    _write_test_file(
+        tests / "test_unit_sample.py",
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_u1():
+            assert True
+        """,
+    )
+    _write_test_file(
+        tests / "test_integration_sample.py",
+        """
+        import pytest
+
+        @pytest.mark.integration
+        def test_i1():
+            assert True
+        """,
+    )
+    _write_test_file(
+        tests / "test_red_sample.py",
+        """
+        import pytest
+
+        @pytest.mark.tdd_red
+        def test_r1():
+            assert False, "deliberately red — impl not written"
+        """,
+    )
+
+
+@pytest.mark.unit
+def test_default_run_excludes_tdd_red(tmp_path):
+    """`pytest` (no args) must not run any @pytest.mark.tdd_red tests — AC-1.4."""
+    _scaffold_sample_suite(tmp_path)
+    result = _run_pytest(["-v"], cwd=tmp_path)
+    assert result.returncode == 0, (
+        f"default run should pass (tdd_red excluded). stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "test_u1" in result.stdout
+    assert "test_i1" in result.stdout
+    assert "test_r1" not in result.stdout, (
+        "default run leaked a tdd_red test"
+    )
+
+
+@pytest.mark.unit
+def test_unit_and_integration_partitions_disjoint(tmp_path):
+    """`pytest -m unit` and `pytest -m integration` produce non-overlapping sets — AC-1.5."""
+    _scaffold_sample_suite(tmp_path)
+    unit_only = _run_pytest(["-m", "unit", "-v", "--collect-only", "-q"], cwd=tmp_path)
+    integ_only = _run_pytest(
+        ["-m", "integration", "-v", "--collect-only", "-q"], cwd=tmp_path
+    )
+    assert unit_only.returncode == 0, unit_only.stdout + unit_only.stderr
+    assert integ_only.returncode == 0, integ_only.stdout + integ_only.stderr
+    assert "test_u1" in unit_only.stdout
+    assert "test_i1" not in unit_only.stdout
+    assert "test_i1" in integ_only.stdout
+    assert "test_u1" not in integ_only.stdout
+
+
+@pytest.mark.unit
+def test_strict_markers_rejects_unregistered(tmp_path):
+    """`--strict-markers` is enforced: an unregistered marker fails the run."""
+    _scaffold_sample_suite(tmp_path)
+    _write_test_file(
+        tmp_path / "tests" / "test_bad_mark.py",
+        """
+        import pytest
+
+        @pytest.mark.bogus_unregistered
+        def test_z():
+            assert True
+        """,
+    )
+    # pick up only the bad-mark file so we don't drag the others in.
+    result = _run_pytest(
+        ["tests/test_bad_mark.py", "-v"],
+        cwd=tmp_path,
+    )
+    assert result.returncode != 0
+    # pytest prints the offending marker name on strict-markers failure.
+    combined = result.stdout + result.stderr
+    assert "bogus_unregistered" in combined

--- a/backend/tests/test_classify_tests.py
+++ b/backend/tests/test_classify_tests.py
@@ -468,12 +468,27 @@ def test_strict_markers_rejects_unregistered(tmp_path):
             assert True
         """,
     )
-    # pick up only the bad-mark file so we don't drag the others in.
+    # Pass `-c` + `--strict-markers` explicitly so the test doesn't depend on
+    # pytest config discovery (which behaves differently when pytest-cov is
+    # loaded in the parent process — observed in CI vs local). The intent of
+    # this test is verifying the strict-markers behavior, not pytest's config
+    # search algorithm.
     result = _run_pytest(
-        ["tests/test_bad_mark.py", "-v"],
+        [
+            "-c", str(tmp_path / "pytest.ini"),
+            "--strict-markers",
+            "-p", "no:cacheprovider",
+            "tests/test_bad_mark.py",
+            "-v",
+        ],
         cwd=tmp_path,
     )
-    assert result.returncode != 0
+    assert result.returncode != 0, (
+        f"pytest should reject the unregistered marker.\n"
+        f"returncode={result.returncode}\n"
+        f"stdout={result.stdout}\n"
+        f"stderr={result.stderr}"
+    )
     # pytest prints the offending marker name on strict-markers failure.
     combined = result.stdout + result.stderr
     assert "bogus_unregistered" in combined

--- a/backend/tests/test_classify_tests.py
+++ b/backend/tests/test_classify_tests.py
@@ -169,7 +169,8 @@ def test_classifier_rejects_double_marked(tmp_path, capsys):
     assert rc == 1
     assert "double-marked" in out
     assert "test_two_marks" in out
-    assert "unit" in out and "integration" in out
+    assert "unit" in out
+    assert "integration" in out
 
 
 @pytest.mark.unit
@@ -242,7 +243,7 @@ def test_classifier_ignores_parametrize_and_skip(tmp_path):
 
 
 @pytest.mark.unit
-def test_classifier_exit_code_clean_repo(tmp_path, capsys):
+def test_classifier_exit_code_clean_repo(capsys):
     """check() against an empty FileScan list exits 0 with zero counts."""
     rc = classify_tests.check([])
     out = capsys.readouterr().out
@@ -256,7 +257,7 @@ def test_classifier_exit_code_clean_repo(tmp_path, capsys):
 
 
 @pytest.mark.unit
-def test_report_mode_writes_sample_to_default_path(tmp_path, monkeypatch):
+def test_report_mode_writes_sample_to_default_path(tmp_path):
     """--report writes a markdown file at the provided path."""
     # Build a fake tests dir with one unit + one integration file.
     tests_dir = tmp_path / "tests"
@@ -369,6 +370,7 @@ def _run_pytest(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
         capture_output=True,
         text=True,
         env=env,
+        check=False,
     )
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -49,12 +49,14 @@ def _seed(factory, **kv):
 
 
 class TestGetFredApiKey:
+    @pytest.mark.unit
     def test_get_fred_api_key_from_env(self):
         """Env var set — returns the env value without touching the DB."""
         with patch("app.config.settings") as mock_settings:
             mock_settings.fred_api_key = "env_fred_key"
             assert get_fred_api_key() == "env_fred_key"
 
+    @pytest.mark.unit
     def test_get_fred_api_key_from_db_fallback(self, db_session_factory):
         """No env var — returns the value stored in the DB."""
         _seed(db_session_factory, fred_api_key="db_fred_key")
@@ -64,6 +66,7 @@ class TestGetFredApiKey:
             mock_settings.fred_api_key = ""
             assert get_fred_api_key() == "db_fred_key"
 
+    @pytest.mark.unit
     def test_get_fred_api_key_env_precedence_over_db(self, db_session_factory):
         """Env var wins even when a DB row also exists."""
         _seed(db_session_factory, fred_api_key="db_fred_key")
@@ -73,6 +76,7 @@ class TestGetFredApiKey:
             mock_settings.fred_api_key = "env_fred_key"
             assert get_fred_api_key() == "env_fred_key"
 
+    @pytest.mark.unit
     def test_get_fred_api_key_missing_both(self, db_session_factory):
         """No env var and no DB row — returns empty string, never raises."""
         with patch("app.config.settings") as mock_settings, patch(
@@ -81,6 +85,7 @@ class TestGetFredApiKey:
             mock_settings.fred_api_key = ""
             assert get_fred_api_key() == ""
 
+    @pytest.mark.unit
     def test_get_fred_api_key_db_error_returns_empty(self):
         """A DB failure is swallowed — returns empty string, never raises."""
         def _boom():
@@ -94,6 +99,7 @@ class TestGetFredApiKey:
 
 
 class TestGetSchwabCredentials:
+    @pytest.mark.unit
     def test_get_schwab_credentials_from_env(self):
         """Both env vars set — returns them without touching the DB."""
         with patch("app.config.settings") as mock_settings:
@@ -101,6 +107,7 @@ class TestGetSchwabCredentials:
             mock_settings.schwab_app_secret = "env_secret"
             assert get_schwab_credentials() == ("env_key", "env_secret")
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_partial_env(self, db_session_factory):
         """Only one env var set — falls through to the DB fallback path.
 
@@ -125,6 +132,7 @@ class TestGetSchwabCredentials:
         assert app_key == "db_key"
         assert app_secret == "db_secret"
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_partial_env_no_db_keeps_env(
         self, db_session_factory
     ):
@@ -143,6 +151,7 @@ class TestGetSchwabCredentials:
         assert app_key == "env_key"
         assert app_secret == ""
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_db_fallback(self, db_session_factory):
         """No env vars — credentials are decrypted from the DB."""
         _seed(
@@ -158,6 +167,7 @@ class TestGetSchwabCredentials:
             enc_settings.schwab_encryption_key = TEST_KEY
             assert get_schwab_credentials() == ("real_key", "real_secret")
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_db_fallback_no_key(self, db_session_factory):
         """No encryption key configured — DB values are returned as stored."""
         _seed(
@@ -173,6 +183,7 @@ class TestGetSchwabCredentials:
             enc_settings.schwab_encryption_key = ""
             assert get_schwab_credentials() == ("plain_key", "plain_secret")
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_env_precedence_over_db(self, db_session_factory):
         """Env vars win even when DB rows also exist."""
         _seed(
@@ -188,6 +199,7 @@ class TestGetSchwabCredentials:
             enc_settings.schwab_encryption_key = TEST_KEY
             assert get_schwab_credentials() == ("env_key", "env_secret")
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_missing_both(self, db_session_factory):
         """No env vars and no DB rows — returns ('', ''), never raises."""
         with patch("app.config.settings") as mock_settings, patch(
@@ -198,6 +210,7 @@ class TestGetSchwabCredentials:
             enc_settings.schwab_encryption_key = TEST_KEY
             assert get_schwab_credentials() == ("", "")
 
+    @pytest.mark.unit
     def test_credential_decryption_failure(self, db_session_factory):
         """A corrupted DB value is handled gracefully — never raises.
 
@@ -219,6 +232,7 @@ class TestGetSchwabCredentials:
             # Must not raise; corrupted ciphertext degrades to the defaults.
             assert get_schwab_credentials() == ("", "")
 
+    @pytest.mark.unit
     def test_get_schwab_credentials_db_error_returns_defaults(self):
         """A DB failure is swallowed — returns ('', ''), never raises."""
         def _boom():
@@ -242,10 +256,12 @@ class TestSettingsExtraIgnore:
     ``GITHUB_SECRET`` into the traceback. ``extra="ignore"`` prevents this.
     """
 
+    @pytest.mark.unit
     def test_model_config_sets_extra_ignore(self):
         """``Settings`` ``model_config`` declares ``extra="ignore"``."""
         assert Settings.model_config.get("extra") == "ignore"
 
+    @pytest.mark.unit
     def test_undeclared_env_keys_do_not_raise(self, monkeypatch):
         """Constructing ``Settings()`` with undeclared env keys does not raise.
 

--- a/backend/tests/test_covered_call_endpoint.py
+++ b/backend/tests/test_covered_call_endpoint.py
@@ -21,6 +21,7 @@ Covers:
 """
 
 from __future__ import annotations
+import pytest
 
 from datetime import date, timedelta
 from unittest.mock import patch
@@ -166,6 +167,7 @@ def _patch_schwab(quote_price: float | None = 13.1579, chain=None):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_canonical_covered_call_reconciles_with_worked_example(client):
     """The headline AC: combined +$17.63, if_assigned ≈ +$217."""
     _seed_position(client)
@@ -191,6 +193,7 @@ def test_canonical_covered_call_reconciles_with_worked_example(client):
     assert entry["if_assigned_pnl"] == 217.34
 
 
+@pytest.mark.integration
 def test_per_leg_breakdown_carries_coverage_and_pnl(client):
     _seed_position(client)
     _seed_trade(client)
@@ -208,6 +211,7 @@ def test_per_leg_breakdown_carries_coverage_and_pnl(client):
     assert row["if_assigned_pnl"] == 217.34
 
 
+@pytest.mark.integration
 def test_position_summary_basis_is_per_share(client):
     """broker_cost_basis on the response is per-share, not the DB total."""
     _seed_position(client, broker_cost_basis=1321.0, shares=100)
@@ -219,6 +223,7 @@ def test_position_summary_basis_is_per_share(client):
     assert summary["broker_cost_basis"] == 13.21
 
 
+@pytest.mark.integration
 def test_disclaimer_is_present(client):
     _seed_position(client)
     _seed_trade(client)
@@ -236,6 +241,7 @@ def test_disclaimer_is_present(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_csp_only_position_returns_not_applicable_no_shares(client):
     _seed_position(client, shares=0, broker_cost_basis=0.0, strategy="csp")
     # Open short put — still not applicable because shares == 0.
@@ -254,6 +260,7 @@ def test_csp_only_position_returns_not_applicable_no_shares(client):
     assert payload["per_leg_breakdown"] == []
 
 
+@pytest.mark.integration
 def test_holding_with_no_short_call_returns_not_applicable_no_short_call(client):
     # 100 shares, no open option leg at all.
     _seed_position(client, strategy="holding")
@@ -263,6 +270,7 @@ def test_holding_with_no_short_call_returns_not_applicable_no_short_call(client)
     assert resp.json()["applicability"] == "not_applicable_no_short_call"
 
 
+@pytest.mark.integration
 def test_holding_with_short_put_only_returns_not_applicable_no_short_call(
     client,
 ):
@@ -275,6 +283,7 @@ def test_holding_with_short_put_only_returns_not_applicable_no_short_call(
     assert resp.json()["applicability"] == "not_applicable_no_short_call"
 
 
+@pytest.mark.integration
 def test_closed_position_returns_not_applicable_closed(client):
     _seed_position(client, status="closed")
     _seed_trade(client)
@@ -289,6 +298,7 @@ def test_closed_position_returns_not_applicable_closed(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_multi_leg_earliest_expiring_first_allocation(client):
     """Two short calls, leg A (DTE 38) and leg B (DTE 60), both qty 1."""
     _seed_position(client)
@@ -329,6 +339,7 @@ def test_multi_leg_earliest_expiring_first_allocation(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_degraded_no_live_mid_keeps_if_assigned_real(client):
     """Empty option chain → options_pnl null, but if_assigned survives."""
     _seed_position(client)
@@ -346,6 +357,7 @@ def test_degraded_no_live_mid_keeps_if_assigned_real(client):
     assert payload["if_assigned"][0]["if_assigned_pnl"] == 217.34
 
 
+@pytest.mark.integration
 def test_degraded_no_live_share_price_keeps_if_assigned_real(client):
     """No live quote → stock_pnl null, options_pnl still real."""
     _seed_position(client)
@@ -373,6 +385,7 @@ def test_degraded_no_live_share_price_keeps_if_assigned_real(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_returns_404_for_unknown_position(client):
     with _patch_schwab():
         resp = client.get("/api/positions/no-such-position/covered-call")
@@ -380,6 +393,7 @@ def test_returns_404_for_unknown_position(client):
     assert resp.json() == {"detail": "Position not found"}
 
 
+@pytest.mark.integration
 def test_500_on_quote_failure_returns_generic_detail(client):
     """A Schwab failure yields the generic 500; no ``str(e)`` leak."""
     _seed_position(client)

--- a/backend/tests/test_covered_call_service.py
+++ b/backend/tests/test_covered_call_service.py
@@ -17,6 +17,7 @@ Covers:
 """
 
 from __future__ import annotations
+import pytest
 
 from app.services.covered_call import (
     _allocate_shares_called,
@@ -60,6 +61,7 @@ F_LEG = {
 
 
 class TestComputeCombinedToday:
+    @pytest.mark.unit
     def test_worked_example_combined_is_plus_17_63(self):
         out = _compute_combined_today(
             shares=F_SHARES,
@@ -71,6 +73,7 @@ class TestComputeCombinedToday:
         assert out["options_pnl"] == 22.84
         assert out["combined_pnl"] == 17.63
 
+    @pytest.mark.unit
     def test_stock_leg_pnl_is_signed_gain(self):
         out = _compute_combined_today(
             shares=100,
@@ -81,6 +84,7 @@ class TestComputeCombinedToday:
         assert out["stock_pnl"] == 500.00
         assert out["combined_pnl"] == 500.00
 
+    @pytest.mark.unit
     def test_stock_leg_pnl_is_signed_loss(self):
         out = _compute_combined_today(
             shares=100,
@@ -91,6 +95,7 @@ class TestComputeCombinedToday:
         assert out["stock_pnl"] == -500.00
         assert out["combined_pnl"] == -500.00
 
+    @pytest.mark.unit
     def test_options_pnl_sums_per_leg_pnl_dollars(self):
         out = _compute_combined_today(
             shares=100,
@@ -105,6 +110,7 @@ class TestComputeCombinedToday:
         # Stock leg is zero (current == basis), so combined == options.
         assert out["combined_pnl"] == 32.84
 
+    @pytest.mark.unit
     def test_no_current_price_degrades_stock_and_combined_to_none(self):
         out = _compute_combined_today(
             shares=100,
@@ -116,6 +122,7 @@ class TestComputeCombinedToday:
         assert out["options_pnl"] == 22.84  # still real
         assert out["combined_pnl"] is None
 
+    @pytest.mark.unit
     def test_no_leg_pnl_dollars_degrades_options_and_combined_to_none(self):
         out = _compute_combined_today(
             shares=100,
@@ -127,6 +134,7 @@ class TestComputeCombinedToday:
         assert out["options_pnl"] is None
         assert out["combined_pnl"] is None
 
+    @pytest.mark.unit
     def test_both_unavailable_combined_is_none(self):
         out = _compute_combined_today(
             shares=100,
@@ -145,17 +153,20 @@ class TestComputeCombinedToday:
 
 
 class TestAllocateSharesCalled:
+    @pytest.mark.unit
     def test_single_leg_claims_all_shares_when_qty_times_100_leq_shares(self):
         legs = [{"id": "L1", "dte": 30, "quantity": 1, "ticker": "F"}]
         out = _allocate_shares_called(legs, shares=100)
         assert out == {"L1": 100}
 
+    @pytest.mark.unit
     def test_single_leg_overflow_is_capped_at_position_shares(self):
         # 100 shares, 2-contract short call → only 100 can be called away.
         legs = [{"id": "L1", "dte": 30, "quantity": 2, "ticker": "F"}]
         out = _allocate_shares_called(legs, shares=100)
         assert out["L1"] == 100
 
+    @pytest.mark.unit
     def test_two_legs_earliest_expiring_claims_first(self):
         # 100 sh, leg A DTE 20 + leg B DTE 40 → A claims 100, B gets 0.
         legs = [
@@ -165,6 +176,7 @@ class TestAllocateSharesCalled:
         out = _allocate_shares_called(legs, shares=100)
         assert out == {"A": 100, "B": 0}
 
+    @pytest.mark.unit
     def test_two_legs_partial_overflow_distributes_remaining(self):
         # 150 sh, leg A DTE 20 (qty 1) gets 100, leg B DTE 40 (qty 1) gets 50.
         legs = [
@@ -174,6 +186,7 @@ class TestAllocateSharesCalled:
         out = _allocate_shares_called(legs, shares=150)
         assert out == {"A": 100, "B": 50}
 
+    @pytest.mark.unit
     def test_three_legs_zero_shares_remaining_after_first(self):
         # 100 sh, leg A (dte 10, qty 1), leg B (dte 30, qty 1), leg C (dte 60, qty 1)
         # A claims 100; B, C get 0.
@@ -185,11 +198,13 @@ class TestAllocateSharesCalled:
         out = _allocate_shares_called(legs, shares=100)
         assert out == {"A": 100, "B": 0, "C": 0}
 
+    @pytest.mark.unit
     def test_zero_shares_returns_zero_allocation(self):
         legs = [{"id": "L1", "dte": 30, "quantity": 1, "ticker": "F"}]
         out = _allocate_shares_called(legs, shares=0)
         assert out == {"L1": 0}
 
+    @pytest.mark.unit
     def test_input_order_does_not_matter(self):
         # Pass legs in reverse-DTE order — earliest-expiring still claims.
         legs = [
@@ -206,6 +221,7 @@ class TestAllocateSharesCalled:
 
 
 class TestBuildIfAssigned:
+    @pytest.mark.unit
     def test_worked_example_if_assigned_is_217_34(self):
         # share_pnl = 100 * (15.00 - 13.21) = 179.00
         # premium_kept = 0.3834 * 100 * 1 = 38.34
@@ -224,6 +240,7 @@ class TestBuildIfAssigned:
         assert entry["premium_kept"] == 38.34
         assert entry["if_assigned_pnl"] == 217.34
 
+    @pytest.mark.unit
     def test_share_pnl_negative_when_strike_below_basis(self):
         # A "rolled-down" CC: strike $12, basis $13.21, shares 100.
         leg = {
@@ -245,6 +262,7 @@ class TestBuildIfAssigned:
         assert out[0]["premium_kept"] == 50.00
         assert out[0]["if_assigned_pnl"] == -71.00
 
+    @pytest.mark.unit
     def test_premium_kept_independent_of_shares_called(self):
         # Leg B in the multi-leg overflow case: shares_called == 0 but the
         # credit booked at open stays with the seller.
@@ -267,6 +285,7 @@ class TestBuildIfAssigned:
         assert out[0]["premium_kept"] == 25.00
         assert out[0]["if_assigned_pnl"] == 25.00
 
+    @pytest.mark.unit
     def test_expired_leg_is_excluded_from_if_assigned(self):
         # An already-expired (dte < 0) leg has no meaningful assignment
         # projection — the array drops it. The per-leg breakdown table
@@ -300,6 +319,7 @@ class TestBuildIfAssigned:
         leg_ids = {entry["leg_id"] for entry in out}
         assert leg_ids == {"live"}
 
+    @pytest.mark.unit
     def test_missing_premium_degrades_to_null_projection(self):
         leg = {
             "id": "L1",
@@ -324,6 +344,7 @@ class TestBuildIfAssigned:
 
 
 class TestClassifyApplicability:
+    @pytest.mark.unit
     def test_csp_only_returns_no_shares(self):
         position = {"shares": 0, "status": "open"}
         # A CSP-only position has no shares — even if it has an open put,
@@ -333,6 +354,7 @@ class TestClassifyApplicability:
             "not_applicable_no_shares"
         )
 
+    @pytest.mark.unit
     def test_holding_with_no_short_call_returns_no_short_call(self):
         position = {"shares": 100, "status": "open"}
         # Position has shares but no open short call — out of scope.
@@ -341,6 +363,7 @@ class TestClassifyApplicability:
             "not_applicable_no_short_call"
         )
 
+    @pytest.mark.unit
     def test_closed_position_returns_closed(self):
         position = {"shares": 100, "status": "closed"}
         legs = [{"id": "L1", "type": "call"}]
@@ -348,11 +371,13 @@ class TestClassifyApplicability:
             "not_applicable_closed"
         )
 
+    @pytest.mark.unit
     def test_covered_call_returns_covered_call(self):
         position = {"shares": 100, "status": "open"}
         legs = [{"id": "L1", "type": "call"}]
         assert _classify_applicability(position, legs) == "covered_call"
 
+    @pytest.mark.unit
     def test_csp_only_with_open_put_still_returns_no_shares(self):
         # A pure-CSP position with an open put: shares==0 wins; the if-assigned
         # screen doesn't apply even though the put is open.

--- a/backend/tests/test_dashboard_kpis.py
+++ b/backend/tests/test_dashboard_kpis.py
@@ -105,6 +105,7 @@ def _open_position_with_trades(
 
 
 class TestComputeLargestRisk:
+    @pytest.mark.unit
     def test_picks_worst_negative_pl(self):
         rows = [
             _row(position_id="p-a", ticker="AAA", unrealized_pl=-100.0, pl_pct=-0.01),
@@ -117,6 +118,7 @@ class TestComputeLargestRisk:
         assert result["unrealized_pl"] == -1500.0
         assert result["unrealized_pl_pct"] == pytest.approx(-0.10)
 
+    @pytest.mark.unit
     def test_returns_none_when_no_losers(self):
         rows = [
             _row(position_id="p-a", ticker="AAA", unrealized_pl=100.0, pl_pct=0.01),
@@ -124,9 +126,11 @@ class TestComputeLargestRisk:
         ]
         assert _compute_largest_risk(rows) is None
 
+    @pytest.mark.unit
     def test_returns_none_when_empty(self):
         assert _compute_largest_risk([]) is None
 
+    @pytest.mark.unit
     def test_skips_rows_without_pl(self):
         # Rows with unrealized_pl=None (quote failed) are excluded.
         rows = [
@@ -135,6 +139,7 @@ class TestComputeLargestRisk:
         ]
         assert _compute_largest_risk(rows)["ticker"] == "BBB"
 
+    @pytest.mark.unit
     def test_breaks_ties_alphabetically(self):
         # Equal-loss positions should sort alphabetically — deterministic
         # output is part of the contract.
@@ -146,6 +151,7 @@ class TestComputeLargestRisk:
 
 
 class TestSumPremiumForPositions:
+    @pytest.mark.unit
     def test_sums_total_premiums(self):
         positions = [
             _open_position_with_trades(
@@ -163,6 +169,7 @@ class TestSumPremiumForPositions:
         assert total == pytest.approx(150.0 + 225.0 + 300.0)
         assert count == 2  # only AAPL has trade rows
 
+    @pytest.mark.unit
     def test_zero_when_no_positions(self):
         total, count = _sum_premium_for_positions([])
         assert total == 0.0
@@ -170,6 +177,7 @@ class TestSumPremiumForPositions:
 
 
 class TestSumPremiumYtd:
+    @pytest.mark.unit
     def test_only_current_year_trades_count(self):
         positions = [
             _open_position_with_trades(
@@ -185,6 +193,7 @@ class TestSumPremiumYtd:
         ytd = _sum_premium_ytd(positions, today=date(2026, 5, 1))
         assert ytd == pytest.approx(200.0)
 
+    @pytest.mark.unit
     def test_uses_closed_at_when_present(self):
         positions = [
             _open_position_with_trades(
@@ -202,6 +211,7 @@ class TestSumPremiumYtd:
 
 
 class TestComputeRealizedPl:
+    @pytest.mark.unit
     def test_sums_total_premiums_for_closed_positions(self):
         closed = [
             _closed_position(ticker="A", total_premiums=500.0, broker_cost_basis=10000.0),
@@ -211,11 +221,13 @@ class TestComputeRealizedPl:
         assert realized == pytest.approx(300.0)
         assert pct == pytest.approx(300.0 / 15000.0)
 
+    @pytest.mark.unit
     def test_returns_zero_and_none_when_empty(self):
         realized, pct = _compute_realized_pl([])
         assert realized == 0.0
         assert pct is None
 
+    @pytest.mark.unit
     def test_returns_none_pct_when_basis_zero(self):
         closed = [_closed_position(total_premiums=200.0, broker_cost_basis=0.0)]
         realized, pct = _compute_realized_pl(closed)
@@ -224,6 +236,7 @@ class TestComputeRealizedPl:
 
 
 class TestComputeLargestLoser:
+    @pytest.mark.unit
     def test_picks_worst_realized_loser(self):
         closed = [
             _closed_position(ticker="A", total_premiums=200.0, broker_cost_basis=10000.0),
@@ -236,10 +249,12 @@ class TestComputeLargestLoser:
         assert result["realized_pl"] == -500.0
         assert result["realized_pl_pct"] == pytest.approx(-0.05)
 
+    @pytest.mark.unit
     def test_returns_none_when_no_losers(self):
         closed = [_closed_position(ticker="A", total_premiums=100.0)]
         assert _compute_largest_loser(closed) is None
 
+    @pytest.mark.unit
     def test_returns_none_when_no_closed_positions(self):
         assert _compute_largest_loser([]) is None
 
@@ -247,6 +262,7 @@ class TestComputeLargestLoser:
 class TestBuildKpis:
     """Integration-level test on _build_kpis to assert the full payload shape."""
 
+    @pytest.mark.unit
     def test_includes_new_kpi_fields(self):
         rows = [
             _row(position_id="p-1", ticker="AAPL", unrealized_pl=-200.0, pl_pct=-0.02),
@@ -287,6 +303,7 @@ class TestBuildKpis:
         # Premium trade count: 1 open trade.
         assert kpis["premium_collected_trades"] == 1
 
+    @pytest.mark.unit
     def test_null_safety_when_empty(self):
         kpis = _build_kpis(
             [], [], [], closed_positions=[], today=date(2026, 5, 11)
@@ -303,6 +320,7 @@ class TestBuildKpis:
 class TestAttachNextSuggestedActions:
     """The post-engine pass that stamps each position row with its action label."""
 
+    @pytest.mark.unit
     def test_position_with_no_matching_action_stays_hold(self):
         from app.services.dashboard import _attach_next_suggested_actions
 
@@ -310,6 +328,7 @@ class TestAttachNextSuggestedActions:
         _attach_next_suggested_actions(rows, next_actions=[], open_legs=[])
         assert rows[0]["next_suggested_action"] == "hold"
 
+    @pytest.mark.unit
     def test_large_loser_label_attaches_by_position_id(self):
         from app.services.dashboard import _attach_next_suggested_actions
 
@@ -328,6 +347,7 @@ class TestAttachNextSuggestedActions:
         _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=[])
         assert rows[0]["next_suggested_action"] == "Review"
 
+    @pytest.mark.unit
     def test_itm_short_dte_label_attaches_via_leg_lookup(self):
         from app.services.dashboard import _attach_next_suggested_actions
 
@@ -349,6 +369,7 @@ class TestAttachNextSuggestedActions:
         _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=open_legs)
         assert rows[0]["next_suggested_action"] == "Roll"
 
+    @pytest.mark.unit
     def test_cc_candidate_label_attaches_by_ticker(self):
         from app.services.dashboard import _attach_next_suggested_actions
 
@@ -367,6 +388,7 @@ class TestAttachNextSuggestedActions:
         _attach_next_suggested_actions(rows, next_actions=next_actions, open_legs=[])
         assert rows[0]["next_suggested_action"] == "Cover"
 
+    @pytest.mark.unit
     def test_highest_priority_action_wins(self):
         """When two actions target the same position, the first one (highest
         priority, since next_actions is pre-sorted) wins."""

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -20,80 +20,98 @@ from app.services.dashboard_legs import (
 
 
 class TestComputeDte:
+    @pytest.mark.unit
     def test_today_is_zero(self):
         today = date(2026, 5, 5)
         assert compute_dte("2026-05-05", today=today) == 0
 
+    @pytest.mark.unit
     def test_tomorrow_is_one(self):
         today = date(2026, 5, 5)
         assert compute_dte("2026-05-06", today=today) == 1
 
+    @pytest.mark.unit
     def test_yesterday_is_negative(self):
         today = date(2026, 5, 5)
         assert compute_dte("2026-05-04", today=today) == -1
 
+    @pytest.mark.unit
     def test_two_weeks_out(self):
         today = date(2026, 5, 5)
         assert compute_dte("2026-05-19", today=today) == 14
 
+    @pytest.mark.unit
     def test_isoformat_with_time_suffix(self):
         today = date(2026, 5, 5)
         assert compute_dte("2026-05-08T10:00:00Z", today=today) == 3
 
+    @pytest.mark.unit
     def test_unparseable_returns_sentinel(self):
         assert compute_dte("not-a-date", today=date(2026, 5, 5)) == 9999
 
+    @pytest.mark.unit
     def test_none_returns_sentinel(self):
         assert compute_dte(None, today=date(2026, 5, 5)) == 9999
 
 
 class TestComputeMoneyness:
+    @pytest.mark.unit
     def test_short_put_itm_when_price_below_strike(self):
         result = compute_moneyness("put", strike=175.0, current_price=174.50)
         assert result["state"] == "ITM"
         assert result["distance_dollars"] == pytest.approx(0.50)
         assert result["distance_pct"] == pytest.approx(0.50 / 175.0)
 
+    @pytest.mark.unit
     def test_short_put_otm_when_price_above_strike(self):
         result = compute_moneyness("put", strike=175.0, current_price=180.0)
         assert result["state"] == "OTM"
         assert result["distance_dollars"] == pytest.approx(5.0)
 
+    @pytest.mark.unit
     def test_short_put_atm_when_equal(self):
         result = compute_moneyness("put", strike=175.0, current_price=175.0)
         assert result["state"] == "ATM"
 
+    @pytest.mark.unit
     def test_short_call_itm_when_price_above_strike(self):
         result = compute_moneyness("call", strike=240.0, current_price=245.0)
         assert result["state"] == "ITM"
         assert result["distance_dollars"] == pytest.approx(5.0)
 
+    @pytest.mark.unit
     def test_short_call_otm_when_price_below_strike(self):
         result = compute_moneyness("call", strike=240.0, current_price=230.0)
         assert result["state"] == "OTM"
 
+    @pytest.mark.unit
     def test_returns_none_when_no_price(self):
         assert compute_moneyness("put", 175.0, None) is None
 
 
 class TestComputeDecisionTag:
+    @pytest.mark.unit
     def test_roll_or_assign_when_short_dte_and_itm(self):
         assert compute_decision_tag(3, "ITM") == "roll-or-assign"
         assert compute_decision_tag(7, "ITM") == "roll-or-assign"
 
+    @pytest.mark.unit
     def test_manage_when_short_dte_and_otm(self):
         assert compute_decision_tag(3, "OTM") == "manage"
         assert compute_decision_tag(0, "ATM") == "manage"  # ATM treated as not-ITM
 
+    @pytest.mark.unit
     def test_watch_when_medium_dte_and_itm(self):
         assert compute_decision_tag(10, "ITM") == "watch"
         assert compute_decision_tag(14, "ITM") == "watch"
 
+    @pytest.mark.unit
     def test_hold_when_far_dte_or_otm_medium(self):
         assert compute_decision_tag(10, "OTM") == "hold"
         assert compute_decision_tag(20, "ITM") == "hold"
         assert compute_decision_tag(30, "OTM") == "hold"
 
+    @pytest.mark.unit
     def test_hold_when_moneyness_unknown(self):
         # Conservative fallback: never recommend an action without a price.
         assert compute_decision_tag(2, None) == "hold"
@@ -108,6 +126,7 @@ class TestDeriveOpenLegs:
             "trades": trades,
         }
 
+    @pytest.mark.unit
     def test_filters_out_closed_trades(self):
         positions = [
             self._position(
@@ -138,6 +157,7 @@ class TestDeriveOpenLegs:
         )
         assert [leg["id"] for leg in legs] == ["t-open"]
 
+    @pytest.mark.unit
     def test_filters_out_exit_event_trades(self):
         # buy_put_close, assignment, called_away, etc. are exit events — not legs.
         positions = [
@@ -165,6 +185,7 @@ class TestDeriveOpenLegs:
         legs = derive_open_legs(positions, quotes_by_ticker={"AAPL": 175.0})
         assert legs == []
 
+    @pytest.mark.unit
     def test_attaches_dte_and_moneyness(self):
         positions = [
             self._position(
@@ -190,6 +211,7 @@ class TestDeriveOpenLegs:
         assert legs[0]["dte"] == 3
         assert legs[0]["moneyness"]["state"] == "ITM"
 
+    @pytest.mark.unit
     def test_exposes_raw_current_mid_passthrough(self):
         # Issue #244 — the leg dict carries the raw matched option mid so the
         # BTC detail endpoint can compute cost-to-close. `None` when no mark.
@@ -226,6 +248,7 @@ class TestDeriveOpenLegs:
         )
         assert no_mark[0]["current_mid"] is None
 
+    @pytest.mark.unit
     def test_sorts_by_dte_then_ticker(self):
         positions = [
             self._position(
@@ -265,24 +288,29 @@ class TestDeriveOpenLegs:
 
 
 class TestComputeAssignmentRisk:
+    @pytest.mark.unit
     def test_high_at_seven_dte_itm(self):
         assert compute_assignment_risk(7, "ITM") == "high"
         assert compute_assignment_risk(0, "ITM") == "high"
 
+    @pytest.mark.unit
     def test_watch_at_fourteen_dte_itm(self):
         # At the boundary the spec rule "dte <= 14 AND ITM" still applies.
         assert compute_assignment_risk(14, "ITM") == "watch"
         assert compute_assignment_risk(8, "ITM") == "watch"
 
+    @pytest.mark.unit
     def test_low_at_fifteen_dte_itm(self):
         # Outside both windows even when ITM.
         assert compute_assignment_risk(15, "ITM") == "low"
         assert compute_assignment_risk(30, "ITM") == "low"
 
+    @pytest.mark.unit
     def test_low_when_not_itm(self):
         assert compute_assignment_risk(3, "OTM") == "low"
         assert compute_assignment_risk(3, "ATM") == "low"
 
+    @pytest.mark.unit
     def test_low_when_moneyness_unknown(self):
         assert compute_assignment_risk(3, None) == "low"
 
@@ -291,6 +319,7 @@ class TestComputeAssignmentRisk:
     # consumes the same 7/14 thresholds; drifting either side breaks the
     # "thresholds must match" AC. These assertions sit alongside the existing
     # tests on purpose so a single test file reads as the canonical pin.
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "dte,moneyness_state,expected",
         [
@@ -312,20 +341,25 @@ class TestComputeAssignmentRisk:
 
 
 class TestComputeSuggestedAction:
+    @pytest.mark.unit
     def test_roll_for_roll_or_assign(self):
         assert compute_suggested_action("roll-or-assign") == "roll"
 
+    @pytest.mark.unit
     def test_manage_for_manage(self):
         assert compute_suggested_action("manage") == "manage"
 
+    @pytest.mark.unit
     def test_hold_for_watch(self):
         # Watch maps to hold because the V0.5 vocabulary is intentionally
         # smaller; the frontend already shows a Watch pill via decision_tag.
         assert compute_suggested_action("watch") == "hold"
 
+    @pytest.mark.unit
     def test_hold_for_hold(self):
         assert compute_suggested_action("hold") == "hold"
 
+    @pytest.mark.unit
     def test_never_emits_close_in_v05(self):
         # Locked architectural decision: V0.5 never emits "close" because
         # the 50%-target signal requires live option-chain data.
@@ -339,6 +373,7 @@ class TestComputeSuggestedAction:
 class TestProfitTargetStatusBuilder:
     """Pure math for the dashboard ``% CAPT`` profit-target signal (#240)."""
 
+    @pytest.mark.unit
     def test_locked_acceptance_screenshot_example(self):
         # LOCKED acceptance test — the F 15C leg from the issue #240 screenshot.
         # premium 0.3834 credit, current mid 0.155 → ~59.57% of credit captured,
@@ -347,30 +382,35 @@ class TestProfitTargetStatusBuilder:
         assert result["captured_pct"] == pytest.approx(0.5957, abs=1e-4)
         assert result["state"] == "captured_50"
 
+    @pytest.mark.unit
     def test_in_progress_below_target(self):
         # 1.00 credit decayed to 0.70 → 30% captured, under the 50% target.
         result = build_profit_target_status(premium=1.00, current_mid=0.70)
         assert result["captured_pct"] == pytest.approx(0.30)
         assert result["state"] == "in_progress"
 
+    @pytest.mark.unit
     def test_captured_50_at_exact_boundary(self):
         # Exactly the 50% threshold counts as captured (>= compare).
         result = build_profit_target_status(premium=1.00, current_mid=0.50)
         assert result["captured_pct"] == pytest.approx(0.50)
         assert result["state"] == "captured_50"
 
+    @pytest.mark.unit
     def test_underwater_when_mid_above_premium(self):
         # 1.00 credit, mid rose to 1.30 → -30% captured (a paper loss).
         result = build_profit_target_status(premium=1.00, current_mid=1.30)
         assert result["captured_pct"] == pytest.approx(-0.30)
         assert result["state"] == "underwater"
 
+    @pytest.mark.unit
     def test_in_progress_when_mid_equals_premium(self):
         # mid == premium → exactly 0% captured → in_progress, not underwater.
         result = build_profit_target_status(premium=1.00, current_mid=1.00)
         assert result["captured_pct"] == pytest.approx(0.0)
         assert result["state"] == "in_progress"
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "premium,current_mid",
         [
@@ -386,6 +426,7 @@ class TestProfitTargetStatusBuilder:
         )
         assert result == {"captured_pct": None, "state": "unknown"}
 
+    @pytest.mark.unit
     def test_expired_leg_is_unknown(self):
         # Once expired (dte < 0) there is no live management decision.
         result = build_profit_target_status(
@@ -393,6 +434,7 @@ class TestProfitTargetStatusBuilder:
         )
         assert result == {"captured_pct": None, "state": "unknown"}
 
+    @pytest.mark.unit
     def test_profit_review_pct_threshold_is_honored(self):
         # ~60% captured, but the user's threshold is 75% → still in_progress.
         result = build_profit_target_status(
@@ -405,6 +447,7 @@ class TestProfitTargetStatusBuilder:
 class TestDeriveLegEconomics:
     """Pure coverage + dollar-economics derivation for an open leg (#246)."""
 
+    @pytest.mark.unit
     def test_covered_call_when_shares_held(self):
         # A short call against shares the user holds → covered.
         result = derive_leg_economics(
@@ -416,6 +459,7 @@ class TestDeriveLegEconomics:
         )
         assert result["coverage"] == "covered"
 
+    @pytest.mark.unit
     def test_naked_call_when_zero_shares(self):
         # A short call with no shares to deliver → naked (the warning state).
         result = derive_leg_economics(
@@ -427,6 +471,7 @@ class TestDeriveLegEconomics:
         )
         assert result["coverage"] == "naked"
 
+    @pytest.mark.unit
     def test_short_put_never_naked(self):
         # A cash-secured put is not "naked" — coverage is a short-call axis.
         result = derive_leg_economics(
@@ -438,6 +483,7 @@ class TestDeriveLegEconomics:
         )
         assert result["coverage"] is None
 
+    @pytest.mark.unit
     def test_worked_example_pnl_and_cost(self):
         # The F 15C worked example from the issue / spec §1.2.
         # premium 0.3834, mid 0.155, quantity 1 → P&L +$22.84, cost $15.50.
@@ -452,6 +498,7 @@ class TestDeriveLegEconomics:
         assert result["cost_to_close"] == 15.50
         assert result["premium"] == 0.3834
 
+    @pytest.mark.unit
     def test_pnl_reconciles_with_captured_pct(self):
         # The whole-position $ P&L must agree with the per-share % CAPT — they
         # are computed by two different functions but share the same inputs,
@@ -472,6 +519,7 @@ class TestDeriveLegEconomics:
         )
         assert captured_from_dollars == round(status["captured_pct"] * 100) == 60
 
+    @pytest.mark.unit
     def test_quantity_scales_dollars(self):
         # Whole-position dollars scale linearly with the contract count.
         one = derive_leg_economics(
@@ -491,6 +539,7 @@ class TestDeriveLegEconomics:
         assert three["pnl_dollars"] == pytest.approx(one["pnl_dollars"] * 3)
         assert three["cost_to_close"] == pytest.approx(one["cost_to_close"] * 3)
 
+    @pytest.mark.unit
     def test_no_mid_degrades_pnl_and_cost(self):
         # No live mid → dollars are None, but coverage + premium survive.
         result = derive_leg_economics(
@@ -505,6 +554,7 @@ class TestDeriveLegEconomics:
         assert result["coverage"] == "naked"
         assert result["premium"] == 0.3834
 
+    @pytest.mark.unit
     def test_underwater_leg_negative_pnl(self):
         # current_mid > premium → a paper loss: P&L must be negative, not
         # abs()'d or floored at 0. Reconciles with the negative % CAPT.
@@ -524,6 +574,7 @@ class TestDeriveLegEconomics:
         )
         assert captured_from_dollars == round(status["captured_pct"] * 100) == -30
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("dte", [-1, -10])
     def test_expired_leg_degrades_economics(self, dte):
         # An expired leg (dte < 0) mirrors build_profit_target_status's guard —
@@ -541,6 +592,7 @@ class TestDeriveLegEconomics:
         # Coverage still derives — it depends only on shares.
         assert result["coverage"] == "covered"
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("quantity", [0, None])
     def test_bad_quantity_degrades_economics(self, quantity):
         # A malformed quantity degrades the dollar figures to None rather than
@@ -557,6 +609,7 @@ class TestDeriveLegEconomics:
         # Coverage is unaffected by a bad quantity.
         assert result["coverage"] == "covered"
 
+    @pytest.mark.unit
     def test_non_credit_premium_degrades_economics(self):
         # premium <= 0 mirrors build_profit_target_status's guard.
         for premium in (0.0, -1.0, None):
@@ -589,6 +642,7 @@ class TestBuildOptionMarkIndex:
             },
         }
 
+    @pytest.mark.unit
     def test_builds_keys_and_mids(self):
         index = build_option_mark_index({"AAPL": self._chain()})
         # Call leg uses the explicit `mark`.
@@ -596,6 +650,7 @@ class TestBuildOptionMarkIndex:
         # Put leg with no `mark` falls back to (bid + ask) / 2.
         assert index[("AAPL", "put", 175.0, "2026-05-08")] == pytest.approx(1.50)
 
+    @pytest.mark.unit
     def test_strike_normalization(self):
         # "15" and "15.0" must both normalize to the float 15.0.
         chain = {
@@ -608,12 +663,14 @@ class TestBuildOptionMarkIndex:
         index = build_option_mark_index({"F": chain})
         assert ("F", "call", 15.0, "2026-06-26") in index
 
+    @pytest.mark.unit
     def test_exp_key_prefix_is_split(self):
         # The exp_key carries a ":DTE" suffix that must be stripped.
         index = build_option_mark_index({"AAPL": self._chain()})
         keys = {key[3] for key in index}
         assert keys == {"2026-06-26", "2026-05-08"}
 
+    @pytest.mark.unit
     def test_mark_preferred_over_bid_ask(self):
         chain = {
             "callExpDateMap": {
@@ -628,6 +685,7 @@ class TestBuildOptionMarkIndex:
         # mark wins even when bid/ask are present.
         assert index[("AAPL", "call", 100.0, "2026-06-26")] == pytest.approx(2.00)
 
+    @pytest.mark.unit
     def test_contract_with_no_usable_mid_is_skipped(self):
         chain = {
             "callExpDateMap": {
@@ -639,6 +697,7 @@ class TestBuildOptionMarkIndex:
         index = build_option_mark_index({"AAPL": chain})
         assert index == {}
 
+    @pytest.mark.unit
     def test_malformed_chains_do_not_raise(self):
         malformed = {
             "AAPL": {
@@ -659,17 +718,20 @@ class TestBuildOptionMarkIndex:
         index = build_option_mark_index(malformed)
         assert index == {}
 
+    @pytest.mark.unit
     def test_none_input_returns_empty(self):
         assert build_option_mark_index(None) == {}
 
 
 class TestComputeEarningsInWindow:
+    @pytest.mark.unit
     def test_false_when_lookup_returns_none(self):
         assert (
             compute_earnings_in_window("AAPL", dte=5, earnings_lookup=lambda _t: None)
             is False
         )
 
+    @pytest.mark.unit
     def test_false_when_dte_zero(self):
         # Zero DTE means the leg expires today — no future window.
         assert (
@@ -679,6 +741,7 @@ class TestComputeEarningsInWindow:
             is False
         )
 
+    @pytest.mark.unit
     def test_true_when_within_window(self):
         future = (date.today() + timedelta(days=3)).isoformat()
         assert (
@@ -688,6 +751,7 @@ class TestComputeEarningsInWindow:
             is True
         )
 
+    @pytest.mark.unit
     def test_false_when_after_window(self):
         future = (date.today() + timedelta(days=30)).isoformat()
         assert (
@@ -697,6 +761,7 @@ class TestComputeEarningsInWindow:
             is False
         )
 
+    @pytest.mark.unit
     def test_false_when_lookup_returns_garbage(self):
         assert (
             compute_earnings_in_window(
@@ -712,6 +777,7 @@ class TestDeriveOpenLegsV05Signals:
     def _position(self, ticker: str, position_id: str, trades: list[dict]) -> dict:
         return {"id": position_id, "ticker": ticker, "trades": trades}
 
+    @pytest.mark.unit
     def test_includes_v05_signal_fields(self):
         positions = [
             self._position(
@@ -748,6 +814,7 @@ class TestDeriveOpenLegsV05Signals:
         # Earnings lookup defaults to cache-miss → False.
         assert leg["earnings_in_window"] is False
 
+    @pytest.mark.unit
     def test_profit_target_status_uses_matching_option_mark(self):
         positions = [
             self._position(
@@ -778,6 +845,7 @@ class TestDeriveOpenLegsV05Signals:
         assert status["captured_pct"] == pytest.approx(0.60)
         assert status["state"] == "captured_50"
 
+    @pytest.mark.unit
     def test_profit_target_status_unknown_when_mark_key_absent(self):
         positions = [
             self._position(
@@ -809,6 +877,7 @@ class TestDeriveOpenLegsV05Signals:
             "state": "unknown",
         }
 
+    @pytest.mark.unit
     def test_earnings_lookup_must_not_be_called_with_network(self):
         # Custom lookup proves derive_open_legs uses cache-only semantics
         # via the injected callable. No real network is allowed.
@@ -863,6 +932,7 @@ class TestDeriveOpenLegsRuleMonitor:
         trade.update(overrides)
         return trade
 
+    @pytest.mark.unit
     def test_every_leg_carries_verdict_layer_fields(self):
         positions = [
             self._position("AAPL", "p-1", [self._trade(expiration="2026-07-31")])
@@ -879,6 +949,7 @@ class TestDeriveOpenLegsRuleMonitor:
         assert "triggered_rules" in leg
         assert len(leg["triggered_rules"]) == 4
 
+    @pytest.mark.unit
     def test_quiet_leg_verdict_is_hold(self):
         # 87 DTE, OTM, no mark → nothing fires.
         positions = [
@@ -892,6 +963,7 @@ class TestDeriveOpenLegsRuleMonitor:
         assert legs[0]["verdict"] == "hold"
         assert legs[0]["verdict_label"] == "Hold"
 
+    @pytest.mark.unit
     def test_profit_take_verdict_with_live_mark(self):
         # Premium 1.00, mark 0.40 → 60% captured → profit-take verdict.
         positions = [
@@ -907,6 +979,7 @@ class TestDeriveOpenLegsRuleMonitor:
         assert legs[0]["verdict"] == "profit_take_review"
         assert legs[0]["verdict_label"] == "Review · 50%"
 
+    @pytest.mark.unit
     def test_dte_review_window_threshold_honored(self):
         # 25-DTE leg with dte_review_days=30 → fires; with default 21 → quiet.
         positions = [
@@ -928,6 +1001,7 @@ class TestDeriveOpenLegsRuleMonitor:
         )
         assert quiet[0]["verdict"] == "hold"
 
+    @pytest.mark.unit
     def test_expiration_warning_threshold_honored(self):
         # 10-DTE OTM leg: fires only when expiration_warning_days >= 10.
         positions = [
@@ -959,6 +1033,7 @@ class TestDeriveOpenLegsEconomics:
             "trades": trades,
         }
 
+    @pytest.mark.unit
     def test_covered_call_leg_carries_economics(self):
         # A short call against 100 held shares, with a live mark — the F 15C
         # worked example surfaced through derive_open_legs.
@@ -993,6 +1068,7 @@ class TestDeriveOpenLegsEconomics:
         assert leg["pnl_dollars"] == 22.84
         assert leg["cost_to_close"] == 15.50
 
+    @pytest.mark.unit
     def test_naked_call_leg_when_no_shares(self):
         # A short call on a position holding 0 shares → naked.
         positions = [
@@ -1020,6 +1096,7 @@ class TestDeriveOpenLegsEconomics:
         )
         assert legs[0]["coverage"] == "naked"
 
+    @pytest.mark.unit
     def test_short_put_leg_has_no_coverage(self):
         # A cash-secured put always has coverage None, even with 0 shares.
         positions = [
@@ -1047,6 +1124,7 @@ class TestDeriveOpenLegsEconomics:
         )
         assert legs[0]["coverage"] is None
 
+    @pytest.mark.unit
     def test_wheel_position_per_leg_coverage(self):
         # One wheel position holding 100 shares carries both a sell_put and a
         # sell_call leg — coverage is derived per-leg, not per-position: the
@@ -1087,6 +1165,7 @@ class TestDeriveOpenLegsEconomics:
         assert by_id["t-call"]["coverage"] == "covered"
         assert by_id["t-put"]["coverage"] is None
 
+    @pytest.mark.unit
     def test_degraded_leg_keeps_coverage_drops_dollars(self):
         # No option mark for the leg → pnl_dollars / cost_to_close degrade to
         # None, but the naked coverage badge (from shares) still derives.
@@ -1121,6 +1200,7 @@ class TestDeriveOpenLegsEconomics:
 
     # ---- V1.0.8 / #251 — partial-coverage tri-state ----
 
+    @pytest.mark.unit
     def test_wheel_position_per_leg_partial_coverage(self):
         # 100 held shares + 2 short calls (200 shares' worth of obligation).
         # Both call legs share the same position dict — the per-leg `quantity`
@@ -1164,6 +1244,7 @@ class TestDeriveOpenLegsEconomics:
         # The cash-secured put leg remains coverage-less.
         assert by_id["t-put-1x"]["coverage"] is None
 
+    @pytest.mark.unit
     def test_partial_at_boundary(self):
         # 99 shares vs. 1 short call (100 shares needed) — one share short of
         # covered. The strict-inequality lower boundary of the `covered` branch.
@@ -1192,6 +1273,7 @@ class TestDeriveOpenLegsEconomics:
         )
         assert legs[0]["coverage"] == "partial"
 
+    @pytest.mark.unit
     def test_covered_when_shares_meet_obligation_exactly(self):
         # 100 shares vs. 1 short call (100 shares needed) — the inclusive
         # boundary of the `covered` branch. An exact match is `covered`, not
@@ -1232,6 +1314,7 @@ class TestDashboardOpenLegSchemaBackwardCompat:
     (legacy tests, cached fixtures, downstream consumers).
     """
 
+    @pytest.mark.unit
     def test_dashboard_open_leg_schema_accepts_new_fields(self):
         # A minimal payload that mirrors the pre-#246 shape — none of the
         # four V1.0.6 economics fields are supplied.
@@ -1279,6 +1362,7 @@ class TestDashboardOpenLegQuantity:
             "trades": trades,
         }
 
+    @pytest.mark.unit
     def test_quantity_field_defaults_to_1(self):
         # A pre-#252 payload (no `quantity` key) must still validate, with
         # `quantity` resolving to `1`. Protects backward compat with legacy
@@ -1300,6 +1384,7 @@ class TestDashboardOpenLegQuantity:
         leg = DashboardOpenLeg(**old_payload)
         assert leg.quantity == 1
 
+    @pytest.mark.unit
     def test_quantity_2_dollars_reconcile(self):
         # qty=2, premium=$3.00/sh, current_mid=$1.50/sh.
         # Credit received  = premium * 100 * qty  = 3.00 * 100 * 2 = $600
@@ -1338,6 +1423,7 @@ class TestDashboardOpenLegQuantity:
         # The reconciliation identity the InspectPanel relies on:
         assert leg["pnl_dollars"] + leg["cost_to_close"] == leg["premium"] * 100 * leg["quantity"]
 
+    @pytest.mark.unit
     def test_quantity_3_economics_scale(self):
         # Two-leg comparison: qty=1 vs qty=3 with identical premium/mid → the
         # qty=3 leg's dollar figures are exactly 3× the qty=1 leg's. Confirms

--- a/backend/tests/test_data_fetcher.py
+++ b/backend/tests/test_data_fetcher.py
@@ -54,11 +54,13 @@ def _make_mock_cache(has_fresh=False, has_stale=False, sample_df=None):
 
 
 class TestSourceDetection:
+    @pytest.mark.unit
     def test_fred_series(self):
         assert detect_source("FEDFUNDS") == "fred"
         assert detect_source("DGS10") == "fred"
         assert detect_source("CSUSHPINSA") == "fred"
 
+    @pytest.mark.unit
     def test_schwab_default(self):
         assert detect_source("AAPL") == "schwab"
         assert detect_source("^GSPC") == "schwab"
@@ -66,6 +68,7 @@ class TestSourceDetection:
 
 
 class TestSerializationRoundtrip:
+    @pytest.mark.unit
     def test_roundtrip(self):
         df = _make_sample_df()
         json_str = _df_to_json(df)
@@ -75,6 +78,7 @@ class TestSerializationRoundtrip:
 
 
 class TestDataFetcherCacheHit:
+    @pytest.mark.unit
     def test_cache_hit_no_api_call(self):
         """When cache is fresh, no external API should be called."""
         cache = _make_mock_cache(has_fresh=True)
@@ -90,6 +94,7 @@ class TestDataFetcherCacheHit:
 
 
 class TestDataFetcherCacheMiss:
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_cache_miss_fetches_and_caches(self, mock_fetch_schwab):
         """When cache is empty, should fetch from API and populate cache."""
@@ -107,6 +112,7 @@ class TestDataFetcherCacheMiss:
 
 
 class TestDataFetcherFallbackToStale:
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_api_failure_uses_stale_cache(self, mock_fetch_schwab):
         """When API fails but stale cache exists, return stale data."""
@@ -120,6 +126,7 @@ class TestDataFetcherFallbackToStale:
         assert meta.is_stale
         assert len(df) > 0
 
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_auth_error_uses_stale_cache(self, mock_fetch_schwab):
         """When Schwab auth fails but stale cache exists, return stale data."""
@@ -136,6 +143,7 @@ class TestDataFetcherFallbackToStale:
 
 
 class TestDataFetcherNoFallback:
+    @pytest.mark.unit
     @patch("app.services.data_fetcher._fetch_schwab")
     def test_api_failure_no_cache_raises(self, mock_fetch_schwab):
         """When API fails and no cache exists, should raise error."""

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -24,6 +24,7 @@ OTHER_KEY = Fernet.generate_key().decode()
 
 
 class TestEncryptDecrypt:
+    @pytest.mark.integration
     def test_roundtrip(self):
         """Encrypt then decrypt returns original value."""
         plaintext = "my_secret_token_value"
@@ -31,17 +32,20 @@ class TestEncryptDecrypt:
         assert ciphertext != plaintext
         assert decrypt_value(ciphertext, key=TEST_KEY) == plaintext
 
+    @pytest.mark.integration
     def test_wrong_key_raises(self):
         """Decrypting with a different key raises InvalidToken."""
         ciphertext = encrypt_value("secret", key=TEST_KEY)
         with pytest.raises(InvalidToken):
             decrypt_value(ciphertext, key=OTHER_KEY)
 
+    @pytest.mark.integration
     def test_empty_string_roundtrip(self):
         """Empty string encrypts and decrypts correctly."""
         ciphertext = encrypt_value("", key=TEST_KEY)
         assert decrypt_value(ciphertext, key=TEST_KEY) == ""
 
+    @pytest.mark.integration
     def test_ciphertext_differs_each_call(self):
         """Fernet uses a random IV, so ciphertexts differ."""
         a = encrypt_value("same", key=TEST_KEY)
@@ -51,27 +55,33 @@ class TestEncryptDecrypt:
 
 
 class TestIsEncrypted:
+    @pytest.mark.integration
     def test_true_for_ciphertext(self):
         ciphertext = encrypt_value("token", key=TEST_KEY)
         assert is_encrypted(ciphertext, key=TEST_KEY) is True
 
+    @pytest.mark.integration
     def test_false_for_plaintext(self):
         assert is_encrypted("plaintext_token", key=TEST_KEY) is False
 
+    @pytest.mark.integration
     def test_false_for_empty(self):
         assert is_encrypted("", key=TEST_KEY) is False
 
+    @pytest.mark.integration
     def test_false_when_no_key(self):
         assert is_encrypted("anything", key=None) is False
 
 
 class TestRequireEncryptionKey:
+    @pytest.mark.integration
     def test_raises_when_missing(self):
         with patch("app.services.encryption.settings") as mock_settings:
             mock_settings.schwab_encryption_key = ""
             with pytest.raises(EncryptionKeyMissing):
                 require_encryption_key()
 
+    @pytest.mark.integration
     def test_returns_key_when_set(self):
         with patch("app.services.encryption.settings") as mock_settings:
             mock_settings.schwab_encryption_key = TEST_KEY
@@ -79,11 +89,13 @@ class TestRequireEncryptionKey:
 
 
 class TestGetEncryptionKey:
+    @pytest.mark.integration
     def test_returns_none_when_empty(self):
         with patch("app.services.encryption.settings") as mock_settings:
             mock_settings.schwab_encryption_key = ""
             assert get_encryption_key() is None
 
+    @pytest.mark.integration
     def test_returns_key_when_set(self):
         with patch("app.services.encryption.settings") as mock_settings:
             mock_settings.schwab_encryption_key = TEST_KEY
@@ -91,6 +103,7 @@ class TestGetEncryptionKey:
 
 
 class TestUpsertEncrypts:
+    @pytest.mark.integration
     def test_upsert_encrypts_sensitive_keys(self):
         """_upsert_setting encrypts values for sensitive keys."""
         from app.services.schwab_auth import _upsert_setting
@@ -108,6 +121,7 @@ class TestUpsertEncrypts:
         # Should decrypt back to original
         assert decrypt_value(added_obj.value, key=TEST_KEY) == "my_token"
 
+    @pytest.mark.integration
     def test_upsert_does_not_encrypt_non_sensitive_keys(self):
         """_upsert_setting stores plaintext for non-sensitive keys."""
         from app.services.schwab_auth import _upsert_setting
@@ -124,6 +138,7 @@ class TestUpsertEncrypts:
 
 
 class TestReadSettingDecrypts:
+    @pytest.mark.integration
     def test_read_setting_decrypts(self):
         """_read_setting decrypts encrypted values."""
         from app.services.schwab_auth import _read_setting
@@ -141,6 +156,7 @@ class TestReadSettingDecrypts:
 
         assert result == "real_token"
 
+    @pytest.mark.integration
     def test_read_setting_returns_plaintext_without_key(self):
         """_read_setting returns raw value when no encryption key."""
         from app.services.schwab_auth import _read_setting
@@ -157,6 +173,7 @@ class TestReadSettingDecrypts:
 
         assert result == "plaintext_token"
 
+    @pytest.mark.integration
     def test_read_setting_returns_none_when_missing(self):
         """_read_setting returns None for missing keys."""
         from app.services.schwab_auth import _read_setting
@@ -169,6 +186,7 @@ class TestReadSettingDecrypts:
 
 
 class TestMigratePlaintextTokens:
+    @pytest.mark.integration
     def test_migrates_plaintext_to_encrypted(self, client):
         """migrate_plaintext_tokens encrypts plaintext values in-place."""
         from app.models.database import AppSetting, get_db
@@ -199,6 +217,7 @@ class TestMigratePlaintextTokens:
 
         db.close()
 
+    @pytest.mark.integration
     def test_skips_already_encrypted(self, client):
         """migrate_plaintext_tokens skips values already encrypted."""
         from app.models.database import AppSetting, get_db
@@ -223,6 +242,7 @@ class TestMigratePlaintextTokens:
         assert count == 0
         db.close()
 
+    @pytest.mark.integration
     def test_no_migration_without_key(self):
         """migrate_plaintext_tokens does nothing without encryption key."""
         mock_db = MagicMock()
@@ -233,6 +253,7 @@ class TestMigratePlaintextTokens:
 
 
 class TestDbFilePermissions:
+    @pytest.mark.integration
     def test_warns_on_world_readable(self, tmp_path):
         """Warns when DB file has group/other permissions."""
         db_file = tmp_path / "test.db"
@@ -243,6 +264,7 @@ class TestDbFilePermissions:
         assert len(warnings) == 1
         assert "chmod 600" in warnings[0]
 
+    @pytest.mark.integration
     def test_no_warning_on_600(self, tmp_path):
         """No warning when file has correct permissions."""
         db_file = tmp_path / "test.db"
@@ -252,6 +274,7 @@ class TestDbFilePermissions:
         warnings = check_db_file_permissions(str(db_file))
         assert len(warnings) == 0
 
+    @pytest.mark.integration
     def test_no_warning_for_missing_file(self, tmp_path):
         """No warning for non-existent file."""
         warnings = check_db_file_permissions(str(tmp_path / "nonexistent.db"))
@@ -259,6 +282,7 @@ class TestDbFilePermissions:
 
 
 class TestEncryptedSettingKeys:
+    @pytest.mark.integration
     def test_correct_keys(self):
         """ENCRYPTED_SETTING_KEYS contains exactly the sensitive keys."""
         assert ENCRYPTED_SETTING_KEYS == {
@@ -268,6 +292,7 @@ class TestEncryptedSettingKeys:
             "schwab_app_secret",
         }
 
+    @pytest.mark.integration
     def test_timestamp_keys_not_encrypted(self):
         """Timestamp keys are NOT in the encrypted set."""
         assert "schwab_access_token_expires" not in ENCRYPTED_SETTING_KEYS

--- a/backend/tests/test_greeks.py
+++ b/backend/tests/test_greeks.py
@@ -6,59 +6,72 @@ from app.services.greeks import calculate_greeks
 class TestBlackScholesGreeks:
     """Validate Black-Scholes Greeks calculations against known values."""
 
+    @pytest.mark.unit
     def test_atm_put_delta_near_minus_half(self):
         result = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert result["delta"] is not None
         assert -0.6 < result["delta"] < -0.4
 
+    @pytest.mark.unit
     def test_atm_call_delta_near_half(self):
         result = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="CALL")
         assert result["delta"] is not None
         assert 0.4 < result["delta"] < 0.6
 
+    @pytest.mark.unit
     def test_deep_otm_put_delta_near_zero(self):
         result = calculate_greeks(spot=100, strike=70, dte=30, iv=0.30, contract_type="PUT")
         assert -0.05 < result["delta"] < 0
 
+    @pytest.mark.unit
     def test_deep_itm_call_delta_near_one(self):
         result = calculate_greeks(spot=100, strike=70, dte=30, iv=0.30, contract_type="CALL")
         assert result["delta"] > 0.95
 
+    @pytest.mark.unit
     def test_gamma_is_positive(self):
         result = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert result["gamma"] > 0
 
+    @pytest.mark.unit
     def test_put_theta_is_negative(self):
         result = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert result["theta"] < 0
 
+    @pytest.mark.unit
     def test_vega_is_positive(self):
         result = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert result["vega"] > 0
 
+    @pytest.mark.unit
     def test_call_put_delta_parity(self):
         """Call delta - put delta should equal ~1."""
         call = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="CALL")
         put = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert abs(call["delta"] - put["delta"] - 1.0) < 0.01
 
+    @pytest.mark.unit
     def test_call_put_same_gamma(self):
         call = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="CALL")
         put = calculate_greeks(spot=100, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert abs(call["gamma"] - put["gamma"]) < 0.0001
 
+    @pytest.mark.unit
     def test_returns_none_when_iv_missing(self):
         result = calculate_greeks(spot=100, strike=100, dte=30, iv=None, contract_type="PUT")
         assert result == {"delta": None, "gamma": None, "theta": None, "vega": None}
 
+    @pytest.mark.unit
     def test_returns_none_when_dte_zero(self):
         result = calculate_greeks(spot=100, strike=100, dte=0, iv=0.30, contract_type="PUT")
         assert result == {"delta": None, "gamma": None, "theta": None, "vega": None}
 
+    @pytest.mark.unit
     def test_returns_none_when_spot_zero(self):
         result = calculate_greeks(spot=0, strike=100, dte=30, iv=0.30, contract_type="PUT")
         assert result == {"delta": None, "gamma": None, "theta": None, "vega": None}
 
+    @pytest.mark.unit
     def test_realistic_csp_scenario(self):
         """F stock at $12.15, $11 put, 30 DTE, 35% IV."""
         result = calculate_greeks(spot=12.15, strike=11.0, dte=30, iv=0.35, contract_type="PUT")

--- a/backend/tests/test_integration_assets.py
+++ b/backend/tests/test_integration_assets.py
@@ -1,7 +1,9 @@
+import pytest
 from unittest.mock import patch
 
 
 class TestAssetSearchEndpoints:
+    @pytest.mark.integration
     def test_search_assets_offline(self, client):
         response = client.get("/api/assets/search?q=SP&offline=true")
         assert response.status_code == 200
@@ -10,6 +12,7 @@ class TestAssetSearchEndpoints:
         identifiers = [r["identifier"] for r in results]
         assert "^GSPC" in identifiers
 
+    @pytest.mark.integration
     def test_search_assets_with_yahoo_mocked(self, client):
         with (
             patch("app.routers.assets._validate_ticker_yahoo", return_value=None),
@@ -19,6 +22,7 @@ class TestAssetSearchEndpoints:
             assert response.status_code == 200
             assert len(response.json()["results"]) > 0
 
+    @pytest.mark.integration
     def test_case_shiller_list(self, client):
         response = client.get("/api/assets/case-shiller")
         assert response.status_code == 200
@@ -26,6 +30,7 @@ class TestAssetSearchEndpoints:
         assert len(metros) > 0
         assert any("Case-Shiller" in m["name"] for m in metros)
 
+    @pytest.mark.integration
     def test_suggest_tickers(self, client):
         response = client.get("/api/assets/suggest?q=GC")
         assert response.status_code == 200

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -88,6 +88,7 @@ def _seed_trade(client, position_id: str, **overrides) -> str:
 # -- Tests -------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_dashboard_empty_journal(client, monkeypatch):
     """No positions, no sessions, no Schwab/FRED, empty cache."""
     _patch_status(monkeypatch, schwab_configured=False, fred_key="")

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -117,6 +117,7 @@ def test_dashboard_empty_journal(client, monkeypatch):
     assert data["data_meta"]["sources_unavailable"] == []
 
 
+@pytest.mark.integration
 def test_dashboard_populated(client, monkeypatch):
     """Two positions, several open legs incl. one ITM ≤ 7 DTE, Schwab connected."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -245,6 +246,7 @@ def test_dashboard_populated(client, monkeypatch):
     assert data["data_meta"]["is_stale"] is False
 
 
+@pytest.mark.integration
 def test_dashboard_schwab_disconnected(client, monkeypatch):
     """Positions exist but Schwab is not configured."""
     _patch_status(monkeypatch, schwab_configured=False, fred_key="")
@@ -276,6 +278,7 @@ def test_dashboard_schwab_disconnected(client, monkeypatch):
     assert data["open_legs"][0]["moneyness"] is None
 
 
+@pytest.mark.integration
 def test_dashboard_schwab_quote_failure(client, monkeypatch):
     """When Schwab is configured but a quote call raises, mark sources_unavailable."""
     from app.services.schwab_client import SchwabClientError
@@ -305,6 +308,7 @@ def test_dashboard_schwab_quote_failure(client, monkeypatch):
     assert data["data_meta"]["is_stale"] is True
 
 
+@pytest.mark.integration
 def test_dashboard_unexpected_quote_exception_does_not_500(client, monkeypatch):
     """A non-Schwab exception escaping a per-ticker quote call must not 500.
 
@@ -360,6 +364,7 @@ def test_dashboard_unexpected_quote_exception_does_not_500(client, monkeypatch):
     assert data["data_meta"]["is_stale"] is True
 
 
+@pytest.mark.integration
 def test_dashboard_option_chain_failure_degrades_gracefully(client, monkeypatch):
     """A failed option-chain fetch flags `schwab` and degrades % CAPT to unknown.
 
@@ -408,6 +413,7 @@ def test_dashboard_option_chain_failure_degrades_gracefully(client, monkeypatch)
     }
 
 
+@pytest.mark.integration
 def test_dashboard_unexpected_chain_exception_does_not_500(client, monkeypatch):
     """A non-Schwab exception escaping a per-ticker chain call must not 500.
 
@@ -448,6 +454,7 @@ def test_dashboard_unexpected_chain_exception_does_not_500(client, monkeypatch):
     assert data["open_legs"][0]["profit_target_status"]["state"] == "unknown"
 
 
+@pytest.mark.integration
 def test_dashboard_stale_cache(client, monkeypatch):
     """Cache contains entries >30 days old → flagged stale."""
     _patch_status(monkeypatch, schwab_configured=False, fred_key="")
@@ -485,6 +492,7 @@ def test_dashboard_stale_cache(client, monkeypatch):
     assert data["data_meta"]["is_stale"] is True
 
 
+@pytest.mark.integration
 def test_dashboard_500_does_not_leak_exception(client, monkeypatch):
     """CLAUDE.md: API responses must not include raw exception messages."""
     _patch_status(monkeypatch, schwab_configured=False, fred_key="")
@@ -510,6 +518,7 @@ def test_dashboard_500_does_not_leak_exception(client, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_dashboard_payload_schema_v05_keys(client, monkeypatch):
     """Snapshot test: assert every V0.5 top-level + nested key is present."""
     _patch_status(monkeypatch, schwab_configured=False, fred_key="")
@@ -552,6 +561,7 @@ def test_dashboard_payload_schema_v05_keys(client, monkeypatch):
     assert isinstance(data["next_actions"], list)
 
 
+@pytest.mark.integration
 def test_dashboard_scanner_card_when_no_open_legs(client, monkeypatch):
     """`journal.no_open_legs` emits even when there are zero positions."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -563,6 +573,7 @@ def test_dashboard_scanner_card_when_no_open_legs(client, monkeypatch):
     assert "journal.no_open_legs" in ids
 
 
+@pytest.mark.integration
 def test_dashboard_schwab_disconnected_action(client, monkeypatch):
     """`data.schwab_disconnected` fires when Schwab is not configured."""
     _patch_status(monkeypatch, schwab_configured=False, fred_key="")
@@ -574,6 +585,7 @@ def test_dashboard_schwab_disconnected_action(client, monkeypatch):
     assert "data.schwab_disconnected" in ids
 
 
+@pytest.mark.integration
 def test_dashboard_itm_short_dte_action(client, monkeypatch):
     """An ITM ≤ 7 DTE leg triggers the per-leg expiration card."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -606,6 +618,7 @@ def test_dashboard_itm_short_dte_action(client, monkeypatch):
     assert "expiration.itm_short_dte" in ids
 
 
+@pytest.mark.integration
 def test_dashboard_per_leg_signals_present(client, monkeypatch):
     """Every open leg carries the V0.5 signal fields (issue #146 §14.5)."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -652,6 +665,7 @@ def test_dashboard_per_leg_signals_present(client, monkeypatch):
     assert leg["earnings_in_window"] is False  # no AV cache hit in tests
 
 
+@pytest.mark.integration
 def test_dashboard_position_rows_have_v05_signals(client, monkeypatch):
     """Position rows include `wheel_status`, `next_suggested_action`, and `pl_pct`."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -683,6 +697,7 @@ def test_dashboard_position_rows_have_v05_signals(client, monkeypatch):
     assert row["broker_cost_basis"] == 17000.0
 
 
+@pytest.mark.integration
 def test_dashboard_rule_monitor_verdict_layer_present(client, monkeypatch):
     """Every open leg carries the §R6 verdict layer fields (issue #240)."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -717,6 +732,7 @@ def test_dashboard_rule_monitor_verdict_layer_present(client, monkeypatch):
     assert len(leg["triggered_rules"]) == 4
 
 
+@pytest.mark.integration
 def test_dashboard_profit_take_card_matches_leg_verdict(client, monkeypatch):
     """A leg past the profit-take threshold yields the verdict AND the card."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
@@ -770,6 +786,7 @@ def test_dashboard_profit_take_card_matches_leg_verdict(client, monkeypatch):
 # ``_fetch_option_chains_parallel``. These tests pin the new contract.
 
 
+@pytest.mark.integration
 def test_schwab_pill_downgrades_to_invalid_when_quotes_fail(client, monkeypatch):
     """When the live quote fan returns ``schwab_failed=True`` the dashboard
     must downgrade ``status.schwab.valid`` to ``False`` and surface the
@@ -805,6 +822,7 @@ def test_schwab_pill_downgrades_to_invalid_when_quotes_fail(client, monkeypatch)
     assert schwab["error"] == "Schwab API calls failing this load"
 
 
+@pytest.mark.integration
 def test_schwab_pill_stays_valid_on_success(client, monkeypatch):
     """Happy path: live calls succeed, ``status.schwab`` stays
     ``{valid: True, error: None}`` (issue #277 regression guard).
@@ -845,6 +863,7 @@ def test_schwab_pill_stays_valid_on_success(client, monkeypatch):
     assert schwab["error"] is None
 
 
+@pytest.mark.integration
 def test_schwab_pill_downgrades_when_chains_fail_but_quotes_succeed(
     client, monkeypatch
 ):
@@ -891,6 +910,7 @@ def test_schwab_pill_downgrades_when_chains_fail_but_quotes_succeed(
     assert data["data_meta"]["is_stale"] is True
 
 
+@pytest.mark.integration
 def test_schwab_pill_error_field_absent_when_schwab_not_configured(
     client, monkeypatch
 ):

--- a/backend/tests/test_integration_data.py
+++ b/backend/tests/test_integration_data.py
@@ -1,9 +1,11 @@
+import pytest
 from unittest.mock import patch
 
 from app.services.data_fetcher import DataFetcher, InvalidTickerError
 
 
 class TestDataEndpoints:
+    @pytest.mark.integration
     def test_get_historical_data(self, client, mock_fetcher):
         response = client.get("/api/data/AAPL?start=2023-01-01&end=2023-03-01")
         assert response.status_code == 200
@@ -13,6 +15,7 @@ class TestDataEndpoints:
         assert len(data["data"]) == 60
         assert all("date" in pt and "value" in pt for pt in data["data"])
 
+    @pytest.mark.integration
     def test_get_data_invalid_ticker(self, client):
         with patch.object(DataFetcher, "fetch", side_effect=InvalidTickerError("Unknown ticker 'XXXX'")):
             response = client.get("/api/data/XXXX?start=2023-01-01&end=2023-03-01")

--- a/backend/tests/test_integration_health.py
+++ b/backend/tests/test_integration_health.py
@@ -1,3 +1,4 @@
+import pytest
 import queue
 from unittest.mock import patch, MagicMock
 
@@ -5,6 +6,7 @@ from app.services.slack_notifier import SlackNotifier
 
 
 class TestHealthEndpoints:
+    @pytest.mark.integration
     def test_health_check(self, client):
         """Top-level health probe returns ``status: ok`` and a logging block.
 
@@ -20,6 +22,7 @@ class TestHealthEndpoints:
         assert body["status"] == "ok"
         assert "logging" in body
 
+    @pytest.mark.integration
     def test_health_sources(self, client):
         with (
             patch("app.routers.health._check_alpha_vantage", return_value={"available": True, "error": None}),
@@ -34,6 +37,7 @@ class TestHealthEndpoints:
             assert data["zillow"]["available"] is True
             assert data["all_down"] is False
 
+    @pytest.mark.integration
     def test_health_sources_includes_slack_when_configured(self, client):
         """Slack status appears in health response when webhook is configured."""
         notifier = SlackNotifier(webhook_url="https://hooks.slack.com/test")
@@ -50,6 +54,7 @@ class TestHealthEndpoints:
             assert "slack" in data
             assert data["slack"]["available"] is True
 
+    @pytest.mark.integration
     def test_health_sources_no_slack_when_not_configured(self, client):
         """Slack status is absent from health response when webhook is not configured."""
         notifier = SlackNotifier(webhook_url="")
@@ -65,6 +70,7 @@ class TestHealthEndpoints:
             data = response.json()
             assert "slack" not in data
 
+    @pytest.mark.integration
     def test_health_sources_sends_degraded_notifications(self, client):
         """Slack notifications are sent for degraded sources."""
         notifier = MagicMock(spec=SlackNotifier)
@@ -108,6 +114,7 @@ class TestLoggingSelfMonitoring:
         "last_flush_error",
     }
 
+    @pytest.mark.integration
     def test_health_includes_logging_block_when_axiom_disabled(self, client):
         """No token → zero/null defaults, schema still present, HTTP 200."""
         with patch("app.routers.health._get_axiom_handler", return_value=None), \
@@ -128,6 +135,7 @@ class TestLoggingSelfMonitoring:
             "last_flush_error": None,
         }
 
+    @pytest.mark.integration
     def test_health_logging_block_when_axiom_enabled_zero_traffic(self, client):
         """Axiom attached but no flushes yet → ``axiom_enabled=true`` and nulls."""
         from app import logging_axiom
@@ -158,6 +166,7 @@ class TestLoggingSelfMonitoring:
         finally:
             handler._atexit_flush()
 
+    @pytest.mark.integration
     def test_health_logging_dropped_total_reflects_overflow(self, client, monkeypatch):
         """Overflowing the handler's queue increments ``dropped_total``."""
         from app import logging_axiom
@@ -214,6 +223,7 @@ class TestLoggingSelfMonitoring:
         finally:
             handler._atexit_flush()
 
+    @pytest.mark.integration
     def test_health_endpoint_makes_no_outbound_http(self, client):
         """The endpoint must never reach the network when answering."""
         # If anything inside /api/health tried to make an httpx call, this
@@ -228,6 +238,7 @@ class TestLoggingSelfMonitoring:
         assert response.status_code == 200
         assert response.json()["status"] == "ok"
 
+    @pytest.mark.integration
     def test_health_returns_200_when_handler_attr_raises(self, client):
         """Defensive: a logging-internal hiccup must not 500 the health endpoint."""
         # Build a fake handler that raises on queue_depth read. The endpoint
@@ -263,6 +274,7 @@ class TestLoggingSelfMonitoring:
         assert log["queue_capacity"] == 1000
         assert log["axiom_enabled"] is True
 
+    @pytest.mark.integration
     def test_health_logging_block_axiom_enabled_reflects_token_when_no_handler(self, client):
         """``axiom_enabled`` follows the token even when the handler is missing.
 
@@ -296,6 +308,7 @@ class TestAxiomHandlerFlushBookkeeping:
     suite. Here we drive the setters directly so we never hit the network.
     """
 
+    @pytest.mark.unit
     def test_last_flush_ok_sets_timestamp_clears_error(self):
         from app.logging_axiom import AxiomHandler
 
@@ -311,6 +324,7 @@ class TestAxiomHandlerFlushBookkeeping:
         finally:
             handler._atexit_flush()
 
+    @pytest.mark.unit
     def test_queue_depth_and_capacity_accessors(self, monkeypatch):
         from app import logging_axiom
         from app.logging_axiom import AxiomHandler

--- a/backend/tests/test_integration_import.py
+++ b/backend/tests/test_integration_import.py
@@ -198,7 +198,8 @@ class TestImportDateRangeValidation:
         assert "365" in resp.json()["detail"]
 
     @pytest.mark.integration
-    def test_preview_accepts_range_at_365_days(self, client, mock_schwab):
+    @pytest.mark.usefixtures("mock_schwab")
+    def test_preview_accepts_range_at_365_days(self, client):
         resp = client.get("/api/journal/import/preview", params={
             "start_date": "2024-01-01",
             "end_date": "2024-12-31",  # exactly 365 days

--- a/backend/tests/test_integration_import.py
+++ b/backend/tests/test_integration_import.py
@@ -65,10 +65,12 @@ def mock_schwab():
 
 
 class TestImportPreview:
+    @pytest.mark.integration
     def test_preview_invalid_date_format(self, client):
         resp = client.get("/api/journal/import/preview", params={"start_date": "not-a-date", "end_date": "2025-03-31"})
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_preview_success(self, client, mock_schwab):
         resp = client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
         assert resp.status_code == 200
@@ -82,6 +84,7 @@ class TestImportPreview:
         assert data["trades"][0]["trade_type"] == "sell_put"
         assert data["trades"][1]["ticker"] == "MSFT"
 
+    @pytest.mark.integration
     def test_preview_no_auth_returns_401(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -91,6 +94,7 @@ class TestImportPreview:
 
 
 class TestImportExecute:
+    @pytest.mark.integration
     def test_import_invalid_date_format(self, client):
         resp = client.post("/api/journal/import", json={
             "start_date": "March 1",
@@ -98,6 +102,7 @@ class TestImportExecute:
         })
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_import_creates_trades(self, client, mock_schwab):
         # Body omits ``position_strategy`` — the field is deprecated under
         # issue #131 and the recomputer derives the label from state.
@@ -125,6 +130,7 @@ class TestImportExecute:
         assert labels["AAPL"] == "csp"
         assert labels["MSFT"] == "cc"
 
+    @pytest.mark.integration
     def test_import_accepts_legacy_strategy_field_but_ignores_it(self, client, mock_schwab):
         """Backwards-compat: old clients sending ``position_strategy`` still
         get a 200, but the value is ignored and the recomputer wins."""
@@ -140,6 +146,7 @@ class TestImportExecute:
         assert labels["AAPL"] == "csp"
         assert labels["MSFT"] == "cc"
 
+    @pytest.mark.integration
     def test_import_skips_duplicates(self, client, mock_schwab):
         # First import
         client.post("/api/journal/import", json={
@@ -157,6 +164,7 @@ class TestImportExecute:
         assert data["skipped_duplicates"] == 2
         assert data["positions_created"] == 0
 
+    @pytest.mark.integration
     def test_import_reuses_existing_position(self, client, mock_schwab):
         # Create a position for AAPL first.
         # ``strategy`` is no longer accepted on PositionCreate (#131); it
@@ -180,6 +188,7 @@ class TestImportExecute:
 class TestImportDateRangeValidation:
     """Tests for date range validation (issue #73)."""
 
+    @pytest.mark.integration
     def test_preview_rejects_range_over_365_days(self, client):
         resp = client.get("/api/journal/import/preview", params={
             "start_date": "2024-01-01",
@@ -188,6 +197,7 @@ class TestImportDateRangeValidation:
         assert resp.status_code == 422
         assert "365" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_preview_accepts_range_at_365_days(self, client, mock_schwab):
         resp = client.get("/api/journal/import/preview", params={
             "start_date": "2024-01-01",
@@ -195,6 +205,7 @@ class TestImportDateRangeValidation:
         })
         assert resp.status_code == 200
 
+    @pytest.mark.integration
     def test_import_rejects_range_over_365_days(self, client):
         resp = client.post("/api/journal/import", json={
             "start_date": "2024-01-01",
@@ -203,6 +214,7 @@ class TestImportDateRangeValidation:
         assert resp.status_code == 422
         assert "365" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_import_accepts_range_at_365_days(self, client, mock_schwab):
         resp = client.post("/api/journal/import", json={
             "start_date": "2024-01-01",
@@ -214,6 +226,7 @@ class TestImportDateRangeValidation:
 class TestImportAuthErrors:
     """Tests for improved auth error messages and logging (issue #69)."""
 
+    @pytest.mark.integration
     def test_preview_expired_token_returns_specific_detail(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -225,6 +238,7 @@ class TestImportAuthErrors:
         assert "expired" in resp.json()["detail"].lower()
         assert "Settings" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_preview_no_token_returns_not_connected(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -235,6 +249,7 @@ class TestImportAuthErrors:
         assert resp.status_code == 401
         assert "not connected" in resp.json()["detail"].lower()
 
+    @pytest.mark.integration
     def test_preview_not_configured_returns_setup_message(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -245,6 +260,7 @@ class TestImportAuthErrors:
         assert resp.status_code == 401
         assert "not configured" in resp.json()["detail"].lower()
 
+    @pytest.mark.integration
     def test_import_expired_token_returns_specific_detail(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -258,6 +274,7 @@ class TestImportAuthErrors:
         assert resp.status_code == 401
         assert "expired" in resp.json()["detail"].lower()
 
+    @pytest.mark.integration
     def test_generic_auth_error_returns_fallback_detail(self, client):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -268,6 +285,7 @@ class TestImportAuthErrors:
         assert resp.status_code == 401
         assert resp.json()["detail"] == "Schwab authentication failed. Please re-authorize in Settings."
 
+    @pytest.mark.integration
     def test_auth_error_is_logged(self, client, caplog):
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
         with patch("app.services.schwab_import.SchwabClient") as mock_cls:
@@ -278,6 +296,7 @@ class TestImportAuthErrors:
                 client.get("/api/journal/import/preview", params={"start_date": "2025-03-01", "end_date": "2025-03-31"})
         assert any("Schwab auth failed" in r.message for r in caplog.records)
 
+    @pytest.mark.unit
     def test_schwab_auth_detail_maps_all_codes(self):
         """Verify _schwab_auth_detail returns expected strings for each code."""
         from app.routers.journal import _schwab_auth_detail

--- a/backend/tests/test_integration_journal.py
+++ b/backend/tests/test_integration_journal.py
@@ -91,6 +91,7 @@ def _create_sample_trade(db_session, position_id, **overrides):
 # --- Position CRUD ---
 
 
+@pytest.mark.unit
 def test_create_position(db_session):
     result = _create_sample_position(db_session)
     assert result["ticker"] == "AAPL"
@@ -104,11 +105,13 @@ def test_create_position(db_session):
     assert len(result["id"]) == 36  # UUID4 format
 
 
+@pytest.mark.unit
 def test_get_positions_empty(db_session):
     result = get_positions(db_session)
     assert result == []
 
 
+@pytest.mark.unit
 def test_get_positions_after_create(db_session):
     _create_sample_position(db_session)
     result = get_positions(db_session)
@@ -116,6 +119,7 @@ def test_get_positions_after_create(db_session):
     assert result[0]["ticker"] == "AAPL"
 
 
+@pytest.mark.unit
 def test_get_positions_filter_by_status(db_session):
     _create_sample_position(db_session, ticker="AAPL")
     pos2 = _create_sample_position(db_session, ticker="MSFT")
@@ -130,6 +134,7 @@ def test_get_positions_filter_by_status(db_session):
     assert closed_positions[0]["ticker"] == "MSFT"
 
 
+@pytest.mark.unit
 def test_get_position_by_id(db_session):
     created = _create_sample_position(db_session)
     result = get_position(db_session, created["id"])
@@ -142,11 +147,13 @@ def test_get_position_by_id(db_session):
     assert "min_compliant_cc_strike" in result
 
 
+@pytest.mark.unit
 def test_get_position_not_found(db_session):
     result = get_position(db_session, "nonexistent-id")
     assert result is None
 
 
+@pytest.mark.unit
 def test_update_position(db_session):
     created = _create_sample_position(db_session)
     updated = update_position(
@@ -161,6 +168,7 @@ def test_update_position(db_session):
     assert updated["ticker"] == "AAPL"
 
 
+@pytest.mark.unit
 def test_update_position_not_found(db_session):
     result = update_position(
         db_session, "nonexistent-id", PositionUpdate(notes="test")
@@ -171,6 +179,7 @@ def test_update_position_not_found(db_session):
 # --- Trade CRUD ---
 
 
+@pytest.mark.unit
 def test_create_trade(db_session):
     position = _create_sample_position(db_session)
     trade = _create_sample_trade(db_session, position["id"])
@@ -184,11 +193,13 @@ def test_create_trade(db_session):
     assert "id" in trade
 
 
+@pytest.mark.unit
 def test_create_trade_invalid_position(db_session):
     trade = _create_sample_trade(db_session, "nonexistent-position-id")
     assert trade is None
 
 
+@pytest.mark.unit
 def test_update_trade(db_session):
     position = _create_sample_position(db_session)
     trade = _create_sample_trade(db_session, position["id"])
@@ -204,6 +215,7 @@ def test_update_trade(db_session):
     assert updated["strike"] == 48.0
 
 
+@pytest.mark.unit
 def test_delete_trade(db_session):
     position = _create_sample_position(db_session)
     trade = _create_sample_trade(db_session, position["id"])
@@ -213,10 +225,12 @@ def test_delete_trade(db_session):
     assert len(pos["trades"]) == 0
 
 
+@pytest.mark.unit
 def test_delete_trade_not_found(db_session):
     assert delete_trade(db_session, "nonexistent-trade-id") is False
 
 
+@pytest.mark.unit
 def test_update_trade_not_found(db_session):
     result = update_trade(
         db_session, "nonexistent-trade-id", TradeUpdate(premium=2.00)
@@ -227,6 +241,7 @@ def test_update_trade_not_found(db_session):
 # --- Computed fields integration ---
 
 
+@pytest.mark.unit
 def test_adjusted_basis_with_premiums(db_session):
     """Create position + sell trades, verify computed adjusted_cost_basis."""
     position = _create_sample_position(db_session, broker_cost_basis=5000.0)
@@ -241,6 +256,7 @@ def test_adjusted_basis_with_premiums(db_session):
     assert result["adjusted_cost_basis"] == 4650.0
 
 
+@pytest.mark.unit
 def test_adjusted_basis_mixed_trades(db_session):
     """Sell + buy-to-close trades should net correctly."""
     position = _create_sample_position(db_session, broker_cost_basis=5000.0)
@@ -259,6 +275,7 @@ def test_adjusted_basis_mixed_trades(db_session):
     assert result["adjusted_cost_basis"] == 4850.0
 
 
+@pytest.mark.unit
 def test_adjusted_basis_no_trades(db_session):
     """With no trades, adjusted_cost_basis equals broker_cost_basis."""
     position = _create_sample_position(db_session, broker_cost_basis=5000.0)
@@ -267,6 +284,7 @@ def test_adjusted_basis_no_trades(db_session):
     assert result["adjusted_cost_basis"] == 5000.0
 
 
+@pytest.mark.unit
 def test_adjusted_basis_excludes_assignment_consumed_premium(db_session):
     """Issue #183: total_premiums must not double-count the put netted into basis.
 
@@ -325,6 +343,7 @@ def test_adjusted_basis_excludes_assignment_consumed_premium(db_session):
     assert result["adjusted_cost_basis"] == pytest.approx(1320.66, abs=1e-4)
 
 
+@pytest.mark.unit
 def test_adjusted_basis_post_assignment_cc_subtracts_only_new_premium(db_session):
     """Issue #183 follow-on: a CC sold after assignment IS subtracted normally.
 
@@ -385,6 +404,7 @@ def test_adjusted_basis_post_assignment_cc_subtracts_only_new_premium(db_session
     assert result["adjusted_cost_basis"] == pytest.approx(1280.66, abs=1e-4)
 
 
+@pytest.mark.unit
 def test_min_compliant_cc_strike(db_session):
     """Verify 1.10x calculation on adjusted basis."""
     position = _create_sample_position(
@@ -404,6 +424,7 @@ def test_min_compliant_cc_strike(db_session):
 # --- Input validation ---
 
 
+@pytest.mark.unit
 def test_strategy_field_silently_ignored_on_create():
     """Issue #131: ``strategy`` is no longer a PositionCreate field.
 
@@ -420,6 +441,7 @@ def test_strategy_field_silently_ignored_on_create():
     assert not hasattr(pos, "strategy")
 
 
+@pytest.mark.unit
 def test_invalid_trade_type_rejected():
     """Invalid trade_type value should be rejected by Pydantic."""
     with pytest.raises(ValidationError):
@@ -433,6 +455,7 @@ def test_invalid_trade_type_rejected():
         )
 
 
+@pytest.mark.unit
 def test_zero_shares_rejected():
     """shares=0 should be rejected by Pydantic validation."""
     with pytest.raises(ValidationError):
@@ -444,6 +467,7 @@ def test_zero_shares_rejected():
         )
 
 
+@pytest.mark.unit
 def test_invalid_close_reason_rejected():
     """Invalid close_reason should be rejected by Pydantic."""
     with pytest.raises(ValidationError):

--- a/backend/tests/test_integration_journal_api.py
+++ b/backend/tests/test_integration_journal_api.py
@@ -1,4 +1,5 @@
 """Integration tests for journal API endpoints (Phase 2)."""
+import pytest
 
 
 def _create_position(client, **overrides):
@@ -38,12 +39,14 @@ def _create_trade(client, position_id, **overrides):
 # --- GET /api/journal/positions ---
 
 
+@pytest.mark.integration
 def test_list_positions_empty(client):
     resp = client.get("/api/journal/positions")
     assert resp.status_code == 200
     assert resp.json()["positions"] == []
 
 
+@pytest.mark.integration
 def test_list_positions_returns_created(client):
     _create_position(client)
     resp = client.get("/api/journal/positions")
@@ -53,6 +56,7 @@ def test_list_positions_returns_created(client):
     assert positions[0]["ticker"] == "AAPL"
 
 
+@pytest.mark.integration
 def test_list_positions_filter_by_status(client):
     _create_position(client, ticker="AAPL")
     r2 = _create_position(client, ticker="MSFT")
@@ -71,6 +75,7 @@ def test_list_positions_filter_by_status(client):
 # --- GET /api/journal/positions/{id} ---
 
 
+@pytest.mark.integration
 def test_get_position_by_id(client):
     r = _create_position(client)
     pos_id = r.json()["id"]
@@ -85,6 +90,7 @@ def test_get_position_by_id(client):
     assert "trades" in data
 
 
+@pytest.mark.integration
 def test_get_position_not_found(client):
     resp = client.get("/api/journal/positions/nonexistent")
     assert resp.status_code == 404
@@ -93,6 +99,7 @@ def test_get_position_not_found(client):
 # --- POST /api/journal/positions ---
 
 
+@pytest.mark.integration
 def test_create_position(client):
     resp = _create_position(client)
     assert resp.status_code == 201
@@ -107,6 +114,7 @@ def test_create_position(client):
     assert len(data["id"]) == 36
 
 
+@pytest.mark.integration
 def test_create_position_ignores_strategy_field(client):
     """Issue #131: ``strategy`` is no longer accepted on PositionCreate.
 
@@ -118,6 +126,7 @@ def test_create_position_ignores_strategy_field(client):
     assert resp.json()["strategy"] == "csp"
 
 
+@pytest.mark.integration
 def test_create_position_zero_shares(client):
     resp = _create_position(client, shares=0)
     assert resp.status_code == 422
@@ -126,6 +135,7 @@ def test_create_position_zero_shares(client):
 # --- PUT /api/journal/positions/{id} ---
 
 
+@pytest.mark.integration
 def test_update_position(client):
     r = _create_position(client)
     pos_id = r.json()["id"]
@@ -140,6 +150,7 @@ def test_update_position(client):
     assert data["ticker"] == "AAPL"
 
 
+@pytest.mark.integration
 def test_update_position_not_found(client):
     resp = client.put(
         "/api/journal/positions/nonexistent", json={"notes": "test"}
@@ -150,6 +161,7 @@ def test_update_position_not_found(client):
 # --- POST /api/journal/trades ---
 
 
+@pytest.mark.integration
 def test_create_trade(client):
     pos = _create_position(client).json()
     resp = _create_trade(client, pos["id"])
@@ -161,11 +173,13 @@ def test_create_trade(client):
     assert data["premium"] == 1.50
 
 
+@pytest.mark.integration
 def test_create_trade_invalid_position(client):
     resp = _create_trade(client, "nonexistent-id")
     assert resp.status_code == 404
 
 
+@pytest.mark.integration
 def test_create_trade_invalid_trade_type(client):
     pos = _create_position(client).json()
     resp = _create_trade(client, pos["id"], trade_type="invalid")
@@ -175,6 +189,7 @@ def test_create_trade_invalid_trade_type(client):
 # --- PUT /api/journal/trades/{id} ---
 
 
+@pytest.mark.integration
 def test_update_trade(client):
     pos = _create_position(client).json()
     trade = _create_trade(client, pos["id"]).json()
@@ -189,6 +204,7 @@ def test_update_trade(client):
     assert data["strike"] == 48.0
 
 
+@pytest.mark.integration
 def test_update_trade_not_found(client):
     resp = client.put(
         "/api/journal/trades/nonexistent", json={"premium": 2.00}
@@ -199,6 +215,7 @@ def test_update_trade_not_found(client):
 # --- DELETE /api/journal/trades/{id} ---
 
 
+@pytest.mark.integration
 def test_delete_trade(client):
     pos = _create_position(client).json()
     trade = _create_trade(client, pos["id"]).json()
@@ -210,6 +227,7 @@ def test_delete_trade(client):
     assert len(pos_resp.json()["trades"]) == 0
 
 
+@pytest.mark.integration
 def test_delete_trade_not_found(client):
     resp = client.delete("/api/journal/trades/nonexistent")
     assert resp.status_code == 404
@@ -218,6 +236,7 @@ def test_delete_trade_not_found(client):
 # --- DELETE /api/journal/positions/{id} ---
 
 
+@pytest.mark.integration
 def test_delete_position_success_cascades_trades(client):
     """Deleting a position removes the row and every child trade in one shot."""
     pos = _create_position(client).json()
@@ -241,11 +260,13 @@ def test_delete_position_success_cascades_trades(client):
     assert listing["positions"] == []
 
 
+@pytest.mark.integration
 def test_delete_position_not_found(client):
     resp = client.delete("/api/journal/positions/does-not-exist")
     assert resp.status_code == 404
 
 
+@pytest.mark.integration
 def test_delete_position_does_not_touch_other_positions(client):
     """Deleting one position leaves siblings intact."""
     keep = _create_position(client, ticker="AAPL").json()
@@ -262,6 +283,7 @@ def test_delete_position_does_not_touch_other_positions(client):
     assert len(surviving[0]["trades"]) == 1
 
 
+@pytest.mark.integration
 def test_delete_position_500_does_not_leak_exception_text(client, monkeypatch):
     """If the service raises, the response stays generic — no ``str(e)`` leak."""
     from app.routers import journal as journal_router
@@ -283,6 +305,7 @@ def test_delete_position_500_does_not_leak_exception_text(client, monkeypatch):
 # --- DELETE /api/journal/all ---
 
 
+@pytest.mark.integration
 def test_clear_all_journal_wipes_everything(client):
     """Clear-all removes every position and trade and returns pre-delete counts."""
     p1 = _create_position(client, ticker="AAPL").json()
@@ -300,6 +323,7 @@ def test_clear_all_journal_wipes_everything(client):
     assert after["positions"] == []
 
 
+@pytest.mark.integration
 def test_clear_all_journal_when_already_empty(client):
     """Empty journal still returns a well-formed zero-count payload."""
     resp = client.delete("/api/journal/all")
@@ -307,6 +331,7 @@ def test_clear_all_journal_when_already_empty(client):
     assert resp.json() == {"deleted_positions": 0, "deleted_trades": 0}
 
 
+@pytest.mark.integration
 def test_clear_all_journal_500_does_not_leak_exception_text(client, monkeypatch):
     """Clear-all 500 errors are generic."""
     from app.routers import journal as journal_router
@@ -377,6 +402,7 @@ def _trade_close_map(client, position_id):
     return {t["id"]: t["closed_at"] for t in pos["trades"]}
 
 
+@pytest.mark.integration
 def test_reconcile_dry_run_returns_summary_without_writes(client):
     """``dry_run=true`` returns a structured summary and writes nothing."""
     pos = _seed_full_cycle(client)
@@ -407,6 +433,7 @@ def test_reconcile_dry_run_returns_summary_without_writes(client):
     assert after_trade_closes == before_trade_closes
 
 
+@pytest.mark.integration
 def test_reconcile_apply_persists_changes(client):
     """``dry_run=false`` commits the recomputed state to the database."""
     pos = _seed_full_cycle(client)
@@ -431,6 +458,7 @@ def test_reconcile_apply_persists_changes(client):
     assert len(closed_trade_ids) >= 2
 
 
+@pytest.mark.integration
 def test_reconcile_default_is_dry_run(client):
     """Empty body / missing field defaults to ``dry_run=true`` — never mutates."""
     pos = _seed_full_cycle(client)
@@ -446,6 +474,7 @@ def test_reconcile_default_is_dry_run(client):
     assert after["status"] == "open"
 
 
+@pytest.mark.integration
 def test_reconcile_empty_journal_returns_zero_counts(client):
     """No positions in DB returns positions_processed=0 with empty diff list."""
     resp = client.post("/api/journal/reconcile", json={"dry_run": True})
@@ -457,6 +486,7 @@ def test_reconcile_empty_journal_returns_zero_counts(client):
     assert body["errors"] == 0
 
 
+@pytest.mark.integration
 def test_reconcile_500_does_not_leak_exception_text(client, monkeypatch):
     """If the service raises, the response stays generic — no ``str(e)`` leak."""
     from app.routers import journal as journal_router
@@ -477,6 +507,7 @@ def test_reconcile_500_does_not_leak_exception_text(client, monkeypatch):
 # --- Computed fields via API ---
 
 
+@pytest.mark.integration
 def test_adjusted_basis_via_api(client):
     pos = _create_position(client, broker_cost_basis=5000.0).json()
     _create_trade(client, pos["id"], premium=1.50, quantity=1)  # 150
@@ -490,6 +521,7 @@ def test_adjusted_basis_via_api(client):
     assert data["min_compliant_cc_strike"] == 51.15
 
 
+@pytest.mark.integration
 def test_adjusted_basis_mixed_trades_via_api(client):
     pos = _create_position(client, broker_cost_basis=5000.0).json()
     _create_trade(client, pos["id"], premium=2.00, quantity=1)  # +200
@@ -503,6 +535,7 @@ def test_adjusted_basis_mixed_trades_via_api(client):
     assert data["adjusted_cost_basis"] == 4850.0
 
 
+@pytest.mark.integration
 def test_position_with_trades_in_list(client):
     """Verify list endpoint includes computed fields."""
     pos = _create_position(client, broker_cost_basis=5000.0).json()
@@ -518,12 +551,14 @@ def test_position_with_trades_in_list(client):
 # --- Input validation via API ---
 
 
+@pytest.mark.integration
 def test_invalid_status_query_param(client):
     """Invalid status query param should return 422."""
     resp = client.get("/api/journal/positions?status=bogus")
     assert resp.status_code == 422
 
 
+@pytest.mark.integration
 def test_update_position_negative_shares(client):
     """shares=-1 in update should return 422."""
     pos = _create_position(client).json()
@@ -533,6 +568,7 @@ def test_update_position_negative_shares(client):
     assert resp.status_code == 422
 
 
+@pytest.mark.integration
 def test_create_trade_zero_quantity(client):
     """quantity=0 should return 422."""
     pos = _create_position(client).json()
@@ -540,6 +576,7 @@ def test_create_trade_zero_quantity(client):
     assert resp.status_code == 422
 
 
+@pytest.mark.integration
 def test_update_trade_zero_quantity(client):
     """quantity=0 in trade update should return 422."""
     pos = _create_position(client).json()
@@ -550,6 +587,7 @@ def test_update_trade_zero_quantity(client):
     assert resp.status_code == 422
 
 
+@pytest.mark.integration
 def test_update_position_ignores_strategy_field(client):
     """Issue #131: ``strategy`` is no longer accepted on PositionUpdate.
 

--- a/backend/tests/test_integration_options.py
+++ b/backend/tests/test_integration_options.py
@@ -1,3 +1,4 @@
+import pytest
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -37,6 +38,7 @@ def _mock_scan_result():
 
 
 class TestScanEndpoint:
+    @pytest.mark.integration
     def test_scan_covered_call_success(self, client):
         with patch.object(OptionScanner, "scan", return_value=_mock_scan_result()):
             response = client.post("/api/options/scan", json={
@@ -52,6 +54,7 @@ class TestScanEndpoint:
         assert len(data["recommendations"]) == 1
         assert data["recommendations"][0]["rank"] == 1
 
+    @pytest.mark.integration
     def test_scan_csp_success(self, client):
         result = _mock_scan_result()
         result["strategy"] = "cash_secured_put"
@@ -64,6 +67,7 @@ class TestScanEndpoint:
         assert response.status_code == 200
         assert response.json()["strategy"] == "cash_secured_put"
 
+    @pytest.mark.integration
     def test_scan_no_options_404(self, client):
         with patch.object(
             OptionScanner, "scan",
@@ -77,6 +81,7 @@ class TestScanEndpoint:
         assert response.status_code == 404
         assert "No options" in response.json()["detail"]
 
+    @pytest.mark.integration
     def test_scan_invalid_strategy_400(self, client):
         with patch.object(
             OptionScanner, "scan",
@@ -89,6 +94,7 @@ class TestScanEndpoint:
         assert response.status_code == 400
 
 
+    @pytest.mark.integration
     def test_scan_schwab_auth_error_returns_sanitized_message(self, client):
         """Schwab auth errors must not leak internal details (issue #41)."""
         with patch.object(
@@ -109,6 +115,7 @@ class TestScanEndpoint:
         assert "refresh token" not in detail
         assert "python -m app.cli" not in detail
 
+    @pytest.mark.integration
     def test_schwab_auth_error_global_handler_sanitized(self, client):
         """Global SchwabAuthError handler must not leak internal details (issue #41)."""
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
@@ -133,6 +140,7 @@ class TestScanEndpoint:
 
 
 class TestEarningsEndpoint:
+    @pytest.mark.integration
     def test_get_earnings(self, client):
         with patch("app.services.alpha_vantage_client.get_next_earnings_date", return_value="2026-05-05"):
             response = client.get("/api/options/earnings/SOFI")

--- a/backend/tests/test_integration_regression.py
+++ b/backend/tests/test_integration_regression.py
@@ -1,7 +1,9 @@
+import pytest
 from unittest.mock import patch
 
 
 class TestLinearRegression:
+    @pytest.mark.integration
     def test_linear_success(self, client, mock_fetcher):
         with patch("app.services.alpha_vantage_client.get_next_earnings_date", return_value=None):
             response = client.post("/api/regression/linear", json={
@@ -18,6 +20,7 @@ class TestLinearRegression:
 
 
 class TestMultiFactorRegression:
+    @pytest.mark.integration
     def test_multi_factor_success(self, client, multi_asset_fetcher):
         response = client.post("/api/regression/multi-factor", json={
             "dependent": "CSUSHPINSA",
@@ -33,6 +36,7 @@ class TestMultiFactorRegression:
 
 
 class TestRollingRegression:
+    @pytest.mark.integration
     def test_rolling_success(self, client, mock_fetcher):
         response = client.post("/api/regression/rolling", json={
             "asset": "AAPL",
@@ -48,6 +52,7 @@ class TestRollingRegression:
 
 
 class TestCompareRegression:
+    @pytest.mark.integration
     def test_compare_success(self, client, multi_asset_fetcher):
         response = client.post("/api/regression/compare", json={
             "assets": ["AAPL", "^GSPC"],
@@ -61,6 +66,7 @@ class TestCompareRegression:
         assert "^GSPC" in data["series"]
         assert "stats" in data
 
+    @pytest.mark.integration
     def test_compare_too_few_assets(self, client):
         response = client.post("/api/regression/compare", json={
             "assets": ["AAPL"],

--- a/backend/tests/test_integration_schwab.py
+++ b/backend/tests/test_integration_schwab.py
@@ -23,6 +23,7 @@ def reset_singleton():
     SchwabTokenManager._instance = None
 
 
+@pytest.mark.integration
 @pytest.fixture()
 def test_session_local(client):
     """Patch SessionLocal so SchwabTokenManager uses the test DB."""
@@ -75,6 +76,7 @@ def _insert_tokens(session_local_fn, access_minutes=30, refresh_days=7):
 class TestSettingsEndpointSchwab:
     """GET /api/settings — schwab_configured and schwab_token_expires fields."""
 
+    @pytest.mark.integration
     def test_unconfigured_returns_false(self, client, test_session_local):
         resp = client.get("/api/settings")
         assert resp.status_code == 200
@@ -82,6 +84,7 @@ class TestSettingsEndpointSchwab:
         assert data["schwab_configured"] is False
         assert data["schwab_token_expires"] is None
 
+    @pytest.mark.integration
     def test_configured_returns_true_with_expiry(self, client, test_session_local):
         _insert_tokens(test_session_local)
         resp = client.get("/api/settings")
@@ -92,6 +95,7 @@ class TestSettingsEndpointSchwab:
         expires_dt = datetime.fromisoformat(data["schwab_token_expires"])
         assert expires_dt > datetime.now(timezone.utc)
 
+    @pytest.mark.integration
     def test_other_settings_still_present(self, client, test_session_local):
         """Schwab fields don't break existing settings response."""
         resp = client.get("/api/settings")
@@ -104,6 +108,7 @@ class TestSettingsEndpointSchwab:
 class TestSchwabHealthEndpoint:
     """GET /api/settings/health/schwab — configured/valid/error fields."""
 
+    @pytest.mark.integration
     def test_unconfigured(self, client, test_session_local):
         resp = client.get("/api/settings/health/schwab")
         assert resp.status_code == 200
@@ -112,6 +117,7 @@ class TestSchwabHealthEndpoint:
         assert data["valid"] is False
         assert data["error"] is None
 
+    @pytest.mark.integration
     def test_configured_and_valid(self, client, test_session_local):
         _insert_tokens(test_session_local)
         mock_resp = MagicMock()
@@ -126,6 +132,7 @@ class TestSchwabHealthEndpoint:
         assert data["valid"] is True
         assert data["error"] is None
 
+    @pytest.mark.integration
     def test_configured_but_api_returns_401(self, client, test_session_local):
         _insert_tokens(test_session_local)
         mock_resp = MagicMock()
@@ -142,6 +149,7 @@ class TestSchwabHealthEndpoint:
         assert data["valid"] is False
         assert data["error"] == "HTTP 401"
 
+    @pytest.mark.integration
     def test_configured_but_connection_fails(self, client, test_session_local):
         _insert_tokens(test_session_local)
 
@@ -153,6 +161,7 @@ class TestSchwabHealthEndpoint:
         assert data["valid"] is False
         assert data["error"] == "Connection failed"
 
+    @pytest.mark.integration
     def test_configured_but_token_expired(self, client, test_session_local):
         """Expired access + expired refresh returns valid=False."""
         _insert_tokens(test_session_local, access_minutes=-5, refresh_days=-1)
@@ -177,6 +186,7 @@ class TestSourcesEndpointSchwab:
             patch("app.routers.health._check_zillow", return_value={"available": True, "error": None}),
         )
 
+    @pytest.mark.integration
     def test_unconfigured_shows_unavailable(self, client, test_session_local):
         p1, p2, p3 = self._patch_other_sources()
         with p1, p2, p3:
@@ -187,6 +197,7 @@ class TestSourcesEndpointSchwab:
         assert data["schwab"]["available"] is False
         assert data["schwab"]["error"] == "Not configured"
 
+    @pytest.mark.integration
     def test_configured_and_available(self, client, test_session_local):
         _insert_tokens(test_session_local)
         mock_resp = MagicMock()
@@ -201,6 +212,7 @@ class TestSourcesEndpointSchwab:
         assert data["schwab"]["error"] is None
         assert data["all_down"] is False
 
+    @pytest.mark.integration
     def test_all_down_includes_schwab(self, client, test_session_local):
         """all_down is True when all sources including schwab are down."""
         with patch("app.routers.health._check_alpha_vantage", return_value={"available": False, "error": "down"}), \
@@ -213,6 +225,7 @@ class TestSourcesEndpointSchwab:
         assert data["schwab"]["available"] is False
         assert data["all_down"] is True
 
+    @pytest.mark.integration
     def test_not_all_down_when_schwab_available(self, client, test_session_local):
         """all_down is False if only schwab is up."""
         _insert_tokens(test_session_local)

--- a/backend/tests/test_integration_schwab.py
+++ b/backend/tests/test_integration_schwab.py
@@ -23,9 +23,8 @@ def reset_singleton():
     SchwabTokenManager._instance = None
 
 
-@pytest.mark.integration
 @pytest.fixture()
-def test_session_local(client):
+def session_local(client):
     """Patch SessionLocal so SchwabTokenManager uses the test DB."""
     from app.main import app
 
@@ -77,7 +76,7 @@ class TestSettingsEndpointSchwab:
     """GET /api/settings — schwab_configured and schwab_token_expires fields."""
 
     @pytest.mark.integration
-    def test_unconfigured_returns_false(self, client, test_session_local):
+    def test_unconfigured_returns_false(self, client, session_local):
         resp = client.get("/api/settings")
         assert resp.status_code == 200
         data = resp.json()
@@ -85,8 +84,8 @@ class TestSettingsEndpointSchwab:
         assert data["schwab_token_expires"] is None
 
     @pytest.mark.integration
-    def test_configured_returns_true_with_expiry(self, client, test_session_local):
-        _insert_tokens(test_session_local)
+    def test_configured_returns_true_with_expiry(self, client, session_local):
+        _insert_tokens(session_local)
         resp = client.get("/api/settings")
         assert resp.status_code == 200
         data = resp.json()
@@ -96,7 +95,7 @@ class TestSettingsEndpointSchwab:
         assert expires_dt > datetime.now(timezone.utc)
 
     @pytest.mark.integration
-    def test_other_settings_still_present(self, client, test_session_local):
+    def test_other_settings_still_present(self, client, session_local):
         """Schwab fields don't break existing settings response."""
         resp = client.get("/api/settings")
         data = resp.json()
@@ -109,7 +108,7 @@ class TestSchwabHealthEndpoint:
     """GET /api/settings/health/schwab — configured/valid/error fields."""
 
     @pytest.mark.integration
-    def test_unconfigured(self, client, test_session_local):
+    def test_unconfigured(self, client, session_local):
         resp = client.get("/api/settings/health/schwab")
         assert resp.status_code == 200
         data = resp.json()
@@ -118,8 +117,8 @@ class TestSchwabHealthEndpoint:
         assert data["error"] is None
 
     @pytest.mark.integration
-    def test_configured_and_valid(self, client, test_session_local):
-        _insert_tokens(test_session_local)
+    def test_configured_and_valid(self, client, session_local):
+        _insert_tokens(session_local)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.raise_for_status = MagicMock()
@@ -133,8 +132,8 @@ class TestSchwabHealthEndpoint:
         assert data["error"] is None
 
     @pytest.mark.integration
-    def test_configured_but_api_returns_401(self, client, test_session_local):
-        _insert_tokens(test_session_local)
+    def test_configured_but_api_returns_401(self, client, session_local):
+        _insert_tokens(session_local)
         mock_resp = MagicMock()
         mock_resp.status_code = 401
         mock_resp.raise_for_status.side_effect = _httpx.HTTPStatusError(
@@ -150,8 +149,8 @@ class TestSchwabHealthEndpoint:
         assert data["error"] == "HTTP 401"
 
     @pytest.mark.integration
-    def test_configured_but_connection_fails(self, client, test_session_local):
-        _insert_tokens(test_session_local)
+    def test_configured_but_connection_fails(self, client, session_local):
+        _insert_tokens(session_local)
 
         with patch("httpx.get", side_effect=_httpx.ConnectError("refused")):
             resp = client.get("/api/settings/health/schwab")
@@ -162,9 +161,9 @@ class TestSchwabHealthEndpoint:
         assert data["error"] == "Connection failed"
 
     @pytest.mark.integration
-    def test_configured_but_token_expired(self, client, test_session_local):
+    def test_configured_but_token_expired(self, client, session_local):
         """Expired access + expired refresh returns valid=False."""
-        _insert_tokens(test_session_local, access_minutes=-5, refresh_days=-1)
+        _insert_tokens(session_local, access_minutes=-5, refresh_days=-1)
 
         with patch("app.services.schwab_auth.get_schwab_credentials",
                     return_value=("test_app_key", "test_app_secret")):
@@ -187,7 +186,7 @@ class TestSourcesEndpointSchwab:
         )
 
     @pytest.mark.integration
-    def test_unconfigured_shows_unavailable(self, client, test_session_local):
+    def test_unconfigured_shows_unavailable(self, client, session_local):
         p1, p2, p3 = self._patch_other_sources()
         with p1, p2, p3:
             resp = client.get("/api/health/sources")
@@ -198,8 +197,8 @@ class TestSourcesEndpointSchwab:
         assert data["schwab"]["error"] == "Not configured"
 
     @pytest.mark.integration
-    def test_configured_and_available(self, client, test_session_local):
-        _insert_tokens(test_session_local)
+    def test_configured_and_available(self, client, session_local):
+        _insert_tokens(session_local)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
 
@@ -213,7 +212,7 @@ class TestSourcesEndpointSchwab:
         assert data["all_down"] is False
 
     @pytest.mark.integration
-    def test_all_down_includes_schwab(self, client, test_session_local):
+    def test_all_down_includes_schwab(self, client, session_local):
         """all_down is True when all sources including schwab are down."""
         with patch("app.routers.health._check_alpha_vantage", return_value={"available": False, "error": "down"}), \
              patch("app.routers.health._check_fred", return_value={"available": False, "error": "down"}), \
@@ -226,9 +225,9 @@ class TestSourcesEndpointSchwab:
         assert data["all_down"] is True
 
     @pytest.mark.integration
-    def test_not_all_down_when_schwab_available(self, client, test_session_local):
+    def test_not_all_down_when_schwab_available(self, client, session_local):
         """all_down is False if only schwab is up."""
-        _insert_tokens(test_session_local)
+        _insert_tokens(session_local)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
 

--- a/backend/tests/test_integration_schwab.py
+++ b/backend/tests/test_integration_schwab.py
@@ -76,7 +76,8 @@ class TestSettingsEndpointSchwab:
     """GET /api/settings — schwab_configured and schwab_token_expires fields."""
 
     @pytest.mark.integration
-    def test_unconfigured_returns_false(self, client, session_local):
+    @pytest.mark.usefixtures("session_local")
+    def test_unconfigured_returns_false(self, client):
         resp = client.get("/api/settings")
         assert resp.status_code == 200
         data = resp.json()
@@ -95,7 +96,8 @@ class TestSettingsEndpointSchwab:
         assert expires_dt > datetime.now(timezone.utc)
 
     @pytest.mark.integration
-    def test_other_settings_still_present(self, client, session_local):
+    @pytest.mark.usefixtures("session_local")
+    def test_other_settings_still_present(self, client):
         """Schwab fields don't break existing settings response."""
         resp = client.get("/api/settings")
         data = resp.json()
@@ -108,7 +110,8 @@ class TestSchwabHealthEndpoint:
     """GET /api/settings/health/schwab — configured/valid/error fields."""
 
     @pytest.mark.integration
-    def test_unconfigured(self, client, session_local):
+    @pytest.mark.usefixtures("session_local")
+    def test_unconfigured(self, client):
         resp = client.get("/api/settings/health/schwab")
         assert resp.status_code == 200
         data = resp.json()
@@ -186,7 +189,8 @@ class TestSourcesEndpointSchwab:
         )
 
     @pytest.mark.integration
-    def test_unconfigured_shows_unavailable(self, client, session_local):
+    @pytest.mark.usefixtures("session_local")
+    def test_unconfigured_shows_unavailable(self, client):
         p1, p2, p3 = self._patch_other_sources()
         with p1, p2, p3:
             resp = client.get("/api/health/sources")
@@ -212,7 +216,8 @@ class TestSourcesEndpointSchwab:
         assert data["all_down"] is False
 
     @pytest.mark.integration
-    def test_all_down_includes_schwab(self, client, session_local):
+    @pytest.mark.usefixtures("session_local")
+    def test_all_down_includes_schwab(self, client):
         """all_down is True when all sources including schwab are down."""
         with patch("app.routers.health._check_alpha_vantage", return_value={"available": False, "error": "down"}), \
              patch("app.routers.health._check_fred", return_value={"available": False, "error": "down"}), \

--- a/backend/tests/test_integration_sessions.py
+++ b/backend/tests/test_integration_sessions.py
@@ -1,4 +1,6 @@
+import pytest
 class TestSessionsCRUD:
+    @pytest.mark.integration
     def test_create_session(self, client):
         payload = {"name": "Test Session", "config": {"type": "linear", "asset": "AAPL"}}
         response = client.post("/api/sessions", json=payload)
@@ -8,17 +10,20 @@ class TestSessionsCRUD:
         assert "id" in data
         assert data["config"]["type"] == "linear"
 
+    @pytest.mark.integration
     def test_list_sessions_empty(self, client):
         response = client.get("/api/sessions")
         assert response.status_code == 200
         assert response.json()["sessions"] == []
 
+    @pytest.mark.integration
     def test_list_sessions_after_create(self, client):
         client.post("/api/sessions", json={"name": "S1", "config": {}})
         response = client.get("/api/sessions")
         assert response.status_code == 200
         assert len(response.json()["sessions"]) == 1
 
+    @pytest.mark.integration
     def test_get_session_by_id(self, client):
         create_resp = client.post("/api/sessions", json={"name": "S1", "config": {"x": 1}})
         session_id = create_resp.json()["id"]
@@ -27,10 +32,12 @@ class TestSessionsCRUD:
         assert response.json()["id"] == session_id
         assert response.json()["config"]["x"] == 1
 
+    @pytest.mark.integration
     def test_get_session_not_found(self, client):
         response = client.get("/api/sessions/nonexistent-id")
         assert response.status_code == 404
 
+    @pytest.mark.integration
     def test_delete_session(self, client):
         create_resp = client.post("/api/sessions", json={"name": "S1", "config": {}})
         session_id = create_resp.json()["id"]
@@ -39,6 +46,7 @@ class TestSessionsCRUD:
         get_resp = client.get(f"/api/sessions/{session_id}")
         assert get_resp.status_code == 404
 
+    @pytest.mark.integration
     def test_delete_session_not_found(self, client):
         response = client.delete("/api/sessions/nonexistent-id")
         assert response.status_code == 404

--- a/backend/tests/test_integration_settings.py
+++ b/backend/tests/test_integration_settings.py
@@ -54,6 +54,7 @@ class TestSettingsEndpoints:
         get_resp = client.get("/api/settings")
         assert get_resp.json()["theme"] == "dark"
 
+    @pytest.mark.integration
     def test_get_cache_stats_empty(self, client):
         response = client.get("/api/settings/cache")
         assert response.status_code == 200
@@ -65,6 +66,7 @@ class TestSettingsEndpoints:
 class TestCacheClearAndFreshness:
     """Tests for DELETE /api/settings/cache and GET /api/settings/cache/freshness."""
 
+    @pytest.mark.integration
     def test_clear_cache_empty(self, client):
         """Clearing an empty cache succeeds with status ok."""
         response = client.delete("/api/settings/cache")
@@ -73,6 +75,7 @@ class TestCacheClearAndFreshness:
         assert data["status"] == "ok"
         assert data["message"] == "Cache cleared"
 
+    @pytest.mark.integration
     def test_clear_cache_with_entries(self, client, db):
         """Clearing a populated cache removes all entries."""
         _insert_cache_entry(db, "fred:DGS10")
@@ -89,6 +92,7 @@ class TestCacheClearAndFreshness:
         stats_after = client.get("/api/settings/cache").json()
         assert stats_after["entry_count"] == 0
 
+    @pytest.mark.integration
     def test_cache_freshness_empty(self, client):
         """No cache entries returns empty entries list."""
         response = client.get("/api/settings/cache/freshness")
@@ -96,6 +100,7 @@ class TestCacheClearAndFreshness:
         data = response.json()
         assert data["entries"] == []
 
+    @pytest.mark.integration
     def test_cache_freshness_fresh_entry(self, client, db):
         """Entry fetched 5 days ago is labeled 'fresh'."""
         fetched_at = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
@@ -109,6 +114,7 @@ class TestCacheClearAndFreshness:
         assert entries[0]["age_days"] == 5
         assert entries[0]["asset_key"] == "fred:DGS10"
 
+    @pytest.mark.integration
     def test_cache_freshness_stale_entry(self, client, db):
         """Entry fetched 60 days ago is labeled 'stale'."""
         fetched_at = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
@@ -119,6 +125,7 @@ class TestCacheClearAndFreshness:
         assert entries[0]["freshness"] == "stale"
         assert entries[0]["age_days"] == 60
 
+    @pytest.mark.integration
     def test_cache_freshness_very_stale_entry(self, client, db):
         """Entry fetched 100 days ago is labeled 'very_stale'."""
         fetched_at = (datetime.now(timezone.utc) - timedelta(days=100)).isoformat()
@@ -129,6 +136,7 @@ class TestCacheClearAndFreshness:
         assert entries[0]["freshness"] == "very_stale"
         assert entries[0]["age_days"] == 100
 
+    @pytest.mark.integration
     def test_cache_freshness_naive_datetime(self, client, db):
         """Naive datetime (no tzinfo) is treated as UTC."""
         fetched_at = (datetime.now(timezone.utc) - timedelta(days=10)).strftime(
@@ -145,6 +153,7 @@ class TestCacheClearAndFreshness:
 class TestHealthChecks:
     """Tests for GET /api/settings/health/fred and /health/schwab."""
 
+    @pytest.mark.integration
     def test_fred_health_no_key(self, client):
         """No FRED key returns configured=False, valid=False."""
         with patch("app.routers.settings.get_fred_api_key", return_value=None):
@@ -154,6 +163,7 @@ class TestHealthChecks:
         assert data["configured"] is False
         assert data["valid"] is False
 
+    @pytest.mark.integration
     def test_fred_health_valid_key(self, client):
         """Valid FRED key returns configured=True, valid=True."""
         mock_fred_cls = MagicMock()
@@ -166,6 +176,7 @@ class TestHealthChecks:
         assert data["configured"] is True
         assert data["valid"] is True
 
+    @pytest.mark.integration
     def test_fred_health_invalid_key(self, client):
         """Invalid FRED key returns configured=True, valid=False."""
         mock_fred_cls = MagicMock()
@@ -178,6 +189,7 @@ class TestHealthChecks:
         assert data["configured"] is True
         assert data["valid"] is False
 
+    @pytest.mark.integration
     def test_schwab_health_not_configured(self, client):
         """No Schwab tokens returns configured=False."""
         with patch("app.routers.settings.SchwabTokenManager") as mock_cls:
@@ -188,6 +200,7 @@ class TestHealthChecks:
         assert data["configured"] is False
         assert data["valid"] is False
 
+    @pytest.mark.integration
     def test_schwab_health_configured_valid(self, client):
         """Configured Schwab with valid token returns valid=True."""
         expiry = (datetime.now(timezone.utc) + timedelta(days=5)).isoformat()
@@ -209,6 +222,7 @@ class TestHealthChecks:
         assert data["token_expiry"]["warning"] is False
         assert data["token_expiry"]["expired"] is False
 
+    @pytest.mark.integration
     def test_schwab_health_expired_token(self, client):
         """Expired Schwab token returns valid=False with sanitized error."""
         with patch("app.routers.settings.SchwabTokenManager") as mock_cls:
@@ -226,6 +240,7 @@ class TestHealthChecks:
         # Verify raw exception message is NOT leaked
         assert "Token expired" not in str(data)
 
+    @pytest.mark.integration
     def test_schwab_health_http_error(self, client):
         """Schwab API HTTP error returns valid=False with HTTP status."""
         mock_response = MagicMock()
@@ -247,6 +262,7 @@ class TestHealthChecks:
         assert data["valid"] is False
         assert data["error"] == "HTTP 401"
 
+    @pytest.mark.integration
     @pytest.mark.skip(reason="Alpha Vantage health check lives in routers/health.py, not settings.py. Tracked separately.")
     def test_alpha_vantage_health_check(self):
         """AC from issue #84 — deferred: endpoint is in health router, not settings router."""
@@ -256,6 +272,7 @@ class TestHealthChecks:
 class TestBackups:
     """Tests for GET /api/settings/backups and POST /api/settings/backups/restore."""
 
+    @pytest.mark.integration
     def test_list_backups_empty(self, client):
         """No backups returns empty list."""
         with patch("app.routers.settings.list_backups", return_value=[]):
@@ -263,6 +280,7 @@ class TestBackups:
         assert response.status_code == 200
         assert response.json()["backups"] == []
 
+    @pytest.mark.integration
     def test_list_backups_with_entries(self, client):
         """Backups list returns proper structure."""
         sample_backups = [
@@ -280,6 +298,7 @@ class TestBackups:
         assert len(data["backups"]) == 2
         assert data["backups"][0]["filename"] == "regression_tool_20240601_120000.db"
 
+    @pytest.mark.integration
     def test_restore_success(self, client):
         """Successful restore returns status ok."""
         with patch("app.routers.settings.restore_backup") as mock_restore:
@@ -293,6 +312,7 @@ class TestBackups:
         assert data["status"] == "ok"
         assert "Restored" in data["message"]
 
+    @pytest.mark.integration
     def test_restore_not_found(self, client):
         """Restoring a nonexistent backup returns 404."""
         with patch(
@@ -306,6 +326,7 @@ class TestBackups:
         assert response.status_code == 404
         assert "not found" in response.json()["detail"]
 
+    @pytest.mark.integration
     def test_restore_failure_sanitized_error(self, client):
         """Generic restore failure returns 500 with sanitized message."""
         with patch(
@@ -326,12 +347,14 @@ class TestBackups:
 class TestCacheRefresh:
     """Tests for POST /api/settings/cache/refresh-all and /cache/refresh-stale."""
 
+    @pytest.mark.integration
     def test_refresh_all_empty(self, client):
         """No cache entries returns empty results."""
         response = client.post("/api/settings/cache/refresh-all")
         assert response.status_code == 200
         assert response.json()["results"] == []
 
+    @pytest.mark.integration
     def test_refresh_all_with_entries(self, client, db, mock_fetcher):
         """All entries are refreshed successfully."""
         _insert_cache_entry(db, "fred:DGS10")
@@ -343,6 +366,7 @@ class TestCacheRefresh:
         assert len(results) == 2
         assert all(r["status"] == "refreshed" for r in results)
 
+    @pytest.mark.integration
     def test_refresh_all_skips_zillow_csv(self, client, db, mock_fetcher):
         """The zillow:__csv__ entry is skipped during refresh-all."""
         _insert_cache_entry(db, "zillow:__csv__", source_name="zillow")
@@ -353,6 +377,7 @@ class TestCacheRefresh:
         assert len(results) == 1
         assert results[0]["asset_key"] == "fred:DGS10"
 
+    @pytest.mark.integration
     def test_refresh_all_partial_failure(self, client, db):
         """Mixed success/failure returns per-entry status with sanitized errors."""
         _insert_cache_entry(db, "fred:DGS10")
@@ -379,6 +404,7 @@ class TestCacheRefresh:
         # Verify raw exception is NOT leaked
         assert "Connection timed out" not in str(results)
 
+    @pytest.mark.integration
     def test_refresh_stale_no_stale_entries(self, client, db):
         """All entries are fresh (<30 days), none are refreshed."""
         fetched_at = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
@@ -388,6 +414,7 @@ class TestCacheRefresh:
         assert response.status_code == 200
         assert response.json()["results"] == []
 
+    @pytest.mark.integration
     def test_refresh_stale_with_stale_entries(self, client, db, mock_fetcher):
         """Only stale entries (>30 days) are refreshed."""
         fresh_at = (datetime.now(timezone.utc) - timedelta(days=5)).isoformat()
@@ -401,6 +428,7 @@ class TestCacheRefresh:
         assert results[0]["asset_key"] == "fred:CPIAUCSL"
         assert results[0]["status"] == "refreshed"
 
+    @pytest.mark.integration
     def test_refresh_stale_skips_zillow_csv(self, client, db, mock_fetcher):
         """The zillow:__csv__ entry is skipped even when stale."""
         stale_at = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()

--- a/backend/tests/test_integration_settings.py
+++ b/backend/tests/test_integration_settings.py
@@ -37,6 +37,7 @@ def _insert_cache_entry(db, asset_key, source_name="fred",
 class TestSettingsEndpoints:
     """Tests for core settings CRUD endpoints."""
 
+    @pytest.mark.integration
     def test_get_settings(self, client):
         response = client.get("/api/settings")
         assert response.status_code == 200
@@ -45,6 +46,7 @@ class TestSettingsEndpoints:
         assert "cache_ttl_daily_hours" in data
         assert "theme" in data
 
+    @pytest.mark.integration
     def test_update_setting(self, client):
         response = client.put("/api/settings", json={"key": "theme", "value": "dark"})
         assert response.status_code == 200

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -22,6 +22,7 @@ def _make_trade(premium: float, quantity: int = 1) -> SimpleNamespace:
     return SimpleNamespace(premium=premium, quantity=quantity)
 
 
+@pytest.mark.unit
 def test_compute_total_premiums_sell_only():
     """Two sell_put trades should produce a positive total."""
     trades = [
@@ -31,6 +32,7 @@ def test_compute_total_premiums_sell_only():
     assert compute_total_premiums(trades) == 350.0
 
 
+@pytest.mark.unit
 def test_compute_total_premiums_multi_contract():
     """Multi-contract trades correctly multiply by quantity."""
     trades = [
@@ -39,6 +41,7 @@ def test_compute_total_premiums_multi_contract():
     assert compute_total_premiums(trades) == 450.0
 
 
+@pytest.mark.unit
 def test_compute_total_premiums_mixed():
     """Sells and buy-to-close should net out correctly."""
     trades = [
@@ -48,21 +51,25 @@ def test_compute_total_premiums_mixed():
     assert compute_total_premiums(trades) == 150.0
 
 
+@pytest.mark.unit
 def test_compute_total_premiums_empty():
     """No trades should return 0.0."""
     assert compute_total_premiums([]) == 0.0
 
 
+@pytest.mark.unit
 def test_compute_adjusted_basis():
     """broker_cost_basis 5000, premiums 350 -> 4650."""
     assert compute_adjusted_basis(5000.0, 350.0) == 4650.0
 
 
+@pytest.mark.unit
 def test_compute_min_cc_strike():
     """adjusted 4650, 100 shares -> (4650/100)*1.10 = 51.15."""
     assert compute_min_cc_strike(4650.0, 100) == 51.15
 
 
+@pytest.mark.unit
 def test_compute_min_cc_strike_rounding():
     """Verify result is rounded to 2 decimal places."""
     # 4777 / 100 = 47.77, * 1.10 = 52.547 -> 52.55
@@ -118,6 +125,7 @@ def _seed_position(db, ticker: str = "AAPL", trade_count: int = 0) -> Position:
     return pos
 
 
+@pytest.mark.unit
 def test_delete_position_cascades_trades(db_session):
     """delete_position should also remove every child trade via ORM cascade."""
     pos = _seed_position(db_session, trade_count=3)
@@ -127,10 +135,12 @@ def test_delete_position_cascades_trades(db_session):
     assert db_session.query(Trade).count() == 0
 
 
+@pytest.mark.unit
 def test_delete_position_returns_false_for_unknown(db_session):
     assert delete_position(db_session, "missing-id") is False
 
 
+@pytest.mark.unit
 def test_clear_all_journal_data_returns_counts(db_session):
     _seed_position(db_session, ticker="AAPL", trade_count=2)
     _seed_position(db_session, ticker="MSFT", trade_count=1)
@@ -141,6 +151,7 @@ def test_clear_all_journal_data_returns_counts(db_session):
     assert db_session.query(Trade).count() == 0
 
 
+@pytest.mark.unit
 def test_clear_all_journal_data_empty_db(db_session):
     result = clear_all_journal_data(db_session)
     assert result == {"deleted_positions": 0, "deleted_trades": 0}
@@ -149,6 +160,7 @@ def test_clear_all_journal_data_empty_db(db_session):
 # --- Issue #278: caller-side guard against compute_min_cc_strike log spam ---
 
 
+@pytest.mark.unit
 def test_build_position_response_no_warning_for_shares_zero(db_session, caplog):
     """``_build_position_response`` must not emit the noisy ``shares=0`` WARNING.
 
@@ -182,6 +194,7 @@ def test_build_position_response_no_warning_for_shares_zero(db_session, caplog):
     assert result["shares"] == 0
 
 
+@pytest.mark.unit
 def test_build_position_response_still_computes_for_positive_shares(db_session, caplog):
     """Positive-shares path is unchanged: real call, no warning, real value."""
     from app.services.journal import _build_position_response
@@ -207,6 +220,7 @@ def test_build_position_response_still_computes_for_positive_shares(db_session, 
     assert result["min_compliant_cc_strike"] == 110.0
 
 
+@pytest.mark.unit
 def test_compute_min_cc_strike_direct_call_still_warns_for_zero_shares(caplog):
     """Direct calls to :func:`compute_min_cc_strike` still emit the defensive WARNING.
 
@@ -221,6 +235,7 @@ def test_compute_min_cc_strike_direct_call_still_warns_for_zero_shares(caplog):
     assert "compute_min_cc_strike called with shares=0" in caplog.text
 
 
+@pytest.mark.unit
 def test_build_position_response_warns_for_negative_shares(db_session, caplog):
     """Negative-shares (data corruption) still reaches the defensive WARNING path.
 

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -85,6 +85,7 @@ def app_client():
 class TestJsonLogging:
     """Tests for JSON log output format."""
 
+    @pytest.mark.integration
     def test_json_output_contains_required_keys(self, json_log_capture):
         logger = logging.getLogger("test.required_keys")
         logger.info("test message")
@@ -98,6 +99,7 @@ class TestJsonLogging:
         assert "message" in record
         assert "request_id" in record
 
+    @pytest.mark.integration
     def test_timestamp_is_iso8601(self, json_log_capture):
         logger = logging.getLogger("test.iso8601")
         logger.info("timestamp check")
@@ -108,6 +110,7 @@ class TestJsonLogging:
         # Should parse without error as ISO 8601
         datetime.fromisoformat(record["timestamp"])
 
+    @pytest.mark.integration
     def test_request_id_propagates_from_context_var(self, json_log_capture):
         token = request_id_ctx.set("test-req-123")
         try:
@@ -120,6 +123,7 @@ class TestJsonLogging:
         finally:
             request_id_ctx.reset(token)
 
+    @pytest.mark.integration
     def test_existing_logger_calls_produce_valid_json(self, json_log_capture):
         logger = logging.getLogger("test.existing")
         logger.info("value is %s and count is %d", "foo", 42)
@@ -128,6 +132,7 @@ class TestJsonLogging:
         record = json.loads(output)
         assert "value is foo and count is 42" in record["message"]
 
+    @pytest.mark.integration
     def test_extra_fields_included_in_json(self, json_log_capture):
         logger = logging.getLogger("test.extras")
         logger.info("with extras", extra={"custom_field": "custom_value"})
@@ -140,6 +145,7 @@ class TestJsonLogging:
 class TestPlainTextLogging:
     """Tests for plain text (non-JSON) logging mode."""
 
+    @pytest.mark.integration
     def test_plain_text_output_is_not_json(self):
         stream = StringIO()
         root = logging.getLogger()
@@ -172,6 +178,7 @@ class TestPlainTextLogging:
 class TestRequestLoggingMiddleware:
     """Tests for the request logging middleware."""
 
+    @pytest.mark.integration
     def test_middleware_logs_request_fields(self, app_client, json_log_capture):
         app_client.get("/api/health")
 
@@ -196,6 +203,7 @@ class TestRequestLoggingMiddleware:
         assert isinstance(middleware_line["duration_ms"], (int, float))
         assert "client_ip" in middleware_line
 
+    @pytest.mark.integration
     def test_custom_request_id_accepted_and_echoed(self, app_client):
         response = app_client.get(
             "/api/health", headers={"X-Request-ID": "custom-id-abc"}
@@ -203,6 +211,7 @@ class TestRequestLoggingMiddleware:
         assert response.status_code == 200
         assert response.headers["X-Request-ID"] == "custom-id-abc"
 
+    @pytest.mark.integration
     def test_generated_request_id_in_response(self, app_client):
         response = app_client.get("/api/health")
         assert response.status_code == 200
@@ -211,6 +220,7 @@ class TestRequestLoggingMiddleware:
         assert len(request_id) > 0
         assert request_id != "-"
 
+    @pytest.mark.integration
     def test_malicious_request_id_is_rejected(self, app_client):
         response = app_client.get(
             "/api/health",
@@ -222,6 +232,7 @@ class TestRequestLoggingMiddleware:
         assert "\n" not in echoed
         assert "evil" not in echoed
 
+    @pytest.mark.integration
     def test_oversized_request_id_is_rejected(self, app_client):
         response = app_client.get(
             "/api/health",
@@ -231,6 +242,7 @@ class TestRequestLoggingMiddleware:
         echoed = response.headers["X-Request-ID"]
         assert len(echoed) <= 128
 
+    @pytest.mark.integration
     def test_custom_request_id_propagates_to_logs(
         self, app_client, json_log_capture
     ):

--- a/backend/tests/test_logging_axiom.py
+++ b/backend/tests/test_logging_axiom.py
@@ -134,6 +134,7 @@ def no_axiom_token(monkeypatch):
 class TestHandlerAttachment:
     """AC: an ``AxiomHandler`` is attached iff ``AXIOM_API_TOKEN`` is set."""
 
+    @pytest.mark.unit
     def test_handler_attached_when_token_set(
         self, isolated_root_logger, mock_axiom_token
     ):
@@ -150,6 +151,7 @@ class TestHandlerAttachment:
             f"expected exactly one AxiomHandler, got {len(axiom_handlers)}"
         )
 
+    @pytest.mark.unit
     def test_no_handler_when_token_unset(
         self, isolated_root_logger, no_axiom_token
     ):
@@ -180,12 +182,14 @@ class TestHandlerAttachment:
             "setup_logging() must not spawn an axiom-log-worker when the token is unset"
         )
 
+    @pytest.mark.unit
     def test_build_handler_returns_none_when_token_blank(self, monkeypatch):
         from app import config as cfg
 
         monkeypatch.setattr(cfg.settings, "axiom_api_token", "", raising=False)
         assert build_axiom_handler() is None
 
+    @pytest.mark.unit
     def test_build_handler_returns_none_when_token_none(self, monkeypatch):
         from app import config as cfg
 
@@ -201,6 +205,7 @@ class TestHandlerAttachment:
 class TestNeverRaises:
     """AC: any failure in the Axiom path is swallowed; the app keeps logging."""
 
+    @pytest.mark.unit
     def test_emit_swallows_exception_from_record_serialization(self, capsys):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -215,6 +220,7 @@ class TestNeverRaises:
         finally:
             _stop_handler(handler)
 
+    @pytest.mark.unit
     def test_http_error_in_flush_does_not_propagate(self, capsys):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -232,6 +238,7 @@ class TestNeverRaises:
         finally:
             _stop_handler(handler)
 
+    @pytest.mark.unit
     def test_logger_remains_functional_after_axiom_failure(
         self, isolated_root_logger, mock_axiom_token
     ):
@@ -256,6 +263,7 @@ class TestNeverRaises:
 class TestRequestIdPropagation:
     """AC: the contextvar request_id appears in events sent to Axiom."""
 
+    @pytest.mark.unit
     def test_request_id_present_in_queued_event(self):
         handler = AxiomHandler(token="t", dataset="d")
         # Halt the worker immediately so events stay on the queue for inspection.
@@ -283,6 +291,7 @@ class TestRequestIdPropagation:
         assert events[0]["request_id"] == "test-id-789"
         assert events[0]["message"] == "propagation test"
 
+    @pytest.mark.unit
     def test_request_id_defaults_to_dash_when_filter_missing(self):
         handler = AxiomHandler(token="t", dataset="d")
         handler._worker.stop()
@@ -309,6 +318,7 @@ class TestLoopGuard:
     another POST — an amplification loop.
     """
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "logger_name",
         ["httpx", "httpx._client", "httpx._trace", "httpcore", "httpcore.http11"],
@@ -335,6 +345,7 @@ class TestLoopGuard:
         )
         assert handler.dropped == 0, "loop-guard drops are NOT counted as overflow"
 
+    @pytest.mark.unit
     def test_application_loggers_still_enqueue(self):
         handler = AxiomHandler(token="t", dataset="d")
         handler._worker.stop()
@@ -348,6 +359,7 @@ class TestLoopGuard:
 class TestQueueOverflow:
     """AC: when the queue is full, oldest events drop and a single warning is emitted."""
 
+    @pytest.mark.unit
     def test_queue_full_drops_silently_and_warns_once(self, monkeypatch, capsys):
         # Shrink the queue so the test is cheap and deterministic.
         monkeypatch.setattr(logging_axiom, "QUEUE_MAX", 3)
@@ -391,6 +403,7 @@ class TestQueueOverflow:
 class TestHttpErrorHandling:
     """4xx / 5xx responses must produce a status-only stderr warning and no exception."""
 
+    @pytest.mark.unit
     def test_4xx_response_warns_but_does_not_raise(self, capsys):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -427,6 +440,7 @@ class TestHttpErrorHandling:
 class TestRecordSerialization:
     """``_record_to_event`` must handle weird ``extra`` values gracefully."""
 
+    @pytest.mark.unit
     def test_non_serializable_extra_is_reprd(self):
         sentinel = object()
         record = _make_record(
@@ -438,6 +452,7 @@ class TestRecordSerialization:
         assert "weird" in event
         assert event["weird"].startswith("<object object")
 
+    @pytest.mark.unit
     def test_serializable_extras_are_kept_as_is(self):
         record = _make_record(
             message="nice extras",
@@ -448,6 +463,7 @@ class TestRecordSerialization:
         assert event["count"] == 42
         assert event["user"] == "alice"
 
+    @pytest.mark.unit
     def test_event_round_trips_through_json(self):
         record = _make_record(
             message="round trip",
@@ -461,6 +477,7 @@ class TestRecordSerialization:
         assert round_tripped["request_id"] == "abc"
         assert round_tripped["nested"] == {"k": [1, 2, 3]}
 
+    @pytest.mark.unit
     def test_exception_info_is_formatted_into_event(self):
         try:
             raise ValueError("test exc")
@@ -491,6 +508,7 @@ class TestRecordSerialization:
 class TestTimestamp:
     """``_time`` must reflect emit-time so queued events keep their original order."""
 
+    @pytest.mark.unit
     def test_event_time_uses_record_created(self):
         record = _make_record(request_id="-")
         # Force a known created time well in the past.
@@ -510,6 +528,7 @@ class TestTimestamp:
 class TestWarnThrottled:
     """``_warn_throttled`` rate-limits per-key, not globally."""
 
+    @pytest.mark.unit
     def test_throttles_repeats_of_same_key(self, capsys, monkeypatch):
         monkeypatch.setattr(logging_axiom, "WARN_THROTTLE_S", 60.0)
         state: dict[str, float] = {}
@@ -522,6 +541,7 @@ class TestWarnThrottled:
         assert len(lines) == 1
         assert "first" in lines[0]
 
+    @pytest.mark.unit
     def test_different_keys_warn_independently(self, capsys):
         state: dict[str, float] = {}
         _warn_throttled(state, "a", "alpha")
@@ -532,6 +552,7 @@ class TestWarnThrottled:
         ]
         assert len(lines) == 2
 
+    @pytest.mark.unit
     def test_throttle_window_elapses(self, capsys, monkeypatch):
         # Use a tiny throttle window and step time forward.
         monkeypatch.setattr(logging_axiom, "WARN_THROTTLE_S", 0.0)
@@ -554,6 +575,7 @@ class TestWarnThrottled:
 class TestWorkerBatching:
     """The worker batches multiple events into a single POST."""
 
+    @pytest.mark.unit
     def test_drain_batch_returns_empty_when_queue_idle(self, monkeypatch):
         # Make the batch timeout near-instant.
         monkeypatch.setattr(logging_axiom, "BATCH_TIMEOUT_S", 0.01)
@@ -565,6 +587,7 @@ class TestWorkerBatching:
         finally:
             worker.stop()
 
+    @pytest.mark.unit
     def test_drain_batch_pulls_up_to_batch_max(self, monkeypatch):
         monkeypatch.setattr(logging_axiom, "BATCH_TIMEOUT_S", 0.5)
         monkeypatch.setattr(logging_axiom, "BATCH_MAX", 5)
@@ -594,6 +617,7 @@ class TestFlushBookkeepingIssue274:
     exception) publishes the expected sanitized state on the handler.
     """
 
+    @pytest.mark.unit
     def test_successful_flush_sets_last_flush_at_clears_error(self):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -616,6 +640,7 @@ class TestFlushBookkeepingIssue274:
         finally:
             _stop_handler(handler)
 
+    @pytest.mark.unit
     def test_4xx_flush_sets_sanitized_error_only_status(self, capsys):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -635,6 +660,7 @@ class TestFlushBookkeepingIssue274:
         finally:
             _stop_handler(handler)
 
+    @pytest.mark.unit
     def test_transport_error_records_exception_class_name_only(self):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -650,6 +676,7 @@ class TestFlushBookkeepingIssue274:
         finally:
             _stop_handler(handler)
 
+    @pytest.mark.unit
     def test_generic_exception_records_exception_class_name_only(self):
         handler = AxiomHandler(token="t", dataset="d")
         try:
@@ -663,6 +690,7 @@ class TestFlushBookkeepingIssue274:
         finally:
             _stop_handler(handler)
 
+    @pytest.mark.unit
     def test_worker_without_handler_back_reference_is_a_noop_on_bookkeeping(self):
         """A worker constructed without a handler back-ref must not crash."""
         # Build a worker directly (no handler) — the production code always

--- a/backend/tests/test_main_security.py
+++ b/backend/tests/test_main_security.py
@@ -46,6 +46,7 @@ def _seed(factory, **kv):
 
 
 class TestSecurityChecks:
+    @pytest.mark.integration
     def test_security_checks_pass_with_valid_key(self, db_session_factory):
         """Valid encryption key — the check completes without raising."""
         with patch("app.main.SessionLocal", db_session_factory), patch(
@@ -56,6 +57,7 @@ class TestSecurityChecks:
             # Must not raise — valid key satisfies the gate.
             _run_security_checks()
 
+    @pytest.mark.integration
     def test_security_checks_pass_without_key_when_no_tokens(
         self, db_session_factory
     ):
@@ -71,6 +73,7 @@ class TestSecurityChecks:
             _run_security_checks()
             assert mock_logger.warning.called
 
+    @pytest.mark.integration
     def test_security_checks_fail_without_key(self, db_session_factory):
         """Fail-closed: stored Schwab tokens + no key — raises EncryptionKeyMissing.
 
@@ -86,6 +89,7 @@ class TestSecurityChecks:
             with pytest.raises(EncryptionKeyMissing):
                 _run_security_checks()
 
+    @pytest.mark.integration
     def test_security_checks_migrates_plaintext_tokens_with_key(
         self, db_session_factory
     ):
@@ -111,6 +115,7 @@ class TestSecurityChecks:
         finally:
             db.close()
 
+    @pytest.mark.integration
     def test_security_checks_db_error_propagates_when_no_key(self):
         """A DB error during the no-key token check propagates — fail-closed.
 
@@ -136,6 +141,7 @@ class TestExceptionHandlers:
     routes so the full FastAPI handler path is covered.
     """
 
+    @pytest.mark.integration
     def test_schwab_auth_handler_returns_generic_message(self, client):
         """SchwabAuthError handler returns a generic message, not raw text."""
         from app.main import app
@@ -161,6 +167,7 @@ class TestExceptionHandlers:
                 if getattr(r, "path", None) != "/api/_test/schwab-error"
             ]
 
+    @pytest.mark.integration
     def test_unhandled_exception_does_not_leak_raw_text(self):
         """A generic unhandled exception does not echo its message to the client.
 
@@ -199,6 +206,7 @@ class TestExceptionHandlers:
                 if getattr(r, "path", None) != "/api/_test/boom"
             ]
 
+    @pytest.mark.integration
     def test_data_fetch_error_handler_status_code(self, client):
         """DataFetchError handler maps to HTTP 502."""
         from app.main import app
@@ -218,6 +226,7 @@ class TestExceptionHandlers:
                 if getattr(r, "path", None) != "/api/_test/data-fetch-error"
             ]
 
+    @pytest.mark.integration
     def test_invalid_ticker_error_handler_status_code(self, client):
         """InvalidTickerError handler maps to HTTP 404."""
         from app.main import app
@@ -237,6 +246,7 @@ class TestExceptionHandlers:
                 if getattr(r, "path", None) != "/api/_test/invalid-ticker"
             ]
 
+    @pytest.mark.integration
     def test_value_error_handler_status_code(self, client):
         """ValueError handler maps to HTTP 400."""
         from app.main import app

--- a/backend/tests/test_no_hardcoded_rule_constants.py
+++ b/backend/tests/test_no_hardcoded_rule_constants.py
@@ -20,6 +20,7 @@ threshold remains a hardcoded heuristic.
 """
 
 from __future__ import annotations
+import pytest
 
 import inspect
 
@@ -31,6 +32,7 @@ from app.services import action_engine, recovery_engine
 
 # The rule constants that issue #156 removed. Each must no longer exist as a
 # module attribute on its engine.
+@pytest.mark.unit
 def test_recovery_engine_default_sizing_cap_constant_removed():
     """``DEFAULT_SIZING_CAP_DOLLARS`` no longer exists on the recovery engine."""
     assert not hasattr(recovery_engine, "DEFAULT_SIZING_CAP_DOLLARS"), (
@@ -40,6 +42,7 @@ def test_recovery_engine_default_sizing_cap_constant_removed():
     assert "DEFAULT_SIZING_CAP_DOLLARS" not in recovery_engine.__all__
 
 
+@pytest.mark.unit
 def test_action_engine_itm_short_dte_max_constant_removed():
     """``ITM_SHORT_DTE_MAX_DTE`` no longer exists on the action engine."""
     assert not hasattr(action_engine, "ITM_SHORT_DTE_MAX_DTE"), (
@@ -48,6 +51,7 @@ def test_action_engine_itm_short_dte_max_constant_removed():
     )
 
 
+@pytest.mark.unit
 def test_large_loser_pct_threshold_constant_removed():
     """``LARGE_LOSER_PCT_THRESHOLD`` no longer exists on either consumer.
 
@@ -71,6 +75,7 @@ def test_large_loser_pct_threshold_constant_removed():
         )
 
 
+@pytest.mark.unit
 def test_option_scan_request_rule_fields_default_to_none():
     """The seven ``OptionScanRequest`` rule fields default to ``None``.
 
@@ -95,6 +100,7 @@ def test_option_scan_request_rule_fields_default_to_none():
         )
 
 
+@pytest.mark.unit
 def test_option_scan_request_has_universe_rule_fields():
     """``OptionScanRequest`` carries the universe-rule fields, all default ``None``."""
     fields = OptionScanRequest.model_fields
@@ -103,6 +109,7 @@ def test_option_scan_request_has_universe_rule_fields():
         assert fields[name].default is None
 
 
+@pytest.mark.unit
 def test_no_migrated_constant_name_in_source():
     """A source-text scan confirms the migrated constant names are gone.
 

--- a/backend/tests/test_observability_configs.py
+++ b/backend/tests/test_observability_configs.py
@@ -36,26 +36,31 @@ def loki_config() -> dict:
 class TestDockerComposeServices:
     """Verify docker-compose.prod.yml has required Loki and Grafana services."""
 
+    @pytest.mark.unit
     def test_loki_service_exists(self, compose_config: dict) -> None:
         """Loki service is defined in docker-compose."""
         assert "loki" in compose_config["services"]
 
+    @pytest.mark.unit
     def test_loki_uses_official_image(self, compose_config: dict) -> None:
         """Loki service uses the official Grafana Loki image."""
         loki = compose_config["services"]["loki"]
         assert loki["image"] == "grafana/loki:3.4.2"
 
+    @pytest.mark.unit
     def test_loki_has_healthcheck(self, compose_config: dict) -> None:
         """Loki service has a healthcheck configured."""
         loki = compose_config["services"]["loki"]
         assert "healthcheck" in loki
 
+    @pytest.mark.unit
     def test_loki_memory_limit(self, compose_config: dict) -> None:
         """Loki service respects the 256MB memory budget."""
         loki = compose_config["services"]["loki"]
         memory = loki["deploy"]["resources"]["limits"]["memory"]
         assert memory == "256M"
 
+    @pytest.mark.unit
     def test_loki_exposes_port_3100_on_loopback(self, compose_config: dict) -> None:
         """Loki exposes port 3100 bound to 127.0.0.1 for the Docker log driver."""
         loki = compose_config["services"]["loki"]
@@ -65,31 +70,37 @@ class TestDockerComposeServices:
         # Verify it binds to loopback only (not externally accessible)
         assert any("127.0.0.1" in str(p) for p in ports)
 
+    @pytest.mark.unit
     def test_grafana_service_exists(self, compose_config: dict) -> None:
         """Grafana service is defined in docker-compose."""
         assert "grafana" in compose_config["services"]
 
+    @pytest.mark.unit
     def test_grafana_uses_official_image(self, compose_config: dict) -> None:
         """Grafana service uses the official Grafana image."""
         grafana = compose_config["services"]["grafana"]
         assert grafana["image"] == "grafana/grafana:11.5.2"
 
+    @pytest.mark.unit
     def test_grafana_has_healthcheck(self, compose_config: dict) -> None:
         """Grafana service has a healthcheck configured."""
         grafana = compose_config["services"]["grafana"]
         assert "healthcheck" in grafana
 
+    @pytest.mark.unit
     def test_grafana_memory_limit(self, compose_config: dict) -> None:
         """Grafana service respects the 128MB memory budget."""
         grafana = compose_config["services"]["grafana"]
         memory = grafana["deploy"]["resources"]["limits"]["memory"]
         assert memory == "128M"
 
+    @pytest.mark.unit
     def test_grafana_depends_on_loki(self, compose_config: dict) -> None:
         """Grafana depends on Loki being healthy."""
         grafana = compose_config["services"]["grafana"]
         assert "loki" in grafana["depends_on"]
 
+    @pytest.mark.unit
     def test_grafana_data_volume_persisted(self, compose_config: dict) -> None:
         """Grafana data volume is defined for persistence across restarts."""
         assert "grafana_data" in compose_config["volumes"]
@@ -97,28 +108,33 @@ class TestDockerComposeServices:
         volume_mounts = grafana["volumes"]
         assert any("grafana_data" in str(v) for v in volume_mounts)
 
+    @pytest.mark.unit
     def test_loki_data_volume_persisted(self, compose_config: dict) -> None:
         """Loki data volume is defined for persistence."""
         assert "loki_data" in compose_config["volumes"]
 
+    @pytest.mark.unit
     def test_grafana_auth_disabled_anonymous(self, compose_config: dict) -> None:
         """Grafana has anonymous access disabled."""
         grafana = compose_config["services"]["grafana"]
         env_list = grafana["environment"]
         assert "GF_AUTH_ANONYMOUS_ENABLED=false" in env_list
 
+    @pytest.mark.unit
     def test_grafana_signup_disabled(self, compose_config: dict) -> None:
         """Grafana has user sign-up disabled."""
         grafana = compose_config["services"]["grafana"]
         env_list = grafana["environment"]
         assert "GF_USERS_ALLOW_SIGN_UP=false" in env_list
 
+    @pytest.mark.unit
     def test_grafana_serve_from_subpath(self, compose_config: dict) -> None:
         """Grafana is configured to serve from a subpath (/grafana/)."""
         grafana = compose_config["services"]["grafana"]
         env_list = grafana["environment"]
         assert "GF_SERVER_SERVE_FROM_SUB_PATH=true" in env_list
 
+    @pytest.mark.unit
     def test_grafana_password_requires_env_var(self, compose_config: dict) -> None:
         """Grafana admin password must be set via env var with no weak default."""
         grafana = compose_config["services"]["grafana"]
@@ -134,6 +150,7 @@ class TestDockerComposeServices:
 class TestDockerLogDriver:
     """Verify backend and frontend containers ship logs to Loki."""
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("service", ["backend", "frontend"])
     def test_service_has_loki_log_driver(
         self, compose_config: dict, service: str
@@ -142,6 +159,7 @@ class TestDockerLogDriver:
         svc = compose_config["services"][service]
         assert svc["logging"]["driver"] == "loki"
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("service", ["backend", "frontend"])
     def test_service_log_driver_has_loki_url(
         self, compose_config: dict, service: str
@@ -155,28 +173,34 @@ class TestDockerLogDriver:
 class TestLokiConfig:
     """Verify Loki configuration file structure and settings."""
 
+    @pytest.mark.unit
     def test_loki_config_file_exists(self) -> None:
         """Loki config file exists in deploy directory."""
         assert (DEPLOY_DIR / "loki-config.yml").is_file()
 
+    @pytest.mark.unit
     def test_retention_period_14_days(self, loki_config: dict) -> None:
         """Loki retention is configured for 14 days (336 hours)."""
         retention = loki_config["limits_config"]["retention_period"]
         assert retention == "336h"
 
+    @pytest.mark.unit
     def test_compactor_retention_enabled(self, loki_config: dict) -> None:
         """Loki compactor has retention enabled."""
         assert loki_config["compactor"]["retention_enabled"] is True
 
+    @pytest.mark.unit
     def test_local_filesystem_storage(self, loki_config: dict) -> None:
         """Loki uses local filesystem storage (not S3/GCS)."""
         storage = loki_config["common"]["storage"]["filesystem"]
         assert "chunks_directory" in storage
 
+    @pytest.mark.unit
     def test_analytics_disabled(self, loki_config: dict) -> None:
         """Loki analytics/telemetry is disabled."""
         assert loki_config["analytics"]["reporting_enabled"] is False
 
+    @pytest.mark.unit
     def test_single_instance_replication(self, loki_config: dict) -> None:
         """Loki is configured for single-instance (replication_factor=1)."""
         assert loki_config["common"]["replication_factor"] == 1
@@ -185,11 +209,13 @@ class TestLokiConfig:
 class TestGrafanaProvisioning:
     """Verify Grafana provisioning files for datasources and dashboards."""
 
+    @pytest.mark.unit
     def test_loki_datasource_file_exists(self) -> None:
         """Loki datasource provisioning file exists."""
         path = DEPLOY_DIR / "grafana/provisioning/datasources/loki.yml"
         assert path.is_file()
 
+    @pytest.mark.unit
     def test_loki_datasource_configured(self) -> None:
         """Loki datasource points to the Loki service."""
         path = DEPLOY_DIR / "grafana/provisioning/datasources/loki.yml"
@@ -201,16 +227,19 @@ class TestGrafanaProvisioning:
         assert "loki" in loki_ds["url"]
         assert loki_ds["isDefault"] is True
 
+    @pytest.mark.unit
     def test_dashboard_provider_file_exists(self) -> None:
         """Dashboard provisioning config exists."""
         path = DEPLOY_DIR / "grafana/provisioning/dashboards/dashboards.yml"
         assert path.is_file()
 
+    @pytest.mark.unit
     def test_application_logs_dashboard_exists(self) -> None:
         """Application Logs dashboard JSON exists."""
         path = DEPLOY_DIR / "grafana/provisioning/dashboards/application-logs.json"
         assert path.is_file()
 
+    @pytest.mark.unit
     def test_errors_dashboard_exists(self) -> None:
         """Errors dashboard JSON exists."""
         path = DEPLOY_DIR / "grafana/provisioning/dashboards/errors.json"
@@ -226,10 +255,12 @@ class TestApplicationLogsDashboard:
         path = DEPLOY_DIR / "grafana/provisioning/dashboards/application-logs.json"
         return json.loads(path.read_text())
 
+    @pytest.mark.unit
     def test_dashboard_title(self, dashboard: dict) -> None:
         """Dashboard has correct title."""
         assert dashboard["title"] == "Application Logs"
 
+    @pytest.mark.unit
     def test_has_template_variables(self, dashboard: dict) -> None:
         """Dashboard has container, level, and module template variables."""
         var_names = [v["name"] for v in dashboard["templating"]["list"]]
@@ -237,11 +268,13 @@ class TestApplicationLogsDashboard:
         assert "level" in var_names
         assert "module" in var_names
 
+    @pytest.mark.unit
     def test_has_log_panel(self, dashboard: dict) -> None:
         """Dashboard includes a logs panel."""
         panel_types = [p["type"] for p in dashboard["panels"]]
         assert "logs" in panel_types
 
+    @pytest.mark.unit
     def test_has_unique_uid(self, dashboard: dict) -> None:
         """Dashboard has a stable UID for provisioning."""
         assert dashboard["uid"] == "app-logs"
@@ -256,10 +289,12 @@ class TestErrorsDashboard:
         path = DEPLOY_DIR / "grafana/provisioning/dashboards/errors.json"
         return json.loads(path.read_text())
 
+    @pytest.mark.unit
     def test_dashboard_title(self, dashboard: dict) -> None:
         """Dashboard has correct title."""
         assert dashboard["title"] == "Errors"
 
+    @pytest.mark.unit
     def test_filters_error_warning_levels(self, dashboard: dict) -> None:
         """Dashboard queries filter for ERROR and WARNING levels."""
         log_panel = next(p for p in dashboard["panels"] if p["type"] == "logs")
@@ -267,11 +302,13 @@ class TestErrorsDashboard:
         assert "ERROR" in expr
         assert "WARNING" in expr
 
+    @pytest.mark.unit
     def test_has_stat_panels(self, dashboard: dict) -> None:
         """Dashboard has stat panels for error/warning counts."""
         stat_panels = [p for p in dashboard["panels"] if p["type"] == "stat"]
         assert len(stat_panels) >= 2
 
+    @pytest.mark.unit
     def test_has_unique_uid(self, dashboard: dict) -> None:
         """Dashboard has a stable UID for provisioning."""
         assert dashboard["uid"] == "errors"
@@ -286,25 +323,30 @@ class TestAlertingConfig:
         path = DEPLOY_DIR / "grafana/provisioning/alerting/alerts.yml"
         return yaml.safe_load(path.read_text())
 
+    @pytest.mark.unit
     def test_alerting_file_exists(self) -> None:
         """Alerting provisioning file exists."""
         path = DEPLOY_DIR / "grafana/provisioning/alerting/alerts.yml"
         assert path.is_file()
 
+    @pytest.mark.unit
     def test_contact_point_configured(self, alert_config: dict) -> None:
         """At least one contact point is configured."""
         assert len(alert_config["contactPoints"]) >= 1
 
+    @pytest.mark.unit
     def test_contact_point_type(self, alert_config: dict) -> None:
         """Contact point uses Slack webhook."""
         cp = alert_config["contactPoints"][0]
         receiver = cp["receivers"][0]
         assert receiver["type"] == "slack"
 
+    @pytest.mark.unit
     def test_alert_rule_exists(self, alert_config: dict) -> None:
         """At least one alert rule group is defined."""
         assert len(alert_config["groups"]) >= 1
 
+    @pytest.mark.unit
     def test_error_rate_alert_threshold(self, alert_config: dict) -> None:
         """Error rate alert has a threshold > 5 errors."""
         rule = alert_config["groups"][0]["rules"][0]
@@ -314,6 +356,7 @@ class TestAlertingConfig:
         threshold_value = threshold_data["model"]["conditions"][0]["evaluator"]["params"][0]
         assert threshold_value == 5
 
+    @pytest.mark.unit
     def test_notification_policy_exists(self, alert_config: dict) -> None:
         """A notification policy routes alerts to the contact point."""
         policies = alert_config["policies"]
@@ -329,20 +372,24 @@ class TestCaddyfileGrafanaRoute:
         """Load the Caddyfile content."""
         return (DEPLOY_DIR / "Caddyfile").read_text()
 
+    @pytest.mark.unit
     def test_grafana_route_exists(self, caddyfile_content: str) -> None:
         """Caddyfile has a /grafana route."""
         assert "/grafana/" in caddyfile_content
 
+    @pytest.mark.unit
     def test_grafana_proxies_to_service(self, caddyfile_content: str) -> None:
         """Caddyfile proxies /grafana to the grafana service on port 3000."""
         assert "grafana:3000" in caddyfile_content
 
+    @pytest.mark.unit
     def test_grafana_route_before_catch_all(self, caddyfile_content: str) -> None:
         """Grafana route is defined before the frontend catch-all handler."""
         grafana_pos = caddyfile_content.index("/grafana/")
         catchall_pos = caddyfile_content.index("handle {")
         assert grafana_pos < catchall_pos
 
+    @pytest.mark.unit
     def test_grafana_route_clears_csp_header(self, caddyfile_content: str) -> None:
         """Grafana handler clears the global CSP so Grafana can manage its own."""
         # Find the grafana handler block and check it contains CSP clearing
@@ -357,11 +404,14 @@ class TestCaddyfileGrafanaRoute:
 class TestLokiServiceHealth:
     """Loki service health verification (requires running Docker environment)."""
 
+    @pytest.mark.unit
     def test_loki_ready_endpoint(self) -> None:
         """Loki /ready endpoint returns 200."""
 
+    @pytest.mark.unit
     def test_grafana_health_endpoint(self) -> None:
         """Grafana /api/health endpoint returns 200."""
 
+    @pytest.mark.unit
     def test_log_ingestion(self) -> None:
         """Logs from backend container appear in Loki."""

--- a/backend/tests/test_options_scanner.py
+++ b/backend/tests/test_options_scanner.py
@@ -118,16 +118,19 @@ def csp_request():
 
 
 class TestValidation:
+    @pytest.mark.unit
     def test_invalid_strategy(self, scanner):
         req = OptionScanRequest(ticker="X", strategy="butterfly", cost_basis=10.0)
         with pytest.raises(ValueError, match="Invalid strategy"):
             scanner._validate_request(req)
 
+    @pytest.mark.unit
     def test_cc_requires_cost_basis(self, scanner):
         req = OptionScanRequest(ticker="X", strategy="covered_call")
         with pytest.raises(ValueError, match="cost_basis"):
             scanner._validate_request(req)
 
+    @pytest.mark.unit
     def test_csp_requires_capital(self, scanner):
         req = OptionScanRequest(ticker="X", strategy="cash_secured_put")
         with pytest.raises(ValueError, match="capital_available"):
@@ -135,6 +138,7 @@ class TestValidation:
 
 
 class TestRejectionFilters:
+    @pytest.mark.unit
     def test_10pct_rule_rejects_close_strike(self, scanner, cc_request):
         # Strike $16 is only 6.7% above $15 cost basis, needs 10%
         reasons = scanner._check_rejection(
@@ -143,6 +147,7 @@ class TestRejectionFilters:
         )
         assert any("fails_10pct_rule" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_10pct_rule_passes_far_strike(self, scanner, cc_request):
         # Strike $17 is 13.3% above $15 cost basis
         reasons = scanner._check_rejection(
@@ -151,6 +156,7 @@ class TestRejectionFilters:
         )
         assert not any("fails_10pct_rule" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_delta_out_of_range_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
@@ -158,6 +164,7 @@ class TestRejectionFilters:
         )
         assert any("delta_out_of_range" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_delta_in_range_passes(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
@@ -165,6 +172,7 @@ class TestRejectionFilters:
         )
         assert not any("delta_out_of_range" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_missing_delta_not_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
@@ -172,6 +180,7 @@ class TestRejectionFilters:
         )
         assert not any("delta" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_low_oi_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
@@ -179,6 +188,7 @@ class TestRejectionFilters:
         )
         assert any("low_open_interest" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_zero_bid_rejected(self, scanner, cc_request):
         reasons = scanner._check_rejection(
             cc_request, strike=17.0, current_price=14.0,
@@ -186,6 +196,7 @@ class TestRejectionFilters:
         )
         assert any("zero_bid" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_itm_put_rejected(self, scanner, csp_request):
         # Put strike $15 > current price $14
         reasons = scanner._check_rejection(
@@ -194,6 +205,7 @@ class TestRejectionFilters:
         )
         assert any("itm_put" in r for r in reasons)
 
+    @pytest.mark.unit
     def test_otm_put_passes(self, scanner, csp_request):
         # Put strike $13 < current price $14
         reasons = scanner._check_rejection(
@@ -204,6 +216,7 @@ class TestRejectionFilters:
 
 
 class TestMetricCalculations:
+    @pytest.mark.unit
     def test_covered_call_metrics(self, scanner, cc_request):
         metrics = scanner._calculate_metrics(
             cc_request, strike=17.0, current_price=14.0, mid=0.45, dte=34,
@@ -221,6 +234,7 @@ class TestMetricCalculations:
         # 50% target = 135 * 0.5 = 67.5
         assert metrics["fifty_pct_profit_target"] == 67.5
 
+    @pytest.mark.unit
     def test_cash_secured_put_metrics(self, scanner, csp_request):
         metrics = scanner._calculate_metrics(
             csp_request, strike=13.0, current_price=14.0, mid=0.40, dte=30,
@@ -240,6 +254,7 @@ class TestMetricCalculations:
 
 
 class TestRanking:
+    @pytest.mark.unit
     def test_ranking_order(self, scanner):
         """Higher return and distance should rank better."""
         compliance = RuleCompliance(
@@ -275,6 +290,7 @@ class TestRanking:
         assert ranked[0].rank == 1
         assert ranked[1].rank == 2
 
+    @pytest.mark.unit
     def test_single_candidate(self, scanner):
         compliance = RuleCompliance(
             passes_10pct_rule=True, passes_dte_range=True,
@@ -294,21 +310,26 @@ class TestRanking:
         assert len(ranked) == 1
         assert ranked[0].rank == 1
 
+    @pytest.mark.unit
     def test_empty_candidates(self, scanner):
         ranked = scanner._rank_strikes([])
         assert ranked == []
 
 
 class TestNormalization:
+    @pytest.mark.unit
     def test_normalize_normal(self):
         assert _normalize_val(5, [0, 5, 10]) == 0.5
 
+    @pytest.mark.unit
     def test_normalize_min(self):
         assert _normalize_val(0, [0, 5, 10]) == 0.0
 
+    @pytest.mark.unit
     def test_normalize_max(self):
         assert _normalize_val(10, [0, 5, 10]) == 1.0
 
+    @pytest.mark.unit
     def test_normalize_equal_values(self):
         assert _normalize_val(5, [5, 5, 5]) == 0.5
 
@@ -316,6 +337,7 @@ class TestNormalization:
 class TestScanWithSchwabChain:
     """Integration-style tests for scan() using mocked Schwab chain responses."""
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_covered_call_scan_returns_results(self, mock_client_cls, _mock_earnings, scanner, cc_request):
@@ -355,6 +377,7 @@ class TestScanWithSchwabChain:
         assert rec.delta == -0.20
         assert rec.gamma == 0.03
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_csp_scan_returns_results(self, mock_client_cls, _mock_earnings, scanner, csp_request):
@@ -390,6 +413,7 @@ class TestScanWithSchwabChain:
         assert rec.greeks_source == "market"
         assert rec.delta == -0.25
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_scan_no_chains_returns_empty(self, mock_client_cls, _mock_earnings, scanner, cc_request):
@@ -410,6 +434,7 @@ class TestScanWithSchwabChain:
 
         assert result["recommendations"] == []
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_greeks_source_market_when_available(self, mock_client_cls, _mock_earnings, scanner, cc_request):
@@ -440,6 +465,7 @@ class TestScanWithSchwabChain:
             assert rec.greeks_source == "market"
             assert "missing_greeks" not in rec.flags
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_schwab_sentinel_greeks_uses_calculated_fallback(self, mock_client_cls, _mock_earnings, scanner, csp_request):
@@ -482,6 +508,7 @@ class TestScanWithSchwabChain:
             assert rec.theta is not None
             assert rec.vega is not None
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_schwab_error_raises_scanner_error(self, mock_client_cls, scanner, cc_request):
         from app.services.schwab_client import SchwabClientError
@@ -493,6 +520,7 @@ class TestScanWithSchwabChain:
         with pytest.raises(OptionScannerError, match="Failed to fetch option chain"):
             scanner.scan(cc_request)
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_schwab_client_error_does_not_leak_internals(self, mock_client_cls, scanner, cc_request):
         """Transport/HTTP errors must not expose raw details to the user."""
@@ -512,6 +540,7 @@ class TestScanWithSchwabChain:
         assert "schwabapi.com" not in error_msg
         assert "Internal Server Error" not in error_msg
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.SchwabClient")
     def test_schwab_auth_error_returns_sanitized_message(self, mock_client_cls, scanner, cc_request):
         """No token configured error must not leak internal details (issue #41)."""
@@ -534,6 +563,7 @@ class TestScanWithSchwabChain:
 
 
 class TestExpirationFiltering:
+    @pytest.mark.unit
     def test_dte_range_filter(self, scanner):
         today = datetime.now().date()
         exp_date_map = {
@@ -546,6 +576,7 @@ class TestExpirationFiltering:
         valid = scanner._get_valid_expirations(exp_date_map, 25, 50, None, 5)
         assert len(valid) == 2
 
+    @pytest.mark.unit
     def test_earnings_buffer_filter(self, scanner):
         today = datetime.now().date()
         earnings = (today + timedelta(days=35)).strftime("%Y-%m-%d")
@@ -563,6 +594,7 @@ class TestExpirationFiltering:
 class TestHumanReasonsPopulated:
     """Issue #190 — every ``RejectedStrike`` carries a parallel human_reasons list."""
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_rejected_strikes_have_human_reasons(self, mock_client_cls, _earnings, scanner, cc_request):
@@ -615,6 +647,7 @@ class TestHumanReasonsPopulated:
                 assert "fails_10pct_rule" not in sentence
                 assert "low_open_interest" not in sentence
 
+    @pytest.mark.unit
     @patch("app.services.options_scanner.get_next_earnings_date", return_value=None)
     @patch("app.services.options_scanner.SchwabClient")
     def test_return_below_target_rejection_has_human_reason(self, mock_client_cls, _earnings, scanner, cc_request):

--- a/backend/tests/test_parsing.py
+++ b/backend/tests/test_parsing.py
@@ -8,49 +8,63 @@ from app.utils.parsing import to_float, to_int
 class TestToFloat:
     """Tests for null-safe float coercion."""
 
+    @pytest.mark.unit
     def test_valid_string(self):
         assert to_float("3.14") == 3.14
 
+    @pytest.mark.unit
     def test_integer_string(self):
         assert to_float("42") == 42.0
 
+    @pytest.mark.unit
     def test_none_input(self):
         assert to_float(None) == 0.0
 
+    @pytest.mark.unit
     def test_empty_string(self):
         assert to_float("") == 0.0
 
+    @pytest.mark.unit
     def test_non_numeric(self):
         assert to_float("abc") == 0.0
 
+    @pytest.mark.unit
     def test_custom_default(self):
         assert to_float("abc", default=None) is None
 
+    @pytest.mark.unit
     def test_custom_default_numeric(self):
         assert to_float(None, default=-1.0) == -1.0
 
+    @pytest.mark.unit
     def test_with_commas_returns_default(self):
         """Python's float() does not handle commas — returns default."""
         assert to_float("1,234.56") == 0.0
 
+    @pytest.mark.unit
     def test_boolean_input(self):
         """Python float(True) == 1.0, float(False) == 0.0."""
         assert to_float(True) == 1.0
         assert to_float(False) == 0.0
 
+    @pytest.mark.unit
     def test_already_float(self):
         assert to_float(3.14) == 3.14
 
+    @pytest.mark.unit
     def test_whitespace_string(self):
         """Python float() strips leading/trailing whitespace."""
         assert to_float("  3.14  ") == 3.14
 
+    @pytest.mark.unit
     def test_negative_string(self):
         assert to_float("-7.5") == -7.5
 
+    @pytest.mark.unit
     def test_scientific_notation(self):
         assert to_float("1e3") == 1000.0
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "value, expected",
         [
@@ -68,38 +82,49 @@ class TestToFloat:
 class TestToInt:
     """Tests for null-safe int coercion via int(float(value))."""
 
+    @pytest.mark.unit
     def test_valid_string(self):
         assert to_int("42") == 42
 
+    @pytest.mark.unit
     def test_none_input(self):
         assert to_int(None) == 0
 
+    @pytest.mark.unit
     def test_empty_string(self):
         assert to_int("") == 0
 
+    @pytest.mark.unit
     def test_float_string_truncates(self):
         """int(float('3.7')) truncates toward zero, not rounds."""
         assert to_int("3.7") == 3
 
+    @pytest.mark.unit
     def test_negative_float_string_truncates_toward_zero(self):
         """int(float('-2.9')) == -2, not -3."""
         assert to_int("-2.9") == -2
 
+    @pytest.mark.unit
     def test_non_numeric(self):
         assert to_int("abc") == 0
 
+    @pytest.mark.unit
     def test_custom_default(self):
         assert to_int("abc", default=-1) == -1
 
+    @pytest.mark.unit
     def test_already_int(self):
         assert to_int(42) == 42
 
+    @pytest.mark.unit
     def test_float_input_truncates(self):
         assert to_int(3.9) == 3
 
+    @pytest.mark.unit
     def test_zero(self):
         assert to_int("0") == 0
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "value, expected",
         [

--- a/backend/tests/test_position_notes_model.py
+++ b/backend/tests/test_position_notes_model.py
@@ -62,6 +62,7 @@ def _seed_position(session, position_id: str | None = None) -> str:
 # --- Migration up: table appears via create_all ---
 
 
+@pytest.mark.unit
 def test_create_all_creates_position_notes_table():
     """``Base.metadata.create_all`` materializes the new table."""
     engine = _make_engine()
@@ -70,6 +71,7 @@ def test_create_all_creates_position_notes_table():
     assert "position_notes" in inspector.get_table_names()
 
 
+@pytest.mark.unit
 def test_position_notes_columns_match_plan():
     """Frozen column set per plan §3.2 / §4.3."""
     engine = _make_engine()
@@ -89,6 +91,7 @@ def test_position_notes_columns_match_plan():
     assert "body" in cols
 
 
+@pytest.mark.unit
 def test_position_notes_position_id_indexed():
     """``position_id`` is indexed (frequent lookup column)."""
     engine = _make_engine()
@@ -102,6 +105,7 @@ def test_position_notes_position_id_indexed():
 # --- Migration down: explicit DROP TABLE cleans up ---
 
 
+@pytest.mark.unit
 def test_drop_table_removes_position_notes_without_touching_positions():
     """The documented manual rollback path removes only the new table."""
     engine = _make_engine()
@@ -119,6 +123,7 @@ def test_drop_table_removes_position_notes_without_touching_positions():
     assert "positions" in inspector.get_table_names()
 
 
+@pytest.mark.unit
 def test_create_all_is_idempotent():
     """Calling ``create_all`` twice on an existing DB is a no-op."""
     engine = _make_engine()
@@ -132,6 +137,7 @@ def test_create_all_is_idempotent():
 # --- Constraint enforcement ---
 
 
+@pytest.mark.unit
 def test_unique_constraint_on_position_id():
     """A single position can hold only one note row."""
     engine = _make_engine()
@@ -168,6 +174,7 @@ def test_unique_constraint_on_position_id():
         session.close()
 
 
+@pytest.mark.unit
 def test_fk_rejects_orphan_position_id():
     """A note pointing at a non-existent position is rejected."""
     engine = _make_engine()
@@ -191,6 +198,7 @@ def test_fk_rejects_orphan_position_id():
         session.close()
 
 
+@pytest.mark.unit
 def test_body_roundtrips_unchanged():
     """``body`` is the column name and the text survives a round-trip."""
     engine = _make_engine()

--- a/backend/tests/test_position_state.py
+++ b/backend/tests/test_position_state.py
@@ -124,6 +124,7 @@ def _seed_position(
 class TestSingleTrades:
     """Recomputer applied to ledgers with a single trade type."""
 
+    @pytest.mark.unit
     def test_sell_put_only_stays_open_zero_shares(self, db_session):
         pos = _seed_position(
             db_session,
@@ -150,6 +151,7 @@ class TestSingleTrades:
         assert result.broker_cost_basis == 0.0
         assert result.closed_at is None
 
+    @pytest.mark.unit
     def test_sell_call_only_stays_open(self, db_session):
         pos = _seed_position(
             db_session,
@@ -178,6 +180,7 @@ class TestSingleTrades:
 class TestLifecycleScenarios:
     """End-to-end cycles a wheel trader actually walks through."""
 
+    @pytest.mark.unit
     def test_sell_put_then_buy_to_close_closes_position(self, db_session):
         pos = _seed_position(
             db_session,
@@ -205,6 +208,7 @@ class TestLifecycleScenarios:
         assert result.broker_cost_basis == 0.0
         assert result.closed_at == "2026-03-05"
 
+    @pytest.mark.unit
     def test_sell_put_then_assignment_acquires_shares(self, db_session):
         pos = _seed_position(
             db_session,
@@ -231,6 +235,7 @@ class TestLifecycleScenarios:
         assert result.shares == 100
         assert result.broker_cost_basis == 1350.0
 
+    @pytest.mark.unit
     def test_full_wheel_cycle_called_away(self, db_session):
         pos = _seed_position(
             db_session,
@@ -270,6 +275,7 @@ class TestLifecycleScenarios:
         assert result.broker_cost_basis == 0.0
         assert result.closed_at == "2026-03-20"
 
+    @pytest.mark.unit
     def test_sell_put_then_expired_closes_position(self, db_session):
         pos = _seed_position(
             db_session,
@@ -297,6 +303,7 @@ class TestLifecycleScenarios:
         assert result.broker_cost_basis == 0.0
         assert result.closed_at == "2026-04-17"
 
+    @pytest.mark.unit
     def test_double_assignment_aggregates_shares_and_basis(self, db_session):
         pos = _seed_position(
             db_session,
@@ -335,6 +342,7 @@ class TestLifecycleScenarios:
         assert result.shares == 200
         assert result.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
 
+    @pytest.mark.unit
     def test_two_open_legs_one_closed_position_stays_open(self, db_session):
         pos = _seed_position(
             db_session,
@@ -372,6 +380,7 @@ class TestLifecycleScenarios:
         assert result.shares == 0
         assert result.closed_at is None
 
+    @pytest.mark.unit
     def test_covered_call_expires_keeps_shares(self, db_session):
         # Wheel mid-cycle: assigned 100 shares from a put, then sold a covered
         # call that expired worthless. Position must stay open with shares and
@@ -418,6 +427,7 @@ class TestLifecycleScenarios:
         assert result.broker_cost_basis == pytest.approx(1350.0)
         assert result.closed_at is None
 
+    @pytest.mark.unit
     def test_partial_called_away_keeps_position_open(self, db_session):
         # 200 shares held (two assignments at $20), 1 call exercised at $22.
         # Expectation: 100 shares remain, basis halved, status stays open.
@@ -480,9 +490,11 @@ class TestLifecycleScenarios:
 class TestEdgeCases:
     """Defensive behavior when the trade ledger is unusual or partially valid."""
 
+    @pytest.mark.unit
     def test_returns_none_for_unknown_position_id(self, db_session):
         assert recompute_position_state(db_session, "nonexistent-id") is None
 
+    @pytest.mark.unit
     def test_orphan_buy_to_close_does_not_raise(self, db_session, caplog):
         # Closing trade with no matching open leg; recomputer must not raise.
         pos = _seed_position(
@@ -509,6 +521,7 @@ class TestEdgeCases:
             for record in caplog.records
         )
 
+    @pytest.mark.unit
     def test_idempotent_two_runs_same_state(self, db_session):
         pos = _seed_position(
             db_session,
@@ -534,6 +547,7 @@ class TestEdgeCases:
         second = recompute_position_state(db_session, pos.id)
         assert (second.status, second.shares, second.broker_cost_basis, second.closed_at) == snapshot
 
+    @pytest.mark.unit
     def test_out_of_order_trades_sorted_by_opened_at(self, db_session):
         # Insert assignment first (chronologically later), then sell_put.
         pos = _seed_position(
@@ -563,6 +577,7 @@ class TestEdgeCases:
         assert result.shares == 100
         assert result.broker_cost_basis == 1350.0
 
+    @pytest.mark.unit
     def test_dry_run_does_not_commit(self, db_session):
         pos = _seed_position(
             db_session,
@@ -597,6 +612,7 @@ class TestEdgeCases:
         assert reloaded.shares == 999
         assert reloaded.broker_cost_basis == 12345.67
 
+    @pytest.mark.unit
     def test_quantity_two_assignment_acquires_two_lots(self, db_session):
         # A single assignment row with quantity=2 should acquire 200 shares
         # at strike, and consume 2 open put legs at the same strike/expiration.
@@ -655,27 +671,33 @@ class TestDeriveStrategyLabel:
             trade_id="test-leg-call",
         )
 
+    @pytest.mark.unit
     def test_zero_shares_only_open_puts_is_csp(self):
         assert _derive_strategy_label(0, [self._put_leg()]) == "csp"
 
+    @pytest.mark.unit
     def test_shares_held_only_open_calls_is_cc(self):
         assert _derive_strategy_label(100, [self._call_leg()]) == "cc"
 
+    @pytest.mark.unit
     def test_shares_held_open_puts_and_calls_is_wheel(self):
         assert (
             _derive_strategy_label(100, [self._put_leg(), self._call_leg()])
             == "wheel"
         )
 
+    @pytest.mark.unit
     def test_shares_held_no_open_legs_is_holding(self):
         assert _derive_strategy_label(100, []) == "holding"
 
+    @pytest.mark.unit
     def test_zero_shares_no_open_legs_is_csp(self):
         # The closed-position case: status is closed and the label is not
         # rendered on the dashboard, but the helper still returns a defined
         # label so callers can use it unconditionally.
         assert _derive_strategy_label(0, []) == "csp"
 
+    @pytest.mark.unit
     def test_zero_shares_only_open_calls_is_cc_with_warning(self, caplog):
         # Anomalous (naked-call) case: derive ``cc`` and log a warning
         # because no shares + open calls should not occur in a wheel-only
@@ -689,6 +711,7 @@ class TestDeriveStrategyLabel:
             for record in caplog.records
         )
 
+    @pytest.mark.unit
     def test_shares_held_only_open_puts_is_csp(self):
         # Layered-entry edge case: short put while holding shares (e.g.
         # selling a deeper put after assignment but before the next call).
@@ -699,6 +722,7 @@ class TestDeriveStrategyLabel:
 class TestRecomputeWritesDerivedStrategy:
     """Integration: ``recompute_position_state`` must persist the derived label."""
 
+    @pytest.mark.unit
     def test_csp_flow_writes_csp_label(self, db_session):
         pos = _seed_position(
             db_session,
@@ -722,6 +746,7 @@ class TestRecomputeWritesDerivedStrategy:
         assert result.shares == 0
         assert result.strategy == "csp"
 
+    @pytest.mark.unit
     def test_holding_flow_writes_holding_label(self, db_session):
         # sell_put → assignment leaves 100 shares, no open legs → holding.
         pos = _seed_position(
@@ -748,6 +773,7 @@ class TestRecomputeWritesDerivedStrategy:
         assert result.shares == 100
         assert result.strategy == "holding"
 
+    @pytest.mark.unit
     def test_cc_flow_writes_cc_label(self, db_session):
         # Hold shares + open call leg → cc.
         pos = _seed_position(
@@ -784,6 +810,7 @@ class TestRecomputeWritesDerivedStrategy:
         assert result.shares == 100
         assert result.strategy == "cc"
 
+    @pytest.mark.unit
     def test_wheel_flow_writes_wheel_label(self, db_session):
         # Hold shares + open call AND open put → wheel.
         pos = _seed_position(
@@ -824,6 +851,7 @@ class TestRecomputeWritesDerivedStrategy:
         assert result.shares == 100
         assert result.strategy == "wheel"
 
+    @pytest.mark.unit
     def test_closed_position_retains_last_derived_label(self, db_session):
         # Full round trip → shares back to 0, no open legs → status closed.
         # The label is whatever the helper says for ``(0, [])`` — currently
@@ -866,6 +894,7 @@ class TestRecomputeWritesDerivedStrategy:
         assert result.shares == 0
         assert result.strategy == "csp"
 
+    @pytest.mark.unit
     def test_recompute_overwrites_stale_label(self, db_session):
         # Seeded with "wheel" but real ledger derives "holding". The
         # recomputer must overwrite the stale value — this is the user-
@@ -909,6 +938,7 @@ class TestLegPairingOnResolution:
     (calendar fallback).
     """
 
+    @pytest.mark.unit
     def test_sell_put_assignment_closes_put_leg(self, db_session):
         # AC #1: After importing a wheel cycle ``sell_put → assignment`` the
         # originating ``sell_put`` leg is closed and does not appear in the
@@ -946,6 +976,7 @@ class TestLegPairingOnResolution:
         assert sell_put is not None
         assert sell_put.closed_at == "2026-03-27"
 
+    @pytest.mark.unit
     def test_sell_call_called_away_closes_call_leg(self, db_session):
         # AC #2: After importing ``sell_call → called_away`` the originating
         # ``sell_call`` leg is closed.
@@ -989,6 +1020,7 @@ class TestLegPairingOnResolution:
         assert result.status == "closed"
         assert result.shares == 0
 
+    @pytest.mark.unit
     def test_sell_put_past_expiration_no_close_trade_closes_calendar(
         self, db_session
     ):
@@ -1026,6 +1058,7 @@ class TestLegPairingOnResolution:
         assert sell_put is not None
         assert sell_put.closed_at == "2025-09-26"
 
+    @pytest.mark.unit
     def test_sell_call_past_expiration_no_close_trade_closes_calendar(
         self, db_session
     ):
@@ -1052,6 +1085,7 @@ class TestLegPairingOnResolution:
         assert result.shares == 0
         assert result.closed_at == "2025-12-19"
 
+    @pytest.mark.unit
     def test_three_stacked_assignments_aggregate_to_300_shares(self, db_session):
         # AC #5: Multiple stacked assignments (the user's reported SOFI case)
         # all close their puts and shares accumulate to 300.
@@ -1112,6 +1146,7 @@ class TestLegPairingOnResolution:
         )
         assert result.strategy == "holding"
 
+    @pytest.mark.unit
     def test_future_expiration_no_close_trade_stays_open(self, db_session):
         # AC #4: Open legs whose expiration is today or later with no
         # closing trade must remain open — calendar fallback must not
@@ -1144,6 +1179,7 @@ class TestFifoFallbackForDirtyData:
     """Strict-then-FIFO pairing covers Schwab CSV rows whose strike or
     expiration drifts slightly from the originating short leg."""
 
+    @pytest.mark.unit
     def test_assignment_with_mismatched_strike_closes_via_fifo(self, db_session):
         # Resolving ``assignment`` strike differs from the open ``sell_put``
         # by a penny. Strict match fails; FIFO fallback consumes the only
@@ -1178,6 +1214,7 @@ class TestFifoFallbackForDirtyData:
         assert result.broker_cost_basis == pytest.approx(1349.0)
         assert result.strategy == "holding"
 
+    @pytest.mark.unit
     def test_called_away_with_mismatched_strike_closes_via_fifo(self, db_session):
         pos = _seed_position(
             db_session,
@@ -1227,6 +1264,7 @@ class TestUnpairedResolvingEvent:
         # genuine first-warning behavior regardless of test order.
         _reset_unpaired_warning_cache()
 
+    @pytest.mark.unit
     def test_assignment_with_no_matching_put_leg_warns_but_no_error(
         self, db_session, caplog
     ):
@@ -1260,6 +1298,7 @@ class TestUnpairedResolvingEvent:
         assert result.shares == 100
         assert result.broker_cost_basis == pytest.approx(5000.0)
 
+    @pytest.mark.unit
     def test_repeat_recompute_does_not_re_emit_warning(
         self, db_session, caplog
     ):
@@ -1322,6 +1361,7 @@ class TestUnpairedResolvingEvent:
 class TestCalendarCloseHelper:
     """Pure-function unit tests for ``_apply_calendar_close``."""
 
+    @pytest.mark.unit
     def test_empty_open_legs_returns_empty_and_none(self):
         still, latest, consumed = _apply_calendar_close(
             [], "F", date(2026, 5, 8)
@@ -1330,6 +1370,7 @@ class TestCalendarCloseHelper:
         assert latest is None
         assert consumed == []
 
+    @pytest.mark.unit
     def test_all_future_legs_unchanged(self):
         legs = [
             _LegKey(
@@ -1352,6 +1393,7 @@ class TestCalendarCloseHelper:
         assert latest is None
         assert consumed == []
 
+    @pytest.mark.unit
     def test_mix_of_past_and_future_legs(self):
         past = _LegKey(
             option_type="put",
@@ -1374,6 +1416,7 @@ class TestCalendarCloseHelper:
         # Trade.closed_at on the originating rows (issue #136).
         assert consumed == [past]
 
+    @pytest.mark.unit
     def test_multiple_past_legs_returns_latest_expiration(self):
         leg_a = _LegKey(
             option_type="put",
@@ -1403,6 +1446,7 @@ class TestCalendarCloseHelper:
         # callers can correlate consumed legs back to opening trades.
         assert consumed == [leg_a, leg_b, leg_c]
 
+    @pytest.mark.unit
     def test_unparseable_expiration_leaves_leg_alone(self):
         # Defensive: a malformed expiration string shouldn't trigger
         # calendar close (we can't prove it's past expiration).
@@ -1424,6 +1468,7 @@ class TestCalendarCloseRegressionGuard:
     """Calendar fallback must not regress the covered-call-with-shares case
     introduced in PR #130 (``test_covered_call_expires_keeps_shares``)."""
 
+    @pytest.mark.unit
     def test_calendar_close_does_not_regress_covered_call_with_shares(
         self, db_session
     ):
@@ -1499,6 +1544,7 @@ class TestPersistsTradeClosedAt:
     regression in the write-back loop is caught here.
     """
 
+    @pytest.mark.unit
     def test_assignment_stamps_closed_at_on_consumed_put(self, db_session):
         # AC #1 (strict-match path): ``sell_put → assignment`` stamps the
         # consumed sell_put's closed_at to the assignment's opened_at.
@@ -1530,6 +1576,7 @@ class TestPersistsTradeClosedAt:
         # closed_at == resolving trade's opened_at (the assignment's date).
         assert sell_put.closed_at == "2026-03-27"
 
+    @pytest.mark.unit
     def test_called_away_stamps_closed_at_on_consumed_call(self, db_session):
         # AC #1 (call side): ``sell_call → called_away`` stamps the consumed
         # sell_call's closed_at to the called_away's opened_at.
@@ -1576,6 +1623,7 @@ class TestPersistsTradeClosedAt:
         assert sell_call.closed_at == "2026-03-20"
         assert sell_put.closed_at == "2026-02-20"
 
+    @pytest.mark.unit
     def test_buy_to_close_stamps_closed_at_on_consumed_leg(self, db_session):
         # AC #1 (BTC variant): a ``sell_put → buy_put_close`` cycle stamps
         # the sell_put's closed_at to the buy_put_close's opened_at.
@@ -1604,6 +1652,7 @@ class TestPersistsTradeClosedAt:
         assert sell_put is not None
         assert sell_put.closed_at == "2026-03-05"
 
+    @pytest.mark.unit
     def test_fifo_fallback_stamps_closed_at_on_consumed_leg(self, db_session):
         # AC #2: penny-drift assignment matches via FIFO fallback. The
         # consumed sell_put still gets ``closed_at`` stamped to the
@@ -1636,6 +1685,7 @@ class TestPersistsTradeClosedAt:
         assert sell_put is not None
         assert sell_put.closed_at == "2026-03-27"
 
+    @pytest.mark.unit
     def test_calendar_close_stamps_closed_at_with_expiration(self, db_session):
         # AC #3: calendar-fallback close stamps the leg's expiration on the
         # consumed Trade (no real resolving trade exists to supply opened_at).
@@ -1661,6 +1711,7 @@ class TestPersistsTradeClosedAt:
         # No resolving trade — the leg's expiration is the canonical close.
         assert sell_put.closed_at == "2025-09-26"
 
+    @pytest.mark.unit
     def test_recompute_idempotent_preserves_trade_closed_at(self, db_session):
         # AC #5: a second recompute on the same ledger does NOT shift the
         # ``closed_at`` value already written on consumed legs. Locks the
@@ -1701,6 +1752,7 @@ class TestPersistsTradeClosedAt:
         db_session.refresh(sell_put)
         assert sell_put.closed_at == first_close
 
+    @pytest.mark.unit
     def test_orphan_assignment_does_not_stamp_anything(self, db_session):
         # When both strict and FIFO passes fail (no matching open leg), no
         # Trade should receive a phantom ``closed_at`` stamp — the orphan
@@ -1727,6 +1779,7 @@ class TestPersistsTradeClosedAt:
         assert assignment is not None
         assert assignment.closed_at is None
 
+    @pytest.mark.unit
     def test_holding_label_yields_empty_open_legs_via_derive_open_legs(
         self, db_session
     ):
@@ -1786,6 +1839,7 @@ class TestPersistsTradeClosedAt:
         # Holding-labeled position must surface zero open legs.
         assert legs == []
 
+    @pytest.mark.unit
     def test_buy_to_close_stamp_outranks_calendar_fallback(self, db_session):
         # When a real ``buy_put_close`` resolves the leg, that resolution
         # stamp must win — even when the recompute runs after the leg's
@@ -1820,6 +1874,7 @@ class TestPersistsTradeClosedAt:
         # Real resolving date wins, not the synthetic expiration.
         assert sell_put.closed_at == "2026-03-05"
 
+    @pytest.mark.unit
     def test_real_resolution_overwrites_synthetic_calendar_stamp(
         self, db_session
     ):
@@ -1879,6 +1934,7 @@ class TestPersistsTradeClosedAt:
         db_session.refresh(sell_put)
         assert sell_put.closed_at == "2026-03-15"
 
+    @pytest.mark.unit
     def test_called_away_overwrites_synthetic_calendar_stamp(self, db_session):
         # Symmetric variant of the issue #138 regression: synthetic calendar
         # stamp on a sell_call must be overwritten by a real ``called_away``
@@ -1941,6 +1997,7 @@ class TestPersistsTradeClosedAt:
         db_session.refresh(sell_call)
         assert sell_call.closed_at == "2026-03-18"
 
+    @pytest.mark.unit
     def test_real_resolution_value_preserved_when_already_stamped(
         self, db_session
     ):
@@ -1987,6 +2044,7 @@ class TestPersistsTradeClosedAt:
         db_session.refresh(sell_put)
         assert sell_put.closed_at == "2025-09-15"
 
+    @pytest.mark.unit
     def test_calendar_close_recompute_is_idempotent_under_equality_skip(
         self, db_session
     ):
@@ -2065,6 +2123,7 @@ class TestAssignmentBasisNetting:
         # creates rather than a demoted INFO from a prior run.
         _reset_unpaired_warning_cache()
 
+    @pytest.mark.unit
     def test_basis_nets_assignment_premium(self, db_session):
         # Canonical wheel cycle: Sell Put @ $13.50, premium $0.30, fees $0.66,
         # 1 contract → Assignment. Net premium = $30 - $0.66 = $29.34. Basis =
@@ -2097,6 +2156,7 @@ class TestAssignmentBasisNetting:
         assert result.shares == 100
         assert result.broker_cost_basis == pytest.approx(1320.66, abs=1e-4)
 
+    @pytest.mark.unit
     def test_basis_nets_multi_contract_assignment(self, db_session):
         # Sell 5 Puts @ $20.00 premium $0.40 fees $3.30; all 5 assigned.
         # Net premium = 5 * 100 * 0.40 - 3.30 = 200 - 3.30 = 196.70.
@@ -2130,6 +2190,7 @@ class TestAssignmentBasisNetting:
         assert result.shares == 500
         assert result.broker_cost_basis == pytest.approx(9803.30, abs=1e-4)
 
+    @pytest.mark.unit
     def test_basis_prorates_fees_on_partial_assignment(self, db_session):
         # Sell 5 Puts @ $20.00 premium $0.40 fees $3.30; only 3 assigned.
         # Each consumed contract gets ``3.30 / 5 = 0.66`` of the fee budget.
@@ -2168,6 +2229,7 @@ class TestAssignmentBasisNetting:
         assert result.shares == 300
         assert result.broker_cost_basis == pytest.approx(5881.98, abs=1e-4)
 
+    @pytest.mark.unit
     def test_basis_canonical_f_case_exact_1320_66(self, db_session):
         # Locks the user-facing AC from issue #183: the canonical F-case
         # must produce exactly $1320.66 (matches Schwab + IRS records).
@@ -2200,6 +2262,7 @@ class TestAssignmentBasisNetting:
         # 1350 - 29.34 = 1320.66 lands cleanly in float.
         assert result.broker_cost_basis == 1320.66
 
+    @pytest.mark.unit
     def test_basis_multi_cycle_matches_assigned_put_not_expired(
         self, db_session
     ):
@@ -2249,6 +2312,7 @@ class TestAssignmentBasisNetting:
         assert result.shares == 100
         assert result.broker_cost_basis == pytest.approx(1955.66, abs=1e-4)
 
+    @pytest.mark.unit
     def test_basis_falls_back_when_no_matching_put(self, db_session, caplog):
         # Orphan assignment row — basis falls back to raw strike × shares,
         # a WARNING is logged, and the recomputer does not crash.
@@ -2277,6 +2341,7 @@ class TestAssignmentBasisNetting:
             for record in caplog.records
         )
 
+    @pytest.mark.unit
     def test_basis_zero_premium_no_netting_no_warning(self, db_session, caplog):
         # Backward-compat: a sell_put with premium=0.0 (legacy imports) still
         # matches — yielding a net premium of 0.0 — so basis equals raw
@@ -2315,6 +2380,7 @@ class TestComputeAssignmentNetting:
     """Pure-function unit tests for the shared netting helper used by the
     journal read path."""
 
+    @pytest.mark.unit
     def test_no_assignment_returns_empty(self, db_session):
         pos = _seed_position(
             db_session,
@@ -2333,6 +2399,7 @@ class TestComputeAssignmentNetting:
 
         assert compute_assignment_netting(list(pos.trades)) == {}
 
+    @pytest.mark.unit
     def test_assignment_returns_gross_premium_dollars(self, db_session):
         # The helper reports gross premium dollars only — fees are NOT
         # included (compute_total_premiums excludes fees in the same way).
@@ -2362,6 +2429,7 @@ class TestComputeAssignmentNetting:
         # 0.30 * 100 = 30.00 gross premium dollars netted for one contract.
         assert result == {sell_put.id: pytest.approx(30.0, abs=1e-4)}
 
+    @pytest.mark.unit
     def test_orphan_assignment_returns_empty(self, db_session):
         # No matching sell_put → nothing to net. The journal read path uses
         # an empty map so it doesn't double-count premiums that aren't there.

--- a/backend/tests/test_reconcile_positions.py
+++ b/backend/tests/test_reconcile_positions.py
@@ -84,6 +84,7 @@ def _seed_ghost_open_position(
 
 
 class TestReconcileAll:
+    @pytest.mark.unit
     def test_dry_run_makes_no_writes(self, db_session, capsys):
         pos = _seed_ghost_open_position(
             db_session,
@@ -121,6 +122,7 @@ class TestReconcileAll:
         assert "DRY RUN" in captured.out
         assert "MARA" in captured.out
 
+    @pytest.mark.unit
     def test_apply_corrects_ghost_open_positions(self, db_session, capsys):
         # Bad state: shares=100, status=open. Real ledger: full cycle ending
         # in called_away → should be closed with 0 shares.
@@ -171,6 +173,7 @@ class TestReconcileAll:
         captured = capsys.readouterr()
         assert "Applied" in captured.out
 
+    @pytest.mark.unit
     def test_apply_aggregates_double_assignment(self, db_session):
         # Bad state: shares=100. Real ledger: two assignments → 200 shares.
         pos = _seed_ghost_open_position(
@@ -213,6 +216,7 @@ class TestReconcileAll:
         assert reloaded.shares == 200
         assert reloaded.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
 
+    @pytest.mark.unit
     def test_no_changes_when_state_already_correct(
         self, db_session, capsys, monkeypatch
     ):
@@ -253,6 +257,7 @@ class TestReconcileAll:
         assert changed == 0
         assert errors == 0
 
+    @pytest.mark.unit
     def test_apply_re_derives_strategy_label(self, db_session):
         # Bad state: stored as "wheel" but the ledger shows held shares with
         # no open option legs → the derived label is "holding". This
@@ -297,6 +302,7 @@ class TestReconcileAll:
 class TestMainCli:
     """Argparse-driven entry point for the script (``python -m scripts...``)."""
 
+    @pytest.mark.unit
     def test_main_dry_run_default(self, db_session):
         # Patch SessionLocal so the CLI uses the test engine.
         with patch(
@@ -310,6 +316,7 @@ class TestMainCli:
 
         assert exit_code == 0
 
+    @pytest.mark.unit
     def test_main_apply_returns_zero_with_no_errors(self, db_session):
         with patch(
             "scripts.reconcile_positions.SessionLocal",

--- a/backend/tests/test_reconcile_service.py
+++ b/backend/tests/test_reconcile_service.py
@@ -107,6 +107,7 @@ def _seed_position_with_full_cycle(db) -> Position:
 
 
 class TestReconcileService:
+    @pytest.mark.unit
     def test_empty_journal_returns_zero_aggregates(self, db_session):
         """With no positions, all aggregates are zero and the diff list is empty."""
         result = reconcile(db_session, apply=False)
@@ -121,6 +122,7 @@ class TestReconcileService:
         assert result.errors == 0
         assert result.per_position == []
 
+    @pytest.mark.unit
     def test_dry_run_does_not_mutate_db(self, db_session):
         pos = _seed_position_with_full_cycle(db_session)
         original_id = pos.id
@@ -147,6 +149,7 @@ class TestReconcileService:
         for trade in reloaded.trades:
             assert trade.closed_at == before_closes[trade.id]
 
+    @pytest.mark.unit
     def test_apply_persists_position_and_trade_writes(self, db_session):
         pos = _seed_position_with_full_cycle(db_session)
         original_id = pos.id
@@ -170,6 +173,7 @@ class TestReconcileService:
         # ``trades_stamped`` aggregate matches the count of actual writes.
         assert result.trades_stamped == len(stamped)
 
+    @pytest.mark.unit
     def test_diff_shape_includes_all_fields(self, db_session):
         _seed_position_with_full_cycle(db_session)
 
@@ -192,6 +196,7 @@ class TestReconcileService:
         assert diff.closed_at_after == "2026-03-20"
         assert diff.legs_consumed >= 2
 
+    @pytest.mark.unit
     def test_no_op_when_state_already_correct(self, db_session, monkeypatch):
         """When stored state matches the ledger, ``changed`` is zero."""
         # Freeze the recomputer's clock so the calendar fallback doesn't
@@ -234,6 +239,7 @@ class TestReconcileService:
         assert result.strategy_changes == 0
         assert result.trades_stamped == 0
 
+    @pytest.mark.unit
     def test_legs_consumed_counts_only_new_writes(self, db_session, monkeypatch):
         """Pre-stamped Trade.closed_at rows do not inflate ``legs_consumed``."""
         # Set today so the calendar fallback does fire on the past leg.

--- a/backend/tests/test_recovery_engine.py
+++ b/backend/tests/test_recovery_engine.py
@@ -93,6 +93,7 @@ class TestCanonicalShape:
             assert isinstance(p["assumptions"], list)
             assert all(isinstance(s, str) for s in p["assumptions"])
 
+    @pytest.mark.unit
     def test_no_irr_field_anywhere(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -111,6 +112,7 @@ class TestCanonicalShape:
 
 
 class TestSellRedeployPath:
+    @pytest.mark.unit
     def test_suppressed_when_target_yield_missing(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -125,6 +127,7 @@ class TestSellRedeployPath:
         assert sell["capital_tied_up"] is None
         assert sell["opportunity_cost_vs_baseline"] is None
 
+    @pytest.mark.unit
     def test_eligible_when_target_yield_set(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -153,6 +156,7 @@ class TestSellRedeployPath:
 
 
 class TestWheelCcPath:
+    @pytest.mark.unit
     def test_premium_pct_in_assumptions(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -169,6 +173,7 @@ class TestWheelCcPath:
         assert pct_str in assumption_blob
         assert "heuristic" in assumption_blob.lower()
 
+    @pytest.mark.unit
     def test_breakeven_range_uses_multipliers(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -187,6 +192,7 @@ class TestWheelCcPath:
         # Multipliers stay in sync with the published constant.
         assert WHEEL_BE_MULTIPLIERS == (0.8, 1.0, 1.3)
 
+    @pytest.mark.unit
     def test_capital_tied_up_is_strike_proxy_x_shares(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -199,6 +205,7 @@ class TestWheelCcPath:
         # strike_proxy = $8, shares = 100 → $800
         assert wheel["capital_tied_up"] == pytest.approx(800.0)
 
+    @pytest.mark.unit
     def test_opportunity_cost_vs_baseline_when_yield_set(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -220,6 +227,7 @@ class TestWheelCcPath:
 
 
 class TestAverageDownPath:
+    @pytest.mark.unit
     def test_suppressed_when_sizing_cap_breached(self):
         # SOFI: shares=100, basis=$3800, current=$8 → adding 100 shares at
         # $8 = $800 in fresh capital; total tied up = $4600 → within $5000
@@ -239,6 +247,7 @@ class TestAverageDownPath:
         assert avg["capital_tied_up"] is None
         assert avg["opportunity_cost_vs_baseline"] is None
 
+    @pytest.mark.unit
     def test_eligible_within_cap(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -254,6 +263,7 @@ class TestAverageDownPath:
         # opp_cost = additional_capital * target_yield = $800 * 0.18 = $144
         assert avg["opportunity_cost_vs_baseline"] == pytest.approx(144.0)
 
+    @pytest.mark.unit
     def test_uses_supplied_sizing_cap(self):
         # The engine no longer carries its own default cap (issue #156):
         # the caller resolves it from rules_config and always supplies a
@@ -269,6 +279,7 @@ class TestAverageDownPath:
         avg = next(p for p in paths if p["path_id"] == "average-down")
         assert avg["eligibility"] == "eligible"
 
+    @pytest.mark.unit
     def test_eligible_breakeven_range_is_positive(self):
         # Average-down now projects a deterministic breakeven by grinding
         # wheel-CC premium on the doubled position (issue #237).
@@ -297,6 +308,7 @@ class TestAverageDownPath:
         assert be["expected"] == 125
         assert be["worst"] == 163
 
+    @pytest.mark.unit
     def test_breakeven_methodology_in_assumptions(self):
         # The assumption blob must document the new premium-grind
         # methodology and must NOT carry the stale "not modeled" copy.
@@ -315,6 +327,7 @@ class TestAverageDownPath:
         assert "doubled position" in assumption_blob.lower()
         assert "not modeled" not in assumption_blob.lower()
 
+    @pytest.mark.unit
     def test_breakeven_collapses_only_on_zero_price_or_zero_shares(self):
         null_range = {"best": None, "expected": None, "worst": None}
 
@@ -365,6 +378,7 @@ class TestAverageDownPath:
 
 
 class TestHoldMonitorPath:
+    @pytest.mark.unit
     def test_breakeven_range_is_all_null(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -380,6 +394,7 @@ class TestHoldMonitorPath:
             "worst": None,
         }
 
+    @pytest.mark.unit
     def test_opportunity_cost_is_freed_capital_x_yield(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -392,6 +407,7 @@ class TestHoldMonitorPath:
         # freed_capital = $800; opp_cost = $800 * 0.18 = $144
         assert hold["opportunity_cost_vs_baseline"] == pytest.approx(144.0)
 
+    @pytest.mark.unit
     def test_capital_tied_up_is_current_basis(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -404,6 +420,7 @@ class TestHoldMonitorPath:
         # adjusted_cost_basis = $3800
         assert hold["capital_tied_up"] == pytest.approx(3800.0)
 
+    @pytest.mark.unit
     def test_eligible_even_when_yield_unset(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -425,6 +442,7 @@ class TestHoldMonitorPath:
 
 
 class TestDeterminism:
+    @pytest.mark.unit
     def test_byte_identical_output_for_same_input(self):
         kwargs = {
             "position": _sofi_position(),
@@ -450,6 +468,7 @@ class TestNoExternalCalls:
         "socket",
     }
 
+    @pytest.mark.unit
     def test_engine_module_has_no_forbidden_imports(self):
         path = (
             Path(__file__).resolve().parents[1]
@@ -476,6 +495,7 @@ class TestNoExternalCalls:
 
 
 class TestEdgeCases:
+    @pytest.mark.unit
     def test_position_above_water_returns_eligible_paths_with_null_breakeven(self):
         # current_price * shares > adjusted_cost_basis → no realized loss.
         paths = compute_recovery_paths(
@@ -489,6 +509,7 @@ class TestEdgeCases:
         sell = next(p for p in paths if p["path_id"] == "sell-redeploy")
         assert sell["months_to_breakeven"]["expected"] is None
 
+    @pytest.mark.unit
     def test_zero_current_price_treated_as_zero_dollars(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -501,6 +522,7 @@ class TestEdgeCases:
         # Premium math collapses to zero — no breakeven horizon.
         assert wheel["months_to_breakeven"]["expected"] is None
 
+    @pytest.mark.unit
     def test_zero_shares_collapses_paths_to_zero_dollars(self):
         paths = compute_recovery_paths(
             position=_sofi_position(shares=0),
@@ -526,6 +548,7 @@ class TestSizingCapPctResolution:
     eligible with the "cap unenforceable" assumption per §6.2.
     """
 
+    @pytest.mark.unit
     def test_average_down_suppressed_when_resolved_cap_breached(self):
         # SOFI override: basis=$1700 + additional ($8 × 100 = $800)
         # → capital_tied_up = $2500. Resolved cap = 10% × $20,000 = $2,000.
@@ -546,6 +569,7 @@ class TestSizingCapPctResolution:
         assert avg["capital_tied_up"] is None
         assert avg["opportunity_cost_vs_baseline"] is None
 
+    @pytest.mark.unit
     def test_average_down_eligible_with_cap_unenforceable_when_total_capital_none(self):
         # §6.2 contract: when Schwab account value is unavailable
         # (total_capital is None) the path must NOT be suppressed —
@@ -571,6 +595,7 @@ class TestSizingCapPctResolution:
         assert "unenforceable" in assumption_blob
         assert "Schwab account value unavailable" in assumption_blob
 
+    @pytest.mark.unit
     def test_average_down_within_resolved_cap_uses_pct_in_message(self):
         # SOFI override: basis=$3200 + $800 = $4000.
         # Resolved cap = 25% × $20,000 = $5,000. 4000 ≤ 5000 ⇒ eligible.

--- a/backend/tests/test_recovery_engine.py
+++ b/backend/tests/test_recovery_engine.py
@@ -47,6 +47,7 @@ def _sofi_position(**overrides) -> dict:
 
 
 class TestCanonicalShape:
+    @pytest.mark.unit
     def test_returns_four_paths_in_canonical_order(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),
@@ -58,6 +59,7 @@ class TestCanonicalShape:
         assert [p["path_id"] for p in paths] == list(canonical_path_order())
         assert len(paths) == 4
 
+    @pytest.mark.unit
     def test_every_path_has_required_fields(self):
         paths = compute_recovery_paths(
             position=_sofi_position(),

--- a/backend/tests/test_recovery_router.py
+++ b/backend/tests/test_recovery_router.py
@@ -106,6 +106,7 @@ def _quote(last_price: float) -> dict:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_recovery_plan_returns_404_when_position_missing(client):
     resp = client.post("/api/positions/nope-id/recovery-plan")
     assert resp.status_code == 404
@@ -117,6 +118,7 @@ def test_recovery_plan_returns_404_when_position_missing(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_recovery_plan_not_applicable_for_zero_shares(client):
     _seed_position(client, shares=0)
     with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
@@ -128,6 +130,7 @@ def test_recovery_plan_not_applicable_for_zero_shares(client):
     assert payload["recommendation"] is None
 
 
+@pytest.mark.integration
 def test_recovery_plan_not_applicable_for_closed_position(client):
     _seed_position(client, status="closed", shares=100)
     with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
@@ -136,6 +139,7 @@ def test_recovery_plan_not_applicable_for_closed_position(client):
     assert resp.json()["state"] == "not-applicable"
 
 
+@pytest.mark.integration
 def test_recovery_plan_not_applicable_for_zero_basis(client):
     _seed_position(client, broker_cost_basis=0.0)
     with patch.object(SchwabClient, "get_quote", return_value=_quote(8.0)):
@@ -144,6 +148,7 @@ def test_recovery_plan_not_applicable_for_zero_basis(client):
     assert resp.json()["state"] == "not-applicable"
 
 
+@pytest.mark.integration
 def test_recovery_plan_not_flagged_above_threshold(client):
     # Position with $3800 basis at $40 current price → $4000 notional, +$200
     # gain → does not breach either threshold.
@@ -163,6 +168,7 @@ def test_recovery_plan_not_flagged_above_threshold(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_recovery_flag_gate_uses_configured_loss_review_threshold(client):
     """The flag gate resolves its loss-review percentage from ``rules_config``.
 
@@ -182,6 +188,7 @@ def test_recovery_flag_gate_uses_configured_loss_review_threshold(client):
     assert resp.json()["state"] == "populated"
 
 
+@pytest.mark.integration
 def test_recovery_flag_gate_not_flagged_when_rule_stricter_than_loss(client):
     """A −8% loser is ``not-flagged`` when the stored rule is −15%."""
     _seed_position(client, broker_cost_basis=3800.0, shares=100)
@@ -192,6 +199,7 @@ def test_recovery_flag_gate_not_flagged_when_rule_stricter_than_loss(client):
     assert resp.json()["state"] == "not-flagged"
 
 
+@pytest.mark.integration
 def test_recovery_default_rules_not_flagged_between_5_and_15_pct(client):
     """With no ``rules_config`` row the default −15% rule applies.
 
@@ -206,6 +214,7 @@ def test_recovery_default_rules_not_flagged_between_5_and_15_pct(client):
     assert resp.json()["state"] == "not-flagged"
 
 
+@pytest.mark.integration
 def test_recovery_default_rules_flagged_below_15_pct(client):
     """A −39% loser flags under the default −15% rule (conversion check).
 
@@ -220,6 +229,7 @@ def test_recovery_default_rules_flagged_below_15_pct(client):
     assert resp.json()["state"] == "populated"
 
 
+@pytest.mark.integration
 def test_recovery_dollar_secondary_trigger_still_fires(client):
     """The −$1,000 absolute trigger flags a shallow-percent large position.
 
@@ -234,6 +244,7 @@ def test_recovery_dollar_secondary_trigger_still_fires(client):
     assert resp.json()["state"] == "populated"
 
 
+@pytest.mark.integration
 def test_recovery_assumptions_sizing_cap_source_is_trading_rules(client):
     """The Sizing-cap assumption row is attributed to Settings → Trading Rules.
 
@@ -262,6 +273,7 @@ def test_recovery_assumptions_sizing_cap_source_is_trading_rules(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_recovery_plan_populated_for_flagged_position(client):
     _seed_position(client, broker_cost_basis=3800.0, shares=100)
     _seed_setting(client, "okr_target_yield", "0.18")
@@ -296,6 +308,7 @@ def test_recovery_plan_populated_for_flagged_position(client):
     assert "fit recommendation" in payload["disclaimer"]
 
 
+@pytest.mark.integration
 def test_recovery_plan_uses_okr_target_yield_from_settings(client):
     _seed_position(client, broker_cost_basis=3800.0)
     _seed_setting(client, "okr_target_yield", "0.20")
@@ -308,6 +321,7 @@ def test_recovery_plan_uses_okr_target_yield_from_settings(client):
     assert sell["eligibility"] == "eligible"
 
 
+@pytest.mark.integration
 def test_recovery_plan_suppresses_sell_redeploy_when_target_yield_unset(client):
     _seed_position(client, broker_cost_basis=3800.0)
     # No target_yield seeded → defaults to None.
@@ -319,6 +333,7 @@ def test_recovery_plan_suppresses_sell_redeploy_when_target_yield_unset(client):
     assert sell["suppression_reason"] == "Target yield not configured"
 
 
+@pytest.mark.integration
 def test_recovery_plan_uses_default_sizing_cap_when_unset(client):
     _seed_position(client, broker_cost_basis=3800.0)
     _seed_setting(client, "okr_target_yield", "0.18")
@@ -330,6 +345,7 @@ def test_recovery_plan_uses_default_sizing_cap_when_unset(client):
     assert payload["inputs"]["okr"]["resolved_sizing_cap_dollars"] == pytest.approx(5000.0)
 
 
+@pytest.mark.integration
 def test_recovery_plan_sell_redeploy_populated_after_target_yield_set(client):
     """Issue #207 AC3 — once a target yield is set, the Sell & redeploy path
     is eligible and its metrics compute (capital tied up + months to
@@ -362,6 +378,7 @@ def test_recovery_plan_sell_redeploy_populated_after_target_yield_set(client):
 _UNIQUE_LEAK_NEEDLE = "ZZZ-do-not-leak-this-needle-ZZZ"
 
 
+@pytest.mark.integration
 def test_recovery_plan_quote_failure_returns_generic_500(client):
     _seed_position(client, broker_cost_basis=3800.0)
 
@@ -379,6 +396,7 @@ def test_recovery_plan_quote_failure_returns_generic_500(client):
     assert _UNIQUE_LEAK_NEEDLE not in resp.text
 
 
+@pytest.mark.integration
 def test_recovery_plan_treats_missing_last_price_as_quote_failure(client):
     _seed_position(client, broker_cost_basis=3800.0)
     with patch.object(SchwabClient, "get_quote", return_value={}):
@@ -394,6 +412,7 @@ def test_recovery_plan_treats_missing_last_price_as_quote_failure(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_recovery_plan_response_matches_schema(client):
     _seed_position(client, broker_cost_basis=3800.0)
     _seed_setting(client, "okr_target_yield", "0.18")
@@ -435,6 +454,7 @@ def _patch_account_cache(monkeypatch, result):
     )
 
 
+@pytest.mark.integration
 def test_okr_inputs_shape_ok_when_schwab_cache_populated(client, monkeypatch):
     """A fresh ok-status cache entry flows into the populated OKR inputs.
 
@@ -469,6 +489,7 @@ def test_okr_inputs_shape_ok_when_schwab_cache_populated(client, monkeypatch):
     assert okr["capital_status"] == "ok"
 
 
+@pytest.mark.integration
 def test_okr_inputs_shape_when_capital_status_error_returns_null_total_capital(
     client, monkeypatch
 ):
@@ -505,6 +526,7 @@ def test_okr_inputs_shape_when_capital_status_error_returns_null_total_capital(
     assert okr["sizing_cap_pct"] == pytest.approx(25.0)
 
 
+@pytest.mark.integration
 def test_assumptions_panel_formats_resolved_dollars_when_ok(client, monkeypatch):
     """Happy path — the Sizing-cap assumption value renders the percent
     plus the resolved dollar ceiling: ``"25% (≈ $5,000)"``.
@@ -534,6 +556,7 @@ def test_assumptions_panel_formats_resolved_dollars_when_ok(client, monkeypatch)
     assert "≈ $5,000" in cap_row["value"]
 
 
+@pytest.mark.integration
 def test_assumptions_panel_formats_unavailable_when_capital_status_error(
     client, monkeypatch
 ):

--- a/backend/tests/test_recovery_scoring.py
+++ b/backend/tests/test_recovery_scoring.py
@@ -105,6 +105,7 @@ def _make_path(
 
 
 class TestCanonicalShape:
+    @pytest.mark.unit
     def test_response_has_required_top_level_keys(self):
         paths = _sofi_paths()
         rec = score_recovery_paths(paths, {})
@@ -118,6 +119,7 @@ class TestCanonicalShape:
             "disclaimer",
         }
 
+    @pytest.mark.unit
     def test_disclaimer_is_canonical_text(self):
         rec = score_recovery_paths(_sofi_paths(), {})
         assert rec["disclaimer"] == DISCLAIMER_TEXT
@@ -127,6 +129,7 @@ class TestCanonicalShape:
                 f"disclaimer leaks prescriptive verb '{verb}'"
             )
 
+    @pytest.mark.unit
     def test_tie_epsilon_matches_module_constant(self):
         rec = score_recovery_paths(_sofi_paths(), {})
         assert rec["tie_epsilon"] == TIE_EPSILON == 1.0
@@ -138,6 +141,7 @@ class TestCanonicalShape:
 
 
 class TestLeaderPerCriterion:
+    @pytest.mark.unit
     def test_unique_leader_collects_full_weight(self):
         # Path A is the unique leader on fastest_breakeven.
         paths = [
@@ -163,6 +167,7 @@ class TestLeaderPerCriterion:
         assert cells["sell-redeploy"]["points"] == 0
         assert cells["hold-monitor"]["points"] == 0
 
+    @pytest.mark.unit
     def test_exact_tie_splits_points_among_leaders(self):
         # All three paths have $0 capital — the AC example: all three get +3.
         paths = [
@@ -194,6 +199,7 @@ class TestLeaderPerCriterion:
 
 
 class TestTieWithinEpsilon:
+    @pytest.mark.unit
     def test_top_two_within_epsilon_yields_no_clear_best_fit(self):
         # Construct two paths that score 5 and 5 on totals → tied.
         paths = [
@@ -218,6 +224,7 @@ class TestTieWithinEpsilon:
         assert rec["ranked_paths"][0]["score"] == 6
         assert rec["ranked_paths"][1]["score"] == 5
 
+    @pytest.mark.unit
     def test_gap_larger_than_epsilon_recommends_single_path(self):
         # wheel-cc dominates: +3 (fastest) +3 (capital) +2 (opp_cost) = 8.
         # hold-monitor: capital ties (+3 if tied) but otherwise 0.
@@ -245,6 +252,7 @@ class TestTieWithinEpsilon:
 
 
 class TestSuppressedHandling:
+    @pytest.mark.unit
     def test_suppressed_path_with_winning_metrics_is_not_recommended(self):
         # Force a suppressed path that *would* dominate the metrics.
         paths = [
@@ -273,6 +281,7 @@ class TestSuppressedHandling:
         assert suppressed_entry["rank"] is None
         assert "sizing cap" in (suppressed_entry["suppression_reason"] or "")
 
+    @pytest.mark.unit
     def test_all_paths_suppressed_yields_no_eligible_path(self):
         paths = [
             _make_path(
@@ -307,6 +316,7 @@ class TestSuppressedHandling:
 
 
 class TestStrategyPreferenceBonus:
+    @pytest.mark.unit
     def test_unset_preference_keeps_bonus_row_with_all_zero_cells(self):
         # V0.5.8 default — strategy_preference unset.
         rec = score_recovery_paths(_sofi_paths(), {})
@@ -319,6 +329,7 @@ class TestStrategyPreferenceBonus:
                 "unset preference must not contribute points"
             )
 
+    @pytest.mark.unit
     def test_set_preference_awards_bonus_to_matching_path(self):
         rec = score_recovery_paths(
             _sofi_paths(), {"strategy_preference": "income-first"}
@@ -332,6 +343,7 @@ class TestStrategyPreferenceBonus:
         )
         assert wheel_cell["points"] == WEIGHT_STRATEGY_PREFERENCE
 
+    @pytest.mark.unit
     def test_unknown_preference_defaults_to_no_bonus(self):
         rec = score_recovery_paths(
             _sofi_paths(), {"strategy_preference": "definitely-not-real"}
@@ -341,6 +353,7 @@ class TestStrategyPreferenceBonus:
         )
         assert all(c["points"] == 0 for c in bonus_row["ranking"])
 
+    @pytest.mark.unit
     def test_passive_preference_yields_no_bonus(self):
         rec = score_recovery_paths(
             _sofi_paths(), {"strategy_preference": "passive"}
@@ -350,6 +363,7 @@ class TestStrategyPreferenceBonus:
         )
         assert all(c["points"] == 0 for c in bonus_row["ranking"])
 
+    @pytest.mark.unit
     def test_label_uses_neutral_template_when_preference_unset(self):
         rec = score_recovery_paths(_sofi_paths(), {})
         if rec["recommended_path_id"] is not None:
@@ -359,6 +373,7 @@ class TestStrategyPreferenceBonus:
                 "Best fit on capital efficiency and breakeven"
             )
 
+    @pytest.mark.unit
     def test_strategy_mapping_locked(self):
         # If this assertion ever fails, dependent #156/#157 work and the
         # design spec §4.5 need updating together.
@@ -375,6 +390,7 @@ class TestStrategyPreferenceBonus:
 
 
 class TestPathScoresMatrix:
+    @pytest.mark.unit
     def test_one_row_per_criterion_in_canonical_order(self):
         rec = score_recovery_paths(_sofi_paths(), {})
         criteria = [r["criterion"] for r in rec["path_scores"]]
@@ -385,6 +401,7 @@ class TestPathScoresMatrix:
             "strategy_preference_bonus",
         ]
 
+    @pytest.mark.unit
     def test_each_row_has_one_cell_per_eligible_path(self):
         paths = _sofi_paths()
         eligible = [p for p in paths if p["eligibility"] == "eligible"]
@@ -395,6 +412,7 @@ class TestPathScoresMatrix:
                 p["path_id"] for p in eligible
             }
 
+    @pytest.mark.unit
     def test_each_cell_has_raw_value_points_rank(self):
         rec = score_recovery_paths(_sofi_paths(), {})
         for row in rec["path_scores"]:
@@ -427,11 +445,13 @@ class TestRecommendationReasons:
         ]
         return score_recovery_paths(paths, {})
 
+    @pytest.mark.unit
     def test_reasons_length_2_to_4_on_happy_path(self):
         rec = self._happy_path_recommendation()
         assert rec["recommended_path_id"] == "wheel-cc"
         assert 2 <= len(rec["recommendation_reasons"]) <= 4
 
+    @pytest.mark.unit
     def test_all_reasons_come_from_templates_on_happy_path(self):
         rec = self._happy_path_recommendation()
         # Every reason must look like one of the frozen templates with the
@@ -448,6 +468,7 @@ class TestRecommendationReasons:
                 f"reason '{reason}' did not match any template prefix"
             )
 
+    @pytest.mark.unit
     def test_reasons_avoid_prescriptive_advice_wording(self):
         # Cover both code paths — happy + degraded — so the advice-framing
         # audit runs against every emitted reason.
@@ -468,12 +489,14 @@ class TestRecommendationReasons:
 
 
 class TestReproducibility:
+    @pytest.mark.unit
     def test_byte_identical_recommendation_object(self):
         paths = _sofi_paths()
         a = score_recovery_paths(paths, {})
         b = score_recovery_paths(paths, {})
         assert json.dumps(a, sort_keys=True) == json.dumps(b, sort_keys=True)
 
+    @pytest.mark.unit
     def test_byte_identical_with_strategy_preference(self):
         paths = _sofi_paths()
         a = score_recovery_paths(paths, {"strategy_preference": "income-first"})
@@ -489,6 +512,7 @@ class TestReproducibility:
 class TestNoExternalCalls:
     FORBIDDEN = {"httpx", "requests", "openai", "anthropic", "urllib", "socket"}
 
+    @pytest.mark.unit
     def test_scoring_module_imports_are_pure(self):
         path = (
             Path(__file__).resolve().parents[1]
@@ -547,12 +571,15 @@ class TestTemplateSnapshots:
         "within_sizing_cap": "Within your per-position sizing cap",
     }
 
+    @pytest.mark.unit
     def test_label_templates_frozen(self):
         assert LABEL_TEMPLATES == self.EXPECTED_LABEL_TEMPLATES
 
+    @pytest.mark.unit
     def test_reason_templates_frozen(self):
         assert REASON_TEMPLATES == self.EXPECTED_REASON_TEMPLATES
 
+    @pytest.mark.unit
     def test_disclaimer_text_frozen(self):
         assert DISCLAIMER_TEXT == (
             "This is a fit recommendation based on your configured "
@@ -567,6 +594,7 @@ class TestTemplateSnapshots:
 
 
 class TestEdgeCases:
+    @pytest.mark.unit
     def test_single_eligible_path_is_always_recommended(self):
         paths = [
             _make_path(
@@ -579,12 +607,14 @@ class TestEdgeCases:
         # has nothing to compare to.
         assert rec["recommended_path_id"] == "hold-monitor"
 
+    @pytest.mark.unit
     def test_empty_okr_settings_treated_as_unset(self):
         rec_a = score_recovery_paths(_sofi_paths(), None)
         rec_b = score_recovery_paths(_sofi_paths(), {})
         # Different empty containers, identical output.
         assert json.dumps(rec_a, sort_keys=True) == json.dumps(rec_b, sort_keys=True)
 
+    @pytest.mark.unit
     def test_hold_monitor_null_breakeven_treated_as_worst_tier(self):
         rec = score_recovery_paths(_sofi_paths(), {})
         row = next(

--- a/backend/tests/test_regression.py
+++ b/backend/tests/test_regression.py
@@ -9,6 +9,7 @@ from app.services.regression import (
 
 
 class TestLinearRegression:
+    @pytest.mark.unit
     def test_perfect_linear_trend(self):
         """y = 2t + 1 should give slope ~2, intercept ~1, r_squared ~1."""
         dates = [f"2024-01-{i+1:02d}" for i in range(50)]
@@ -25,6 +26,7 @@ class TestLinearRegression:
         assert len(result["confidence_interval_upper"]) == 50
         assert len(result["confidence_interval_lower"]) == 50
 
+    @pytest.mark.unit
     def test_noisy_linear_trend(self):
         """Noisy data should still find approximate trend."""
         np.random.seed(42)
@@ -38,11 +40,13 @@ class TestLinearRegression:
         assert result["intercept"] == pytest.approx(10.0, abs=5.0)
         assert result["r_squared"] > 0.9
 
+    @pytest.mark.unit
     def test_too_few_points_raises(self):
         """Need at least 3 data points."""
         with pytest.raises(ValueError, match="at least 3"):
             compute_linear_regression(["2024-01-01", "2024-01-02"], [1.0, 2.0])
 
+    @pytest.mark.unit
     def test_confidence_intervals_bracket_predictions(self):
         """Upper CI should be above predicted, lower should be below."""
         dates = [f"2024-01-{i+1:02d}" for i in range(20)]
@@ -56,6 +60,7 @@ class TestLinearRegression:
 
 
 class TestMultiFactorOLS:
+    @pytest.mark.unit
     def test_known_coefficients(self):
         """y = 2*x1 + 3*x2 + 5 should recover coefficients."""
         np.random.seed(42)
@@ -77,6 +82,7 @@ class TestMultiFactorOLS:
         assert len(result["residuals"]) == n
         assert len(result["predicted_values"]) == n
 
+    @pytest.mark.unit
     def test_noisy_coefficients(self):
         """With noise, should still approximately recover coefficients."""
         np.random.seed(42)
@@ -96,6 +102,7 @@ class TestMultiFactorOLS:
         assert result["coefficients"]["x2"] == pytest.approx(3.0, abs=0.5)
         assert result["r_squared"] > 0.9
 
+    @pytest.mark.unit
     def test_insufficient_observations_raises(self):
         """Should raise if fewer observations than factors + 2."""
         with pytest.raises(ValueError, match="observations"):
@@ -107,6 +114,7 @@ class TestMultiFactorOLS:
 
 
 class TestRollingRegression:
+    @pytest.mark.unit
     def test_output_length(self):
         """Output length should be n - window + 1."""
         n = 50
@@ -121,6 +129,7 @@ class TestRollingRegression:
         assert len(result["r_squared_over_time"]) == n - window + 1
         assert len(result["actual_values"]) == n
 
+    @pytest.mark.unit
     def test_constant_slope(self):
         """A perfect linear series should have constant slope across windows."""
         n = 30
@@ -135,6 +144,7 @@ class TestRollingRegression:
         for r_sq in result["r_squared_over_time"]:
             assert r_sq == pytest.approx(1.0, abs=1e-10)
 
+    @pytest.mark.unit
     def test_insufficient_data_raises(self):
         """Should raise if fewer data points than window size."""
         with pytest.raises(ValueError, match="at least"):
@@ -144,6 +154,7 @@ class TestRollingRegression:
                 window_size=5,
             )
 
+    @pytest.mark.unit
     def test_window_too_small_raises(self):
         """Window size must be at least 3."""
         with pytest.raises(ValueError, match="at least 3"):
@@ -157,6 +168,7 @@ class TestRollingRegression:
 class TestStatisticalSafeguards:
     """Tests for Phase 4 statistical safeguards: DW, VIF, ADF, differenced regression."""
 
+    @pytest.mark.unit
     def test_multifactor_returns_durbin_watson(self):
         """Durbin-Watson should be in valid range [0, 4]."""
         np.random.seed(42)
@@ -171,6 +183,7 @@ class TestStatisticalSafeguards:
         assert "durbin_watson" in result
         assert 0 <= result["durbin_watson"] <= 4
 
+    @pytest.mark.unit
     def test_multifactor_returns_vif(self):
         """Uncorrelated variables should have low VIF (< 5)."""
         np.random.seed(42)
@@ -188,6 +201,7 @@ class TestStatisticalSafeguards:
         assert result["vif"]["x1"] < 5
         assert result["vif"]["x2"] < 5
 
+    @pytest.mark.unit
     def test_multifactor_stationarity_on_random_walk(self):
         """Random walk (cumulative sum) should be detected as non-stationary, triggering differenced regression."""
         np.random.seed(42)
@@ -211,6 +225,7 @@ class TestStatisticalSafeguards:
         assert "r_squared" in result["differenced"]
         assert "durbin_watson" in result["differenced"]
 
+    @pytest.mark.unit
     def test_multifactor_stationary_series(self):
         """Stationary white noise should be detected as stationary with no differenced key."""
         np.random.seed(42)
@@ -231,6 +246,7 @@ class TestStatisticalSafeguards:
         # No differenced regression needed
         assert "differenced" not in result
 
+    @pytest.mark.unit
     def test_linear_returns_durbin_watson(self):
         """Linear regression should include Durbin-Watson statistic."""
         np.random.seed(42)
@@ -243,6 +259,7 @@ class TestStatisticalSafeguards:
         assert "durbin_watson" in result
         assert 0 <= result["durbin_watson"] <= 4
 
+    @pytest.mark.unit
     def test_sample_size_returned(self):
         """Both linear and multi-factor should return sample_size matching input length."""
         np.random.seed(42)

--- a/backend/tests/test_regression_summary.py
+++ b/backend/tests/test_regression_summary.py
@@ -79,6 +79,7 @@ BIOTECH_FACTORS: list[SummaryFactor] = [
 # --- Spec example tests ----------------------------------------------------
 
 
+@pytest.mark.unit
 def test_spec_example_sofi_rate_sensitive_financial() -> None:
     """SOFI: dominant market, secondary rate exposure (negative)."""
     out = build_regression_summary(
@@ -93,6 +94,7 @@ def test_spec_example_sofi_rate_sensitive_financial() -> None:
     )
 
 
+@pytest.mark.unit
 def test_spec_example_aapl_low_rates_tech_heavy() -> None:
     """AAPL: dominant market, secondary sector adds positively."""
     out = build_regression_summary(
@@ -107,6 +109,7 @@ def test_spec_example_aapl_low_rates_tech_heavy() -> None:
     )
 
 
+@pytest.mark.unit
 def test_spec_example_tlt_rate_tracker() -> None:
     """TLT: dominant rates, market exposure is minor (non-meaningful fallback)."""
     out = build_regression_summary(
@@ -121,6 +124,7 @@ def test_spec_example_tlt_rate_tracker() -> None:
     )
 
 
+@pytest.mark.unit
 def test_spec_example_idiosyncratic_biotech() -> None:
     """Biotech: idiosyncratic-dominant special form."""
     out = build_regression_summary(
@@ -138,6 +142,7 @@ def test_spec_example_idiosyncratic_biotech() -> None:
 # --- Rule branch coverage --------------------------------------------------
 
 
+@pytest.mark.unit
 def test_rule_2_primarily_when_dominant_between_30_and_50_pct() -> None:
     """Rule 2: ``Primarily`` label kicks in for 0.30 < dominant <= 0.50."""
     factors = [
@@ -152,6 +157,7 @@ def test_rule_2_primarily_when_dominant_between_30_and_50_pct() -> None:
     assert out.startswith("Primarily market-driven")
 
 
+@pytest.mark.unit
 def test_rule_2_diversified_when_no_factor_above_30_pct() -> None:
     """Rule 2: ``Diversified driver mix`` when no factor dominates.
 
@@ -170,6 +176,7 @@ def test_rule_2_diversified_when_no_factor_above_30_pct() -> None:
     assert out.startswith("Diversified driver mix")
 
 
+@pytest.mark.unit
 def test_rule_3_positive_beta_on_rates_renders_meaningful_and_positive() -> None:
     """Sign-aware: positive rate beta produces ``...and positive``."""
     factors = [
@@ -183,6 +190,7 @@ def test_rule_3_positive_beta_on_rates_renders_meaningful_and_positive() -> None
     assert "rate exposure is meaningful and positive" in out
 
 
+@pytest.mark.unit
 def test_rule_3_negative_beta_on_sector_renders_detracts() -> None:
     """Sign-aware: negative sector beta produces ``sector exposure detracts``."""
     factors = [
@@ -196,6 +204,7 @@ def test_rule_3_negative_beta_on_sector_renders_detracts() -> None:
     assert "sector exposure detracts" in out
 
 
+@pytest.mark.unit
 def test_rule_3_non_meaningful_factor_is_excluded() -> None:
     """A factor with p>0.05 is dropped from the meaningful list."""
     factors = [
@@ -218,6 +227,7 @@ def test_rule_3_non_meaningful_factor_is_excluded() -> None:
 # --- Sector-omitted branch -------------------------------------------------
 
 
+@pytest.mark.unit
 def test_sector_omitted_skips_sector_clause() -> None:
     """When the sector factor is omitted, the rules skip any sector clause."""
     factors = [
@@ -235,6 +245,7 @@ def test_sector_omitted_skips_sector_clause() -> None:
     assert "rate exposure is meaningful and negative" in out
 
 
+@pytest.mark.unit
 def test_sector_omitted_idiosyncratic_uses_two_factor_basket_phrase() -> None:
     """Idiosyncratic-dominant + sector-omitted lists market/rates only."""
     factors = [
@@ -255,6 +266,7 @@ def test_sector_omitted_idiosyncratic_uses_two_factor_basket_phrase() -> None:
 # --- Format / cap coverage -------------------------------------------------
 
 
+@pytest.mark.unit
 def test_r_squared_is_two_decimals() -> None:
     """R² renders with two decimals (matches spec examples)."""
     factors = [
@@ -265,6 +277,7 @@ def test_r_squared_is_two_decimals() -> None:
     assert "R²=0.12 over 200 trading days" in out
 
 
+@pytest.mark.unit
 def test_summary_is_at_most_120_characters_under_normal_conditions() -> None:
     """All four spec examples + the rule-branch tests stay under 120 chars."""
     cases = [SOFI_FACTORS, AAPL_FACTORS, TLT_FACTORS, BIOTECH_FACTORS]
@@ -273,6 +286,7 @@ def test_summary_is_at_most_120_characters_under_normal_conditions() -> None:
         assert len(out) <= 120, f"summary exceeds 120 chars: {out!r}"
 
 
+@pytest.mark.unit
 def test_empty_factors_returns_safe_fallback() -> None:
     """Defensive: empty factor list still returns a deterministic string."""
     out = build_regression_summary(
@@ -282,6 +296,7 @@ def test_empty_factors_returns_safe_fallback() -> None:
     assert "R²=0.00 over 0 trading days" in out
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "p_value, abs_beta, contribution, expected_meaningful",
     [

--- a/backend/tests/test_rejection_messages.py
+++ b/backend/tests/test_rejection_messages.py
@@ -19,6 +19,7 @@ from app.services.rejection_messages import HumanizeContext, humanize_reasons
 class TestFails10PctRule:
     """``fails_10pct_rule`` — strike is too close to or below cost basis."""
 
+    @pytest.mark.unit
     def test_with_cost_basis_in_context(self):
         raw = ["fails_10pct_rule: strike 645.7% above basis, requires 10.0%"]
         ctx: HumanizeContext = {"cost_basis": 13.26}
@@ -29,6 +30,7 @@ class TestFails10PctRule:
         assert "$13.26 basis" in sentence
         assert "10.0% rule requires" in sentence
 
+    @pytest.mark.unit
     def test_without_cost_basis_in_context(self):
         raw = ["fails_10pct_rule: strike 5.0% above basis, requires 10.0%"]
         out = humanize_reasons(raw, context=None)
@@ -40,6 +42,7 @@ class TestFails10PctRule:
 class TestItmPut:
     """``itm_put`` — put strike sits above the current price."""
 
+    @pytest.mark.unit
     def test_basic(self):
         raw = ["itm_put: strike $15.00 > price $14.00"]
         out = humanize_reasons(raw, None)
@@ -51,6 +54,7 @@ class TestItmPut:
 class TestDeltaOutOfRange:
     """``delta_out_of_range`` has two distinct sub-cases (too high vs too low)."""
 
+    @pytest.mark.unit
     def test_too_high_explanation(self):
         # |0.42| > max_delta 0.35
         raw = ["delta_out_of_range: |0.42| not in [0.15, 0.35]"]
@@ -62,6 +66,7 @@ class TestDeltaOutOfRange:
         # Sub-case sanity: the "too far OTM" clause must NOT appear here.
         assert "too far out of the money" not in sentence
 
+    @pytest.mark.unit
     def test_too_low_explanation(self):
         # |0.05| < min_delta 0.15
         raw = ["delta_out_of_range: |0.05| not in [0.15, 0.35]"]
@@ -72,6 +77,7 @@ class TestDeltaOutOfRange:
         # Sub-case sanity: the "too close" clause must NOT appear here.
         assert "too close to the money" not in sentence
 
+    @pytest.mark.unit
     def test_negative_delta_for_csp(self):
         # Puts have negative delta; sign should be preserved in the sentence.
         raw = ["delta_out_of_range: |-0.42| not in [0.15, 0.35]"]
@@ -84,6 +90,7 @@ class TestDeltaOutOfRange:
 class TestLowOpenInterest:
     """``low_open_interest`` — strike below the OI threshold."""
 
+    @pytest.mark.unit
     def test_basic(self):
         raw = ["low_open_interest: 12 < 50"]
         out = humanize_reasons(raw, None)
@@ -94,6 +101,7 @@ class TestLowOpenInterest:
 class TestZeroBid:
     """``zero_bid`` — no bid in the market."""
 
+    @pytest.mark.unit
     def test_basic(self):
         out = humanize_reasons(["zero_bid"], None)
         assert "No buyer" in out[0]
@@ -103,6 +111,7 @@ class TestZeroBid:
 class TestReturnBelowTarget:
     """``return_below_target`` — premium yield under user threshold."""
 
+    @pytest.mark.unit
     def test_basic(self):
         raw = ["return_below_target: 0.34% < 1.0%"]
         out = humanize_reasons(raw, None)
@@ -114,6 +123,7 @@ class TestReturnBelowTarget:
 class TestReturnAboveCap:
     """``return_above_cap`` — premium yield above user sanity cap."""
 
+    @pytest.mark.unit
     def test_basic(self):
         raw = ["return_above_cap: 25.50% > 15.0%"]
         out = humanize_reasons(raw, None)
@@ -129,10 +139,12 @@ class TestReturnAboveCap:
 class TestUnknownCodeFallback:
     """Unknown codes pass through unchanged — never crash, never lose info."""
 
+    @pytest.mark.unit
     def test_unknown_code_returns_raw(self):
         out = humanize_reasons(["some_future_rule_we_have_not_mapped"], None)
         assert out == ["some_future_rule_we_have_not_mapped"]
 
+    @pytest.mark.unit
     def test_malformed_known_code_returns_raw(self):
         # The prefix matches but the body doesn't fit the regex — fall through.
         raw_str = "fails_10pct_rule: some garbled message"
@@ -143,9 +155,11 @@ class TestUnknownCodeFallback:
 class TestMapperShape:
     """Length and order invariants — the output list mirrors the input list."""
 
+    @pytest.mark.unit
     def test_empty_input_returns_empty(self):
         assert humanize_reasons([], None) == []
 
+    @pytest.mark.unit
     def test_multiple_reasons_preserve_order(self):
         raw = [
             "fails_10pct_rule: strike 5.0% above basis, requires 10.0%",
@@ -158,6 +172,7 @@ class TestMapperShape:
         assert out[1].startswith("No buyer")
         assert out[2].startswith("Only 12 contracts")
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "raw",
         [

--- a/backend/tests/test_rejection_relax.py
+++ b/backend/tests/test_rejection_relax.py
@@ -16,6 +16,7 @@ Test plan (~12 cases):
 """
 
 from __future__ import annotations
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +43,7 @@ def _post(client, body: dict):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_relax_delta_widens_band_and_recovers(client):
     """``delta_out_of_range`` — band widens ±0.05; |0.38| is now inside
     [0.15, 0.40], so the strike recovers.
@@ -76,6 +78,7 @@ def test_relax_delta_widens_band_and_recovers(client):
     ]
 
 
+@pytest.mark.integration
 def test_relax_low_oi_halves_floor_and_recovers(client):
     """``low_open_interest`` — floor ÷ 2; OI=25 vs min=50 recovers when
     new floor = 25.
@@ -103,6 +106,7 @@ def test_relax_low_oi_halves_floor_and_recovers(client):
     assert data["recovered_strikes"][0]["strike"] == 14.0
 
 
+@pytest.mark.integration
 def test_relax_wide_spread_caps_x_1_5_and_recovers(client):
     """``wide_bid_ask_spread`` — cap × 1.5; 12% vs cap=10% recovers when
     new cap=15%.
@@ -130,6 +134,7 @@ def test_relax_wide_spread_caps_x_1_5_and_recovers(client):
     assert data["recovered_strikes"][0]["strike"] == 5.0
 
 
+@pytest.mark.integration
 def test_relax_fails_10pct_drops_required_by_5pp_and_recovers(client):
     """``fails_10pct_rule`` — required distance − 5pp; strike at 6%
     above basis vs 10% rule → new threshold 5% → 6 >= 5 → recovers.
@@ -161,6 +166,7 @@ def test_relax_fails_10pct_drops_required_by_5pp_and_recovers(client):
     assert data["recovered_strikes"][0]["strike"] == 14.0
 
 
+@pytest.mark.integration
 def test_relax_below_cost_basis_drops_floor_and_recovers(client):
     """``below_cost_basis`` — floor − 5pp (≈ floor × 0.95 at the default
     0% baseline); strike $12.80 vs $13.21 floor → relaxed floor ≈ $12.55
@@ -188,6 +194,7 @@ def test_relax_below_cost_basis_drops_floor_and_recovers(client):
     assert data["recovered_strikes"][0]["strike"] == 12.80
 
 
+@pytest.mark.integration
 def test_relax_return_below_drops_target_by_1pp_and_recovers(client):
     """``return_below_target`` — target − 1pp; 1.5% vs 2% target →
     relaxed 1% → 1.5 >= 1 → recovers.
@@ -214,6 +221,7 @@ def test_relax_return_below_drops_target_by_1pp_and_recovers(client):
     assert data["recovered_strikes"][0]["strike"] == 14.0
 
 
+@pytest.mark.integration
 def test_relax_return_above_lifts_cap_by_50pp_and_recovers(client):
     """``return_above_cap`` — cap + 50pp; 120% vs 100% cap → relaxed 150%
     → 120 <= 150 → recovers. Threshold text reads the cap inline (no
@@ -250,6 +258,7 @@ def test_relax_return_above_lifts_cap_by_50pp_and_recovers(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_relax_itm_put_is_not_relaxable_400(client):
     """``itm_put`` is binary — endpoint returns 400 with the generic detail."""
     rejected = [
@@ -265,6 +274,7 @@ def test_relax_itm_put_is_not_relaxable_400(client):
     assert res.json()["detail"] == "rule not relaxable"
 
 
+@pytest.mark.integration
 def test_relax_zero_bid_is_not_relaxable_400(client):
     """``zero_bid`` is binary — endpoint returns 400 with the generic detail."""
     rejected = [
@@ -280,6 +290,7 @@ def test_relax_zero_bid_is_not_relaxable_400(client):
     assert res.json()["detail"] == "rule not relaxable"
 
 
+@pytest.mark.integration
 def test_relax_unknown_rule_is_not_relaxable_400(client):
     """An unknown rule family is treated the same as a binary rule.
 
@@ -296,6 +307,7 @@ def test_relax_unknown_rule_is_not_relaxable_400(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_relax_empty_rejected_returns_zero_count(client):
     """An empty ``rejected`` payload still validates and returns a 200
     with ``recovered_count: 0`` and an empty strike list.
@@ -311,6 +323,7 @@ def test_relax_empty_rejected_returns_zero_count(client):
     assert data["relaxed_threshold_text"] != ""
 
 
+@pytest.mark.integration
 def test_relax_multi_reason_strike_does_not_recover(client):
     """A strike failing TWO rules — including the relaxed one — does NOT
     recover. Relaxing one rule does not free a strike still failing the
@@ -347,6 +360,7 @@ def test_relax_multi_reason_strike_does_not_recover(client):
     ]
 
 
+@pytest.mark.integration
 def test_relax_single_reason_still_failing_does_not_recover(client):
     """A strike whose ONLY rejection is the relaxed rule but whose value
     is still below the relaxed threshold does NOT recover.
@@ -374,6 +388,7 @@ def test_relax_single_reason_still_failing_does_not_recover(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_relax_low_oi_threshold_text_uses_rules_config(client):
     """``current_threshold_text`` reads from the persisted rules_config;
     the default ``min_open_interest`` is 500 → relaxed = 250.

--- a/backend/tests/test_research_business.py
+++ b/backend/tests/test_research_business.py
@@ -83,6 +83,7 @@ def _fake_info(**overrides: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_build_business_payload_success_returns_payload(client):
     """yfinance returns full info → payload matches PRD contract verbatim."""
     _seed_position(client)
@@ -106,6 +107,7 @@ def test_build_business_payload_success_returns_payload(client):
     fetcher.assert_called_once_with("SOFI")
 
 
+@pytest.mark.integration
 def test_build_business_payload_normalizes_ticker_to_upper(client):
     """Lowercase ticker is uppercased before the fetch and in the payload."""
     _seed_position(client, ticker="sofi")
@@ -120,6 +122,7 @@ def test_build_business_payload_normalizes_ticker_to_upper(client):
     fetcher.assert_called_once_with("SOFI")
 
 
+@pytest.mark.integration
 def test_build_business_payload_surfaces_partial_fields_as_none(client):
     """yfinance omitted fields → JSON null, not fabricated values."""
     _seed_position(client)
@@ -148,6 +151,7 @@ def test_build_business_payload_surfaces_partial_fields_as_none(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_build_business_payload_raises_when_yfinance_returns_none(client):
     """yfinance hard fail → ResearchSourceUnavailable with sanitized detail."""
     _seed_position(client)
@@ -168,6 +172,7 @@ def test_build_business_payload_raises_when_yfinance_returns_none(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_in_memory_cache_hit_skips_yfinance_on_second_call(client):
     """Second call inside TTL serves from research_cache — no fetcher call."""
     _seed_position(client)
@@ -190,6 +195,7 @@ def test_in_memory_cache_hit_skips_yfinance_on_second_call(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_app_setting_cache_hit_skips_yfinance_after_in_memory_eviction(
     client,
 ):
@@ -231,6 +237,7 @@ def test_app_setting_cache_hit_skips_yfinance_after_in_memory_eviction(
     assert payload["summary"] == "Pre-seeded."
 
 
+@pytest.mark.integration
 def test_stale_app_setting_falls_through_to_yfinance(client):
     """app_settings row older than 24h → yfinance is called again."""
     _seed_position(client)
@@ -274,6 +281,7 @@ def test_stale_app_setting_falls_through_to_yfinance(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_rate_limited_yfinance_raises_throttling_research_source_unavailable(
     client,
 ):

--- a/backend/tests/test_research_business_router.py
+++ b/backend/tests/test_research_business_router.py
@@ -59,6 +59,7 @@ def _fake_info() -> dict:
     }
 
 
+@pytest.mark.integration
 def test_get_business_404_for_missing_position(client):
     """Unknown ``position_id`` → 404 with sanitized detail (never str(e))."""
     resp = client.get("/api/positions/does-not-exist/research/business")
@@ -66,6 +67,7 @@ def test_get_business_404_for_missing_position(client):
     assert resp.json() == {"detail": "Position not found"}
 
 
+@pytest.mark.integration
 def test_get_business_200_returns_payload(client):
     """yfinance returns full info → 200 with the BusinessResponse shape."""
     pid = _create_position(client)
@@ -87,6 +89,7 @@ def test_get_business_200_returns_payload(client):
     assert body["fetched_at"].endswith("Z")
 
 
+@pytest.mark.integration
 def test_get_business_502_on_source_unavailable(client):
     """yfinance hard-fail + empty cache → 502 with sanitized detail."""
     pid = _create_position(client)
@@ -100,6 +103,7 @@ def test_get_business_502_on_source_unavailable(client):
     assert resp.json() == {"detail": "Source unavailable"}
 
 
+@pytest.mark.integration
 def test_get_business_500_on_unexpected_exception(client):
     """Unexpected service exception → 500 with the generic CLAUDE.md detail."""
     pid = _create_position(client)

--- a/backend/tests/test_research_cache_utils.py
+++ b/backend/tests/test_research_cache_utils.py
@@ -14,6 +14,7 @@ research_financials. Test surface focuses on:
 """
 
 from __future__ import annotations
+import pytest
 
 import json
 from datetime import datetime, timezone
@@ -34,6 +35,7 @@ def _db_session(client):
     return next(override())
 
 
+@pytest.mark.integration
 def test_roundtrip_read_after_write_returns_payload_and_timestamp(client):
     """Happy path — write then read returns the exact payload + timestamp."""
     db = _db_session(client)
@@ -49,12 +51,14 @@ def test_roundtrip_read_after_write_returns_payload_and_timestamp(client):
     assert persisted_ts == fetched_at
 
 
+@pytest.mark.integration
 def test_read_returns_none_for_missing_key(client):
     """No row for the key → ``None``, no exception."""
     db = _db_session(client)
     assert read_app_setting(db, "yf_business:NOPE") is None
 
 
+@pytest.mark.integration
 def test_read_returns_none_for_malformed_value_no_pipe(client):
     """Value without the ``|`` separator → ``None`` (defensive)."""
     db = _db_session(client)
@@ -64,6 +68,7 @@ def test_read_returns_none_for_malformed_value_no_pipe(client):
     assert read_app_setting(db, "yf_business:BAD") is None
 
 
+@pytest.mark.integration
 def test_read_returns_none_for_non_dict_payload(client):
     """JSON list payload → ``None`` (the contract is dict-only)."""
     db = _db_session(client)
@@ -79,6 +84,7 @@ def test_read_returns_none_for_non_dict_payload(client):
     assert read_app_setting(db, "yf_business:LIST") is None
 
 
+@pytest.mark.integration
 def test_read_returns_none_for_invalid_timestamp(client):
     """Unparseable ISO timestamp → ``None`` (caller falls through to fetch)."""
     db = _db_session(client)
@@ -93,6 +99,7 @@ def test_read_returns_none_for_invalid_timestamp(client):
     assert read_app_setting(db, "yf_business:BADTS") is None
 
 
+@pytest.mark.integration
 def test_write_upserts_existing_key(client):
     """Second write to the same key replaces the row — no duplicate inserts."""
     db = _db_session(client)
@@ -115,6 +122,7 @@ def test_write_upserts_existing_key(client):
     assert persisted_ts == fetched_at_v2
 
 
+@pytest.mark.integration
 def test_write_swallows_typeerror_on_non_serializable_payload(client):
     """Non-JSON-serializable payload (set) raises ``TypeError`` inside
     ``json.dumps`` — helper must catch it per the "never propagate"

--- a/backend/tests/test_research_financials.py
+++ b/backend/tests/test_research_financials.py
@@ -109,6 +109,7 @@ def _ten_av_quarters() -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_build_financials_payload_av_primary_success(client):
     """AV returns 10 quarters → response carries 8, source=alphavantage."""
     db = _db_session(client)
@@ -127,6 +128,7 @@ def test_build_financials_payload_av_primary_success(client):
     yf_fetcher.assert_not_called()
 
 
+@pytest.mark.integration
 def test_av_quarter_projection_computes_margins(client):
     """gross_margin = gross_profit / total_revenue; operating_margin same shape."""
     db = _db_session(client)
@@ -154,6 +156,7 @@ def test_av_quarter_projection_computes_margins(client):
     assert q["operating_margin"] == pytest.approx(0.04)
 
 
+@pytest.mark.integration
 def test_av_quarter_with_missing_fields_surfaces_none_margins(client):
     """Missing numerator/denominator → margins are JSON null, not 0."""
     db = _db_session(client)
@@ -186,6 +189,7 @@ def test_av_quarter_with_missing_fields_surfaces_none_margins(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_av_rate_limited_falls_back_to_yfinance(client):
     """AV returns None → yfinance is called; source attribution flips."""
     db = _db_session(client)
@@ -208,6 +212,7 @@ def test_av_rate_limited_falls_back_to_yfinance(client):
     assert payload["quarters"][0]["period_end"] == "2025-03-31"
 
 
+@pytest.mark.integration
 def test_yfinance_fallback_payload_is_persisted_to_app_settings(client):
     """yfinance fallback writes a durable yf_financials:{ticker} row."""
     db = _db_session(client)
@@ -237,6 +242,7 @@ def test_yfinance_fallback_payload_is_persisted_to_app_settings(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_both_sources_fail_raises_sanitized_error(client):
     """AV None + yfinance None → ResearchSourceUnavailable; no str(e) leak.
 
@@ -265,6 +271,7 @@ def test_both_sources_fail_raises_sanitized_error(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_cache_hit_skips_both_upstreams_on_second_call(client):
     """Second call within TTL serves the composed payload from research_cache."""
     db = _db_session(client)
@@ -283,6 +290,7 @@ def test_cache_hit_skips_both_upstreams_on_second_call(client):
     assert av_fetcher.call_count == 1
 
 
+@pytest.mark.integration
 def test_durable_yf_cache_serves_after_in_memory_eviction(client):
     """Pre-seeded yf_financials app_setting served when AV is unavailable."""
     db = _db_session(client)
@@ -328,6 +336,7 @@ def test_durable_yf_cache_serves_after_in_memory_eviction(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.skip(
     reason="Position-not-found returns 404 at the HTTP router layer; "
     "that test belongs alongside backend/app/routers/research.py "
@@ -343,6 +352,7 @@ def test_position_not_found_returns_404_via_router():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_section_d_both_sources_empty_includes_ticker_in_detail(client):
     """AV None + yfinance None → detail names the ticker + both sources verbatim."""
     db = _db_session(client)
@@ -360,6 +370,7 @@ def test_section_d_both_sources_empty_includes_ticker_in_detail(client):
     )
 
 
+@pytest.mark.integration
 def test_section_d_av_empty_then_yfinance_throttled_raises_throttling(client):
     """AV None + yfinance throttled → ResearchSourceUnavailable with throttling copy."""
     from app.services.yfinance_client import YFinanceRateLimitedError

--- a/backend/tests/test_research_financials_router.py
+++ b/backend/tests/test_research_financials_router.py
@@ -59,6 +59,7 @@ def _av_quarter(period: str = "2025-03-31") -> dict:
     }
 
 
+@pytest.mark.integration
 def test_get_financials_404_for_missing_position(client):
     """Unknown ``position_id`` → 404 with sanitized detail."""
     resp = client.get("/api/positions/does-not-exist/research/financials")
@@ -66,6 +67,7 @@ def test_get_financials_404_for_missing_position(client):
     assert resp.json() == {"detail": "Position not found"}
 
 
+@pytest.mark.integration
 def test_get_financials_200_returns_av_payload(client):
     """AV primary returns data → 200 with ``source=alphavantage``."""
     pid = _create_position(client)
@@ -111,6 +113,7 @@ def test_get_financials_200_returns_av_payload(client):
     assert 0.42 < first["gross_margin"] < 0.44
 
 
+@pytest.mark.integration
 def test_get_financials_200_falls_back_to_yfinance(client):
     """AV down + yfinance up → 200 with ``source=yfinance``."""
     pid = _create_position(client)
@@ -138,6 +141,7 @@ def test_get_financials_200_falls_back_to_yfinance(client):
     assert len(body["quarters"]) == 1
 
 
+@pytest.mark.integration
 def test_get_financials_502_when_both_sources_unavailable(client):
     """AV ``None`` + yfinance ``None`` → 502 with sanitized detail.
 
@@ -164,6 +168,7 @@ def test_get_financials_502_when_both_sources_unavailable(client):
     }
 
 
+@pytest.mark.integration
 def test_get_financials_500_on_unexpected_exception(client):
     """Unexpected service exception → 500 with the generic CLAUDE.md detail."""
     pid = _create_position(client)

--- a/backend/tests/test_research_price_history.py
+++ b/backend/tests/test_research_price_history.py
@@ -168,7 +168,7 @@ def _clear_price_history_cache():
 class TestTradeEventMapping:
     """:func:`_trade_events_from_position` correctly normalizes legacy types."""
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_normalizes_buy_put_close_to_buy_close(self):
         events = svc._trade_events_from_position(
             {
@@ -187,7 +187,7 @@ class TestTradeEventMapping:
         assert events[0].date == "2025-02-15"
         assert events[0].strike == 26.0
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_normalizes_buy_call_close_to_buy_close(self):
         events = svc._trade_events_from_position(
             {
@@ -203,7 +203,7 @@ class TestTradeEventMapping:
         )
         assert events[0].type == "buy_close"
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_passes_through_v1_vocabulary_unchanged(self):
         for raw in ("sell_put", "sell_call", "assignment", "called_away", "expired"):
             events = svc._trade_events_from_position(
@@ -220,7 +220,7 @@ class TestTradeEventMapping:
             )
             assert events and events[0].type == raw, raw
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_skips_unknown_trade_types(self):
         events = svc._trade_events_from_position(
             {
@@ -241,7 +241,7 @@ class TestTradeEventMapping:
         )
         assert [e.type for e in events] == ["sell_put"]
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_skips_rows_without_opened_at(self):
         events = svc._trade_events_from_position(
             {
@@ -251,7 +251,7 @@ class TestTradeEventMapping:
         )
         assert events == []
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_sorts_events_by_date(self):
         events = svc._trade_events_from_position(
             {
@@ -269,14 +269,14 @@ class TestTradeEventMapping:
 class TestWindowResolution:
     """:func:`_window_dates` returns a sensible (start, end) range."""
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_default_window_is_one_year(self):
         start, end = svc._window_dates("1Y")
         # The window is 365 days; allow ±1 day for the day-boundary edge.
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
         assert 364 <= delta <= 366
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     @pytest.mark.parametrize("window,min_days,max_days", [
         ("6M", 182, 184),
         ("1Y", 364, 366),
@@ -287,7 +287,7 @@ class TestWindowResolution:
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
         assert min_days <= delta <= max_days
 
-    @pytest.mark.integration
+    @pytest.mark.unit
     def test_unsupported_window_raises(self):
         with pytest.raises(svc.InvalidWindowError):
             svc._window_dates("3D")

--- a/backend/tests/test_research_price_history.py
+++ b/backend/tests/test_research_price_history.py
@@ -168,6 +168,7 @@ def _clear_price_history_cache():
 class TestTradeEventMapping:
     """:func:`_trade_events_from_position` correctly normalizes legacy types."""
 
+    @pytest.mark.integration
     def test_normalizes_buy_put_close_to_buy_close(self):
         events = svc._trade_events_from_position(
             {
@@ -186,6 +187,7 @@ class TestTradeEventMapping:
         assert events[0].date == "2025-02-15"
         assert events[0].strike == 26.0
 
+    @pytest.mark.integration
     def test_normalizes_buy_call_close_to_buy_close(self):
         events = svc._trade_events_from_position(
             {
@@ -201,6 +203,7 @@ class TestTradeEventMapping:
         )
         assert events[0].type == "buy_close"
 
+    @pytest.mark.integration
     def test_passes_through_v1_vocabulary_unchanged(self):
         for raw in ("sell_put", "sell_call", "assignment", "called_away", "expired"):
             events = svc._trade_events_from_position(
@@ -217,6 +220,7 @@ class TestTradeEventMapping:
             )
             assert events and events[0].type == raw, raw
 
+    @pytest.mark.integration
     def test_skips_unknown_trade_types(self):
         events = svc._trade_events_from_position(
             {
@@ -237,6 +241,7 @@ class TestTradeEventMapping:
         )
         assert [e.type for e in events] == ["sell_put"]
 
+    @pytest.mark.integration
     def test_skips_rows_without_opened_at(self):
         events = svc._trade_events_from_position(
             {
@@ -246,6 +251,7 @@ class TestTradeEventMapping:
         )
         assert events == []
 
+    @pytest.mark.integration
     def test_sorts_events_by_date(self):
         events = svc._trade_events_from_position(
             {
@@ -263,12 +269,14 @@ class TestTradeEventMapping:
 class TestWindowResolution:
     """:func:`_window_dates` returns a sensible (start, end) range."""
 
+    @pytest.mark.integration
     def test_default_window_is_one_year(self):
         start, end = svc._window_dates("1Y")
         # The window is 365 days; allow ±1 day for the day-boundary edge.
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
         assert 364 <= delta <= 366
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("window,min_days,max_days", [
         ("6M", 182, 184),
         ("1Y", 364, 366),
@@ -279,6 +287,7 @@ class TestWindowResolution:
         delta = (date.fromisoformat(end) - date.fromisoformat(start)).days
         assert min_days <= delta <= max_days
 
+    @pytest.mark.integration
     def test_unsupported_window_raises(self):
         with pytest.raises(svc.InvalidWindowError):
             svc._window_dates("3D")
@@ -297,6 +306,7 @@ _AV_PATCH = "app.services.research_price_history.get_historical_earnings"
 class TestPriceHistoryEndpoint:
     """End-to-end behavior of ``GET /research/price-history``."""
 
+    @pytest.mark.integration
     def test_success_path_with_trades_and_earnings(self, client):
         _seed_position_with_trades(client)
         earnings = [
@@ -330,6 +340,7 @@ class TestPriceHistoryEndpoint:
         for e in payload["earnings_events"]:
             assert e["label"] == "Earnings"
 
+    @pytest.mark.integration
     def test_empty_position_returns_basis_and_empty_trade_events(self, client):
         _seed_position_with_trades(client, with_trades=False)
         with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
@@ -344,6 +355,7 @@ class TestPriceHistoryEndpoint:
         # No trades → adjusted basis equals broker basis (no premium offset).
         assert payload["basis"]["adjusted"] == _BROKER_BASIS
 
+    @pytest.mark.integration
     def test_av_failure_degrades_to_empty_earnings_with_200(self, client):
         """AV unavailable must NOT fail the whole payload (NFR-3)."""
         _seed_position_with_trades(client)
@@ -357,6 +369,7 @@ class TestPriceHistoryEndpoint:
         assert payload["earnings_events"] == []
         assert len(payload["prices"]) > 0  # primary signal still rendered
 
+    @pytest.mark.integration
     def test_av_raises_unexpected_exception_still_degrades_to_empty(self, client):
         """Even if the AV client raises, the endpoint must stay 200."""
         _seed_position_with_trades(client)
@@ -368,6 +381,7 @@ class TestPriceHistoryEndpoint:
         assert resp.status_code == 200
         assert resp.json()["earnings_events"] == []
 
+    @pytest.mark.integration
     def test_price_source_failure_returns_502(self, client):
         _seed_position_with_trades(client)
         with patch(_FETCH_PATCH, side_effect=RuntimeError("schwab kaboom")), \
@@ -381,6 +395,7 @@ class TestPriceHistoryEndpoint:
         # CLAUDE.md: no raw exception messages in API responses.
         assert "kaboom" not in body["detail"]
 
+    @pytest.mark.integration
     def test_position_not_found_returns_404(self, client):
         with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
              patch(_AV_PATCH, return_value=[]):
@@ -390,6 +405,7 @@ class TestPriceHistoryEndpoint:
         assert resp.status_code == 404
         assert resp.json()["detail"] == "Position not found"
 
+    @pytest.mark.integration
     def test_default_window_is_one_year(self, client):
         _seed_position_with_trades(client)
         with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
@@ -400,6 +416,7 @@ class TestPriceHistoryEndpoint:
         assert resp.status_code == 200
         assert resp.json()["window"] == "1Y"
 
+    @pytest.mark.integration
     @pytest.mark.parametrize("window", ["6M", "1Y", "2Y"])
     def test_supported_windows_accepted(self, client, window):
         _seed_position_with_trades(client)
@@ -411,6 +428,7 @@ class TestPriceHistoryEndpoint:
         assert resp.status_code == 200, resp.text
         assert resp.json()["window"] == window
 
+    @pytest.mark.integration
     def test_lowercase_window_accepted(self, client):
         """The service uppercases ``window`` before validating."""
         _seed_position_with_trades(client)
@@ -422,6 +440,7 @@ class TestPriceHistoryEndpoint:
         assert resp.status_code == 200
         assert resp.json()["window"] == "1Y"
 
+    @pytest.mark.integration
     def test_unsupported_window_returns_422(self, client):
         _seed_position_with_trades(client)
         with patch(_FETCH_PATCH, return_value=(_price_df(), _price_meta())), \
@@ -435,6 +454,7 @@ class TestPriceHistoryEndpoint:
         for w in ("6M", "1Y", "2Y"):
             assert w in detail
 
+    @pytest.mark.integration
     def test_cache_hit_skips_second_fetch_within_ttl(self, client):
         """Second call within 15 min should NOT re-fetch prices or earnings."""
         _seed_position_with_trades(client)
@@ -453,6 +473,7 @@ class TestPriceHistoryEndpoint:
         assert fetch_mock.call_count == 1
         assert av_mock.call_count == 1
 
+    @pytest.mark.integration
     def test_cache_key_is_per_window(self, client):
         """Different window params get separate cache entries."""
         _seed_position_with_trades(client)

--- a/backend/tests/test_research_regression.py
+++ b/backend/tests/test_research_regression.py
@@ -120,6 +120,7 @@ def _clear_regression_cache():
 # --- Success path with all 3 factors --------------------------------------
 
 
+@pytest.mark.integration
 def test_success_with_all_three_factors(client):
     """Financial Services position → basket includes SPY + XLF + DGS10."""
     position_id = _create_position(client, ticker="JPM")
@@ -166,6 +167,7 @@ def test_success_with_all_three_factors(client):
 # --- Sector-omitted branch -------------------------------------------------
 
 
+@pytest.mark.integration
 def test_sector_unknown_drops_to_two_factor_basket(client):
     """Unmapped sector → basket is SPY + DGS10 only and sector_omitted=True."""
     position_id = _create_position(client, ticker="ZZZX")
@@ -196,6 +198,7 @@ def test_sector_unknown_drops_to_two_factor_basket(client):
 # --- Insufficient-data branch ---------------------------------------------
 
 
+@pytest.mark.integration
 def test_insufficient_sample_size_returns_422(client):
     """Fewer than 60 aligned trading days → 422 with sanitized message."""
     position_id = _create_position(client, ticker="AAPL")
@@ -227,6 +230,7 @@ def test_insufficient_sample_size_returns_422(client):
 # --- Upstream-source failure ----------------------------------------------
 
 
+@pytest.mark.integration
 def test_upstream_fetch_failure_returns_502(client):
     """Any upstream fetch raising → 502 with generic source message."""
     position_id = _create_position(client, ticker="AAPL")
@@ -253,6 +257,7 @@ def test_upstream_fetch_failure_returns_502(client):
 # --- Position not found ---------------------------------------------------
 
 
+@pytest.mark.integration
 def test_unknown_position_returns_404(client):
     """A position id that does not exist → 404."""
     resp = client.get(
@@ -265,6 +270,7 @@ def test_unknown_position_returns_404(client):
 # --- Window validation -----------------------------------------------------
 
 
+@pytest.mark.integration
 def test_invalid_window_returns_422(client):
     """Any ``window`` value other than ``1Y`` → 422."""
     position_id = _create_position(client, ticker="AAPL")
@@ -278,6 +284,7 @@ def test_invalid_window_returns_422(client):
 # --- Cache behavior --------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_cache_hit_on_second_call_within_ttl(client):
     """Second call within TTL serves the cached response without fetching."""
     position_id = _create_position(client, ticker="JPM")
@@ -313,6 +320,7 @@ def test_cache_hit_on_second_call_within_ttl(client):
 # --- Factor variance share normalization ----------------------------------
 
 
+@pytest.mark.integration
 def test_factor_contributions_sum_to_approximately_one(client):
     """Sanity check: factor + idiosyncratic shares sum to ~1.0 (donut-ready)."""
     position_id = _create_position(client, ticker="JPM")

--- a/backend/tests/test_research_thesis.py
+++ b/backend/tests/test_research_thesis.py
@@ -14,6 +14,7 @@ Covers the eight required scenarios from the worker brief:
 """
 
 from __future__ import annotations
+import pytest
 
 
 def _create_position(client, ticker: str = "AAPL") -> str:
@@ -34,6 +35,7 @@ def _create_position(client, ticker: str = "AAPL") -> str:
 # --- GET ---
 
 
+@pytest.mark.integration
 def test_get_thesis_empty_state_when_no_row(client):
     """Position exists but no thesis row → empty-state shape (NOT 404)."""
     pid = _create_position(client)
@@ -43,6 +45,7 @@ def test_get_thesis_empty_state_when_no_row(client):
     assert body == {"thesis": None, "updated_at": None, "version": 0}
 
 
+@pytest.mark.integration
 def test_get_thesis_404_for_missing_position(client):
     """A missing position id returns sanitized 404."""
     resp = client.get("/api/positions/does-not-exist/research/thesis")
@@ -53,6 +56,7 @@ def test_get_thesis_404_for_missing_position(client):
 # --- PUT create ---
 
 
+@pytest.mark.integration
 def test_put_creates_row_version_one(client):
     """First PUT creates the row at version 1; GET returns it."""
     pid = _create_position(client)
@@ -72,6 +76,7 @@ def test_put_creates_row_version_one(client):
     assert get_resp.json() == payload
 
 
+@pytest.mark.integration
 def test_put_404_for_missing_position(client):
     """PUT on a missing position id returns sanitized 404."""
     resp = client.put(
@@ -85,6 +90,7 @@ def test_put_404_for_missing_position(client):
 # --- PUT update / versioning ---
 
 
+@pytest.mark.integration
 def test_put_update_increments_version_and_refreshes_updated_at(client):
     """Second PUT bumps version, refreshes updated_at, replaces body."""
     pid = _create_position(client)
@@ -106,6 +112,7 @@ def test_put_update_increments_version_and_refreshes_updated_at(client):
     assert second["updated_at"] >= first["updated_at"]
 
 
+@pytest.mark.integration
 def test_put_three_times_increments_version_each_call(client):
     """Three sequential PUTs land at versions 1, 2, 3 in order."""
     pid = _create_position(client)
@@ -123,6 +130,7 @@ def test_put_three_times_increments_version_each_call(client):
 # --- PUT validation ---
 
 
+@pytest.mark.integration
 def test_put_rejects_over_4000_chars(client):
     """Bodies longer than the cap return 422 with a sanitized message."""
     pid = _create_position(client)
@@ -142,6 +150,7 @@ def test_put_rejects_over_4000_chars(client):
     assert "4000" in text or "limit" in text.lower() or "length" in text.lower()
 
 
+@pytest.mark.integration
 def test_put_accepts_exactly_4000_chars(client):
     """Exactly 4000 characters is within the cap (boundary)."""
     pid = _create_position(client)
@@ -154,6 +163,7 @@ def test_put_accepts_exactly_4000_chars(client):
     assert resp.json()["thesis"] == boundary
 
 
+@pytest.mark.integration
 def test_put_empty_string_is_allowed_and_bumps_version(client):
     """Empty body clears the note but still increments the version."""
     pid = _create_position(client)
@@ -174,6 +184,7 @@ def test_put_empty_string_is_allowed_and_bumps_version(client):
 # --- Round-trip / sanity ---
 
 
+@pytest.mark.integration
 def test_body_column_round_trips_complex_text(client):
     """``body`` round-trips newlines, unicode, and punctuation losslessly."""
     pid = _create_position(client)
@@ -189,6 +200,7 @@ def test_body_column_round_trips_complex_text(client):
     assert get_resp.json()["thesis"] == original
 
 
+@pytest.mark.integration
 def test_two_positions_have_independent_notes(client):
     """Each position has its own thesis — no cross-pollination."""
     pid_a = _create_position(client, ticker="AAPL")

--- a/backend/tests/test_rule_monitor.py
+++ b/backend/tests/test_rule_monitor.py
@@ -52,6 +52,7 @@ def _evaluate(**overrides):
 
 
 class TestTriggeredRulesShape:
+    @pytest.mark.unit
     def test_always_four_rows_in_precedence_order(self):
         _, _, _, rules = _evaluate()
         assert len(rules) == 4
@@ -62,6 +63,7 @@ class TestTriggeredRulesShape:
             "dte_review",
         ]
 
+    @pytest.mark.unit
     def test_precedence_constant_has_four_keys(self):
         assert RULE_PRECEDENCE == (
             "assignment",
@@ -70,6 +72,7 @@ class TestTriggeredRulesShape:
             "dte_review",
         )
 
+    @pytest.mark.unit
     def test_every_row_has_required_keys(self):
         _, _, _, rules = _evaluate()
         for row in rules:
@@ -90,6 +93,7 @@ class TestTriggeredRulesShape:
 
 
 class TestQuietLeg:
+    @pytest.mark.unit
     def test_no_rule_fires_yields_hold(self):
         verdict, label, reasoning, rules = _evaluate(
             dte=40, profit_target_status=_profit_status(0.18)
@@ -99,6 +103,7 @@ class TestQuietLeg:
         assert reasoning == "No management rule has triggered for this leg yet."
         assert all(not r["is_governing"] for r in rules)
 
+    @pytest.mark.unit
     def test_quiet_leg_rows_are_not_triggered(self):
         _, _, _, rules = _evaluate(dte=40, profit_target_status=_profit_status(0.18))
         statuses = {r["rule_id"]: r["status"] for r in rules}
@@ -114,6 +119,7 @@ class TestQuietLeg:
 
 
 class TestProfitTakeRule:
+    @pytest.mark.unit
     def test_fires_above_threshold(self):
         verdict, label, _, _ = _evaluate(
             dte=40, profit_target_status=_profit_status(0.60)
@@ -121,6 +127,7 @@ class TestProfitTakeRule:
         assert verdict == "profit_take_review"
         assert label == "Review · 50%"
 
+    @pytest.mark.unit
     def test_fires_exactly_at_threshold(self):
         verdict, _, _, rules = _evaluate(
             dte=40, profit_target_status=_profit_status(0.50)
@@ -129,6 +136,7 @@ class TestProfitTakeRule:
         profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
         assert profit_row["status"] == "triggered"
 
+    @pytest.mark.unit
     def test_just_below_threshold_not_yet(self):
         verdict, _, _, rules = _evaluate(
             dte=40, profit_target_status=_profit_status(0.49)
@@ -137,6 +145,7 @@ class TestProfitTakeRule:
         profit_row = next(r for r in rules if r["rule_id"] == "profit_review")
         assert profit_row["status"] == "not_yet"
 
+    @pytest.mark.unit
     def test_custom_threshold_interpolated_in_label(self):
         verdict, label, _, rules = _evaluate(
             dte=40,
@@ -155,6 +164,7 @@ class TestProfitTakeRule:
 
 
 class TestDteReviewRule:
+    @pytest.mark.unit
     def test_fires_inside_window(self):
         verdict, label, _, _ = _evaluate(
             dte=20, profit_target_status=_profit_status(0.10)
@@ -162,12 +172,14 @@ class TestDteReviewRule:
         assert verdict == "dte_review"
         assert label == "Review · 21d"
 
+    @pytest.mark.unit
     def test_fires_exactly_at_window_boundary(self):
         verdict, _, _, _ = _evaluate(
             dte=21, profit_target_status=_profit_status(0.10)
         )
         assert verdict == "dte_review"
 
+    @pytest.mark.unit
     def test_one_day_past_window_not_yet(self):
         verdict, _, _, rules = _evaluate(
             dte=22, profit_target_status=_profit_status(0.10)
@@ -176,6 +188,7 @@ class TestDteReviewRule:
         dte_row = next(r for r in rules if r["rule_id"] == "dte_review")
         assert dte_row["status"] == "not_yet"
 
+    @pytest.mark.unit
     def test_custom_dte_window_honored(self):
         verdict, label, _, _ = _evaluate(
             dte=25,
@@ -192,6 +205,7 @@ class TestDteReviewRule:
 
 
 class TestExpirationRule:
+    @pytest.mark.unit
     def test_expiration_fires_otm_inside_warning_window(self):
         verdict, label, _, _ = _evaluate(
             dte=5, moneyness_state="OTM", profit_target_status=_profit_status(0.10)
@@ -199,6 +213,7 @@ class TestExpirationRule:
         assert verdict == "expiration"
         assert label == "Close · exp"
 
+    @pytest.mark.unit
     def test_assignment_fires_itm_inside_warning_window(self):
         verdict, label, _, _ = _evaluate(
             dte=5, moneyness_state="ITM", profit_target_status=_profit_status(0.10)
@@ -206,12 +221,14 @@ class TestExpirationRule:
         assert verdict == "assignment"
         assert label == "Close · ITM"
 
+    @pytest.mark.unit
     def test_expiration_boundary_at_warning_window(self):
         verdict, _, _, _ = _evaluate(
             dte=7, moneyness_state="OTM", profit_target_status=_profit_status(0.10)
         )
         assert verdict == "expiration"
 
+    @pytest.mark.unit
     def test_assignment_row_never_not_yet(self):
         # An OTM leg approaching expiry is an expiration case, never an
         # armed assignment countdown (spec §3.3).
@@ -221,6 +238,7 @@ class TestExpirationRule:
         assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
         assert assignment_row["status"] == "no"
 
+    @pytest.mark.unit
     def test_expired_leg_yields_hold(self):
         verdict, _, _, rules = _evaluate(
             dte=-3, moneyness_state="OTM", profit_target_status=_profit_status(None)
@@ -238,6 +256,7 @@ class TestExpirationRule:
 
 
 class TestPrecedence:
+    @pytest.mark.unit
     def test_profit_take_outranks_dte_review(self):
         # Inside the 21d window AND past 50% capture.
         verdict, _, reasoning, rules = _evaluate(
@@ -254,6 +273,7 @@ class TestPrecedence:
         assert "profit-take rule triggered" in reasoning
         assert "21-day review window" in reasoning
 
+    @pytest.mark.unit
     def test_assignment_outranks_everything(self):
         # 5-DTE ITM leg also past 50% capture: assignment governs.
         verdict, label, _, rules = _evaluate(
@@ -264,6 +284,7 @@ class TestPrecedence:
         assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
         assert assignment_row["is_governing"] is True
 
+    @pytest.mark.unit
     def test_only_governing_rule_carries_reasoning(self):
         _, _, _, rules = _evaluate(
             dte=14, profit_target_status=_profit_status(0.67)
@@ -283,6 +304,7 @@ class TestPrecedence:
 
 
 class TestTriState:
+    @pytest.mark.unit
     def test_far_dte_leg_is_not_yet(self):
         _, _, _, rules = _evaluate(
             dte=38, profit_target_status=_profit_status(0.20)
@@ -291,6 +313,7 @@ class TestTriState:
         assert dte_row["status"] == "not_yet"
         assert dte_row["value_display"] == "38 d"
 
+    @pytest.mark.unit
     def test_otm_leg_assignment_row_is_no(self):
         _, _, _, rules = _evaluate(
             dte=38, moneyness_state="OTM", profit_target_status=_profit_status(0.20)
@@ -310,6 +333,7 @@ class TestAssignmentRiskRowValue:
     not the ITM/ATM/OTM moneyness label (CodeRabbit fix).
     """
 
+    @pytest.mark.unit
     def test_high_risk_row_shows_high_not_moneyness(self):
         _, _, _, rules = _evaluate(
             dte=5,
@@ -321,6 +345,7 @@ class TestAssignmentRiskRowValue:
         assert assignment_row["value_display"] == "High"
         assert assignment_row["value_display"] not in {"ITM", "ATM", "OTM"}
 
+    @pytest.mark.unit
     def test_watch_risk_row_shows_watch(self):
         _, _, _, rules = _evaluate(
             dte=12,
@@ -331,6 +356,7 @@ class TestAssignmentRiskRowValue:
         assignment_row = next(r for r in rules if r["rule_id"] == "assignment_risk")
         assert assignment_row["value_display"] == "Watch"
 
+    @pytest.mark.unit
     def test_low_risk_row_shows_low(self):
         _, _, _, rules = _evaluate(
             dte=38,
@@ -348,6 +374,7 @@ class TestAssignmentRiskRowValue:
 
 
 class TestDegradedNoMid:
+    @pytest.mark.unit
     def test_no_mid_profit_row_is_no_with_dash(self):
         _, _, _, rules = _evaluate(
             dte=12,
@@ -358,6 +385,7 @@ class TestDegradedNoMid:
         assert profit_row["status"] == "no"
         assert profit_row["value_display"] == "—"
 
+    @pytest.mark.unit
     def test_verdict_falls_back_to_dte_rules_without_mid(self):
         # 12-DTE leg, no mid: profit-take unevaluable, DTE-review still fires.
         verdict, _, _, _ = _evaluate(
@@ -367,6 +395,7 @@ class TestDegradedNoMid:
         )
         assert verdict == "dte_review"
 
+    @pytest.mark.unit
     def test_profit_take_never_governs_without_mid(self):
         verdict, _, _, _ = _evaluate(
             dte=40,
@@ -382,6 +411,7 @@ class TestDegradedNoMid:
 
 
 class TestAdviceFraming:
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "kwargs",
         [
@@ -404,6 +434,7 @@ class TestAdviceFraming:
         assert "Your" in reasoning or "your" in reasoning
         assert "rule" in reasoning.lower()
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "kwargs",
         [
@@ -421,6 +452,7 @@ class TestAdviceFraming:
         words = lowered.replace(".", " ").replace(",", " ").replace("(", " ").split()
         assert "our" not in words
 
+    @pytest.mark.unit
     def test_profit_take_reasoning_names_dollar_amounts(self):
         _, _, reasoning, _ = _evaluate(
             dte=40, profit_target_status=_profit_status(0.60), premium=38.34
@@ -436,6 +468,7 @@ class TestAdviceFraming:
 
 
 class TestCardReason:
+    @pytest.mark.unit
     def test_profit_take_short_reason(self):
         _, _, _, rules = _evaluate(
             dte=40, profit_target_status=_profit_status(0.60)
@@ -444,6 +477,7 @@ class TestCardReason:
         assert "profit-take rule triggered" in reason
         assert "60%" in reason
 
+    @pytest.mark.unit
     def test_dte_review_short_reason(self):
         _, _, _, rules = _evaluate(
             dte=18, profit_target_status=_profit_status(0.20)
@@ -451,12 +485,14 @@ class TestCardReason:
         reason = card_reason_for(rules, profit_review_pct=50.0, dte_review_days=21)
         assert "18 days to expiration" in reason
 
+    @pytest.mark.unit
     def test_no_governing_rule_yields_empty_reason(self):
         _, _, _, rules = _evaluate(
             dte=40, profit_target_status=_profit_status(0.18)
         )
         assert card_reason_for(rules, profit_review_pct=50.0, dte_review_days=21) == ""
 
+    @pytest.mark.unit
     def test_custom_dte_review_days_in_short_reason(self):
         # A custom 30-day review window must surface in the dte_review card
         # reason — the caller threads rules.management.dte_review_days, never
@@ -471,6 +507,7 @@ class TestCardReason:
         )
         assert "25 days to expiration" in reason
 
+    @pytest.mark.unit
     def test_expiration_warning_days_is_a_threadable_parameter(self):
         # card_reason_for accepts expiration_warning_days so the caller can
         # pass the user's configured window instead of a hardcoded 7.

--- a/backend/tests/test_rules_config.py
+++ b/backend/tests/test_rules_config.py
@@ -67,6 +67,7 @@ def _store(db, value: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_module_constants():
     """The key and schema-version constants match the ADR-002 spec."""
     assert RULES_CONFIG_KEY == "rules_config"
@@ -140,12 +141,14 @@ def test_default_config_carries_schema_version():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_validator_rejects_negative_dte():
     """A negative DTE minimum is rejected."""
     with pytest.raises(ValidationError):
         EntryRules(dte_range=RangeRule(min=-1, max=45))
 
 
+@pytest.mark.unit
 def test_validator_rejects_delta_above_one():
     """A delta above 1.0 is rejected."""
     with pytest.raises(ValidationError):

--- a/backend/tests/test_rules_config.py
+++ b/backend/tests/test_rules_config.py
@@ -81,6 +81,7 @@ def test_module_constants():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_default_config_universe_matches_catalog():
     """Universe defaults equal PRD #209 §R2."""
     u = DEFAULT_RULES_CONFIG.universe
@@ -90,6 +91,7 @@ def test_default_config_universe_matches_catalog():
     assert u.min_iv_percentile is None
 
 
+@pytest.mark.unit
 def test_default_config_entry_matches_catalog():
     """Entry defaults equal the reconciled PRD #209 §R3 catalog."""
     e = DEFAULT_RULES_CONFIG.entry
@@ -102,6 +104,7 @@ def test_default_config_entry_matches_catalog():
     assert e.min_call_distance_from_cost_basis_pct == 0.0
 
 
+@pytest.mark.unit
 def test_default_config_position_matches_catalog():
     """Position defaults equal PRD #209 §R4 (v1.0.7 / issue #234)."""
     p = DEFAULT_RULES_CONFIG.position
@@ -112,6 +115,7 @@ def test_default_config_position_matches_catalog():
     assert p.max_open_positions is None
 
 
+@pytest.mark.unit
 def test_default_config_risk_matches_catalog():
     """Risk defaults equal PRD #209 §R5."""
     r = DEFAULT_RULES_CONFIG.risk
@@ -120,6 +124,7 @@ def test_default_config_risk_matches_catalog():
     assert r.max_consecutive_rolls is None
 
 
+@pytest.mark.unit
 def test_default_config_management_matches_catalog():
     """Management defaults equal PRD #209 §R6."""
     m = DEFAULT_RULES_CONFIG.management
@@ -129,6 +134,7 @@ def test_default_config_management_matches_catalog():
     assert m.assignment_risk_review == "High"
 
 
+@pytest.mark.unit
 def test_default_config_carries_schema_version():
     """The top-level model carries the schema-version integer."""
     assert DEFAULT_RULES_CONFIG.schema_version == RULES_CONFIG_SCHEMA_VERSION
@@ -155,12 +161,14 @@ def test_validator_rejects_delta_above_one():
         EntryRules(delta_range_csp=RangeRule(min=0.2, max=1.5))
 
 
+@pytest.mark.unit
 def test_validator_rejects_delta_below_zero():
     """A negative delta bound is rejected."""
     with pytest.raises(ValidationError):
         EntryRules(delta_range_csp=RangeRule(min=-0.1, max=0.3))
 
 
+@pytest.mark.unit
 def test_validator_rejects_inverted_range():
     """A range with ``min >= max`` is rejected."""
     with pytest.raises(ValidationError):
@@ -169,30 +177,35 @@ def test_validator_rejects_inverted_range():
         RangeRule(min=30, max=30)
 
 
+@pytest.mark.unit
 def test_validator_rejects_positive_loss_threshold():
     """A loss-review threshold above zero is rejected — a loss is not a gain."""
     with pytest.raises(ValidationError):
         RiskRules(loss_review_threshold_pct=5.0)
 
 
+@pytest.mark.unit
 def test_validator_rejects_profit_review_over_100():
     """A profit-review percent above 100 is rejected."""
     with pytest.raises(ValidationError):
         ManagementTriggers(profit_review_pct=150.0)
 
 
+@pytest.mark.unit
 def test_validator_rejects_zero_max_open_positions():
     """A max-open-positions cap below 1 is rejected when set."""
     with pytest.raises(ValidationError):
         PositionRules(max_open_positions=0)
 
 
+@pytest.mark.unit
 def test_validator_rejects_negative_open_interest():
     """A negative open-interest floor is rejected."""
     with pytest.raises(ValidationError):
         UniverseRules(min_open_interest=-1)
 
 
+@pytest.mark.unit
 def test_validator_rejects_out_of_range_sizing_cap_pct():
     """``sizing_cap_pct`` is a whole-percent in ``(0, 100]``.
 
@@ -219,6 +232,7 @@ def test_validator_rejects_out_of_range_sizing_cap_pct():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_unset_optionals_accept_none():
     """The four PRD #209 "unset" rules are valid as ``None`` — no enforcement.
 
@@ -242,6 +256,7 @@ def test_unset_optionals_accept_none():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_load_missing_row_returns_defaults(db, caplog):
     """No ``rules_config`` row → the full default config + an INFO log."""
     with caplog.at_level(logging.INFO):
@@ -250,6 +265,7 @@ def test_load_missing_row_returns_defaults(db, caplog):
     assert any("default trading rules" in r.message for r in caplog.records)
 
 
+@pytest.mark.unit
 def test_load_empty_value_returns_defaults(db):
     """An empty-string stored value is treated as missing → defaults."""
     _store(db, "   ")
@@ -261,6 +277,7 @@ def test_load_empty_value_returns_defaults(db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_load_valid_full_object_returns_stored_values(db):
     """A valid full stored object → exactly those values are returned."""
     stored = {
@@ -314,6 +331,7 @@ def test_load_valid_full_object_returns_stored_values(db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_load_partial_object_merges_over_defaults(db):
     """A partial stored object → stored fields honored, the rest defaulted."""
     _store(db, json.dumps({"entry": {"min_monthly_return_pct": 4.0}}))
@@ -330,6 +348,7 @@ def test_load_partial_object_merges_over_defaults(db):
     assert cfg.management == DEFAULT_RULES_CONFIG.management
 
 
+@pytest.mark.unit
 def test_load_partial_group_only(db):
     """An older build that stored only ``entry`` → other four groups defaulted."""
     _store(db, json.dumps({"entry": {"dte_range": {"min": 25, "max": 50}}}))
@@ -343,6 +362,7 @@ def test_load_partial_group_only(db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_load_malformed_json_returns_defaults_and_warns(db, caplog):
     """Malformed JSON → defaults + a generic WARNING that leaks no exception text."""
     _store(db, "{not valid json")
@@ -360,6 +380,7 @@ def test_load_malformed_json_returns_defaults_and_warns(db, caplog):
     assert "char" not in joined
 
 
+@pytest.mark.unit
 def test_load_non_object_json_returns_defaults(db):
     """Valid JSON that is not an object (e.g. a list) → defaults."""
     _store(db, json.dumps([1, 2, 3]))
@@ -371,6 +392,7 @@ def test_load_non_object_json_returns_defaults(db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_load_single_bad_field_falls_back_that_field_only(db):
     """One out-of-range field reverts to its default; the rest is honored."""
     _store(
@@ -391,6 +413,7 @@ def test_load_single_bad_field_falls_back_that_field_only(db):
     assert cfg.entry.earnings_buffer_days == 14
 
 
+@pytest.mark.unit
 def test_load_inverted_range_reverts_range_only(db, caplog):
     """An inverted ``dte_range`` reverts as a unit; other fields are honored."""
     _store(
@@ -415,6 +438,7 @@ def test_load_inverted_range_reverts_range_only(db, caplog):
     assert any("entry.dte_range" in r.message for r in warnings)
 
 
+@pytest.mark.unit
 def test_load_bad_field_in_one_group_does_not_poison_others(db):
     """A bad field in ``risk`` does not discard a valid ``position`` group."""
     _store(
@@ -436,6 +460,7 @@ def test_load_bad_field_in_one_group_does_not_poison_others(db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "stored_value",
     [
@@ -470,6 +495,7 @@ def _store_v1(db, position: dict) -> None:
     _store(db, json.dumps({"position": position}))
 
 
+@pytest.mark.unit
 def test_migration_idempotent(db):
     """Running ``load_rules_config`` twice on a v1 row migrates once.
 
@@ -503,6 +529,7 @@ def test_migration_idempotent(db):
     assert markers[0].value == marker_value_before
 
 
+@pytest.mark.unit
 def test_migration_preserves_other_position_fields(db):
     """The migration only touches sizing-cap fields; other rules pass through."""
     _store_v1(
@@ -529,6 +556,7 @@ def test_migration_preserves_other_position_fields(db):
     assert cfg.management == DEFAULT_RULES_CONFIG.management
 
 
+@pytest.mark.unit
 def test_migration_writes_marker_row(db):
     """First migration creates a marker row with the expected JSON shape."""
     _store_v1(db, {"sizing_cap_dollars": 5000.0})
@@ -550,6 +578,7 @@ def test_migration_writes_marker_row(db):
     assert parsed_ts.tzinfo is not None  # carries a timezone
 
 
+@pytest.mark.unit
 def test_migration_does_not_overwrite_existing_marker(db):
     """A pre-existing ``sizing_cap_migration`` row (e.g. dismissed) is left alone.
 
@@ -592,6 +621,7 @@ def test_migration_does_not_overwrite_existing_marker(db):
     assert payload["previous_sizing_cap_dollars"] == 9999.0  # original, not 5000
 
 
+@pytest.mark.unit
 def test_migration_persists_v2_schema_back_to_row(db):
     """After migration the persisted ``rules_config`` row carries v2 + no v1 key."""
     _store_v1(db, {"sizing_cap_dollars": 5000.0})
@@ -610,6 +640,7 @@ def test_migration_persists_v2_schema_back_to_row(db):
     assert "sizing_cap_dollars" not in persisted.get("position", {})
 
 
+@pytest.mark.unit
 def test_no_migration_marker_when_no_old_key(db):
     """A fresh-install row that never carried ``sizing_cap_dollars`` writes no marker."""
     _store(db, json.dumps({"position": {"sizing_cap_pct": 15.0}}))
@@ -629,12 +660,14 @@ def test_no_migration_marker_when_no_old_key(db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_sizing_cap_account_field_defaults_null():
     """``sizing_cap_account`` defaults to ``None`` — first-account behavior."""
     assert PositionRules().sizing_cap_account is None
     assert DEFAULT_RULES_CONFIG.position.sizing_cap_account is None
 
 
+@pytest.mark.unit
 def test_sizing_cap_account_accepts_strings():
     """``sizing_cap_account`` accepts ``None``, ``"sum"``, and a masked id string."""
     # ``None`` (default / first account).

--- a/backend/tests/test_rules_config_integration.py
+++ b/backend/tests/test_rules_config_integration.py
@@ -155,6 +155,7 @@ def _full_rules_config(**overrides) -> str:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_scan_no_stored_row_uses_catalog_defaults(client):
     """With no ``rules_config`` row, the catalog defaults are backfilled.
 
@@ -174,6 +175,7 @@ def test_scan_no_stored_row_uses_catalog_defaults(client):
     assert req.min_iv_rank == 30.0
 
 
+@pytest.mark.integration
 def test_scan_covered_call_uses_cc_delta_band(client):
     """A covered-call scan with no delta override gets the CC band (0.20-0.35)."""
     req = _scan(
@@ -183,6 +185,7 @@ def test_scan_covered_call_uses_cc_delta_band(client):
     assert req.min_delta == 0.20 and req.max_delta == 0.35
 
 
+@pytest.mark.integration
 def test_scan_stored_config_is_honored(client):
     """A stored ``rules_config`` is backfilled onto the request."""
     _seed_setting(
@@ -200,6 +203,7 @@ def test_scan_stored_config_is_honored(client):
     assert req.min_return_pct == 3.0
 
 
+@pytest.mark.integration
 def test_scan_explicit_per_request_value_overrides_stored_config(client):
     """An explicit per-request rule value wins over the stored config."""
     _seed_setting(
@@ -222,6 +226,7 @@ def test_scan_explicit_per_request_value_overrides_stored_config(client):
     assert req.min_return_pct == 2.0  # not overridden → from config
 
 
+@pytest.mark.integration
 def test_fresh_db_yields_working_scan_no_migration(client):
     """Rollout AC: a fresh DB with no ``rules_config`` row still scans.
 
@@ -282,6 +287,7 @@ def _schwab_call_chain(strike: float, *, oi: int, dte: int = 30):
     }
 
 
+@pytest.mark.integration
 def test_cc_scan_surfaces_below_cost_basis_reason(client):
     """A CC strike below cost basis is flagged ``below_cost_basis``, not dropped."""
     # Strike $14 sits below the $20 cost basis.
@@ -306,6 +312,7 @@ def test_cc_scan_surfaces_below_cost_basis_reason(client):
     assert any("cost-basis floor" in s for s in below[0]["human_reasons"])
 
 
+@pytest.mark.integration
 def test_cc_scan_below_cost_basis_suppressed_when_floor_disabled(client):
     """``cost_basis_floor_enabled=False`` suppresses the ``below_cost_basis`` reason."""
     chain = _schwab_call_chain(14.0, oi=500)
@@ -330,6 +337,7 @@ def test_cc_scan_below_cost_basis_suppressed_when_floor_disabled(client):
     )
 
 
+@pytest.mark.integration
 def test_scan_min_open_interest_rejects_thin_strike(client):
     """A stored ``min_open_interest`` of 1000 rejects a 600-OI strike.
 
@@ -364,6 +372,7 @@ def test_scan_min_open_interest_rejects_thin_strike(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_recovery_endpoint_honors_stored_sizing_cap(client):
     """The recovery endpoint resolves its sizing cap from ``rules_config``.
 
@@ -394,6 +403,7 @@ def test_recovery_endpoint_honors_stored_sizing_cap(client):
     assert avg["eligibility"] == "suppressed"
 
 
+@pytest.mark.integration
 def test_recovery_endpoint_default_sizing_cap_with_no_rules_row(client):
     """With no ``rules_config`` row the recovery endpoint uses the $5,000 default."""
     _seed_position(client, broker_cost_basis=3800.0)
@@ -410,6 +420,7 @@ def test_recovery_endpoint_default_sizing_cap_with_no_rules_row(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize(
     ("loss_review_threshold_pct", "pl_pct"),
     [
@@ -461,6 +472,7 @@ def test_flag_gate_and_largest_loser_card_agree(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 @pytest.mark.skip(
     reason="iv_rank has no data source — the gate is plumbed but inert (ADR-002 OQ4). "
     "Wiring a real IV-rank feed is a data-pipeline change beyond #156."
@@ -514,6 +526,7 @@ def _itm_short_dte_ids(rules: RulesConfig) -> list[str]:
     return [a["action_id"] for a in actions]
 
 
+@pytest.mark.integration
 def test_action_engine_default_threshold_excludes_10dte_itm_leg():
     """With the default 7-day window, a 10-DTE ITM leg is outside the warning.
 
@@ -523,6 +536,7 @@ def test_action_engine_default_threshold_excludes_10dte_itm_leg():
     assert "expiration.itm_short_dte" not in _itm_short_dte_ids(DEFAULT_RULES_CONFIG)
 
 
+@pytest.mark.integration
 def test_action_engine_honors_non_default_expiration_warning_days():
     """A stored ``expiration_warning_days`` of 14 shifts the ITM/short-DTE boundary.
 
@@ -548,6 +562,7 @@ def test_action_engine_honors_non_default_expiration_warning_days():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.integration
 def test_okr_response_includes_capital_status_field(client, monkeypatch):
     """The recovery endpoint's OKR inputs match the V1 ``RecoveryOkrInputs``
     contract — sizing_cap_pct, total_capital, resolved_sizing_cap_dollars,

--- a/backend/tests/test_schwab_account_value.py
+++ b/backend/tests/test_schwab_account_value.py
@@ -106,6 +106,7 @@ def _patch_schwab(accounts):
 
 
 class TestCacheHit:
+    @pytest.mark.unit
     def test_cache_hit_returns_fresh_value(self, db_session):
         """1. test_cache_hit_returns_fresh_value — within TTL, returns cached."""
         # Pre-populate the hot cache with a fresh ok result.
@@ -132,6 +133,7 @@ class TestCacheHit:
 
 
 class TestCacheMiss:
+    @pytest.mark.unit
     def test_cache_miss_calls_network(self, db_session):
         """2. test_cache_miss_calls_network — stale, calls get_accounts()."""
         with _patch_schwab([_account("12344471", 25000.0, "CASH")]) as mock_get:
@@ -149,6 +151,7 @@ class TestCacheMiss:
 
 
 class TestForceRefresh:
+    @pytest.mark.unit
     def test_force_refresh_bypasses_cache(self, db_session):
         """3. force_refresh=True forces a network call even when the cache is fresh."""
         sav._cache[_cache_key(None)] = AccountValueResult(
@@ -164,6 +167,7 @@ class TestForceRefresh:
         assert result.total_capital == 99999.0
         assert result.account_id_masked == "…4471"
 
+    @pytest.mark.unit
     def test_force_refresh_falls_through_to_fresh_cache_on_failure(
         self, db_session, caplog
     ):
@@ -195,6 +199,7 @@ class TestForceRefresh:
 
 
 class TestAuthStatusMapping:
+    @pytest.mark.unit
     def test_disconnected_status(self, db_session):
         """5. TOKEN_MISSING / NOT_CONFIGURED -> 'disconnected'."""
         for code in (SchwabAuthCode.TOKEN_MISSING, SchwabAuthCode.NOT_CONFIGURED):
@@ -208,6 +213,7 @@ class TestAuthStatusMapping:
             assert "not configured" not in (result.error_detail or "").lower() or \
                 result.error_detail == "Schwab is not connected"
 
+    @pytest.mark.unit
     def test_expired_status(self, db_session):
         """6. TOKEN_EXPIRED / REFRESH_FAILED_401 -> 'expired'."""
         for code in (
@@ -224,6 +230,7 @@ class TestAuthStatusMapping:
 
 
 class TestErrorStatus:
+    @pytest.mark.unit
     def test_error_status_on_transport_failure(self, db_session):
         """7. transport / client error -> 'error'."""
         with _patch_schwab(SchwabClientError("Unable to reach Schwab API")):
@@ -233,6 +240,7 @@ class TestErrorStatus:
         # Per CLAUDE.md, error_detail is generic — never raw exception text.
         assert result.error_detail == "Schwab API error"
 
+    @pytest.mark.unit
     def test_error_status_on_malformed_json(self, db_session):
         """8. non-list payload from get_accounts() -> 'error'."""
         with _patch_schwab({"unexpected": "shape"}):
@@ -240,6 +248,7 @@ class TestErrorStatus:
         assert result.status == "error"
         assert "malformed" in (result.error_detail or "").lower()
 
+    @pytest.mark.unit
     def test_error_status_on_zero_liquidation_value(self, db_session):
         """9. liquidationValue == 0 -> 'error' (account-zero failure cause)."""
         with _patch_schwab([_account("00000000", 0.0)]):
@@ -247,6 +256,7 @@ class TestErrorStatus:
         assert result.status == "error"
         assert "zero" in (result.error_detail or "").lower()
 
+    @pytest.mark.unit
     def test_error_status_on_missing_liquidation_value_field(self, db_session):
         """10. all candidate keys absent -> 'error', no exception."""
         # Build a securitiesAccount with neither liquidationValue nor any
@@ -268,6 +278,7 @@ class TestErrorStatus:
 
 
 class TestMultiAccountSelection:
+    @pytest.mark.unit
     def test_first_account_default_selection(self, db_session):
         """11. sizing_cap_account=None -> picks the first account in the response."""
         accounts = [
@@ -284,6 +295,7 @@ class TestMultiAccountSelection:
         # accounts list still contains both sanitised entries
         assert len(result.accounts or []) == 2
 
+    @pytest.mark.unit
     def test_sum_across_all_accounts(self, db_session):
         """12. sizing_cap_account='sum' -> sum across all sanitised accounts."""
         accounts = [
@@ -299,6 +311,7 @@ class TestMultiAccountSelection:
         assert result.account_id_masked is None
         assert len(result.accounts or []) == 2
 
+    @pytest.mark.unit
     def test_match_by_masked_id(self, db_session):
         """13. sizing_cap_account='...4471' matches that specific account."""
         accounts = [
@@ -320,6 +333,7 @@ class TestMultiAccountSelection:
         assert result2.total_capital == 70000.0
         assert result2.account_id_masked == "…8888"
 
+    @pytest.mark.unit
     def test_match_by_masked_id_not_found(self, db_session):
         """14. masked id not in response -> 'error'."""
         accounts = [_account("11114471", 30000.0, "CASH")]
@@ -332,6 +346,7 @@ class TestMultiAccountSelection:
 
 
 class TestCachedNeverCallsNetwork:
+    @pytest.mark.unit
     def test_get_cached_never_calls_network(self, db_session):
         """15. get_cached_account_value never invokes Schwab even on empty cache."""
         with patch(
@@ -358,6 +373,7 @@ class TestCachedNeverCallsNetwork:
 
 
 class TestDbPersistence:
+    @pytest.mark.unit
     def test_db_persistence_across_in_memory_reset(self, db_session):
         """16. write to DB, clear in-memory, read back from DB."""
         accounts = [_account("33334471", 55000.0, "CASH")]

--- a/backend/tests/test_schwab_auth.py
+++ b/backend/tests/test_schwab_auth.py
@@ -52,6 +52,7 @@ def db_with_tokens(client):
 
 
 class TestSchwabTokenManager:
+    @pytest.mark.integration
     def test_is_configured_false_no_tokens(self, client):
         """is_configured returns False with empty test DB."""
         from app.models.database import get_db
@@ -68,6 +69,7 @@ class TestSchwabTokenManager:
         assert not result
         mock_session_local.assert_called_once()
 
+    @pytest.mark.integration
     def test_get_access_token_returns_cached(self):
         """get_access_token returns cached token when valid."""
         mgr = SchwabTokenManager()
@@ -78,6 +80,7 @@ class TestSchwabTokenManager:
         token = mgr.get_access_token()
         assert token == "cached_token"
 
+    @pytest.mark.integration
     def test_get_access_token_refreshes_when_expired(self):
         """Auto-refresh when access token is within 2 min of expiry."""
         mgr = SchwabTokenManager()
@@ -127,6 +130,7 @@ class TestSchwabTokenManager:
             assert token == "new_access"
             assert mgr._cached_access_token == "new_access"
 
+    @pytest.mark.integration
     def test_schwab_auth_error_on_expired_refresh(self):
         """SchwabAuthError raised when refresh token is expired."""
         mgr = SchwabTokenManager()
@@ -160,6 +164,7 @@ class TestSchwabTokenManager:
                 mgr.get_access_token()
             assert exc_info.value.code == SchwabAuthCode.TOKEN_EXPIRED
 
+    @pytest.mark.integration
     def test_thread_safety(self):
         """Concurrent access doesn't create multiple instances."""
         instances = []
@@ -177,6 +182,7 @@ class TestSchwabTokenManager:
 
 
 class TestSchwabHealthEndpoint:
+    @pytest.mark.integration
     def test_schwab_health_not_configured(self, client):
         """GET /api/settings/health/schwab returns configured=False when not set up."""
         with patch.object(SchwabTokenManager, "is_configured", return_value=False):
@@ -186,6 +192,7 @@ class TestSchwabHealthEndpoint:
         assert data["configured"] is False
         assert data["valid"] is False
 
+    @pytest.mark.integration
     def test_schwab_health_configured_valid(self, client):
         """GET /api/settings/health/schwab returns valid=True when token works."""
         mock_httpx_resp = MagicMock()
@@ -201,6 +208,7 @@ class TestSchwabHealthEndpoint:
         assert data["configured"] is True
         assert data["valid"] is True
 
+    @pytest.mark.integration
     def test_schwab_health_configured_invalid(self, client):
         """GET /api/settings/health/schwab returns valid=False on API error."""
         with patch.object(SchwabTokenManager, "is_configured", return_value=True), \
@@ -213,6 +221,7 @@ class TestSchwabHealthEndpoint:
 
 
 class TestSourceHealthIncludesSchwab:
+    @pytest.mark.integration
     def test_sources_includes_schwab(self, client):
         """GET /api/health/sources includes schwab key."""
         with patch("app.routers.health._check_schwab", return_value={"available": False, "error": "Not configured"}), \
@@ -227,6 +236,7 @@ class TestSourceHealthIncludesSchwab:
 
 
 class TestSettingsIncludesSchwab:
+    @pytest.mark.integration
     def test_settings_has_schwab_fields(self, client):
         """GET /api/settings includes schwab_configured and schwab_token_expires."""
         with patch.object(SchwabTokenManager, "is_configured", return_value=False), \
@@ -240,6 +250,7 @@ class TestSettingsIncludesSchwab:
 
 
 class TestSchwabAuthErrorHandler:
+    @pytest.mark.integration
     def test_401_on_schwab_auth_error(self, client):
         """SchwabAuthError returns 401 response."""
         from app.services.schwab_auth import SchwabAuthError

--- a/backend/tests/test_schwab_auth_errors.py
+++ b/backend/tests/test_schwab_auth_errors.py
@@ -41,6 +41,7 @@ def _make_mgr_needing_refresh():
 
 
 class TestRefreshTokenErrorSanitization:
+    @pytest.mark.unit
     def test_non_401_http_error_does_not_leak_url(self):
         """Non-401 HTTP errors must not expose internal URLs."""
         mgr, mock_db = _make_mgr_needing_refresh()
@@ -66,6 +67,7 @@ class TestRefreshTokenErrorSanitization:
         assert "re-authorize" in msg.lower() or "schwab-auth" in msg.lower()
         assert exc_info.value.code == SchwabAuthCode.REFRESH_FAILED
 
+    @pytest.mark.unit
     def test_request_error_does_not_leak_url(self):
         """Network-level errors must not expose raw exception text."""
         mgr, mock_db = _make_mgr_needing_refresh()
@@ -86,6 +88,7 @@ class TestRefreshTokenErrorSanitization:
         assert "try again" in msg.lower()
         assert exc_info.value.code == SchwabAuthCode.NETWORK_ERROR
 
+    @pytest.mark.unit
     def test_401_still_mentions_reauth(self):
         """401 errors should still tell the user to re-authorize."""
         mgr, mock_db = _make_mgr_needing_refresh()

--- a/backend/tests/test_schwab_client.py
+++ b/backend/tests/test_schwab_client.py
@@ -15,6 +15,7 @@ from app.services.schwab_auth import SchwabAuthError
 
 
 class TestSymbolMapping:
+    @pytest.mark.unit
     def test_all_mapped_symbols(self):
         assert to_schwab_symbol("^GSPC") == "$SPX.X"
         assert to_schwab_symbol("^IXIC") == "$COMPX"
@@ -24,6 +25,7 @@ class TestSymbolMapping:
         assert to_schwab_symbol("SI=F") == "/SI"
         assert to_schwab_symbol("PL=F") == "/PL"
 
+    @pytest.mark.unit
     def test_passthrough_regular_tickers(self):
         assert to_schwab_symbol("AAPL") == "AAPL"
         assert to_schwab_symbol("MSFT") == "MSFT"
@@ -31,6 +33,7 @@ class TestSymbolMapping:
 
 
 class TestGetQuote:
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_success(self, mock_get, mock_tm_cls):
@@ -60,6 +63,7 @@ class TestGetQuote:
         assert call_kwargs.kwargs["params"] == {"symbols": "AAPL"}
         assert "Bearer test-token" in call_kwargs.kwargs["headers"]["Authorization"]
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_maps_index_symbol(self, mock_get, mock_tm_cls):
@@ -77,6 +81,7 @@ class TestGetQuote:
         assert quote["lastPrice"] == 18.5
         assert mock_get.call_args.kwargs["params"] == {"symbols": "$VIX.X"}
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_401_raises_auth_error(self, mock_get, mock_tm_cls):
@@ -92,6 +97,7 @@ class TestGetQuote:
         with pytest.raises(SchwabAuthError):
             client.get_quote("AAPL")
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_500_raises_client_error(self, mock_get, mock_tm_cls):
@@ -107,6 +113,7 @@ class TestGetQuote:
         with pytest.raises(SchwabClientError):
             client.get_quote("AAPL")
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_missing_symbol_raises(self, mock_get, mock_tm_cls):
@@ -122,6 +129,7 @@ class TestGetQuote:
             client.get_quote("AAPL")
 
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_network_error_raises_client_error(self, mock_get, mock_tm_cls):
@@ -132,6 +140,7 @@ class TestGetQuote:
         with pytest.raises(SchwabClientError, match="Unable to reach Schwab API"):
             client.get_quote("AAPL")
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_401_invalidates_token(self, mock_get, mock_tm_cls):
@@ -152,6 +161,7 @@ class TestGetQuote:
 
 
 class TestGetPriceHistory:
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_success(self, mock_get, mock_tm_cls):
@@ -177,6 +187,7 @@ class TestGetPriceHistory:
         assert df["value"].iloc[0] == 100.0
         assert df["value"].iloc[1] == 102.0
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_empty_candles_raises(self, mock_get, mock_tm_cls):
@@ -191,6 +202,7 @@ class TestGetPriceHistory:
         with pytest.raises(SchwabClientError, match="No price history"):
             client.get_price_history("BADTICKER", "2024-01-01", "2024-01-03")
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_401_raises_auth_error(self, mock_get, mock_tm_cls):
@@ -206,6 +218,7 @@ class TestGetPriceHistory:
         with pytest.raises(SchwabAuthError):
             client.get_price_history("AAPL", "2024-01-01", "2024-01-03")
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_maps_symbol(self, mock_get, mock_tm_cls):
@@ -228,6 +241,7 @@ class TestGetPriceHistory:
         call_kwargs = mock_get.call_args.kwargs
         assert call_kwargs["params"]["symbol"] == "$SPX.X"
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_network_error_raises_client_error(self, mock_get, mock_tm_cls):
@@ -238,6 +252,7 @@ class TestGetPriceHistory:
         with pytest.raises(SchwabClientError, match="Unable to reach Schwab API"):
             client.get_price_history("AAPL", "2024-01-01", "2024-01-03")
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_401_invalidates_token(self, mock_get, mock_tm_cls):
@@ -270,6 +285,7 @@ HANDLER_CALL_ARGS = {
 class TestGetTransactions:
     """Tests for get_transactions request parameters (issue #119)."""
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_transactions_passes_trade_and_receive_and_deliver_types(
@@ -291,6 +307,7 @@ class TestGetTransactions:
         assert "startDate" in params
         assert "endDate" in params
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_transactions_returns_response_json(self, mock_get, mock_tm_cls):
@@ -310,6 +327,7 @@ class TestGetTransactions:
 class TestErrorResponseLogging:
     """Tests for logging Schwab error response bodies (issue #73)."""
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("handler_name", list(HANDLER_CALL_ARGS.keys()))
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
@@ -331,6 +349,7 @@ class TestErrorResponseLogging:
 
         assert any("date range too large" in r.message for r in caplog.records)
 
+    @pytest.mark.unit
     @pytest.mark.parametrize("handler_name", list(HANDLER_CALL_ARGS.keys()))
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
@@ -355,6 +374,7 @@ class TestErrorResponseLogging:
 class TestPeriodTypeAndRetryOn4xx:
     """Issue #286: pricehistory must include periodType=year; 4xx must not be retried."""
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_includes_period_type_year(self, mock_get, mock_tm_cls):
@@ -374,6 +394,7 @@ class TestPeriodTypeAndRetryOn4xx:
         assert params["frequencyType"] == "daily"
         assert params["frequency"] == 1
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_does_not_retry_on_4xx(self, mock_get, mock_tm_cls):
@@ -392,6 +413,7 @@ class TestPeriodTypeAndRetryOn4xx:
 
         assert mock_get.call_count == 1
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_price_history_still_retries_on_5xx(self, mock_get, mock_tm_cls):
@@ -420,6 +442,7 @@ class TestPeriodTypeAndRetryOn4xx:
         assert len(df) == 1
         assert df["value"].iloc[0] == 100.0
 
+    @pytest.mark.unit
     @patch("app.services.schwab_client.SchwabTokenManager")
     @patch("app.services.schwab_client.httpx.get")
     def test_get_quote_does_not_retry_on_4xx(self, mock_get, mock_tm_cls):

--- a/backend/tests/test_schwab_client_accounts.py
+++ b/backend/tests/test_schwab_client_accounts.py
@@ -16,6 +16,7 @@ def mock_token():
 
 
 class TestGetAccounts:
+    @pytest.mark.unit
     def test_success(self):
         accounts = [{"hashValue": "abc123", "securitiesAccount": {"accountNumber": "12345678"}}]
         mock_resp = MagicMock()
@@ -27,12 +28,14 @@ class TestGetAccounts:
 
         assert result == accounts
 
+    @pytest.mark.unit
     def test_401_raises_auth_error(self):
         resp = httpx.Response(401, request=httpx.Request("GET", "https://example.com"))
         with patch("app.services.schwab_client.httpx.get", side_effect=httpx.HTTPStatusError("", request=resp.request, response=resp)):
             with pytest.raises(SchwabAuthError):
                 SchwabClient().get_accounts()
 
+    @pytest.mark.unit
     def test_network_error_raises_client_error(self):
         with patch("app.services.schwab_client.httpx.get", side_effect=httpx.ConnectError("connection failed")):
             with pytest.raises(SchwabClientError):
@@ -40,6 +43,7 @@ class TestGetAccounts:
 
 
 class TestGetTransactions:
+    @pytest.mark.unit
     def test_success(self):
         txns = [{"transactionId": "1", "type": "TRADE"}]
         mock_resp = MagicMock()
@@ -51,12 +55,14 @@ class TestGetTransactions:
 
         assert result == txns
 
+    @pytest.mark.unit
     def test_401_raises_auth_error(self):
         resp = httpx.Response(401, request=httpx.Request("GET", "https://example.com"))
         with patch("app.services.schwab_client.httpx.get", side_effect=httpx.HTTPStatusError("", request=resp.request, response=resp)):
             with pytest.raises(SchwabAuthError):
                 SchwabClient().get_transactions("abc123", "2025-01-01", "2025-03-01")
 
+    @pytest.mark.unit
     def test_empty_list(self):
         mock_resp = MagicMock()
         mock_resp.json.return_value = []
@@ -67,6 +73,7 @@ class TestGetTransactions:
 
         assert result == []
 
+    @pytest.mark.unit
     def test_invalid_account_hash(self):
         with pytest.raises(SchwabClientError, match="Invalid account hash"):
             SchwabClient().get_transactions("abc/123!!", "2025-01-01", "2025-03-01")

--- a/backend/tests/test_schwab_client_errors.py
+++ b/backend/tests/test_schwab_client_errors.py
@@ -20,6 +20,7 @@ def client_obj():
 
 
 class TestQuoteErrorSanitization:
+    @pytest.mark.unit
     def test_http_error_no_url_leak(self, client_obj):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 500
@@ -41,6 +42,7 @@ class TestQuoteErrorSanitization:
         assert not URL_PATTERN.search(msg), f"URL leaked: {msg}"
         assert "500" not in msg
 
+    @pytest.mark.unit
     def test_request_error_no_raw_text(self, client_obj):
         exc = httpx.RequestError("Connection refused for https://api.schwabapi.com/v1/quotes")
 
@@ -54,6 +56,7 @@ class TestQuoteErrorSanitization:
 
 
 class TestChainsErrorSanitization:
+    @pytest.mark.unit
     def test_http_error_no_url_leak(self, client_obj):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 403
@@ -77,6 +80,7 @@ class TestChainsErrorSanitization:
 
 
 class TestPriceHistoryErrorSanitization:
+    @pytest.mark.unit
     def test_http_error_no_url_leak(self, client_obj):
         mock_resp = MagicMock(spec=httpx.Response)
         mock_resp.status_code = 500
@@ -98,6 +102,7 @@ class TestPriceHistoryErrorSanitization:
         assert not URL_PATTERN.search(msg), f"URL leaked: {msg}"
         assert "500" not in msg
 
+    @pytest.mark.unit
     def test_request_error_no_raw_text(self, client_obj):
         exc = httpx.RequestError("SSL error connecting to https://api.schwabapi.com")
 

--- a/backend/tests/test_schwab_csv_import.py
+++ b/backend/tests/test_schwab_csv_import.py
@@ -63,6 +63,7 @@ OCC_SELL_PUT_ROW = (
 class TestParseSchwabCsv:
     """Cover the happy-path mappings, skip rules, and malformed input."""
 
+    @pytest.mark.unit
     def test_sell_to_open_put_human_symbol(self):
         result = parse_schwab_csv(_csv([SELL_PUT_ROW]))
         assert len(result) == 1
@@ -78,6 +79,7 @@ class TestParseSchwabCsv:
         assert row["fees"] == 0.65
         assert row["opened_at"] == "2026-03-01"
 
+    @pytest.mark.unit
     def test_sell_to_open_call_multi_contract(self):
         result = parse_schwab_csv(_csv([SELL_CALL_ROW]))
         assert len(result) == 1
@@ -89,6 +91,7 @@ class TestParseSchwabCsv:
         # — the post-fee net — corrected after #184).
         assert row["premium"] == pytest.approx(0.50, abs=1e-4)
 
+    @pytest.mark.unit
     def test_buy_to_close_premium_is_negative(self):
         result = parse_schwab_csv(_csv([BUY_TO_CLOSE_ROW]))
         assert len(result) == 1
@@ -98,11 +101,13 @@ class TestParseSchwabCsv:
         # Pre-#184 this used post-fee net (-0.1065).
         assert row["premium"] == pytest.approx(-0.10, abs=1e-4)
 
+    @pytest.mark.unit
     def test_assigned_maps_to_assignment(self):
         result = parse_schwab_csv(_csv([ASSIGNED_PUT_ROW]))
         assert len(result) == 1
         assert result[0]["trade_type"] == "assignment"
 
+    @pytest.mark.unit
     def test_expired_call_maps_to_expired(self):
         """An expired call must map to ``trade_type="expired"``, not ``called_away``.
 
@@ -115,6 +120,7 @@ class TestParseSchwabCsv:
         assert len(result) == 1
         assert result[0]["trade_type"] == "expired"
 
+    @pytest.mark.unit
     def test_expired_put_maps_to_expired(self):
         """An expired put also maps to ``trade_type="expired"`` — not ``assignment``.
 
@@ -131,6 +137,7 @@ class TestParseSchwabCsv:
         assert result[0]["trade_type"] == "expired"
         assert result[0]["ticker"] == "SOFI"
 
+    @pytest.mark.unit
     def test_occ_format_symbol_parses(self):
         result = parse_schwab_csv(_csv([OCC_SELL_PUT_ROW]))
         assert len(result) == 1
@@ -140,6 +147,7 @@ class TestParseSchwabCsv:
         assert row["expiration"] == "2026-03-15"
         assert row["trade_type"] == "sell_put"
 
+    @pytest.mark.unit
     def test_full_mix_round_trip(self):
         rows = [
             SELL_PUT_ROW,
@@ -165,10 +173,12 @@ class TestParseSchwabCsv:
             "sell_put",
         ]
 
+    @pytest.mark.unit
     def test_non_options_rows_skipped(self):
         result = parse_schwab_csv(_csv([STOCK_BUY_ROW, DIVIDEND_ROW, ACH_ROW]))
         assert result == []
 
+    @pytest.mark.unit
     def test_unknown_action_skipped(self):
         # "Journal" / "Wire Transfer" / etc. should never crash the parser.
         rows = [
@@ -177,6 +187,7 @@ class TestParseSchwabCsv:
         ]
         assert parse_schwab_csv(_csv(rows)) == []
 
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "bad_symbol",
         [
@@ -194,6 +205,7 @@ class TestParseSchwabCsv:
         )
         assert parse_schwab_csv(_csv([row])) == []
 
+    @pytest.mark.unit
     def test_missing_required_columns_returns_empty(self):
         # No "Symbol" column at all — entire file rejected.
         body = (
@@ -202,14 +214,17 @@ class TestParseSchwabCsv:
         ).encode("utf-8")
         assert parse_schwab_csv(body) == []
 
+    @pytest.mark.unit
     def test_empty_file_returns_empty(self):
         assert parse_schwab_csv(b"") == []
         assert parse_schwab_csv(b"\n") == []
 
+    @pytest.mark.unit
     def test_utf8_bom_tolerated(self):
         body = b"\xef\xbb\xbf" + _csv([SELL_PUT_ROW])
         assert len(parse_schwab_csv(body)) == 1
 
+    @pytest.mark.unit
     def test_zero_quantity_row_skipped(self):
         row = (
             '03/01/2026,Sell to Open,F 03/27/2026 13.50 P,'
@@ -217,6 +232,7 @@ class TestParseSchwabCsv:
         )
         assert parse_schwab_csv(_csv([row])) == []
 
+    @pytest.mark.unit
     def test_amount_with_dollar_and_comma(self):
         # Schwab sometimes formats Amount as "$1,234.56".
         row = (
@@ -241,6 +257,7 @@ def _csv_file(content: bytes, filename: str = "schwab.csv") -> dict:
 class TestImportCsvPreviewEndpoint:
     """Cover ``POST /api/journal/import/csv/preview`` validation + happy path."""
 
+    @pytest.mark.integration
     def test_preview_rejects_wrong_extension(self, client):
         resp = client.post(
             "/api/journal/import/csv/preview",
@@ -249,6 +266,7 @@ class TestImportCsvPreviewEndpoint:
         assert resp.status_code == 422
         assert resp.json()["detail"] == "Only .csv files are accepted"
 
+    @pytest.mark.integration
     def test_preview_rejects_oversized_file(self, client):
         # 6 MB synthetic body — header byte + filler. Body content is irrelevant
         # because size is checked before parsing.
@@ -261,6 +279,7 @@ class TestImportCsvPreviewEndpoint:
         assert resp.status_code == 422
         assert "5 MB" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_preview_rejects_empty_file(self, client):
         resp = client.post(
             "/api/journal/import/csv/preview",
@@ -269,6 +288,7 @@ class TestImportCsvPreviewEndpoint:
         assert resp.status_code == 422
         assert resp.json()["detail"] == "Uploaded file is empty"
 
+    @pytest.mark.integration
     def test_preview_returns_correct_shape(self, client):
         resp = client.post(
             "/api/journal/import/csv/preview",
@@ -286,6 +306,7 @@ class TestImportCsvPreviewEndpoint:
         for trade in data["trades"]:
             assert trade["is_duplicate"] is False
 
+    @pytest.mark.integration
     def test_preview_with_only_non_options_returns_empty(self, client):
         resp = client.post(
             "/api/journal/import/csv/preview",
@@ -301,6 +322,7 @@ class TestImportCsvPreviewEndpoint:
             "new_count": 0,
         }
 
+    @pytest.mark.integration
     def test_preview_does_not_leak_exception_message(self, client):
         # If parsing somehow crashes (defensive, since parse_schwab_csv catches
         # per-row errors), the endpoint must return a generic 422.
@@ -321,6 +343,7 @@ class TestImportCsvPreviewEndpoint:
 class TestImportCsvEndpoint:
     """Cover ``POST /api/journal/import/csv`` write path + duplicate handling."""
 
+    @pytest.mark.integration
     def test_import_creates_trades_and_positions(self, client):
         # Stale clients may still post `position_strategy`; the field is
         # ignored by FastAPI under #131 but the request must still succeed.
@@ -339,6 +362,7 @@ class TestImportCsvEndpoint:
         tickers = {p["ticker"] for p in positions}
         assert tickers == {"F", "SOFI"}
 
+    @pytest.mark.integration
     def test_import_derives_strategy_label(self, client, monkeypatch):
         # `position_strategy` form field is no longer accepted under #131.
         # The recomputer derives the label per position state. F has a single
@@ -364,6 +388,7 @@ class TestImportCsvEndpoint:
         assert labels["F"] == "csp"
         assert labels["SOFI"] == "cc"
 
+    @pytest.mark.integration
     def test_import_skips_duplicates_on_second_upload(self, client):
         body = _csv([SELL_PUT_ROW, SELL_CALL_ROW])
         first = client.post("/api/journal/import/csv", files=_csv_file(body))
@@ -375,6 +400,7 @@ class TestImportCsvEndpoint:
         assert data["skipped_duplicates"] == 2
         assert data["positions_created"] == 0
 
+    @pytest.mark.integration
     def test_import_ignores_legacy_strategy_field(self, client):
         # Stale clients may still post `position_strategy`; under #131 the
         # field is no longer declared on the handler so FastAPI silently
@@ -387,6 +413,7 @@ class TestImportCsvEndpoint:
         )
         assert resp.status_code == 200
 
+    @pytest.mark.integration
     def test_import_rejects_oversized_file(self, client):
         oversized = b"Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount\n"
         oversized += b"x" * (6 * 1024 * 1024)
@@ -396,6 +423,7 @@ class TestImportCsvEndpoint:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_import_does_not_leak_exception_message(self, client):
         with patch(
             "app.routers.journal.parse_schwab_csv",

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -46,6 +46,7 @@ def _make_txn(instruction, put_call, ticker="AAPL", strike=150.0,
 # --- Mapping tests ---
 
 class TestMapSchwabTransaction:
+    @pytest.mark.unit
     def test_sell_to_open_put(self):
         txn = _make_txn("SELL_TO_OPEN", "PUT", net_amount=300.0)
         result = map_schwab_transaction(txn)
@@ -57,34 +58,40 @@ class TestMapSchwabTransaction:
         assert result["premium"] == 3.0  # 300 / (1 * 100)
         assert result["quantity"] == 1
 
+    @pytest.mark.unit
     def test_sell_to_open_call(self):
         txn = _make_txn("SELL_TO_OPEN", "CALL", net_amount=500.0)
         result = map_schwab_transaction(txn)
         assert result["trade_type"] == "sell_call"
         assert result["premium"] == 5.0
 
+    @pytest.mark.unit
     def test_buy_to_close_put(self):
         txn = _make_txn("BUY_TO_CLOSE", "PUT", net_amount=-150.0)
         result = map_schwab_transaction(txn)
         assert result["trade_type"] == "buy_put_close"
         assert result["premium"] == -1.5  # negative for buys
 
+    @pytest.mark.unit
     def test_buy_to_close_call(self):
         txn = _make_txn("BUY_TO_CLOSE", "CALL", net_amount=-200.0)
         result = map_schwab_transaction(txn)
         assert result["trade_type"] == "buy_call_close"
         assert result["premium"] == -2.0
 
+    @pytest.mark.unit
     def test_receive_deliver_put_assignment(self):
         txn = _make_txn("RECEIVE_DELIVER", "PUT", net_amount=0)
         result = map_schwab_transaction(txn)
         assert result["trade_type"] == "assignment"
 
+    @pytest.mark.unit
     def test_receive_deliver_call_called_away(self):
         txn = _make_txn("RECEIVE_DELIVER", "CALL", net_amount=0)
         result = map_schwab_transaction(txn)
         assert result["trade_type"] == "called_away"
 
+    @pytest.mark.unit
     def test_non_option_returns_none(self):
         txn = {
             "transactionDate": "2025-03-01T10:00:00Z",
@@ -102,31 +109,37 @@ class TestMapSchwabTransaction:
         }
         assert map_schwab_transaction(txn) is None
 
+    @pytest.mark.unit
     def test_unknown_instruction_returns_none(self):
         txn = _make_txn("BUY_TO_OPEN", "PUT")
         assert map_schwab_transaction(txn) is None
 
+    @pytest.mark.unit
     def test_no_transfer_items_returns_none(self):
         txn = {"transactionDate": "2025-03-01", "netAmount": 0, "transferItems": []}
         assert map_schwab_transaction(txn) is None
 
+    @pytest.mark.unit
     def test_premium_calculation_multiple_contracts(self):
         txn = _make_txn("SELL_TO_OPEN", "PUT", net_amount=600.0, amount=2)
         result = map_schwab_transaction(txn)
         assert result["premium"] == 3.0  # 600 / (2 * 100)
         assert result["quantity"] == 2
 
+    @pytest.mark.unit
     def test_fee_extraction(self):
         fees = {"commission": 0.65, "secFee": 0.02, "optRegFee": 0.04, "rFee": 0, "cdscFee": 0, "otherCharges": 0}
         txn = _make_txn("SELL_TO_OPEN", "PUT", net_amount=300.0, fees=fees)
         result = map_schwab_transaction(txn)
         assert result["fees"] == 0.71
 
+    @pytest.mark.unit
     def test_fee_extraction_no_fees(self):
         txn = _make_txn("SELL_TO_OPEN", "PUT", net_amount=300.0)
         result = map_schwab_transaction(txn)
         assert result["fees"] == 0.0
 
+    @pytest.mark.unit
     def test_premium_grossed_up_when_netamount_excludes_fees(self):
         """Sell-put net=$29.34 + $0.66 fees + qty=1 → gross premium $0.30, not $0.29.
 
@@ -156,6 +169,7 @@ class TestMapSchwabTransaction:
         assert result["premium"] == pytest.approx(0.30, abs=1e-4)
         assert result["premium"] != pytest.approx(0.2934, abs=1e-4)
 
+    @pytest.mark.unit
     def test_buy_to_close_premium_grossed_down_when_netamount_includes_fees(self):
         """Buy-to-close: |netAmount| = gross + fees, so subtract fees to recover gross.
 
@@ -184,6 +198,7 @@ class TestMapSchwabTransaction:
         assert result is not None
         assert result["premium"] == pytest.approx(-0.30, abs=1e-4)
 
+    @pytest.mark.unit
     def test_receive_deliver_with_fees_emits_zero_premium(self):
         """Assignment / called-away rows are not premium-bearing trades.
 
@@ -215,6 +230,7 @@ class TestMapSchwabTransaction:
         assert result["premium"] == 0.0
         assert result["fees"] == pytest.approx(0.10)
 
+    @pytest.mark.unit
     def test_premium_prefers_transferitem_price_when_present(self):
         """If Schwab exposes ``transferItem.price`` use it directly as gross.
 
@@ -235,6 +251,7 @@ class TestMapSchwabTransaction:
         result = map_schwab_transaction(txn)
         assert result["premium"] == pytest.approx(0.30, abs=1e-4)
 
+    @pytest.mark.unit
     def test_premium_preserves_subpenny_precision(self):
         """Gross-up math preserves sub-penny precision (e.g. $0.295).
 
@@ -277,9 +294,11 @@ def db_session():
 
 
 class TestIsDuplicate:
+    @pytest.mark.unit
     def test_no_match_returns_false(self, db_session):
         assert is_duplicate(db_session, "AAPL", 150.0, "2025-03-21", "sell_put", "2025-03-01T10:00:00Z") is False
 
+    @pytest.mark.unit
     def test_exact_match_returns_true(self, db_session):
         pos = Position(id="p1", ticker="AAPL", shares=100, broker_cost_basis=15000, status="open", strategy="wheel", opened_at="2025-01-01")
         db_session.add(pos)
@@ -290,6 +309,7 @@ class TestIsDuplicate:
 
         assert is_duplicate(db_session, "AAPL", 150.0, "2025-03-21", "sell_put", "2025-03-01T10:00:00Z") is True
 
+    @pytest.mark.unit
     def test_different_strike_returns_false(self, db_session):
         pos = Position(id="p1", ticker="AAPL", shares=100, broker_cost_basis=15000, status="open", strategy="wheel", opened_at="2025-01-01")
         db_session.add(pos)
@@ -310,6 +330,7 @@ class TestPreviewImportReceiveAndDeliver:
     when the Schwab response includes RECEIVE_AND_DELIVER transactions.
     """
 
+    @pytest.mark.unit
     @patch("app.services.schwab_import.SchwabClient")
     def test_assignment_and_called_away_appear_in_preview(self, mock_client_cls, db_session):
         """RECEIVE_DELIVER PUT and CALL transactions map to assignment + called_away."""
@@ -409,6 +430,7 @@ class TestPositionLifecycleOnImport:
     import finalizer.
     """
 
+    @pytest.mark.unit
     def test_ac1_called_away_closes_position(self, db_session):
         """AC #1: full wheel cycle ending in called_away → status=closed."""
         mapped = [
@@ -428,6 +450,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 0
         assert position.closed_at == "2026-03-20"
 
+    @pytest.mark.unit
     def test_ac1_expired_closes_position(self, db_session):
         """AC #1: sell_put → expired → status=closed (no shares acquired)."""
         mapped = [
@@ -444,6 +467,7 @@ class TestPositionLifecycleOnImport:
         assert position.broker_cost_basis == 0.0
         assert position.closed_at == "2026-04-17"
 
+    @pytest.mark.unit
     def test_ac2_assignment_sets_broker_cost_basis(self, db_session):
         """AC #2: after assignment, broker_cost_basis = strike * shares."""
         mapped = [
@@ -458,6 +482,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 100
         assert position.broker_cost_basis == pytest.approx(13.50 * 100)
 
+    @pytest.mark.unit
     def test_ac3_double_assignment_aggregates_shares_and_basis(self, db_session):
         """AC #3: a second assignment increments shares (no silent no-op)."""
         mapped = [
@@ -475,6 +500,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 200
         assert position.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
 
+    @pytest.mark.unit
     def test_ac4_buy_to_close_closes_position(self, db_session):
         """AC #4: sell_put → buy_to_close (no reopen) → status=closed."""
         mapped = [
@@ -489,6 +515,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 0
         assert position.closed_at == "2026-03-25"
 
+    @pytest.mark.unit
     def test_reopen_after_close_creates_new_position(
         self, db_session, monkeypatch
     ):
@@ -526,6 +553,7 @@ class TestPositionLifecycleOnImport:
         assert positions[0].status == "closed"
         assert positions[1].status == "open"
 
+    @pytest.mark.unit
     def test_ghost_open_positions_no_longer_appear_after_called_away(self, db_session):
         """Regression for the real-world repro in issue #127 (Schwab ****885).
 

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -330,7 +330,7 @@ class TestPreviewImportReceiveAndDeliver:
     when the Schwab response includes RECEIVE_AND_DELIVER transactions.
     """
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     @patch("app.services.schwab_import.SchwabClient")
     def test_assignment_and_called_away_appear_in_preview(self, mock_client_cls, db_session):
         """RECEIVE_DELIVER PUT and CALL transactions map to assignment + called_away."""
@@ -430,7 +430,7 @@ class TestPositionLifecycleOnImport:
     import finalizer.
     """
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_ac1_called_away_closes_position(self, db_session):
         """AC #1: full wheel cycle ending in called_away → status=closed."""
         mapped = [
@@ -450,7 +450,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 0
         assert position.closed_at == "2026-03-20"
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_ac1_expired_closes_position(self, db_session):
         """AC #1: sell_put → expired → status=closed (no shares acquired)."""
         mapped = [
@@ -467,7 +467,7 @@ class TestPositionLifecycleOnImport:
         assert position.broker_cost_basis == 0.0
         assert position.closed_at == "2026-04-17"
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_ac2_assignment_sets_broker_cost_basis(self, db_session):
         """AC #2: after assignment, broker_cost_basis = strike * shares."""
         mapped = [
@@ -482,7 +482,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 100
         assert position.broker_cost_basis == pytest.approx(13.50 * 100)
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_ac3_double_assignment_aggregates_shares_and_basis(self, db_session):
         """AC #3: a second assignment increments shares (no silent no-op)."""
         mapped = [
@@ -500,7 +500,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 200
         assert position.broker_cost_basis == pytest.approx(2800.0 + 3000.0)
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_ac4_buy_to_close_closes_position(self, db_session):
         """AC #4: sell_put → buy_to_close (no reopen) → status=closed."""
         mapped = [
@@ -515,7 +515,7 @@ class TestPositionLifecycleOnImport:
         assert position.shares == 0
         assert position.closed_at == "2026-03-25"
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_reopen_after_close_creates_new_position(
         self, db_session, monkeypatch
     ):
@@ -553,7 +553,7 @@ class TestPositionLifecycleOnImport:
         assert positions[0].status == "closed"
         assert positions[1].status == "open"
 
-    @pytest.mark.unit
+    @pytest.mark.integration
     def test_ghost_open_positions_no_longer_appear_after_called_away(self, db_session):
         """Regression for the real-world repro in issue #127 (Schwab ****885).
 

--- a/backend/tests/test_schwab_settings_auth.py
+++ b/backend/tests/test_schwab_settings_auth.py
@@ -8,6 +8,7 @@ from app.models.database import AppSetting
 
 
 class TestSchwabAuthUrl:
+    @pytest.mark.integration
     def test_generates_auth_url(self, client):
         resp = client.post("/api/settings/schwab/auth-url", json={"app_key": "test-key-123"})
         assert resp.status_code == 200
@@ -16,10 +17,12 @@ class TestSchwabAuthUrl:
         assert "test-key-123" in data["auth_url"]
         assert "redirect_uri" in data
 
+    @pytest.mark.integration
     def test_empty_app_key_returns_422(self, client):
         resp = client.post("/api/settings/schwab/auth-url", json={"app_key": "  "})
         assert resp.status_code == 422
 
+    @pytest.mark.integration
     def test_auth_url_includes_readonly_scope(self, client):
         # Regression for #125: Schwab's /trader/v1/accounts/{hash}/transactions
         # endpoint silently returns 200 + [] when the OAuth grant lacks scope.
@@ -42,6 +45,7 @@ def _mock_token_response():
 
 
 class TestSchwabCallback:
+    @pytest.mark.integration
     def test_success(self, client):
         with patch("app.routers.settings.httpx.post", return_value=_mock_token_response()):
             resp = client.post("/api/settings/schwab/callback", json={
@@ -56,6 +60,7 @@ class TestSchwabCallback:
         assert "access_token_expires" in data
         assert "refresh_token_expires" in data
 
+    @pytest.mark.integration
     def test_tokens_persisted_in_db(self, client):
         """Verify tokens are actually stored in the database after successful exchange."""
         with patch("app.routers.settings.httpx.post", return_value=_mock_token_response()):
@@ -83,6 +88,7 @@ class TestSchwabCallback:
         finally:
             db.close()
 
+    @pytest.mark.integration
     def test_no_code_in_url(self, client):
         resp = client.post("/api/settings/schwab/callback", json={
             "app_key": "key",
@@ -92,6 +98,7 @@ class TestSchwabCallback:
         assert resp.status_code == 422
         assert "authorization code" in resp.json()["detail"].lower()
 
+    @pytest.mark.integration
     def test_token_exchange_http_error(self, client):
         error_resp = httpx.Response(401, request=httpx.Request("POST", "https://example.com"))
         with patch("app.routers.settings.httpx.post", side_effect=httpx.HTTPStatusError("", request=error_resp.request, response=error_resp)):
@@ -103,6 +110,7 @@ class TestSchwabCallback:
         assert resp.status_code == 502
         assert "App Key and Secret" in resp.json()["detail"]
 
+    @pytest.mark.integration
     def test_token_exchange_network_error(self, client):
         with patch("app.routers.settings.httpx.post", side_effect=httpx.ConnectError("connection refused")):
             resp = client.post("/api/settings/schwab/callback", json={

--- a/backend/tests/test_sector_etf_map.py
+++ b/backend/tests/test_sector_etf_map.py
@@ -43,15 +43,18 @@ _EXPECTED: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_sector_etf_map_has_eleven_entries():
     assert len(SECTOR_ETF_MAP) == 11
 
 
+@pytest.mark.unit
 def test_sector_etf_map_matches_frozen_contract():
     """Every plan-§3.3 entry maps to the frozen ticker. No extra entries."""
     assert SECTOR_ETF_MAP == _EXPECTED
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(("sector", "etf"), list(_EXPECTED.items()))
 def test_resolve_sector_etf_returns_etf_for_each_known_sector(
     sector: str, etf: str
@@ -59,17 +62,20 @@ def test_resolve_sector_etf_returns_etf_for_each_known_sector(
     assert resolve_sector_etf(sector) == etf
 
 
+@pytest.mark.unit
 def test_resolve_sector_etf_returns_none_for_unmapped_sector():
     """Unknown GICS sector → None so the regression service drops the factor."""
     assert resolve_sector_etf("Magical Cryptocurrencies") is None
 
 
+@pytest.mark.unit
 def test_resolve_sector_etf_returns_none_for_missing_sector():
     """yfinance sometimes omits ``info.sector`` entirely → None propagates."""
     assert resolve_sector_etf(None) is None
     assert resolve_sector_etf("") is None
 
 
+@pytest.mark.unit
 def test_resolve_sector_etf_is_case_sensitive():
     """Casing drift should NOT silently misclassify — caller falls back instead."""
     assert resolve_sector_etf("financial services") is None
@@ -81,6 +87,7 @@ def test_resolve_sector_etf_is_case_sensitive():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("sector", "expected_etf"),
     [
@@ -102,45 +109,53 @@ def test_all_eleven_gics_sectors_map_to_spdr_etfs(sector: str, expected_etf: str
     assert lookup_sector_etf(sector) == expected_etf
 
 
+@pytest.mark.unit
 def test_map_has_exactly_eleven_entries() -> None:
     """The map covers all 11 GICS sectors — no extras, no omissions."""
     assert len(SECTOR_ETF_MAP) == 11
 
 
+@pytest.mark.unit
 def test_unknown_sector_returns_none() -> None:
     """An unmapped sector string returns ``None`` (sector-omitted branch)."""
     assert lookup_sector_etf("Telecommunications") is None
     assert lookup_sector_etf("Crypto") is None
 
 
+@pytest.mark.unit
 def test_none_returns_none() -> None:
     """``None`` input (missing sector) returns ``None``."""
     assert lookup_sector_etf(None) is None
 
 
+@pytest.mark.unit
 def test_empty_string_returns_none() -> None:
     """Empty / whitespace-only sector strings return ``None``."""
     assert lookup_sector_etf("") is None
     assert lookup_sector_etf("   ") is None
 
 
+@pytest.mark.unit
 def test_lookup_is_case_sensitive() -> None:
     """yfinance returns canonical-cased strings; we don't lower-case lookups."""
     assert lookup_sector_etf("financial services") is None
     assert lookup_sector_etf("FINANCIAL SERVICES") is None
 
 
+@pytest.mark.unit
 def test_surrounding_whitespace_is_tolerated() -> None:
     """Defensive: a stray space around a known sector still resolves."""
     assert lookup_sector_etf("  Technology  ") == "XLK"
 
 
+@pytest.mark.unit
 def test_non_string_input_returns_none() -> None:
     """Non-string inputs (e.g. a yfinance None-coerced int) return None."""
     assert lookup_sector_etf(123) is None  # type: ignore[arg-type]
     assert lookup_sector_etf(["Technology"]) is None  # type: ignore[arg-type]
 
 
+@pytest.mark.unit
 def test_all_etf_values_are_xl_prefixed() -> None:
     """All values follow the SPDR ``XL*`` naming convention."""
     for etf in SECTOR_ETF_MAP.values():

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -20,6 +20,7 @@ This file covers the three W-E deliverables:
 """
 
 from __future__ import annotations
+import pytest
 
 import json
 from datetime import datetime, timezone
@@ -115,6 +116,7 @@ def _set_sizing_cap_account(client, value: str | None) -> None:
 class TestRulesEndpointMigration:
     """The GET /rules response carries a ``migration`` sibling (S4)."""
 
+    @pytest.mark.integration
     def test_get_rules_includes_migration_field_when_no_migration_happened(self, client):
         """With no ``sizing_cap_migration`` row, ``migration.sizing_cap`` is None."""
         response = client.get("/api/settings/rules")
@@ -123,6 +125,7 @@ class TestRulesEndpointMigration:
         assert "migration" in data
         assert data["migration"] == {"sizing_cap": None}
 
+    @pytest.mark.integration
     def test_get_rules_includes_migration_field_after_v1_to_v2_migration(self, client):
         """A v1 row triggers the migration block; GET surfaces the marker."""
         previous_dollars = _seed_v1_rules_row(client)
@@ -141,6 +144,7 @@ class TestRulesEndpointMigration:
         assert isinstance(sizing_cap["migrated_at"], str)
         datetime.fromisoformat(sizing_cap["migrated_at"])
 
+    @pytest.mark.integration
     def test_dismiss_migration_sets_dismissed_at(self, client):
         """POST dismiss stamps ``dismissed_at``; the next GET surfaces it."""
         _seed_v1_rules_row(client)
@@ -159,6 +163,7 @@ class TestRulesEndpointMigration:
         got = client.get("/api/settings/rules").json()
         assert got["migration"]["sizing_cap"]["dismissed_at"] == first_dismissed
 
+    @pytest.mark.integration
     def test_dismiss_migration_idempotent(self, client):
         """A second POST is a no-op-success: 200 with a fresh ``dismissed_at``."""
         _seed_v1_rules_row(client)
@@ -176,6 +181,7 @@ class TestRulesEndpointMigration:
         # didn't 4xx and the field is still populated.
         assert second_dismissed >= first_dismissed
 
+    @pytest.mark.integration
     def test_dismiss_is_safe_when_no_migration_row(self, client):
         """Dismiss on a clean DB returns 200 with ``sizing_cap: null``.
 
@@ -196,6 +202,7 @@ class TestRulesEndpointMigration:
 class TestAccountValueEndpoints:
     """The account-value endpoints surface W-A's service via the router."""
 
+    @pytest.mark.integration
     def test_get_account_value_returns_cached_when_available(self, client):
         """A fresh hot-cache hit short-circuits — the network function is not called."""
         cached = _fresh_account_value()
@@ -218,6 +225,7 @@ class TestAccountValueEndpoints:
         # Cold-cache fall-through must NOT fire when the cache is warm.
         mock_network.assert_not_called()
 
+    @pytest.mark.integration
     def test_get_account_value_falls_through_to_network_when_cache_empty(self, client):
         """On a cold cache, the GET endpoint warms it with one ordinary fetch."""
         fetched = _fresh_account_value(total_capital=37500.0)
@@ -242,6 +250,7 @@ class TestAccountValueEndpoints:
         _, kwargs = mock_network.call_args
         assert kwargs.get("force_refresh") is False
 
+    @pytest.mark.integration
     def test_post_refresh_calls_force_refresh(self, client):
         """POST /refresh calls get_account_value with ``force_refresh=True``."""
         fetched = _fresh_account_value()
@@ -256,6 +265,7 @@ class TestAccountValueEndpoints:
         _, kwargs = mock_network.call_args
         assert kwargs.get("force_refresh") is True
 
+    @pytest.mark.integration
     def test_endpoints_pass_sizing_cap_account_from_rules(self, client):
         """``rules.position.sizing_cap_account`` is threaded into the W-A service."""
         _set_sizing_cap_account(client, "…4471")
@@ -280,6 +290,7 @@ class TestAccountValueEndpoints:
         assert kwargs.get("sizing_cap_account") == "…4471"
         assert kwargs.get("force_refresh") is True
 
+    @pytest.mark.integration
     def test_endpoints_return_503_on_schwab_client_error(self, client):
         """A raised :class:`SchwabClientError` is mapped to a generic 503."""
         # GET path: a raise out of get_cached_account_value (defence in
@@ -306,6 +317,7 @@ class TestAccountValueEndpoints:
         assert body["detail"] == "Schwab service unavailable"
         assert "internal transport text" not in json.dumps(body)
 
+    @pytest.mark.integration
     def test_endpoints_return_503_on_schwab_auth_error(self, client):
         """A raised :class:`SchwabAuthError` is mapped to a generic 503.
 
@@ -322,6 +334,7 @@ class TestAccountValueEndpoints:
         assert resp.status_code == 503
         assert resp.json()["detail"] == "Schwab service unavailable"
 
+    @pytest.mark.integration
     def test_endpoints_return_disconnected_status_in_payload(self, client):
         """``status='disconnected'`` is a structured success — 200, not 503."""
         disconnected = AccountValueResult(
@@ -354,6 +367,7 @@ class TestAccountValueEndpoints:
         assert resp.status_code == 200
         assert resp.json()["status"] == "disconnected"
 
+    @pytest.mark.integration
     def test_get_serialises_cached_at_as_iso_string(self, client):
         """The dataclass ``datetime`` field is surfaced as an ISO string."""
         cached_at = datetime(2026, 4, 1, 9, 30, 0, tzinfo=timezone.utc)

--- a/backend/tests/test_settings_rules_endpoint.py
+++ b/backend/tests/test_settings_rules_endpoint.py
@@ -8,6 +8,7 @@ Settings page uses to edit the ``rules_config`` keystone (#156). The generic
 ``app_settings`` key/value persistence — no new table, no migration.
 """
 
+import pytest
 import json
 
 from app.models.database import AppSetting, get_db
@@ -34,6 +35,7 @@ def _read_rules_row(client) -> str | None:
 class TestGetRulesConfig:
     """GET /api/settings/rules — read the Trading Rules config."""
 
+    @pytest.mark.integration
     def test_returns_defaults_when_unset(self, client):
         """With no stored row, the endpoint returns the catalog defaults.
 
@@ -55,6 +57,7 @@ class TestGetRulesConfig:
         assert data["risk"]["loss_review_threshold_pct"] == -15.0
         assert data["management"]["assignment_risk_review"] == "High"
 
+    @pytest.mark.integration
     def test_optional_fields_default_to_null(self, client):
         """The four Optional/unset rules come back as null, not 0."""
         data = client.get("/api/settings/rules").json()
@@ -63,6 +66,7 @@ class TestGetRulesConfig:
         assert data["risk"]["hard_max_loss_pct"] is None
         assert data["risk"]["max_consecutive_rolls"] is None
 
+    @pytest.mark.integration
     def test_returns_stored_config(self, client):
         """A stored row is merged over defaults and returned."""
         stored = DEFAULT_RULES_CONFIG.model_dump()
@@ -83,6 +87,7 @@ class TestGetRulesConfig:
 class TestPutRulesConfig:
     """PUT /api/settings/rules — persist the Trading Rules config."""
 
+    @pytest.mark.integration
     def test_persists_and_round_trips(self, client):
         """A valid PUT is stored and the next GET reflects it."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -97,6 +102,7 @@ class TestPutRulesConfig:
         assert got["entry"]["dte_range"] == {"min": 14, "max": 35}
         assert got["position"]["max_open_positions"] == 8
 
+    @pytest.mark.integration
     def test_optional_field_persists_as_null(self, client):
         """An Optional field sent as null is stored as null — never invented."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -110,6 +116,7 @@ class TestPutRulesConfig:
         assert raw is not None
         assert json.loads(raw)["risk"]["hard_max_loss_pct"] is None
 
+    @pytest.mark.integration
     def test_schema_version_is_restamped(self, client):
         """A stale schema_version in the body is overwritten on save."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -119,6 +126,7 @@ class TestPutRulesConfig:
         assert put.status_code == 200
         assert put.json()["schema_version"] == RULES_CONFIG_SCHEMA_VERSION
 
+    @pytest.mark.integration
     def test_inverted_range_rejected(self, client):
         """A range with min >= max is rejected with 422 (Pydantic validator)."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -127,6 +135,7 @@ class TestPutRulesConfig:
         response = client.put("/api/settings/rules", json=config)
         assert response.status_code == 422
 
+    @pytest.mark.integration
     def test_out_of_range_delta_rejected(self, client):
         """A delta bound outside [0, 1] is rejected with 422."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -135,6 +144,7 @@ class TestPutRulesConfig:
         response = client.put("/api/settings/rules", json=config)
         assert response.status_code == 422
 
+    @pytest.mark.integration
     def test_positive_loss_threshold_rejected(self, client):
         """A loss threshold must be <= 0 — a positive value is rejected."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -143,6 +153,7 @@ class TestPutRulesConfig:
         response = client.put("/api/settings/rules", json=config)
         assert response.status_code == 422
 
+    @pytest.mark.integration
     def test_invalid_save_does_not_persist(self, client):
         """A rejected PUT writes nothing — the next GET is still defaults."""
         config = DEFAULT_RULES_CONFIG.model_dump()
@@ -157,6 +168,7 @@ class TestPutRulesConfig:
         assert got.pop("migration") == {"sizing_cap": None}
         assert got == DEFAULT_RULES_CONFIG.model_dump()
 
+    @pytest.mark.integration
     def test_overwrites_existing_row(self, client):
         """A second PUT overwrites the first stored config."""
         first = DEFAULT_RULES_CONFIG.model_dump()

--- a/backend/tests/test_settings_target_yield.py
+++ b/backend/tests/test_settings_target_yield.py
@@ -7,6 +7,7 @@ settings endpoints — and the CLAUDE.md boundary-validation discipline.
 Uses the in-memory SQLite ``client`` fixture from ``conftest.py``.
 """
 
+import pytest
 from app.models.database import AppSetting, get_db
 
 
@@ -30,12 +31,14 @@ def _stored_target_yield(client) -> object:
 class TestTargetYieldRead:
     """GET /api/settings carries okr_target_yield (AC1)."""
 
+    @pytest.mark.integration
     def test_get_settings_target_yield_none_when_unseeded(self, client):
         """No stored row → okr_target_yield is null."""
         response = client.get("/api/settings")
         assert response.status_code == 200
         assert response.json()["okr_target_yield"] is None
 
+    @pytest.mark.integration
     def test_put_then_get_round_trips_fraction(self, client):
         """PUT a fraction, then GET returns the same fraction (AC1)."""
         put_resp = client.put(
@@ -49,6 +52,7 @@ class TestTargetYieldRead:
         assert get_resp.status_code == 200
         assert get_resp.json()["okr_target_yield"] == 0.12
 
+    @pytest.mark.integration
     def test_get_settings_target_yield_none_when_row_malformed(self, client):
         """A non-numeric stored row degrades to None — never breaks the read."""
         client.put(
@@ -75,6 +79,7 @@ class TestTargetYieldRead:
 class TestTargetYieldValidation:
     """PUT /api/settings boundary validation for okr_target_yield (AC1)."""
 
+    @pytest.mark.integration
     def test_put_above_upper_bound_rejected(self, client):
         """A fraction > 1.0 is rejected with a generic 422."""
         response = client.put(
@@ -87,6 +92,7 @@ class TestTargetYieldValidation:
         # No row written on a rejected value.
         assert _stored_target_yield(client) is None
 
+    @pytest.mark.integration
     def test_put_at_or_below_zero_rejected(self, client):
         """A non-positive fraction is rejected (0% is meaningless / out of bounds)."""
         for bad in ("-0.1", "0", "0.0"):
@@ -101,6 +107,7 @@ class TestTargetYieldValidation:
             )
         assert _stored_target_yield(client) is None
 
+    @pytest.mark.integration
     def test_put_non_numeric_rejected_without_leaking_exception(self, client):
         """A non-numeric value is rejected; the raw parse exception never leaks."""
         response = client.put(
@@ -115,6 +122,7 @@ class TestTargetYieldValidation:
         assert "float" not in detail
         assert _stored_target_yield(client) is None
 
+    @pytest.mark.integration
     def test_put_nan_and_inf_rejected(self, client):
         """NaN / inf parse as floats but are out of bounds — rejected."""
         for bad in ("nan", "inf", "-inf"):
@@ -125,6 +133,7 @@ class TestTargetYieldValidation:
             assert response.status_code == 422, bad
         assert _stored_target_yield(client) is None
 
+    @pytest.mark.integration
     def test_put_at_bounds_accepted(self, client):
         """The inclusive upper bound (1.0) and small positive values are accepted."""
         for good in ("1.0", "0.0001"):
@@ -134,6 +143,7 @@ class TestTargetYieldValidation:
             )
             assert response.status_code == 200, good
 
+    @pytest.mark.integration
     def test_other_keys_pass_through_unchanged(self, client):
         """The boundary check only gates okr_target_yield — other keys are blind upserts."""
         response = client.put(

--- a/backend/tests/test_slack_notifier.py
+++ b/backend/tests/test_slack_notifier.py
@@ -11,16 +11,19 @@ from app.services.slack_notifier import SlackNotifier, get_slack_notifier
 class TestSlackNotifierConfigured:
     """Tests for SlackNotifier when a webhook URL is provided."""
 
+    @pytest.mark.unit
     def test_is_configured_with_url(self):
         """Notifier reports configured when URL is provided."""
         notifier = SlackNotifier(webhook_url="https://hooks.slack.com/test")
         assert notifier.is_configured is True
 
+    @pytest.mark.unit
     def test_is_configured_empty_url(self):
         """Notifier reports not configured when URL is empty."""
         notifier = SlackNotifier(webhook_url="")
         assert notifier.is_configured is False
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.httpx.post")
     def test_notify_startup_sends_post(self, mock_post):
         """Startup notification sends POST to webhook URL."""
@@ -36,6 +39,7 @@ class TestSlackNotifierConfigured:
         payload = call_kwargs.kwargs["json"]
         assert payload["blocks"][0]["text"]["text"] == "Application Started"
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.httpx.post")
     def test_notify_health_degraded_sends_post(self, mock_post):
         """Health degraded notification sends POST with source details."""
@@ -50,6 +54,7 @@ class TestSlackNotifierConfigured:
         assert "fred" in text_block
         assert "API key not configured" in text_block
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.httpx.post")
     def test_notify_health_degraded_none_error(self, mock_post):
         """Health degraded notification handles None error gracefully."""
@@ -62,6 +67,7 @@ class TestSlackNotifierConfigured:
         payload = mock_post.call_args.kwargs["json"]
         assert "unknown error" in payload["blocks"][1]["text"]["text"]
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.httpx.post")
     def test_send_returns_false_on_http_error(self, mock_post):
         """Returns False when webhook returns non-200 status."""
@@ -72,6 +78,7 @@ class TestSlackNotifierConfigured:
 
         assert result is False
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.httpx.post")
     def test_send_returns_false_on_exception(self, mock_post):
         """Returns False and does not raise when HTTP request fails."""
@@ -86,6 +93,7 @@ class TestSlackNotifierConfigured:
 class TestSlackNotifierNotConfigured:
     """Tests for graceful degradation when webhook is not configured."""
 
+    @pytest.mark.unit
     def test_no_url_skips_notification(self):
         """Notification is a no-op when URL is empty."""
         notifier = SlackNotifier(webhook_url="")
@@ -94,6 +102,7 @@ class TestSlackNotifierNotConfigured:
 
         assert result is False
 
+    @pytest.mark.unit
     def test_no_url_health_degraded_skips(self):
         """Health degraded notification is a no-op when URL is empty."""
         notifier = SlackNotifier(webhook_url="")
@@ -102,6 +111,7 @@ class TestSlackNotifierNotConfigured:
 
         assert result is False
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.httpx.post")
     def test_no_http_call_when_not_configured(self, mock_post):
         """No HTTP call is made when webhook URL is absent."""
@@ -115,12 +125,14 @@ class TestSlackNotifierNotConfigured:
 class TestSlackNotifierFallback:
     """Tests for config fallback behavior."""
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier.get_slack_webhook_url", return_value="")
     def test_fallback_to_config_empty(self, mock_get_url):
         """Notifier falls back to config when no URL is provided."""
         notifier = SlackNotifier()
         assert notifier.is_configured is False
 
+    @pytest.mark.unit
     @patch(
         "app.services.slack_notifier.get_slack_webhook_url",
         return_value="https://hooks.slack.com/from-config",
@@ -135,12 +147,14 @@ class TestSlackNotifierFallback:
 class TestGetSlackNotifier:
     """Tests for the module-level singleton getter."""
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier._default_notifier", None)
     def test_returns_singleton(self):
         """get_slack_notifier returns a SlackNotifier instance."""
         notifier = get_slack_notifier()
         assert isinstance(notifier, SlackNotifier)
 
+    @pytest.mark.unit
     @patch("app.services.slack_notifier._default_notifier", None)
     def test_returns_same_instance(self):
         """get_slack_notifier returns the same instance on repeated calls."""

--- a/backend/tests/test_slack_notifier.py
+++ b/backend/tests/test_slack_notifier.py
@@ -127,7 +127,7 @@ class TestSlackNotifierFallback:
 
     @pytest.mark.unit
     @patch("app.services.slack_notifier.get_slack_webhook_url", return_value="")
-    def test_fallback_to_config_empty(self, mock_get_url):
+    def test_fallback_to_config_empty(self, _mock_get_url):
         """Notifier falls back to config when no URL is provided."""
         notifier = SlackNotifier()
         assert notifier.is_configured is False

--- a/backend/tests/test_transforms.py
+++ b/backend/tests/test_transforms.py
@@ -63,7 +63,7 @@ class TestAlignDatasets:
     def test_align_single_dataset(self):
         """Single DataFrame returns one-column result with all rows."""
         df = _make_df("2023-01-01", 20)
-        combined, notes = align_datasets({"only": df})
+        combined, _notes = align_datasets({"only": df})
         assert len(combined) == 20
         assert list(combined.columns) == ["only"]
 

--- a/backend/tests/test_transforms.py
+++ b/backend/tests/test_transforms.py
@@ -27,6 +27,7 @@ def _make_df(start: str, periods: int, freq: str = "D", values: list[float] | No
 class TestAlignDatasets:
     """Tests for align_datasets() — multi-series alignment to common frequency."""
 
+    @pytest.mark.unit
     def test_align_two_datasets_matching_dates(self):
         """Two daily series with identical dates preserve all rows."""
         df_a = _make_df("2023-01-01", 30)
@@ -36,6 +37,7 @@ class TestAlignDatasets:
         assert list(combined.columns) == ["A", "B"]
         assert not any("Dropped" in n for n in notes)
 
+    @pytest.mark.unit
     def test_align_datasets_with_partial_overlap(self):
         """Two daily series with partial overlap — ffill extends beyond raw intersection.
 
@@ -51,11 +53,13 @@ class TestAlignDatasets:
         assert combined.index[0] == pd.Timestamp("2023-01-15")
         assert combined.index[-1] == pd.Timestamp("2023-02-05")
 
+    @pytest.mark.unit
     def test_align_empty_dict_raises(self):
         """Empty input raises ValueError."""
         with pytest.raises(ValueError, match="No datasets provided"):
             align_datasets({})
 
+    @pytest.mark.unit
     def test_align_single_dataset(self):
         """Single DataFrame returns one-column result with all rows."""
         df = _make_df("2023-01-01", 20)
@@ -63,6 +67,7 @@ class TestAlignDatasets:
         assert len(combined) == 20
         assert list(combined.columns) == ["only"]
 
+    @pytest.mark.unit
     def test_align_datasets_preserves_chronological_order(self):
         """Output index is monotonically increasing."""
         df_a = _make_df("2023-01-01", 30)
@@ -70,6 +75,7 @@ class TestAlignDatasets:
         combined, _ = align_datasets({"A": df_a, "B": df_b})
         assert combined.index.is_monotonic_increasing
 
+    @pytest.mark.unit
     def test_align_datasets_notes_contain_observation_count(self):
         """Notes include the 'Aligned dataset: N observations' string."""
         df_a = _make_df("2023-01-01", 10)
@@ -77,6 +83,7 @@ class TestAlignDatasets:
         _, notes = align_datasets({"A": df_a, "B": df_b})
         assert any("Aligned dataset: 10 observations" in n for n in notes)
 
+    @pytest.mark.unit
     def test_align_mixed_frequencies_resamples(self):
         """Daily + monthly series triggers resampling note."""
         df_daily = _make_df("2023-01-01", 90, freq="D")
@@ -85,6 +92,7 @@ class TestAlignDatasets:
         assert any("Resampled" in n for n in notes)
         assert any("monthly" in n for n in notes)
 
+    @pytest.mark.unit
     def test_align_datasets_ffill_limit(self):
         """Gaps beyond ffill limit=5 cause rows to be dropped."""
         # Create two series where one has a 7-day gap
@@ -99,6 +107,7 @@ class TestAlignDatasets:
         combined, notes = align_datasets({"A": df_a, "B": df_b})
         assert any("Dropped" in n for n in notes)
 
+    @pytest.mark.unit
     def test_align_datasets_empty_result_raises_index_error(self):
         """When alignment produces zero rows, accessing index[0] raises IndexError.
 
@@ -117,6 +126,7 @@ class TestAlignDatasets:
         with pytest.raises(IndexError):
             align_datasets({"A": df_a, "B": df_b})
 
+    @pytest.mark.unit
     def test_align_datasets_column_values_correct(self):
         """Aligned values match the original series values."""
         df_a = _make_df("2023-01-01", 5, values=[10.0, 20.0, 30.0, 40.0, 50.0])
@@ -129,23 +139,28 @@ class TestAlignDatasets:
 class TestInferFrequency:
     """Tests for _infer_frequency() — median-gap frequency detection."""
 
+    @pytest.mark.unit
     def test_daily_frequency(self):
         df = _make_df("2023-01-01", 30, freq="D")
         assert _infer_frequency(df) == "daily"
 
+    @pytest.mark.unit
     def test_monthly_frequency(self):
         df = _make_df("2023-01-31", 6, freq="ME")
         assert _infer_frequency(df) == "monthly"
 
+    @pytest.mark.unit
     def test_quarterly_frequency(self):
         df = _make_df("2023-03-31", 4, freq="QE")
         assert _infer_frequency(df) == "quarterly"
 
+    @pytest.mark.unit
     def test_single_row_returns_daily(self):
         """A single-row DataFrame defaults to 'daily'."""
         df = _make_df("2023-01-01", 1)
         assert _infer_frequency(df) == "daily"
 
+    @pytest.mark.unit
     def test_weekly_infers_as_daily(self):
         """Weekly data (median ~7 days) falls within the daily threshold (<=7)."""
         df = _make_df("2023-01-01", 10, freq="W")
@@ -155,26 +170,32 @@ class TestInferFrequency:
 class TestParseDate:
     """Tests for parse_date() — YYYY-MM-DD string to datetime."""
 
+    @pytest.mark.unit
     def test_valid_date(self):
         result = parse_date("2023-06-15")
         assert result == datetime(2023, 6, 15)
 
+    @pytest.mark.unit
     def test_valid_date_type(self):
         result = parse_date("2023-01-01")
         assert isinstance(result, datetime)
 
+    @pytest.mark.unit
     def test_invalid_format_raises(self):
         with pytest.raises(ValueError):
             parse_date("06/15/2023")
 
+    @pytest.mark.unit
     def test_nonsense_string_raises(self):
         with pytest.raises(ValueError):
             parse_date("not-a-date")
 
+    @pytest.mark.unit
     def test_empty_string_raises(self):
         with pytest.raises(ValueError):
             parse_date("")
 
+    @pytest.mark.unit
     def test_leap_day(self):
         result = parse_date("2024-02-29")
         assert result == datetime(2024, 2, 29)
@@ -183,27 +204,33 @@ class TestParseDate:
 class TestMakeTimeIndex:
     """Tests for make_time_index() — sequential float array generation."""
 
+    @pytest.mark.unit
     def test_returns_correct_length(self):
         result = make_time_index(5)
         assert len(result) == 5
 
+    @pytest.mark.unit
     def test_returns_float_dtype(self):
         result = make_time_index(3)
         assert result.dtype == float
 
+    @pytest.mark.unit
     def test_values_are_sequential(self):
         result = make_time_index(4)
         np.testing.assert_array_equal(result, [0.0, 1.0, 2.0, 3.0])
 
+    @pytest.mark.unit
     def test_zero_length(self):
         result = make_time_index(0)
         assert len(result) == 0
         assert result.dtype == float
 
+    @pytest.mark.unit
     def test_single_element(self):
         result = make_time_index(1)
         np.testing.assert_array_equal(result, [0.0])
 
+    @pytest.mark.unit
     def test_returns_numpy_array(self):
         result = make_time_index(3)
         assert isinstance(result, np.ndarray)

--- a/backend/tests/test_yfinance_client.py
+++ b/backend/tests/test_yfinance_client.py
@@ -28,12 +28,14 @@ from app.services import yfinance_client
 from app.services.yfinance_client import YFinanceRateLimitedError
 
 
+@pytest.mark.unit
 def test_cache_dir_is_configured_on_module_import():
     """``YFINANCE_CACHE_DIR`` is set at module import and points to a real path."""
     assert isinstance(yfinance_client.YFINANCE_CACHE_DIR, str)
     assert yfinance_client.YFINANCE_CACHE_DIR != ""
 
 
+@pytest.mark.unit
 def test_cache_dir_default_is_tmp_when_env_unset(monkeypatch):
     """No env var → default ``/tmp/yfinance-cache``."""
     monkeypatch.delenv("YFINANCE_CACHE_DIR", raising=False)
@@ -45,6 +47,7 @@ def test_cache_dir_default_is_tmp_when_env_unset(monkeypatch):
     set_loc.assert_called_once_with("/tmp/yfinance-cache")
 
 
+@pytest.mark.unit
 def test_env_var_override_picks_up_custom_dir(monkeypatch, tmp_path):
     """``YFINANCE_CACHE_DIR`` env var overrides the default."""
     target = tmp_path / "yfin"
@@ -57,6 +60,7 @@ def test_env_var_override_picks_up_custom_dir(monkeypatch, tmp_path):
     set_loc.assert_called_once_with(str(target))
 
 
+@pytest.mark.unit
 def test_explicit_env_override_arg_bypasses_environ(tmp_path):
     """``env_override`` parameter is honored without consulting the environment."""
     target = tmp_path / "explicit"
@@ -75,6 +79,7 @@ def test_explicit_env_override_arg_bypasses_environ(tmp_path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_json_decode_error_expecting_value_classified_as_rate_limit():
     """The Yahoo HTML-as-JSON signature → YFinanceRateLimitedError."""
     exc = json.JSONDecodeError(
@@ -84,6 +89,7 @@ def test_json_decode_error_expecting_value_classified_as_rate_limit():
     assert isinstance(result, YFinanceRateLimitedError)
 
 
+@pytest.mark.unit
 def test_other_json_decode_error_propagated_unchanged():
     """Different JSONDecodeError messages pass through unchanged."""
     exc = json.JSONDecodeError(
@@ -93,6 +99,7 @@ def test_other_json_decode_error_propagated_unchanged():
     assert result is exc
 
 
+@pytest.mark.unit
 def test_non_json_decode_error_propagated_unchanged():
     """Any non-JSONDecodeError exception passes through unchanged."""
     exc = ValueError("nope")
@@ -100,6 +107,7 @@ def test_non_json_decode_error_propagated_unchanged():
     assert result is exc
 
 
+@pytest.mark.unit
 def test_fetch_business_info_raises_rate_limit_on_html_429():
     """fetch_business_info re-raises YFinanceRateLimitedError on the 429 signature."""
     fake_ticker = MagicMock()
@@ -117,6 +125,7 @@ def test_fetch_business_info_raises_rate_limit_on_html_429():
             yfinance_client.fetch_business_info("SOFI")
 
 
+@pytest.mark.unit
 def test_fetch_quarterly_income_stmt_raises_rate_limit_on_html_429():
     """fetch_quarterly_income_stmt re-raises YFinanceRateLimitedError on the 429 signature."""
     fake_ticker = MagicMock()
@@ -134,6 +143,7 @@ def test_fetch_quarterly_income_stmt_raises_rate_limit_on_html_429():
             yfinance_client.fetch_quarterly_income_stmt("SOFI", 8)
 
 
+@pytest.mark.unit
 def test_fetch_business_info_returns_none_on_other_failure():
     """Non-classified failure still returns None (existing contract)."""
     fake_ticker = MagicMock()


### PR DESCRIPTION
## What this is

**Platform-lane release — no SemVer tag.** Quality v1 Wave 1 establishes the test pyramid infrastructure that anchors Contract v1 (#28) and Platform v2 (#29) downstream per [PRD #261](https://github.com/ssandy33/regress/discussions/261).

Closes: **#265, #266, #267** (full Wave 1)
Milestone: [Quality v1 — TDD Adoption + Test Pyramid](https://github.com/ssandy33/regress/milestone/27) (Wave 1 of 3)

## Worker DAG

```
feat/quality-v1-wave-1 (off main)
├── W1  feat/quality-v1-w1-markers-classifier   (#265) — pytest.ini + classifier + PF-Q1 sample
├── W2  feat/quality-v1-w2-tag-backend-tests    (#266) — applied 1,402 markers across 76 files
└── W3  feat/quality-v1-w3-ci-three-job-matrix  (#267) — backend-unit / backend-integration / frontend-playwright
```

Merge order: W1 → human PF-Q1 gate → W2 + W3 in parallel → integration PR (this).

## What changed

### Marker vocabulary + pytest.ini (W1, #265)

- Three markers: `unit`, `integration`, `tdd_red` (Wave 2 will use the third)
- `--strict-markers` ON; `addopts = -m "not tdd_red"` so default `pytest` skips Red tests
- New `backend/scripts/classify_tests.py` — AST-based heuristic classifier with `--check` and `--report` modes
- New `backend/tests/test_classify_tests.py` — 17 tests for the classifier itself
- PF-Q1 sample (8 hand-marked tests) at `backend/design-specs/quality-v1-pf-q1-sample.md` (untracked)

### Backend test tagging (W2, #266)

- **1,402 markers applied** across all 76 backend test files
- 917 `@pytest.mark.unit` (51 files) + 460 `@pytest.mark.integration` (25 files) + 8 PF-Q1 hand-marked = 1,402
- Per-test markers (not file-level `pytestmark`) because the classifier inspects `decorator_list` only
- Mixed file `test_schwab_csv_import.py` correctly split per-test (16 unit + 12 integration based on `client` fixture usage)

### CI three-job matrix (W3, #267)

- `backend-unit` — `pytest -m unit` + `coverage-unit.xml`
- `backend-integration` — `pytest -m integration` + `coverage-integration.xml`
- `frontend-checks` — unchanged (lint + build)
- `frontend-playwright` — NEW; `continue-on-error: true` during a **48-hour shakedown until 2026-05-25**, then flip to strict. Closes #231 as a side effect.
- `deploy.yml` untouched (it calls `ci.yml` at workflow-level via `workflow_call` — internal job renaming is safe)

## Validation

- [x] Local: `pytest -m unit --collect-only` collects ~1,026 (matches expected unit subset)
- [x] Local: `pytest -m integration --collect-only` collects ~469
- [x] Local: `pytest -m "not unit and not integration" --collect-only` collects 0 (every test tagged)
- [x] Full suite: 1,482 passed, 13 skipped — no regressions from W1's PF-Q1 baseline
- [ ] CI on this PR — three new jobs validate
- [ ] Phase 5 review
- [ ] Phase 5.5 CodeRabbit triage

## Release positioning

- **No SemVer tag** — Platform-lane methodology shift per the [Roadmap](https://github.com/ssandy33/regress/wiki/Roadmap#versioning) and PRD #261
- Wave 2 (#268, #269, #270) follows: CLAUDE.md Testing section, `tdd_red` PR gate, Playwright `@smoke`/`@e2e` tagging
- Wave 3 (#271): pilot on V1.1 issue #160 to capture lessons before Quality v1 closes

## Notable findings (worth knowing before merge)

1. **CTO plan file was missing from worker worktrees** — both W1 and W3 reported the file at `backend/design-specs/quality-v1-wave-1-plan.md` wasn't there. They proceeded successfully using inline locked decisions in the dispatch prompts. Worth investigating after Wave 1 ships — possibly the CTO claimed to write a file they didn't.
2. **Classifier limitation discovered by W2** — the AST analysis matches all top-level `test_*` functions, including pytest fixtures. One fixture (`test_session_local` in `test_integration_schwab.py:26`) got tagged and now emits a `PytestRemovedIn9Warning: Marks applied to fixtures have no effect`. Not blocking. Wave 2 or a follow-up issue should extend the classifier to skip `@pytest.fixture`-decorated functions.
3. **W2 chose Option B (per-test markers)** instead of Option A (file-level `pytestmark`). Reason: the classifier only checks `decorator_list`, not module-level `pytestmark`. File-level would pass pytest selection but fail `classify_tests --check`. Per-test is the only approach compatible with the locked classifier.

## Branch protection follow-up (user action)

After this PR merges, the user needs to manually flip the four-required-check branch protection rule on `main` to require: `backend-unit`, `backend-integration`, `frontend-checks`, `frontend-playwright`. Agents can't change repo settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)