### PR TITLE
Quality v1 Wave 2 — tdd_red gate + Playwright @smoke/@e2e tagging + CLAUDE.md Testing Requirements (closes #268 #269 #270)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,8 +126,23 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run Playwright tests
-        run: npx playwright test
+      # Quality v1 — Wave 2 (#270): enforce @smoke / @e2e tagging convention.
+      # Fails the job if any frontend/e2e/*.spec.js (non-prod) has an untagged
+      # test() or test.describe() call at column 0. See CLAUDE.md "Testing
+      # Requirements → Playwright tagging — @smoke / @e2e (R6)".
+      - name: Playwright tag check
+        id: playwright_tag_check
+        run: bash scripts/check-playwright-tags.sh
+
+      # Quality v1 — Wave 2 (#270): smoke-then-e2e split. @smoke is the
+      # critical-path subset (dashboard, auth, schwab, trading-rules); failing
+      # smoke short-circuits the broader e2e run. Both steps inherit the
+      # job-level continue-on-error: true until the 2026-05-25 shakedown flip.
+      - name: Run Playwright smoke
+        run: npx playwright test --grep "@smoke"
+
+      - name: Run Playwright e2e
+        run: npx playwright test --grep "@e2e"
 
       - name: Upload Playwright report
         if: failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ jobs:
           path: backend/coverage-unit.xml
           if-no-files-found: ignore
 
+      # Quality v1 — Wave 2 (#269): block PR merges that leave a tdd_red
+      # marker behind. Diff-based grep over .py files added/modified on
+      # this PR relative to its base SHA. Skipped on push-to-main runs
+      # (no pull_request context exists).
+      - name: tdd_red gate (PR diff scan)
+        id: tdd_red_gate
+        if: github.event_name == 'pull_request'
+        run: python -m scripts.check_tdd_red --diff-base ${{ github.event.pull_request.base.sha }}
+
   backend-integration:
     name: Backend tests (integration)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Need PR base SHA available locally for the tdd_red diff scan below
+          fetch-depth: 0
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,86 @@
 
 ## Testing Requirements
 
+Test methodology and pyramid are governed by [PRD #261 — Quality v1: TDD Adoption + Test Pyramid](https://github.com/ssandy33/regress/discussions/261). PRD #261 is the historical *why*; this section is the operational *what*.
+
 - Every issue must have automated test coverage for all its acceptance criteria before the PR is merged.
 - Tests must be written as part of the implementation, not as a separate follow-up step.
 - If an AC is a manual/infrastructure step (e.g., "create an OAuth app"), document it in the test file as a skipped test or comment explaining why it's not automatable.
-- Backend tests: `backend/tests/` using pytest (in-memory SQLite via conftest fixtures).
-- Frontend tests: `frontend/e2e/` using Playwright for integration/e2e flows.
-- Run backend tests: `cd backend && python -m pytest`
-- Run frontend tests: `cd frontend && npx playwright test`
-- CI runs both backend tests and frontend lint/build on every PR.
+
+### Test pyramid (R1)
+
+| Layer | Runner | Definition | Speed budget |
+|---|---|---|---|
+| **Unit** | pytest + `@pytest.mark.unit` | A single function or class in isolation. No FastAPI app, no `TestClient`, no DB session, no network. | < 1s/test; suite < 30s |
+| **Integration** | pytest + `@pytest.mark.integration` | Full backend stack: FastAPI `TestClient` + in-memory SQLite (`conftest.py` fixture) + routers + services + ORM. | < 2s/test; suite < 2min |
+| **E2E** | Playwright (`frontend/e2e/*.spec.js`) | Real browser + a running app. Frontend is the system under test. | < 30s/test; suite < 10min |
+
+Frontend has no unit / integration tier in v1 — Playwright is the only frontend test runner.
+
+### Per-AC test spread (R2)
+
+Every AC defaults to:
+
+- **0–1 E2E** test (one if the AC is a rendered user flow; zero if backend-only).
+- **1–3 integration** tests (always ≥1 — proves wiring).
+- **3–10 unit** tests (branches, edge cases, error paths).
+
+Deviations are explicit and justified in the plan file's Test List, not silent.
+
+### File-naming + marker convention (R3)
+
+**Backend** — marker is the source of truth; filename is a hint:
+
+| Layer | Filename hint | Marker |
+|---|---|---|
+| Unit | `test_<module>.py` | `@pytest.mark.unit` |
+| Integration | `test_<router>_router.py` or `test_<feature>_integration.py` | `@pytest.mark.integration` |
+| In-flight Red | any | `@pytest.mark.tdd_red` |
+
+Markers are registered in `backend/pytest.ini` with `--strict-markers`. A test missing a classifier marker fails `backend/scripts/classify_tests.py --check` (CI step in `backend-unit`).
+
+**Frontend** — specs live in `frontend/e2e/<feature>.spec.js`; tagging via `@smoke` and/or `@e2e` in `test.describe()` / `test()` titles (see *Playwright tagging* below).
+
+### Pragmatic TDD rhythm (R4)
+
+Adopt the up-front-Test-List flavor, NOT strict one-cycle-per-assertion Beck-style TDD:
+
+1. **Test List** — enumerate test cases in the plan file before any implementation.
+2. **Write the tests** in their target layer (Red — they fail because impl doesn't exist).
+3. **Implement** the smallest change that turns the tests Green.
+4. **Refactor** without changing behavior; tests stay Green.
+
+### tdd_red marker discipline (R4/R5)
+
+In-flight Red tests carry `@pytest.mark.tdd_red`. The default pytest invocation (`pytest`, `pytest -m unit`, etc.) excludes them — `addopts` in `pytest.ini` sets `-m "not tdd_red"`. Run `pytest -m tdd_red` to exercise them explicitly during development.
+
+**The PR merge gate (`tdd_red_gate` step in CI `backend-unit` job) fails if any `@pytest.mark.tdd_red` decorator or `pytestmark = pytest.mark.tdd_red` line survives in a PR's changed `.py` files.** A Red test must either be deleted or converted to passing before merge. Local check: `python -m scripts.check_tdd_red --diff-base origin/main`.
+
+### Playwright tagging — @smoke / @e2e (R6)
+
+Every `frontend/e2e/*.spec.js` carries `@smoke` and/or `@e2e` in its top-level `test.describe()` title (or each `test()` title for spec files without a top-level describe).
+
+- **`@smoke`** — critical-path subset; runs first in CI; failure short-circuits the e2e run.
+- **`@e2e`** — broader E2E set; runs after smoke passes.
+- A test may carry both (e.g., `'Dashboard renders @smoke @e2e'`).
+
+CI step `playwright_tag_check` (in `frontend-playwright` job) fails if any spec has neither tag. Run locally: `cd frontend && bash scripts/check-playwright-tags.sh`. Two npm scripts: `npm run test:smoke` and `npm run test:e2e:tags`.
+
+`.prod.spec.js` files (run under `playwright.prod.config.js`) are exempt — they're excluded by the default Playwright config.
+
+### Test List section requirement (R7)
+
+Every plan file (`<spec>-plan.md`) includes a `## Test List` section enumerating each test by name + layer + AC. The planner-architect or CTO rejects plans without it.
+
+### Where these rules apply
+
+These rules govern **new tests on new issues**. The Quality v1 Wave 1 tagging pass (#266) classified the existing 63 backend test files; it did NOT rewrite them. Existing tests are correctly classified; they were not refactored to fit the new layer definitions retroactively.
+
+- Backend tests live in `backend/tests/` (pytest, in-memory SQLite via conftest).
+- Frontend tests live in `frontend/e2e/` (Playwright; `npx playwright test`).
+- Run backend tests: `cd backend && python -m pytest`.
+- Run frontend tests: `cd frontend && npm run test:e2e` (all), `npm run test:smoke` (smoke only).
+- CI runs the three-job matrix on every PR: `backend-unit` (with classifier + tdd_red gate), `backend-integration`, `frontend-playwright` (with tag check + smoke-then-e2e).
 
 ## Code Quality
 

--- a/backend/scripts/check_tdd_red.py
+++ b/backend/scripts/check_tdd_red.py
@@ -1,0 +1,323 @@
+"""Quality v1 — ``tdd_red`` PR merge gate (issue #269).
+
+Scans the set of ``.py`` files added or changed in a PR for any surviving
+``tdd_red`` marker references and blocks the merge if any are found.
+
+Why a diff-based grep (not ``pytest --collect-only -m tdd_red``)?
+
+    A ``@pytest.mark.tdd_red`` decorator combined with an outer
+    ``@pytest.mark.skip`` would NOT appear in a ``--collect-only -m tdd_red``
+    listing — pytest filters by marker AFTER honouring skip — but the marker
+    is still present in source. A literal grep over PR-changed ``.py`` files
+    is unambiguous, fast, deterministic, and easy to reproduce locally.
+
+The three patterns we flag (locked by the Wave 2 V1 Contract Freeze):
+
+1. ``@pytest.mark.tdd_red``            — bare/called decorator form.
+2. ``pytestmark = pytest.mark.tdd_red`` — module-scope single mark.
+3. ``pytestmark = [pytest.mark.tdd_red`` — module-scope list form (open
+   bracket; the rest of the list is irrelevant to detection).
+
+Known limitation (PRD #261 R-1 accepted risk):
+
+    ``import pytest as pt; @pt.mark.tdd_red`` slips past the literal grep.
+    Aliased ``pytest`` imports are not a realistic pattern in this codebase;
+    the gate optimises for zero false-negatives on the realistic cases over
+    perfect coverage of pathological ones.
+
+Two entry modes:
+
+    python -m scripts.check_tdd_red --diff-base <ref>
+        CI mode. Runs ``git diff --name-only <ref>...HEAD -- '*.py'``
+        and scans each changed/added ``.py`` for the three patterns.
+
+    python -m scripts.check_tdd_red --files FILE [FILE ...]
+        Test mode. Scans the explicit list (no git invocation). Used by
+        the unit tests with ``tmp_path`` fixtures.
+
+Exit codes:
+
+    0  no ``tdd_red`` marker found in any scanned file.
+    1  at least one marker found — file:line listing printed to stderr.
+
+The script is intentionally pytest + stdlib only; no third-party deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Locked patterns (Wave 2 V1 Contract Freeze)
+# ---------------------------------------------------------------------------
+#
+# Each pattern is anchored at the start of a logical line (leading whitespace
+# permitted) so the trivial false-positive of a quoted string somewhere in a
+# docstring containing the literal ``@pytest.mark.tdd_red`` does NOT trigger
+# the gate. A real decorator or real module-scope ``pytestmark`` always lives
+# at column 0 after stripping leading whitespace.
+#
+# Trade-off (documented in CTO plan §"Edge Cases & Risks" #1):
+#   - A code comment whose FIRST non-whitespace token is the literal
+#     ``@pytest.mark.tdd_red`` (e.g. ``    # @pytest.mark.tdd_red``) is
+#     conservatively flagged. The remediation is trivial — delete or
+#     reword the comment. We accept that false positive over the
+#     false-negative risk of letting a sneaky real marker through.
+
+_DECORATOR_RE = re.compile(r"^\s*@pytest\.mark\.tdd_red\b")
+_PYTESTMARK_SINGLE_RE = re.compile(r"^\s*pytestmark\s*=\s*pytest\.mark\.tdd_red\b")
+_PYTESTMARK_LIST_RE = re.compile(r"^\s*pytestmark\s*=\s*\[\s*pytest\.mark\.tdd_red\b")
+
+# Public for the unit tests — the canonical (label, regex) pairs in scan order.
+PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("@pytest.mark.tdd_red", _DECORATOR_RE),
+    ("pytestmark = pytest.mark.tdd_red", _PYTESTMARK_SINGLE_RE),
+    ("pytestmark = [pytest.mark.tdd_red", _PYTESTMARK_LIST_RE),
+)
+
+# The pointer string we surface in error messages so a contributor knows
+# where to read about the marker discipline.
+CLAUDE_MD_POINTER = "see CLAUDE.md ## Testing Requirements"
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Offense:
+    """One flagged occurrence in one file."""
+
+    file: Path
+    lineno: int
+    pattern_label: str
+    line_text: str  # raw line for diagnostics (stripped of trailing newline)
+
+    def format(self) -> str:
+        """Render as ``<file>:<lineno>: tdd_red marker found (<pattern>) — ...``."""
+        return (
+            f"{self.file}:{self.lineno}: tdd_red marker found "
+            f"({self.pattern_label}) — remove before merge "
+            f"({CLAUDE_MD_POINTER})."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core scan
+# ---------------------------------------------------------------------------
+
+
+def scan_file(path: Path) -> list[Offense]:
+    """Scan one ``.py`` file for tdd_red markers; return all offences.
+
+    Returns an empty list on:
+      - missing files (the diff listed a file that's been deleted),
+      - non-``.py`` paths (defensive — the caller should filter),
+      - files that fail to decode as UTF-8 (unexpected for a Python source
+        tree but handled gracefully).
+    """
+    if path.suffix != ".py":
+        return []
+    if not path.is_file():
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        logger.warning(
+            "tdd_red_gate: failed to read %s — skipping",
+            path,
+            extra={"event": "tdd_red_gate.read_error", "file": str(path)},
+        )
+        return []
+
+    offences: list[Offense] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for label, pattern in PATTERNS:
+            if pattern.search(line):
+                offences.append(
+                    Offense(
+                        file=path,
+                        lineno=lineno,
+                        pattern_label=label,
+                        line_text=line.rstrip(),
+                    )
+                )
+                # Only flag once per line even if a contrived line matched
+                # multiple patterns — the first label is informative enough.
+                break
+    return offences
+
+
+def scan_files(paths: list[Path]) -> list[Offense]:
+    """Scan many ``.py`` files; return offences in input order then line order."""
+    offences: list[Offense] = []
+    for path in paths:
+        offences.extend(scan_file(path))
+    return offences
+
+
+# ---------------------------------------------------------------------------
+# Git diff enumeration
+# ---------------------------------------------------------------------------
+
+
+def _changed_py_files(diff_base: str, repo_root: Path) -> list[Path]:
+    """Return the ``.py`` files changed between ``diff_base`` and ``HEAD``.
+
+    Uses ``git diff --name-only --diff-filter=AM <base>...HEAD -- '*.py'`` so
+    only **A**dded and **M**odified files are scanned (deletions are
+    irrelevant — they can't contain a surviving marker).
+
+    The three-dot form (``<base>...HEAD``) gives the diff from the merge-base
+    of <base> and HEAD to HEAD — i.e. only changes introduced on the feature
+    branch since it diverged. That's the semantic the PR gate wants.
+    """
+    cmd = [
+        "git",
+        "diff",
+        "--name-only",
+        "--diff-filter=AM",
+        f"{diff_base}...HEAD",
+        "--",
+        "*.py",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        # Generic message; never surface raw exception text.
+        raise SystemExit("tdd_red_gate: git not available on PATH") from None
+    except subprocess.CalledProcessError:
+        raise SystemExit(
+            f"tdd_red_gate: git diff failed for base {diff_base!r}"
+        ) from None
+
+    paths: list[Path] = []
+    for raw in result.stdout.splitlines():
+        name = raw.strip()
+        if not name:
+            continue
+        paths.append((repo_root / name).resolve())
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _repo_root() -> Path:
+    """Locate the repository root relative to this script (``backend/scripts/``)."""
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="check_tdd_red",
+        description=(
+            "PR merge gate: fail if any @pytest.mark.tdd_red or "
+            "module-scope pytestmark = pytest.mark.tdd_red marker survives "
+            "in the PR's changed .py files."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--diff-base",
+        "--base",
+        dest="diff_base",
+        metavar="REF",
+        help=(
+            "Git ref or SHA to diff against (typically "
+            "${{ github.event.pull_request.base.sha }} in CI, or "
+            "origin/main locally). Scans every .py file added or modified "
+            "between <REF> and HEAD."
+        ),
+    )
+    mode.add_argument(
+        "--files",
+        nargs="+",
+        type=Path,
+        metavar="FILE",
+        help="Explicit list of .py files to scan (test mode; bypasses git).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help=(
+            "Override the repository root (default: inferred from this "
+            "script's location). Used by unit tests."
+        ),
+    )
+    return parser
+
+
+def _print_offences(offences: list[Offense]) -> None:
+    """Print one error line per offence to stderr."""
+    for o in offences:
+        print(o.format(), file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    logger.info(
+        "tdd_red_gate starting",
+        extra={
+            "event": "tdd_red_gate.start",
+            "mode": "diff" if args.diff_base else "files",
+        },
+    )
+
+    if args.files is not None:
+        paths = [p.resolve() for p in args.files]
+    else:
+        repo_root = (args.repo_root or _repo_root()).resolve()
+        paths = _changed_py_files(args.diff_base, repo_root)
+
+    offences = scan_files(paths)
+
+    logger.info(
+        "tdd_red_gate complete",
+        extra={
+            "event": "tdd_red_gate.complete",
+            "files_scanned": len(paths),
+            "offences": len(offences),
+        },
+    )
+
+    if offences:
+        _print_offences(offences)
+        print(
+            f"tdd_red_gate: FAIL — {len(offences)} marker(s) found in "
+            f"{len({o.file for o in offences})} file(s). "
+            "A Red test must be deleted or converted to passing before merge.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"tdd_red_gate: OK — scanned {len(paths)} changed .py file(s); "
+        "no tdd_red markers found."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/scripts/check_tdd_red.py
+++ b/backend/scripts/check_tdd_red.py
@@ -50,10 +50,24 @@ import logging
 import re
 import subprocess
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+class TddRedGateReadError(Exception):
+    """Raised when a changed ``.py`` file cannot be read in gate mode.
+
+    The gate is fail-closed: an unreadable file is a policy failure, not a
+    silently-skipped scan. ``main()`` catches this and exits non-zero with a
+    clear error message identifying the unreadable file.
+    """
+
+    def __init__(self, path: Path) -> None:
+        super().__init__(str(path))
+        self.path = path
 
 
 # ---------------------------------------------------------------------------
@@ -122,9 +136,11 @@ def scan_file(path: Path) -> list[Offense]:
 
     Returns an empty list on:
       - missing files (the diff listed a file that's been deleted),
-      - non-``.py`` paths (defensive — the caller should filter),
-      - files that fail to decode as UTF-8 (unexpected for a Python source
-        tree but handled gracefully).
+      - non-``.py`` paths (defensive — the caller should filter).
+
+    Raises :class:`TddRedGateReadError` when a present ``.py`` file fails to
+    open or decode. This is a fail-closed policy gate: an unreadable file is
+    propagated up so the gate exits non-zero rather than silently passing.
     """
     if path.suffix != ".py":
         return []
@@ -132,13 +148,14 @@ def scan_file(path: Path) -> list[Offense]:
         return []
     try:
         text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    except (OSError, UnicodeDecodeError) as exc:
+        # Keep the warning for diagnostics, then fail-closed by raising.
         logger.warning(
-            "tdd_red_gate: failed to read %s — skipping",
+            "tdd_red_gate: failed to read %s — failing closed",
             path,
-            extra={"event": "tdd_red_gate.read_error", "file": str(path)},
+            extra={"event": "tdd_red_gate.read_error", "outcome": "failed"},
         )
-        return []
+        raise TddRedGateReadError(path) from exc
 
     offences: list[Offense] = []
     for lineno, line in enumerate(text.splitlines(), start=1):
@@ -277,12 +294,17 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
+    # ADR #292 observability: `.complete` and `.failed` lifecycle events carry
+    # `outcome` + `duration_ms`. Start the clock here so we report end-to-end
+    # gate latency, not just scan time.
+    started = time.perf_counter()
+    event_prefix = (
+        "tdd_red_gate.diff_mode" if args.diff_base else "tdd_red_gate.file_mode"
+    )
+
     logger.info(
         "tdd_red_gate starting",
-        extra={
-            "event": "tdd_red_gate.start",
-            "mode": "diff" if args.diff_base else "files",
-        },
+        extra={"event": f"{event_prefix}.start"},
     )
 
     if args.files is not None:
@@ -291,14 +313,36 @@ def main(argv: list[str] | None = None) -> int:
         repo_root = (args.repo_root or _repo_root()).resolve()
         paths = _changed_py_files(args.diff_base, repo_root)
 
-    offences = scan_files(paths)
+    try:
+        offences = scan_files(paths)
+    except TddRedGateReadError as exc:
+        duration_ms = int((time.perf_counter() - started) * 1000)
+        logger.error(
+            "tdd_red_gate failed: could not read %s",
+            exc.path,
+            extra={
+                "event": f"{event_prefix}.failed",
+                "outcome": "failed",
+                "duration_ms": duration_ms,
+                "error_class": "TddRedGateReadError",
+            },
+        )
+        print(
+            f"tdd_red_gate: could not read {exc.path} — failing closed.",
+            file=sys.stderr,
+        )
+        return 1
 
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    outcome = "failed" if offences else "success"
     logger.info(
-        "tdd_red_gate complete",
+        "tdd_red_gate complete: scanned %d file(s), %d offence(s)",
+        len(paths),
+        len(offences),
         extra={
-            "event": "tdd_red_gate.complete",
-            "files_scanned": len(paths),
-            "offences": len(offences),
+            "event": f"{event_prefix}.complete",
+            "outcome": outcome,
+            "duration_ms": duration_ms,
         },
     )
 

--- a/backend/tests/test_check_tdd_red.py
+++ b/backend/tests/test_check_tdd_red.py
@@ -1,0 +1,552 @@
+"""Tests for ``backend/scripts/check_tdd_red.py`` — the tdd_red PR merge gate.
+
+Covers the AC test list in issue #269 (Quality v1 Wave 2):
+
+| AC    | Test                                                             |
+|-------|------------------------------------------------------------------|
+| 5.3   | test_flags_decorator_form                                        |
+| 5.3   | test_flags_module_pytestmark_single                              |
+| 5.3   | test_flags_module_pytestmark_list                                |
+| 5.3   | test_clean_diff_passes                                           |
+| 5.3   | test_ignores_non_py_files                                        |
+| 5.6   | test_error_message_includes_claude_md_pointer                    |
+| 5.6   | test_multiple_offenders_lists_all                                |
+| 5.3   | test_removed_marker_does_not_flag                                |
+| 5.3   | test_marker_in_docstring_string_literal_is_not_flagged           |
+| 5.3   | test_indented_decorator_inside_class_is_flagged                  |
+| 5.3   | test_files_mode_scans_explicit_paths                             |
+| 5.3   | test_diff_mode_invokes_git_and_scans_results                     |
+
+The gate is a pure-function classifier — no FastAPI app, no DB, no network.
+Every test here is marked ``@pytest.mark.unit`` per the Wave 1 pyramid.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts import check_tdd_red
+
+
+REPO_BACKEND = Path(__file__).resolve().parent.parent  # backend/
+REPO_ROOT = REPO_BACKEND.parent  # repo root
+
+
+# The literal marker tokens we test against. Assembled at runtime from
+# substrings so the gate cannot flag THIS file (the gate's own test file
+# must stay clean — see Edge Cases & Risks #5 in the CTO plan).
+_MARK = "pytest.mark." + "tdd_red"
+_DEC = "@" + _MARK
+_PYTESTMARK_SINGLE = "pytestmark = " + _MARK
+_PYTESTMARK_LIST = "pytestmark = [" + _MARK + ", pytest.mark.unit]"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, source: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# AC-5.3 — scan_file detects each of the three locked patterns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_flags_decorator_form(tmp_path: Path) -> None:
+    """The decorator form is flagged."""
+    f = _write(
+        tmp_path / "test_red_decorator.py",
+        f"""
+        import pytest
+
+        {_DEC}
+        def test_foo():
+            assert False
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    assert len(offences) == 1
+    assert offences[0].file == f
+    assert offences[0].lineno == 3  # decorator is on line 3 after dedent
+    assert offences[0].pattern_label == _DEC
+
+
+@pytest.mark.unit
+def test_flags_module_pytestmark_single(tmp_path: Path) -> None:
+    """Module-scope single ``pytestmark =`` assignment is flagged."""
+    f = _write(
+        tmp_path / "test_red_module_mark.py",
+        f"""
+        import pytest
+
+        {_PYTESTMARK_SINGLE}
+
+
+        def test_foo():
+            assert False
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    assert len(offences) == 1
+    assert offences[0].lineno == 3
+    assert offences[0].pattern_label == "pytestmark = " + "pytest.mark." + "tdd_red"
+
+
+@pytest.mark.unit
+def test_flags_module_pytestmark_list(tmp_path: Path) -> None:
+    """Module-scope list-form ``pytestmark = [...]`` is flagged."""
+    f = _write(
+        tmp_path / "test_red_module_list.py",
+        f"""
+        import pytest
+
+        {_PYTESTMARK_LIST}
+
+
+        def test_foo():
+            assert False
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    assert len(offences) == 1
+    assert offences[0].lineno == 3
+    assert offences[0].pattern_label == "pytestmark = [" + "pytest.mark." + "tdd_red"
+
+
+@pytest.mark.unit
+def test_clean_diff_passes(tmp_path: Path) -> None:
+    """A file with no tdd_red references produces zero offences."""
+    f = _write(
+        tmp_path / "test_clean.py",
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_ok():
+            assert 1 + 1 == 2
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    assert offences == []
+
+
+@pytest.mark.unit
+def test_ignores_non_py_files(tmp_path: Path) -> None:
+    """A non-``.py`` file containing the literal marker is NOT scanned."""
+    f = _write(
+        tmp_path / "README.md",
+        f"""
+        Don't forget to remove ``{_DEC}`` before merging.
+        Also: {_PYTESTMARK_SINGLE}.
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    assert offences == []
+
+
+# ---------------------------------------------------------------------------
+# AC-5.6 — error messages are actionable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_error_message_includes_claude_md_pointer(tmp_path: Path) -> None:
+    """Each formatted offence points at the CLAUDE.md section for context."""
+    f = _write(
+        tmp_path / "test_red.py",
+        f"""
+        import pytest
+
+        {_DEC}
+        def test_foo():
+            pass
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+    msg = offences[0].format()
+
+    assert "CLAUDE.md" in msg
+    assert "Testing Requirements" in msg
+    assert str(f) in msg
+    assert ":3:" in msg  # file:line in the message
+
+
+@pytest.mark.unit
+def test_multiple_offenders_lists_all(tmp_path: Path) -> None:
+    """``scan_files`` reports every offence across every file."""
+    f1 = _write(
+        tmp_path / "test_one.py",
+        f"""
+        import pytest
+
+        {_DEC}
+        def test_one():
+            pass
+        """,
+    )
+    f2 = _write(
+        tmp_path / "test_two.py",
+        f"""
+        import pytest
+
+        {_PYTESTMARK_SINGLE}
+
+
+        def test_two():
+            pass
+        """,
+    )
+
+    offences = check_tdd_red.scan_files([f1, f2])
+
+    assert len(offences) == 2
+    files_seen = {o.file for o in offences}
+    assert files_seen == {f1, f2}
+
+
+# ---------------------------------------------------------------------------
+# AC-5.3 (edge cases)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_removed_marker_does_not_flag(tmp_path: Path, monkeypatch) -> None:
+    """In diff mode, a marker REMOVED on the feature branch is not flagged.
+
+    Concretely: a real git history where the previous commit had
+    ``@pytest.mark.tdd_red`` and HEAD removed it. The diff-base scan
+    enumerates files that were Added or Modified in HEAD relative to
+    base; we then re-scan those files at HEAD. Since the marker is gone
+    from HEAD, no offence is reported.
+    """
+    repo = tmp_path
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+
+    target = repo / "backend" / "tests" / "test_red.py"
+    _write(
+        target,
+        f"""
+        import pytest
+
+        {_DEC}
+        def test_foo():
+            pass
+        """,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "initial with tdd_red"],
+        cwd=repo,
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # Now remove the marker on HEAD.
+    _write(
+        target,
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_foo():
+            pass
+        """,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "remove tdd_red"],
+        cwd=repo,
+        check=True,
+    )
+
+    paths = check_tdd_red._changed_py_files(base_sha, repo)
+    offences = check_tdd_red.scan_files(paths)
+
+    # The file IS in the diff (it was modified), but its CURRENT content has
+    # no marker — no offence.
+    assert any(p.name == "test_red.py" for p in paths)
+    assert offences == []
+
+
+@pytest.mark.unit
+def test_marker_in_docstring_string_literal_is_not_flagged(tmp_path: Path) -> None:
+    """A docstring mentioning the literal marker (with leading non-whitespace
+    text) is NOT flagged because the regex anchors at the start of a logical
+    line. A real decorator always starts at column 0 of its line."""
+    f = _write(
+        tmp_path / "test_docstring.py",
+        f'''
+        """Docstring example.
+
+        Don't put {_DEC} on merged tests.
+        Also: {_PYTESTMARK_SINGLE} is wrong on main.
+        """
+
+        import pytest
+
+
+        @pytest.mark.unit
+        def test_ok():
+            pass
+        ''',
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    # The two mentions are inside a docstring with leading "Don't put " or
+    # "Also: " — the line does NOT start with @pytest or pytestmark. Clean.
+    assert offences == []
+
+
+@pytest.mark.unit
+def test_indented_decorator_inside_class_is_flagged(tmp_path: Path) -> None:
+    """A decorator inside ``class TestFoo:`` is still flagged (leading WS allowed)."""
+    f = _write(
+        tmp_path / "test_class_red.py",
+        f"""
+        import pytest
+
+
+        class TestRed:
+            {_DEC}
+            def test_x(self):
+                pass
+        """,
+    )
+
+    offences = check_tdd_red.scan_file(f)
+
+    assert len(offences) == 1
+    assert offences[0].pattern_label == _DEC
+
+
+@pytest.mark.unit
+def test_files_mode_scans_explicit_paths(tmp_path: Path, capsys) -> None:
+    """``--files`` mode bypasses git and scans the explicit list; exits 1 on
+    finding a marker."""
+    f = _write(
+        tmp_path / "test_explicit.py",
+        f"""
+        import pytest
+
+        {_DEC}
+        def test_foo():
+            pass
+        """,
+    )
+
+    exit_code = check_tdd_red.main(["--files", str(f)])
+
+    err = capsys.readouterr().err
+    assert exit_code == 1
+    assert str(f) in err
+    assert "tdd_red marker found" in err
+    assert "CLAUDE.md" in err
+
+
+@pytest.mark.unit
+def test_files_mode_clean_exits_zero(tmp_path: Path, capsys) -> None:
+    """``--files`` mode on a clean file exits 0 with a one-line OK message."""
+    f = _write(
+        tmp_path / "test_clean.py",
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_foo():
+            assert True
+        """,
+    )
+
+    exit_code = check_tdd_red.main(["--files", str(f)])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "OK" in out
+    assert "tdd_red_gate" in out
+
+
+@pytest.mark.unit
+def test_diff_mode_invokes_git_and_scans_results(tmp_path: Path, capsys) -> None:
+    """``--diff-base`` mode runs ``git diff`` against the supplied base SHA
+    and scans whatever files come back."""
+    repo = tmp_path
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+
+    # Base commit: empty placeholder.
+    _write(repo / "placeholder.py", "# baseline\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "base"],
+        cwd=repo,
+        check=True,
+    )
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # HEAD commit: add an offending file.
+    _write(
+        repo / "backend" / "tests" / "test_red.py",
+        f"""
+        import pytest
+
+        {_DEC}
+        def test_foo():
+            pass
+        """,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "add red"],
+        cwd=repo,
+        check=True,
+    )
+
+    exit_code = check_tdd_red.main(
+        ["--diff-base", base_sha, "--repo-root", str(repo)]
+    )
+
+    err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "test_red.py" in err
+    assert "tdd_red marker found" in err
+
+
+@pytest.mark.unit
+def test_diff_mode_clean_pr_exits_zero(tmp_path: Path, capsys) -> None:
+    """A PR that touches a .py file but adds no tdd_red marker exits 0."""
+    repo = tmp_path
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=repo, check=True)
+
+    _write(repo / "placeholder.py", "# baseline\n")
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base"], cwd=repo, check=True)
+    base_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    _write(
+        repo / "backend" / "tests" / "test_ok.py",
+        """
+        import pytest
+
+        @pytest.mark.unit
+        def test_ok():
+            assert True
+        """,
+    )
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add ok"], cwd=repo, check=True)
+
+    exit_code = check_tdd_red.main(
+        ["--diff-base", base_sha, "--repo-root", str(repo)]
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "OK" in out
+
+
+@pytest.mark.unit
+def test_scan_file_handles_missing_path(tmp_path: Path) -> None:
+    """A missing file (e.g. deleted on branch) yields zero offences, no raise."""
+    ghost = tmp_path / "does_not_exist.py"
+    assert check_tdd_red.scan_file(ghost) == []
+
+
+@pytest.mark.unit
+def test_scan_file_skips_non_py(tmp_path: Path) -> None:
+    """A .md / .txt file passed directly is silently skipped."""
+    txt = _write(
+        tmp_path / "README.txt",
+        _DEC + "\n",
+    )
+    assert check_tdd_red.scan_file(txt) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI parser shape (catches regressions to the locked CLI surface)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_cli_requires_exactly_one_mode(tmp_path: Path) -> None:
+    """``--diff-base`` and ``--files`` are mutually exclusive and one is required."""
+    parser = check_tdd_red.build_parser()
+
+    # Neither -> SystemExit (parser error).
+    with pytest.raises(SystemExit):
+        parser.parse_args([])
+
+    # Both -> SystemExit.
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            ["--diff-base", "origin/main", "--files", str(tmp_path / "x.py")]
+        )
+
+    # --diff-base alone -> ok.
+    ns = parser.parse_args(["--diff-base", "origin/main"])
+    assert ns.diff_base == "origin/main"
+    assert ns.files is None
+
+    # --base alias works (the CTO plan accepted either --diff-base or --base).
+    ns = parser.parse_args(["--base", "abc123"])
+    assert ns.diff_base == "abc123"
+
+
+@pytest.mark.unit
+def test_module_runnable_as_script() -> None:
+    """``python -m scripts.check_tdd_red --help`` works (CI-invocation shape)."""
+    result = subprocess.run(
+        [sys.executable, "-m", "scripts.check_tdd_red", "--help"],
+        cwd=str(REPO_BACKEND),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "tdd_red" in result.stdout
+    assert "--diff-base" in result.stdout
+    assert "--files" in result.stdout

--- a/backend/tests/test_check_tdd_red.py
+++ b/backend/tests/test_check_tdd_red.py
@@ -232,7 +232,7 @@ def test_multiple_offenders_lists_all(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_removed_marker_does_not_flag(tmp_path: Path, monkeypatch) -> None:
+def test_removed_marker_does_not_flag(tmp_path: Path) -> None:
     """In diff mode, a marker REMOVED on the feature branch is not flagged.
 
     Concretely: a real git history where the previous commit had
@@ -505,6 +505,27 @@ def test_scan_file_skips_non_py(tmp_path: Path) -> None:
         _DEC + "\n",
     )
     assert check_tdd_red.scan_file(txt) == []
+
+
+@pytest.mark.unit
+def test_unreadable_file_fails_closed(tmp_path: Path, capsys) -> None:
+    """An undecodable ``.py`` file makes the gate exit non-zero (fail-closed).
+
+    Regression guard for the CodeRabbit triage on PR #300: previously the
+    scanner caught ``(OSError, UnicodeDecodeError)`` and returned ``[]``,
+    letting the gate pass even though a changed file was never actually
+    scanned. A policy gate must fail closed, not open.
+    """
+    bad = tmp_path / "test_garbled.py"
+    # Write invalid UTF-8 bytes so .read_text(encoding="utf-8") raises.
+    bad.write_bytes(b"\xff\xfe\xfd not valid utf-8 \xc3\x28")
+
+    exit_code = check_tdd_red.main(["--files", str(bad)])
+
+    err = capsys.readouterr().err
+    assert exit_code == 1
+    assert "could not read" in err
+    assert str(bad) in err
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/e2e/auth-flow.spec.js
+++ b/frontend/e2e/auth-flow.spec.js
@@ -32,7 +32,7 @@ async function isAuthEnforced(page) {
   return page.url().includes('/auth/signin');
 }
 
-test.describe('Auth redirect flow (auth configured)', () => {
+test.describe('Auth redirect flow (auth configured) @smoke @e2e', () => {
   test.beforeEach(async ({ page }) => {
     const enforced = await isAuthEnforced(page);
     if (!enforced) {
@@ -61,7 +61,7 @@ test.describe('Auth redirect flow (auth configured)', () => {
   });
 });
 
-test.describe('Sign-in page', () => {
+test.describe('Sign-in page @smoke @e2e', () => {
   test('shows GitHub sign-in button', async ({ page }) => {
     await page.goto('/auth/signin');
     await page.waitForLoadState('networkidle');
@@ -89,7 +89,7 @@ test.describe('Sign-in page', () => {
   });
 });
 
-test.describe('Auth disabled (no env vars)', () => {
+test.describe('Auth disabled (no env vars) @smoke @e2e', () => {
   test.beforeEach(async ({ page }) => {
     const enforced = await isAuthEnforced(page);
     if (enforced) {
@@ -127,7 +127,7 @@ test.describe('Auth disabled (no env vars)', () => {
  *   2. Only NEXTAUTH_SECRET set → auth enabled (Issue #80 key scenario)
  *   3. All three vars set → auth enabled
  */
-test.describe('Issue #80: NEXTAUTH_SECRET-only auth enablement', () => {
+test.describe('Issue #80: NEXTAUTH_SECRET-only auth enablement @smoke @e2e', () => {
   test('auth enforcement is consistent — either redirects or passes through', async ({ page }) => {
     // Verify the middleware behaves consistently: when auth is enforced,
     // all protected routes redirect; when not, none do. This confirms the

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -213,7 +213,7 @@ function mockDashboard(page, card) {
 
 // --- Tests: route renders + states -----------------------------------------
 
-test.describe('BTC detail screen — route + states', () => {
+test.describe('BTC detail screen — route + states @e2e', () => {
   test('renders the populated page for a valid leg', async ({ page }) => {
     await mockBtcDetail(page, populatedPayload());
     await openBtcDetail(page);
@@ -348,7 +348,7 @@ test.describe('BTC detail screen — route + states', () => {
 
 // --- Tests: CTA navigation from the dashboard action cards ------------------
 
-test.describe('BTC detail screen — reachable from dashboard card CTA', () => {
+test.describe('BTC detail screen — reachable from dashboard card CTA @e2e', () => {
   test('"Review buy-to-close →" on a profit-take card navigates to the BTC route', async ({
     page,
   }) => {
@@ -456,7 +456,7 @@ async function mockJournalPositions(page, positions) {
   });
 }
 
-test.describe('BTC detail — journal close-leg pre-fill (issue #244)', () => {
+test.describe('BTC detail — journal close-leg pre-fill (issue #244) @e2e', () => {
   test('"Buy to close" CTA points at the close-leg journal deep-link', async ({
     page,
   }) => {

--- a/frontend/e2e/covered-call.spec.js
+++ b/frontend/e2e/covered-call.spec.js
@@ -198,7 +198,7 @@ async function openCoveredCall(page, route = COVERED_CALL_ROUTE) {
 
 // --- Tests: route renders + populated view ---------------------------------
 
-test.describe('Covered-call screen — route + populated view', () => {
+test.describe('Covered-call screen — route + populated view @e2e', () => {
   test('loads and renders combined P&L and if-assigned for the canonical F covered call', async ({
     page,
   }) => {
@@ -274,7 +274,7 @@ test.describe('Covered-call screen — route + populated view', () => {
 
 // --- Tests: empty states ----------------------------------------------------
 
-test.describe('Covered-call screen — empty states', () => {
+test.describe('Covered-call screen — empty states @e2e', () => {
   test('CSP-only renders covered-call-empty-no-shares', async ({ page }) => {
     await mockCoveredCall(page, emptyPayload('not_applicable_no_shares'));
     await openCoveredCall(page);
@@ -326,7 +326,7 @@ test.describe('Covered-call screen — empty states', () => {
 
 // --- Tests: degraded + multi-leg --------------------------------------------
 
-test.describe('Covered-call screen — degraded + multi-leg', () => {
+test.describe('Covered-call screen — degraded + multi-leg @e2e', () => {
   test('degraded — no live mid — today hero shows em-dash, if-assigned renders normally', async ({
     page,
   }) => {
@@ -463,7 +463,7 @@ function mockDashboard(page) {
   );
 }
 
-test.describe('Dashboard — Covered call view → link visibility', () => {
+test.describe('Dashboard — Covered call view → link visibility @e2e', () => {
   test('Covered call view → link appears on CC and Wheel rows; absent on CSP and Holding', async ({
     page,
   }) => {

--- a/frontend/e2e/csp-nonce.spec.js
+++ b/frontend/e2e/csp-nonce.spec.js
@@ -85,7 +85,7 @@ function fetchDashboard(request, suffix = '') {
   return request.get(`/dashboard${suffix}`, { maxRedirects: 0 });
 }
 
-test.describe('Nonce-based CSP (#33)', () => {
+test.describe('Nonce-based CSP (#33) @e2e', () => {
   test('script-src uses a nonce, drops unsafe-inline, keeps wasm-unsafe-eval', async ({
     request,
   }) => {

--- a/frontend/e2e/dark-mode-toggle.spec.js
+++ b/frontend/e2e/dark-mode-toggle.spec.js
@@ -36,7 +36,7 @@ async function bgLuminance(locator) {
   });
 }
 
-test.describe('Dark mode toggle (#117)', () => {
+test.describe('Dark mode toggle (#117) @e2e', () => {
   test('toggles every dark: variant when OS prefers light', async ({ browser }) => {
     const ctx = await browser.newContext({ colorScheme: 'light' });
     const page = await ctx.newPage();

--- a/frontend/e2e/dashboard-dte-pill.spec.js
+++ b/frontend/e2e/dashboard-dte-pill.spec.js
@@ -115,7 +115,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('OpenLegsCard — urgency-aware DTE pill (issue #248)', () => {
+test.describe('OpenLegsCard — urgency-aware DTE pill (issue #248) @e2e', () => {
   test('dte 5 → red urgency tier', async ({ page }) => {
     const leg = makeLeg({ dte: 5 });
     await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });

--- a/frontend/e2e/dashboard-kpi-row.spec.js
+++ b/frontend/e2e/dashboard-kpi-row.spec.js
@@ -100,7 +100,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('KPI row (V0.5 — 7 tiles)', () => {
+test.describe('KPI row (V0.5 — 7 tiles) @e2e', () => {
   test('renders all seven tiles when populated', async ({ page }) => {
     await mockDashboard(page, { ...BASE_PAYLOAD, kpis: POPULATED_KPIS });
     await page.goto('/dashboard');

--- a/frontend/e2e/dashboard-next-actions.spec.js
+++ b/frontend/e2e/dashboard-next-actions.spec.js
@@ -75,7 +75,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('NextActionsSection', () => {
+test.describe('NextActionsSection @e2e', () => {
   test('section is always visible (even when empty)', async ({ page }) => {
     await mockDashboard(page, BASE_PAYLOAD);
     await page.goto('/dashboard');

--- a/frontend/e2e/dashboard-open-legs-card.spec.js
+++ b/frontend/e2e/dashboard-open-legs-card.spec.js
@@ -141,7 +141,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
+test.describe('OpenLegsCard (V0.5 — triage columns) @e2e', () => {
   test('%CAPTURED column renders `—` when state is unknown (universal V0.5 case)', async ({ page }) => {
     const leg = makeLeg();
     await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
@@ -324,7 +324,7 @@ test.describe('OpenLegsCard (V0.5 — triage columns)', () => {
  *     collapses with the `% Capt` cell.
  *   - Degraded path (no live mid) keeps the badge, shows `—` for the dollars.
  */
-test.describe('OpenLegsCard (V1.0.6 — coverage badge + dollar P&L)', () => {
+test.describe('OpenLegsCard (V1.0.6 — coverage badge + dollar P&L) @e2e', () => {
   // The F 15C covered worked example from the issue / spec §1.2.
   function coveredLeg(overrides = {}) {
     return makeLeg({
@@ -589,7 +589,7 @@ test.describe('OpenLegsCard (V1.0.6 — coverage badge + dollar P&L)', () => {
   });
 });
 
-test.describe('OpenLegsCard (V1.0.8 #252 — quantity scales degraded Credit received)', () => {
+test.describe('OpenLegsCard (V1.0.8 #252 — quantity scales degraded Credit received) @e2e', () => {
   // The primary path (`pnl_dollars + cost_to_close`) is already qty-scaled by
   // `derive_leg_economics`. These tests pin the degraded fallback formula in
   // `OpenLegsCard.jsx:204`: `creditReceived = premium * 100 * (quantity ?? 1)`.

--- a/frontend/e2e/dashboard-positions-triage.spec.js
+++ b/frontend/e2e/dashboard-positions-triage.spec.js
@@ -124,7 +124,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('Positions triage table', () => {
+test.describe('Positions triage table @e2e', () => {
   test('renders one row per position with required testIds', async ({ page }) => {
     await mockDashboard(page, TRIAGE_PAYLOAD);
     await page.goto('/dashboard');

--- a/frontend/e2e/dashboard-readiness-banner.spec.js
+++ b/frontend/e2e/dashboard-readiness-banner.spec.js
@@ -65,7 +65,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('DataReadinessBanner', () => {
+test.describe('DataReadinessBanner @e2e', () => {
   test('hidden when all sources healthy', async ({ page }) => {
     await mockDashboard(page, BASE_PAYLOAD);
     await page.goto('/dashboard');

--- a/frontend/e2e/dashboard-recent-activity.spec.js
+++ b/frontend/e2e/dashboard-recent-activity.spec.js
@@ -100,7 +100,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('RecentActivityCard — V0.5.4 refactor (issue #153)', () => {
+test.describe('RecentActivityCard — V0.5.4 refactor (issue #153) @e2e', () => {
   test('renders summary, filter chips, search input, and rows', async ({ page }) => {
     await mockDashboard(page, BASE_PAYLOAD);
     await page.goto('/dashboard');

--- a/frontend/e2e/dashboard-rule-monitor.spec.js
+++ b/frontend/e2e/dashboard-rule-monitor.spec.js
@@ -223,7 +223,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('OpenLegsCard rule monitor — ACTION verdict column', () => {
+test.describe('OpenLegsCard rule monitor — ACTION verdict column @e2e', () => {
   test('profit-take verdict renders "Review · 50%" emerald', async ({ page }) => {
     const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
     await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
@@ -303,7 +303,7 @@ test.describe('OpenLegsCard rule monitor — ACTION verdict column', () => {
   });
 });
 
-test.describe('OpenLegsCard rule monitor — InspectPanel', () => {
+test.describe('OpenLegsCard rule monitor — InspectPanel @e2e', () => {
   test('clicking a leg row expands the inspect panel', async ({ page }) => {
     const leg = makeLeg({ verdict: 'profit_take_review', capturedPct: 0.6 });
     await mockDashboard(page, { ...BASE_PAYLOAD, open_legs: [leg] });
@@ -412,7 +412,7 @@ test.describe('OpenLegsCard rule monitor — InspectPanel', () => {
   });
 });
 
-test.describe('OpenLegsCard rule monitor — degraded path', () => {
+test.describe('OpenLegsCard rule monitor — degraded path @e2e', () => {
   test('no live mid → % Capt shows — and verdict falls back to DTE rule', async ({ page }) => {
     const leg = makeLeg({
       id: 'leg-nvda',
@@ -437,7 +437,7 @@ test.describe('OpenLegsCard rule monitor — degraded path', () => {
   });
 });
 
-test.describe('NextActionCard — rule-monitor cards', () => {
+test.describe('NextActionCard — rule-monitor cards @e2e', () => {
   test('leg.profit_take_review card renders emerald, ✓, [P1]', async ({ page }) => {
     const card = makeCard({ action_id: 'leg.profit_take_review', tone: 'opportunity', priority: 'P1' });
     await mockDashboard(page, {
@@ -483,7 +483,7 @@ test.describe('NextActionCard — rule-monitor cards', () => {
   });
 });
 
-test.describe('OpenLegsCard — dead #leg hash deep link removed (issue #244)', () => {
+test.describe('OpenLegsCard — dead #leg hash deep link removed (issue #244) @e2e', () => {
   test('navigating to /dashboard#leg-{id} does NOT auto-expand any row', async ({
     page,
   }) => {

--- a/frontend/e2e/dashboard-time-formatting.spec.js
+++ b/frontend/e2e/dashboard-time-formatting.spec.js
@@ -80,7 +80,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('Dashboard activity timestamp formatting', () => {
+test.describe('Dashboard activity timestamp formatting @e2e', () => {
   test('a UTC timestamp from 2 hours ago renders as HH:MM (today), not "yest" or a date', async ({
     page,
   }) => {

--- a/frontend/e2e/dashboard.spec.js
+++ b/frontend/e2e/dashboard.spec.js
@@ -224,7 +224,7 @@ function mockDashboard(page, payload) {
   );
 }
 
-test.describe('Dashboard route', () => {
+test.describe('Dashboard route @smoke @e2e', () => {
   test('default route `/` redirects to /dashboard', async ({ page }) => {
     await mockDashboard(page, EMPTY_PAYLOAD);
     await page.goto('/');

--- a/frontend/e2e/import-csv.spec.js
+++ b/frontend/e2e/import-csv.spec.js
@@ -75,7 +75,7 @@ function setupMocks(page) {
   ]);
 }
 
-test.describe('Schwab CSV Import (issue #104)', () => {
+test.describe('Schwab CSV Import (issue #104) @e2e', () => {
   test.beforeEach(async ({ page }) => {
     await setupMocks(page);
     await page.goto('/journal');

--- a/frontend/e2e/import.spec.js
+++ b/frontend/e2e/import.spec.js
@@ -69,7 +69,7 @@ function setupMocks(page) {
   ]);
 }
 
-test.describe('Schwab Import', () => {
+test.describe('Schwab Import @e2e', () => {
   // Manual acceptance criterion from issue #119: verify the fix end-to-end against a
   // real Schwab brokerage account with assignments / called-away events in the last
   // 90 days. Not automatable in CI (requires live OAuth + non-deterministic data).

--- a/frontend/e2e/journal-data-management.spec.js
+++ b/frontend/e2e/journal-data-management.spec.js
@@ -131,7 +131,7 @@ function setupMocks(page) {
   ]);
 }
 
-test.describe('Journal data management', () => {
+test.describe('Journal data management @e2e', () => {
   test('kebab menu opens and exposes a Delete action', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/journal');
@@ -247,7 +247,7 @@ function setupSettingsMocks(page) {
   ]);
 }
 
-test.describe('Settings → Danger Zone', () => {
+test.describe('Settings → Danger Zone @e2e', () => {
   test('clear-all confirm button is gated by exact "DELETE" text', async ({ page }) => {
     await setupSettingsMocks(page);
 

--- a/frontend/e2e/journal-reconcile.spec.js
+++ b/frontend/e2e/journal-reconcile.spec.js
@@ -82,7 +82,7 @@ function setupSettingsMocks(page, { positions = SEEDED_POSITIONS } = {}) {
   ]);
 }
 
-test.describe('Settings → Reconcile journal', () => {
+test.describe('Settings → Reconcile journal @e2e', () => {
   test('renders above Danger Zone with both buttons enabled', async ({ page }) => {
     await setupSettingsMocks(page);
 

--- a/frontend/e2e/journal.spec.js
+++ b/frontend/e2e/journal.spec.js
@@ -99,7 +99,7 @@ function setupMocks(page) {
   ]);
 }
 
-test.describe('Journal page', () => {
+test.describe('Journal page @e2e', () => {
   test('renders positions table with data', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/journal');

--- a/frontend/e2e/mode-switch.spec.js
+++ b/frontend/e2e/mode-switch.spec.js
@@ -7,7 +7,7 @@ const MODES = [
   { label: 'Compare', description: 'Side-by-side assets' },
 ];
 
-test.describe('Regression mode selector bar', () => {
+test.describe('Regression mode selector bar @e2e', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/analysis');
     await page.waitForLoadState('networkidle');

--- a/frontend/e2e/options-capital-awareness.spec.js
+++ b/frontend/e2e/options-capital-awareness.spec.js
@@ -113,7 +113,7 @@ async function fillAndScan(page, capital) {
   await page.waitForSelector('[data-testid="strike-table"], [data-testid="budget-alert-banner"]', { timeout: 5000 });
 }
 
-test.describe('Options capital awareness & affordability', () => {
+test.describe('Options capital awareness & affordability @e2e', () => {
   test.skip('light and dark mode styling is correct', async () => {
     // Manual verification: budget alert banner, capital utilization card, dimmed rows,
     // and lock icons should be visually correct in both light and dark themes.

--- a/frontend/e2e/options-pill-badges.spec.js
+++ b/frontend/e2e/options-pill-badges.spec.js
@@ -156,7 +156,7 @@ async function scanAndSelectStrikes(page, capital, strikesToSelect) {
   }
 }
 
-test.describe('Comparison card pill badges (#38)', () => {
+test.describe('Comparison card pill badges (#38) @e2e', () => {
   test('highlight tags render as colored pill badges instead of plain text', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/options');

--- a/frontend/e2e/options-prefill-from-url.spec.js
+++ b/frontend/e2e/options-prefill-from-url.spec.js
@@ -43,7 +43,7 @@ const ccButton = (page) => page.getByRole('button', { name: 'Covered Call' });
 
 const ACTIVE_CLASS = /bg-blue-600/;
 
-test.describe('Options scanner — URL pre-fill', () => {
+test.describe('Options scanner — URL pre-fill @e2e', () => {
   test('?ticker=F pre-fills the ticker input', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/options?ticker=F');

--- a/frontend/e2e/options-schwab-status.spec.js
+++ b/frontend/e2e/options-schwab-status.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Options page Schwab API status indicator', () => {
+test.describe('Options page Schwab API status indicator @e2e', () => {
   test('shows not-connected banner when Schwab is not configured', async ({ page }) => {
     // Mock the Schwab health endpoint to return not configured
     await page.route('**/api/settings/health/schwab', (route) =>

--- a/frontend/e2e/options-sidebar-sections.spec.js
+++ b/frontend/e2e/options-sidebar-sections.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Options sidebar section grouping', () => {
+test.describe('Options sidebar section grouping @e2e', () => {
   test.skip('light and dark mode styling is correct', async () => {
     // Manual verification required: section headers, dividers, and input styling
     // should be visually correct in both light and dark themes.

--- a/frontend/e2e/recovery-plan.spec.js
+++ b/frontend/e2e/recovery-plan.spec.js
@@ -327,7 +327,7 @@ async function openRecoveryPlan(page) {
 
 // --- Tests ------------------------------------------------------------------
 
-test.describe('Recovery Plan panel', () => {
+test.describe('Recovery Plan panel @e2e', () => {
   test('flagged position renders 3-4 path cards with values', async ({ page }) => {
     await mockRecoveryPlan(page, populatedPayload());
     await openRecoveryPlan(page);
@@ -606,7 +606,7 @@ test.describe('Recovery Plan panel', () => {
 // #237 PR, which also appends to this file, resolves only a trivial conflict.
 // ---------------------------------------------------------------------------
 
-test.describe('Recovery Plan — target yield (issue #207)', () => {
+test.describe('Recovery Plan — target yield (issue #207) @e2e', () => {
   /** A payload where Sell & redeploy is suppressed for an unset target yield —
    * the exact state the recovery "Set target yield →" CTA exists to fix. */
   function targetYieldSuppressedPayload() {
@@ -697,7 +697,7 @@ test.describe('Recovery Plan — target yield (issue #207)', () => {
 // text surfaces "unenforceable" so the user sees the gap honestly.
 // ---------------------------------------------------------------------------
 
-test.describe('Recovery Plan — sizing-cap percent (issue #234)', () => {
+test.describe('Recovery Plan — sizing-cap percent (issue #234) @e2e', () => {
   /** A populated payload whose okr block carries the v2 fields (sizing_cap_pct,
    * total_capital, resolved_sizing_cap_dollars, account_id_masked,
    * capital_status) and whose assumptions panel renders the formatted

--- a/frontend/e2e/scanner-education.spec.js
+++ b/frontend/e2e/scanner-education.spec.js
@@ -144,7 +144,7 @@ async function clearScannerStorage(page) {
   });
 }
 
-test.describe('Scanner education — strategy primer', () => {
+test.describe('Scanner education — strategy primer @e2e', () => {
   test('renders collapsed by default and toggles on click', async ({ page }) => {
     await setupMocks(page);
     await clearScannerStorage(page);
@@ -197,7 +197,7 @@ test.describe('Scanner education — strategy primer', () => {
   });
 });
 
-test.describe('Scanner education — column tooltips', () => {
+test.describe('Scanner education — column tooltips @e2e', () => {
   test('clicking ⓘ opens a 3-part tooltip; Escape closes it', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
@@ -239,7 +239,7 @@ test.describe('Scanner education — column tooltips', () => {
   });
 });
 
-test.describe('Scanner education — per-row expansion', () => {
+test.describe('Scanner education — per-row expansion @e2e', () => {
   test('expanding a row reveals the "What this trade commits you to" panel', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
@@ -264,7 +264,7 @@ test.describe('Scanner education — per-row expansion', () => {
   });
 });
 
-test.describe('Scanner education — humanized rejected strikes', () => {
+test.describe('Scanner education — humanized rejected strikes @e2e', () => {
   test('renders human sentences from the backend, not raw codes', async ({ page }) => {
     await setupMocks(page);
     await page.goto('/options?ticker=F&strategy=covered_call&shares=100&cost_basis=13.2066');
@@ -437,7 +437,7 @@ async function openPanelAndGetRowLabels(page) {
   return rows.locator('> div > span').first();
 }
 
-test.describe('Scanner education — Rejected Strikes sort + summary + near-pass (#257)', () => {
+test.describe('Scanner education — Rejected Strikes sort + summary + near-pass (#257) @e2e', () => {
   test('default sort is failure_count_asc — 1-reason rows surface first', async ({
     page,
   }) => {
@@ -741,7 +741,7 @@ function setupRelaxMocks(page, { relaxStatus = 200, relaxBody = RELAX_PAYLOAD_LO
   ]);
 }
 
-test.describe('Scanner education — Relax-to-X preview popover (#258)', () => {
+test.describe('Scanner education — Relax-to-X preview popover (#258) @e2e', () => {
   test('clicking a relaxable chip opens the popover and renders the ready state', async ({
     page,
   }) => {
@@ -1110,7 +1110,7 @@ async function clearRowCollapseStorage(page) {
   });
 }
 
-test.describe('Scanner education — Rejected Strikes ≥3-reason collapse (#259)', () => {
+test.describe('Scanner education — Rejected Strikes ≥3-reason collapse (#259) @e2e', () => {
   test('rows with >= 3 reasons render collapsed by default (data-collapsed="true")', async ({
     page,
   }) => {

--- a/frontend/e2e/schwab-setup.spec.js
+++ b/frontend/e2e/schwab-setup.spec.js
@@ -53,7 +53,7 @@ function setupMocks(page, { schwabConfigured = false } = {}) {
   ]);
 }
 
-test.describe('Schwab OAuth Setup', () => {
+test.describe('Schwab OAuth Setup @smoke @e2e', () => {
   test('shows setup form when Schwab is not configured', async ({ page }) => {
     await setupMocks(page, { schwabConfigured: false });
     await page.goto('/settings');

--- a/frontend/e2e/settings-objectives.spec.js
+++ b/frontend/e2e/settings-objectives.spec.js
@@ -79,7 +79,7 @@ async function openObjectivesTab(page) {
   await expect(page.getByTestId('settings-objectives-section')).toBeVisible();
 }
 
-test.describe('Settings → Trading Objectives — tab & deep link', () => {
+test.describe('Settings → Trading Objectives — tab & deep link @e2e', () => {
   test('the tab bar exposes a third "Trading Objectives" tab', async ({
     page,
   }) => {
@@ -126,7 +126,7 @@ test.describe('Settings → Trading Objectives — tab & deep link', () => {
   });
 });
 
-test.describe('Settings → Trading Objectives — field render', () => {
+test.describe('Settings → Trading Objectives — field render @e2e', () => {
   test('the Target Yield field renders inside settings-objectives-section, not a rules group', async ({
     page,
   }) => {
@@ -182,7 +182,7 @@ test.describe('Settings → Trading Objectives — field render', () => {
   });
 });
 
-test.describe('Settings → Trading Objectives — save lifecycle', () => {
+test.describe('Settings → Trading Objectives — save lifecycle @e2e', () => {
   test('enter a value → save → reload → value persists', async ({ page }) => {
     await mockSettingsEndpoint(page, { initial: null });
     await openObjectivesTab(page);
@@ -253,7 +253,7 @@ test.describe('Settings → Trading Objectives — save lifecycle', () => {
   });
 });
 
-test.describe('Settings → Trading Objectives — validation', () => {
+test.describe('Settings → Trading Objectives — validation @e2e', () => {
   test('an out-of-bounds value shows an inline error and blocks Save', async ({
     page,
   }) => {
@@ -305,7 +305,7 @@ test.describe('Settings → Trading Objectives — validation', () => {
   });
 });
 
-test.describe('Settings → Trading Objectives — load failure', () => {
+test.describe('Settings → Trading Objectives — load failure @e2e', () => {
   test('a failed settings GET shows a generic error block with Retry', async ({
     page,
   }) => {

--- a/frontend/e2e/settings-trading-rules.spec.js
+++ b/frontend/e2e/settings-trading-rules.spec.js
@@ -99,7 +99,7 @@ async function openTradingRulesTab(page) {
   await expect(page.getByTestId('settings-rules-form')).toBeVisible();
 }
 
-test.describe('Settings → Trading Rules — page & tabs', () => {
+test.describe('Settings → Trading Rules — page & tabs @smoke @e2e', () => {
   test('tab bar exposes General and Trading Rules tabs', async ({ page }) => {
     await mockRulesEndpoint(page);
     await page.goto('/settings');
@@ -129,7 +129,7 @@ test.describe('Settings → Trading Rules — page & tabs', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — deep link (issue #235)', () => {
+test.describe('Settings → Trading Rules — deep link (issue #235) @smoke @e2e', () => {
   test('/settings?tab=rules opens the Trading Rules tab without a click', async ({
     page,
   }) => {
@@ -178,7 +178,7 @@ test.describe('Settings → Trading Rules — deep link (issue #235)', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — field render', () => {
+test.describe('Settings → Trading Rules — field render @smoke @e2e', () => {
   test('a field renders with its label, helper text and value', async ({
     page,
   }) => {
@@ -239,7 +239,7 @@ test.describe('Settings → Trading Rules — field render', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — Optional fields', () => {
+test.describe('Settings → Trading Rules — Optional fields @smoke @e2e', () => {
   test('an unset Optional field renders empty with a non-numeric placeholder', async ({
     page,
   }) => {
@@ -306,7 +306,7 @@ test.describe('Settings → Trading Rules — Optional fields', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — validation', () => {
+test.describe('Settings → Trading Rules — validation @smoke @e2e', () => {
   test('an inverted range (min >= max) shows an inline error and blocks save', async ({
     page,
   }) => {
@@ -377,7 +377,7 @@ test.describe('Settings → Trading Rules — validation', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — save lifecycle', () => {
+test.describe('Settings → Trading Rules — save lifecycle @smoke @e2e', () => {
   test('edit → save → reload → value persists', async ({ page }) => {
     await mockRulesEndpoint(page);
     await openTradingRulesTab(page);
@@ -446,7 +446,7 @@ test.describe('Settings → Trading Rules — save lifecycle', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — load failure', () => {
+test.describe('Settings → Trading Rules — load failure @smoke @e2e', () => {
   test('a failed config GET shows a generic error block with Retry', async ({
     page,
   }) => {
@@ -483,7 +483,7 @@ test.describe('Settings → Trading Rules — load failure', () => {
   });
 });
 
-test.describe('Settings → Trading Rules — accessibility', () => {
+test.describe('Settings → Trading Rules — accessibility @smoke @e2e', () => {
   test('every input is associated with a label', async ({ page }) => {
     await mockRulesEndpoint(page);
     await openTradingRulesTab(page);
@@ -650,7 +650,7 @@ function mockMigrationDismiss(page) {
   return state;
 }
 
-test.describe('Sizing cap percent — V1.0.7 (#234)', () => {
+test.describe('Sizing cap percent — V1.0.7 (#234) @smoke @e2e', () => {
   test('field renders with % suffix and default 25', async ({ page }) => {
     mockRulesEndpointWithCapture(page);
     mockAccountValueEndpoints(page, {

--- a/frontend/e2e/stats-grouped-display.spec.js
+++ b/frontend/e2e/stats-grouped-display.spec.js
@@ -121,7 +121,7 @@ async function selectAssetAndRun(page, { multiFactor = false } = {}) {
   await page.getByRole('button', { name: 'Run Analysis' }).click();
 }
 
-test.describe('Regression stats grouped display', () => {
+test.describe('Regression stats grouped display @e2e', () => {
   test.describe('Linear mode sections', () => {
     test('displays Model Fit, Trend, and Diagnostics section headers', async ({ page }) => {
       await mockBackendAPIs(page);

--- a/frontend/e2e/stock-research.spec.js
+++ b/frontend/e2e/stock-research.spec.js
@@ -176,7 +176,7 @@ async function openResearchPage(page) {
 
 // --- Tests ------------------------------------------------------------------
 
-test.describe('Stock Research page — populated state', () => {
+test.describe('Stock Research page — populated state @e2e', () => {
   test('renders all six sections + header + footer', async ({ page }) => {
     await mockAllSectionsHappy(page);
     await openResearchPage(page);
@@ -259,7 +259,7 @@ test.describe('Stock Research page — populated state', () => {
   });
 });
 
-test.describe('Stock Research page — per-section failure', () => {
+test.describe('Stock Research page — per-section failure @e2e', () => {
   test('Section D 502 surfaces the section error tile while the rest render', async ({
     page,
   }) => {
@@ -284,7 +284,7 @@ test.describe('Stock Research page — per-section failure', () => {
   });
 });
 
-test.describe('Stock Research page — full-page states', () => {
+test.describe('Stock Research page — full-page states @e2e', () => {
   test('404 on position renders the not-found EmptyState', async ({ page }) => {
     await mockPosition(
       page,
@@ -310,7 +310,7 @@ test.describe('Stock Research page — full-page states', () => {
   });
 });
 
-test.describe('Stock Research page — thesis editor', () => {
+test.describe('Stock Research page — thesis editor @e2e', () => {
   test('autosave fires after debounce and transitions through saved state', async ({
     page,
   }) => {
@@ -387,7 +387,7 @@ test.describe('Stock Research page — thesis editor', () => {
 
 // --- Dashboard CTA wire-up (issue #280 §9) ----------------------------------
 
-test.describe('Dashboard Positions Card — Review CTA', () => {
+test.describe('Dashboard Positions Card — Review CTA @e2e', () => {
   function dashboardPayload() {
     // Mirror the shape used by existing dashboard-* e2e specs so the
     // /dashboard surface renders without crashing.
@@ -502,7 +502,7 @@ async function mockAllSectionsWithRegression(page, regression) {
   await mockResearchEndpoint(page, 'thesis', thesisPayload());
 }
 
-test.describe('Section E · unknown factor bucket (#285)', () => {
+test.describe('Section E · unknown factor bucket (#285) @e2e', () => {
   test('single unknown factor (VIX) renders a row + wedge', async ({ page }) => {
     const regression = regressionPayloadWithFactors([
       { name: 'SPY', beta: 1.42, p_value: 0.001, share: 0.55 },
@@ -608,7 +608,7 @@ test.describe('Section E · unknown factor bucket (#285)', () => {
 
 // --- Issue #288: per-section failure copy ----------------------------------
 
-test.describe('Stock Research page — Section A throttling copy (#288)', () => {
+test.describe('Stock Research page — Section A throttling copy (#288) @e2e', () => {
   test('Section A renders throttling copy when API returns rate-limit detail', async ({
     page,
   }) => {
@@ -635,7 +635,7 @@ test.describe('Stock Research page — Section A throttling copy (#288)', () => 
   });
 });
 
-test.describe('Stock Research page — Section D both-empty copy (#288)', () => {
+test.describe('Stock Research page — Section D both-empty copy (#288) @e2e', () => {
   test('Section D renders verbatim no-data copy when both sources empty', async ({
     page,
   }) => {

--- a/frontend/e2e/storybook.spec.js
+++ b/frontend/e2e/storybook.spec.js
@@ -25,7 +25,7 @@ import { test } from '@playwright/test';
  *   5. `git status` shows storybook-static/ is gitignored (not staged).
  */
 
-test.describe.skip('Storybook (issue #196) — deferred to follow-up', () => {
+test.describe.skip('Storybook (issue #196) — deferred to follow-up @e2e', () => {
   test('storybook dev server boots on :6006', async () => {
     // Future: spawn `npm run storybook` and assert the iframe loads the
     // StatCard story. Skipped in Phase A — requires a separate dev server

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "test:e2e": "playwright test",
+    "test:smoke": "playwright test --grep '@smoke'",
+    "test:e2e:tags": "playwright test --grep '@e2e'",
     "test:e2e:prod": "playwright test --config playwright.prod.config.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/frontend/scripts/check-playwright-tags.sh
+++ b/frontend/scripts/check-playwright-tags.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# check-playwright-tags.sh — Quality v1 Wave 2 (#270)
+#
+# Enforces the @smoke / @e2e tagging convention from PRD #261 R6.
+# Every test.describe(...) and test(...) call in frontend/e2e/*.spec.{js,jsx}
+# (excluding *.prod.spec.* — those run under playwright.prod.config.js) must
+# carry @smoke and/or @e2e in its title string. The title may live on the
+# same line as the call opening or on the following line (multi-line form).
+#
+# Exit 0  — every test/describe in scope is tagged.
+# Exit 1  — at least one untagged call; offending file:line pairs printed to
+#           stderr.
+#
+# Run locally:
+#   cd frontend && bash scripts/check-playwright-tags.sh
+#
+# Pure bash + grep + awk; no node deps. Mirrors the read-only-stdout, exit-code
+# discipline of backend/scripts/check_tdd_red.py (#269).
+
+set -euo pipefail
+
+# Resolve the e2e directory relative to this script so the script works whether
+# invoked from frontend/ or repo root.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+e2e_dir="${script_dir}/../e2e"
+
+if [[ ! -d "${e2e_dir}" ]]; then
+  echo "check-playwright-tags: e2e directory not found at ${e2e_dir}" >&2
+  exit 2
+fi
+
+shopt -s nullglob
+specs=("${e2e_dir}"/*.spec.js "${e2e_dir}"/*.spec.jsx)
+shopt -u nullglob
+
+# Track total scanned / failed for a concise summary.
+total_files=0
+failed_files=0
+declare -a offenses=()
+
+for spec in "${specs[@]}"; do
+  base="$(basename "${spec}")"
+  # *.prod.spec.* files run under a separate config (playwright.prod.config.js)
+  # and are exempt from the tag convention (PRD #261 R6 — Worker C contract).
+  case "${base}" in
+    *.prod.spec.js|*.prod.spec.jsx)
+      continue
+      ;;
+  esac
+
+  total_files=$((total_files + 1))
+
+  # awk scans the file once and emits "<lineno>" for each TOP-LEVEL (unindented,
+  # column-zero) test.describe(...) or test(...) call whose first string-literal
+  # argument lacks @smoke and @e2e on its opening line OR the next line.
+  #
+  # Why top-level only:
+  # - Playwright concatenates parent-describe + nested-describe + test titles
+  #   when matching --grep, so tagging the top-level wrapper propagates to
+  #   every nested test. Enforcing tags on the outermost calls is enough.
+  # - Most e2e specs have ONE top-level `test.describe('…', …)` at column 0;
+  #   some (scanner-education, settings-objectives, stats-grouped-display) have
+  #   multiple — each must be tagged independently.
+  # - Bare `test('…', …)` calls at column 0 (storybook.spec.js post-skip-wrap)
+  #   also count.
+  #
+  # We match call openings at word boundaries to avoid stray substring hits.
+  # `test.describe.skip(` / `test.only(` etc. count too.
+  bad_lines=$(awk '
+    function has_tag(s) {
+      return (index(s, "@smoke") > 0 || index(s, "@e2e") > 0)
+    }
+    {
+      lines[NR] = $0
+    }
+    END {
+      for (i = 1; i <= NR; i++) {
+        line = lines[i]
+        # Top-level only: line must start with "test" (no leading whitespace).
+        if (line !~ /^test(\.describe)?(\.only|\.skip|\.fixme|\.serial|\.parallel)?[[:space:]]*\(/) continue
+        # Skip the no-op test.describe.configure(...) — a config call, not a
+        # test wrapper.
+        if (line ~ /^test\.describe\.configure[[:space:]]*\(/) continue
+        combined = line
+        if (i < NR) combined = combined " " lines[i + 1]
+        if (!has_tag(combined)) {
+          print i
+        }
+      }
+    }
+  ' "${spec}") || bad_lines=""
+
+  if [[ -n "${bad_lines}" ]]; then
+    failed_files=$((failed_files + 1))
+    while IFS= read -r ln; do
+      [[ -z "${ln}" ]] && continue
+      offenses+=("${spec}:${ln}: test() or test.describe() title missing @smoke or @e2e tag")
+    done <<< "${bad_lines}"
+  fi
+done
+
+if (( failed_files > 0 )); then
+  echo "check-playwright-tags: ${failed_files}/${total_files} spec file(s) have untagged test/describe calls." >&2
+  echo "Required: each test() or test.describe() title must contain @smoke and/or @e2e (see CLAUDE.md ## Testing Requirements)." >&2
+  for line in "${offenses[@]}"; do
+    echo "${line}" >&2
+  done
+  exit 1
+fi
+
+echo "check-playwright-tags: OK — ${total_files} spec file(s) tagged."
+exit 0

--- a/frontend/scripts/check-playwright-tags.sh
+++ b/frontend/scripts/check-playwright-tags.sh
@@ -52,7 +52,7 @@ for spec in "${specs[@]}"; do
 
   # awk scans the file once and emits "<lineno>" for each TOP-LEVEL (unindented,
   # column-zero) test.describe(...) or test(...) call whose first string-literal
-  # argument lacks @smoke and @e2e on its opening line OR the next line.
+  # argument lacks @smoke and @e2e in the TITLE STRING only.
   #
   # Why top-level only:
   # - Playwright concatenates parent-describe + nested-describe + test titles
@@ -64,11 +64,29 @@ for spec in "${specs[@]}"; do
   # - Bare `test('…', …)` calls at column 0 (storybook.spec.js post-skip-wrap)
   #   also count.
   #
+  # Title-only check (CodeRabbit triage on PR #300): we MUST NOT count a tag
+  # that appears in a trailing comment or elsewhere outside the title string
+  # literal. We isolate the first '...' or "..." string literal after the
+  # opening `(`, looking on the opening line first and then the next line
+  # (multi-line title form), and check ONLY that string for the tag.
+  #
   # We match call openings at word boundaries to avoid stray substring hits.
   # `test.describe.skip(` / `test.only(` etc. count too.
   bad_lines=$(awk '
     function has_tag(s) {
       return (index(s, "@smoke") > 0 || index(s, "@e2e") > 0)
+    }
+    # Extract the first single- or double-quoted string literal in s and
+    # return its inner content. Returns "" if none found.
+    function extract_title(s,    m, rest, q, end) {
+      # Find the first single or double quote.
+      m = match(s, /[\x27"]/)
+      if (m == 0) return ""
+      q = substr(s, RSTART, 1)
+      rest = substr(s, RSTART + 1)
+      end = index(rest, q)
+      if (end == 0) return ""
+      return substr(rest, 1, end - 1)
     }
     {
       lines[NR] = $0
@@ -81,9 +99,17 @@ for spec in "${specs[@]}"; do
         # Skip the no-op test.describe.configure(...) — a config call, not a
         # test wrapper.
         if (line ~ /^test\.describe\.configure[[:space:]]*\(/) continue
-        combined = line
-        if (i < NR) combined = combined " " lines[i + 1]
-        if (!has_tag(combined)) {
+        # Strip everything up to and including the first "(" so extract_title
+        # ignores any quotes that might appear inside the callee path (none
+        # exist today, but be defensive).
+        paren = index(line, "(")
+        after = (paren > 0) ? substr(line, paren + 1) : line
+        title = extract_title(after)
+        # Multi-line title form: title literal lives on the next line.
+        if (title == "" && i < NR) {
+          title = extract_title(lines[i + 1])
+        }
+        if (!has_tag(title)) {
           print i
         }
       }

--- a/frontend/scripts/check-playwright-tags.test.sh
+++ b/frontend/scripts/check-playwright-tags.test.sh
@@ -126,6 +126,19 @@ test('bare test no tags', async ({ page }) => {});
 EOF
 )"
 
+# Regression fixture for CodeRabbit triage on PR #300:
+# A tag injected via a comment after the title must NOT count — only the
+# title string literal counts.
+run_case "comment_tag_should_not_count_fail" 1 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe('Demo flow no tags', // @e2e
+  () => {
+    test('renders', async ({ page }) => {});
+  }
+);
+EOF
+)"
+
 echo
 echo "Results: ${pass_count} passed, ${fail_count} failed"
 

--- a/frontend/scripts/check-playwright-tags.test.sh
+++ b/frontend/scripts/check-playwright-tags.test.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# check-playwright-tags.test.sh — smoke tests for the tag-check script (#270).
+#
+# Runs five fixtures in a temp dir and asserts the script's exit code matches
+# expectation. Tests written as part of the implementation per CLAUDE.md
+# "Testing Requirements" (Quality v1 R7).
+#
+#   1. smoke_only_pass    — describe tagged @smoke → exit 0
+#   2. e2e_only_pass      — describe tagged @e2e → exit 0
+#   3. both_pass          — describe tagged @smoke @e2e → exit 0
+#   4. neither_fail       — describe missing both tags → exit 1
+#   5. prod_spec_skipped  — *.prod.spec.js missing tags is OK → exit 0
+#
+# Run:
+#   cd frontend && bash scripts/check-playwright-tags.test.sh
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_under_test="${script_dir}/check-playwright-tags.sh"
+
+if [[ ! -x "${script_under_test}" ]]; then
+  echo "test: ${script_under_test} is not executable" >&2
+  exit 2
+fi
+
+pass_count=0
+fail_count=0
+
+# run_case <name> <expected_exit> — sets up a tmp frontend/scripts + frontend/e2e
+# layout, copies the script-under-test into ./scripts, writes the fixture(s)
+# into ./e2e/<provided name(s)>, runs the script, asserts the exit code.
+run_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  # Remaining args are pairs: fixture_filename, fixture_contents.
+  local tmp
+  tmp="$(mktemp -d)"
+  mkdir -p "${tmp}/scripts" "${tmp}/e2e"
+  cp "${script_under_test}" "${tmp}/scripts/check-playwright-tags.sh"
+  chmod +x "${tmp}/scripts/check-playwright-tags.sh"
+
+  while (($# >= 2)); do
+    printf '%s' "$2" > "${tmp}/e2e/$1"
+    shift 2
+  done
+
+  local actual=0
+  bash "${tmp}/scripts/check-playwright-tags.sh" >/dev/null 2>&1 || actual=$?
+
+  if [[ "${actual}" == "${expected}" ]]; then
+    echo "  PASS: ${name} (exit ${actual})"
+    pass_count=$((pass_count + 1))
+  else
+    echo "  FAIL: ${name} — expected exit ${expected}, got ${actual}" >&2
+    fail_count=$((fail_count + 1))
+  fi
+  rm -rf "${tmp}"
+}
+
+echo "check-playwright-tags.test.sh — running fixtures..."
+
+run_case "smoke_only_pass" 0 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe('Demo flow @smoke', () => {
+  test('renders', async ({ page }) => {});
+});
+EOF
+)"
+
+run_case "e2e_only_pass" 0 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe('Demo flow @e2e', () => {
+  test('renders', async ({ page }) => {});
+});
+EOF
+)"
+
+run_case "both_pass" 0 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe('Demo flow @smoke @e2e', () => {
+  test('renders', async ({ page }) => {});
+});
+EOF
+)"
+
+run_case "neither_fail" 1 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe('Demo flow (no tags)', () => {
+  test('renders', async ({ page }) => {});
+});
+EOF
+)"
+
+run_case "prod_spec_skipped" 0 "demo.prod.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe('Prod-only flow with no tags is fine', () => {
+  test('renders', async ({ page }) => {});
+});
+EOF
+)"
+
+# Multi-line describe call — title is on the next line; the tag still counts.
+run_case "multiline_title_pass" 0 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test.describe(
+  'Multi-line title @smoke @e2e',
+  () => {
+    test('renders', async ({ page }) => {});
+  }
+);
+EOF
+)"
+
+# Bare test() (no describe) — must also be tagged.
+run_case "bare_test_tagged_pass" 0 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test('bare test @e2e', async ({ page }) => {});
+EOF
+)"
+
+run_case "bare_test_untagged_fail" 1 "demo.spec.js" "$(cat <<'EOF'
+import { test, expect } from '@playwright/test';
+test('bare test no tags', async ({ page }) => {});
+EOF
+)"
+
+echo
+echo "Results: ${pass_count} passed, ${fail_count} failed"
+
+if (( fail_count > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Wave 2 of the Quality v1 Platform-lane milestone (#27). Three disjoint workers fanned out in parallel from `feat/quality-v1-wave-2`:

- **#268** — CLAUDE.md `## Testing Requirements` expanded with 8 H3 sub-anchors mirroring PRD #261 R1-R7 (test pyramid spread, per-AC test budget, file-naming + marker convention, pragmatic TDD rhythm, `tdd_red` discipline, Playwright `@smoke`/`@e2e` tagging, Test List section, scope rules)
- **#269** — `tdd_red` PR merge gate: `backend/scripts/check_tdd_red.py` (stdlib-only, diff-based grep against `pull_request.base.sha`) + new `tdd_red_gate` step inside the existing `backend-unit` CI job
- **#270** — Playwright `@smoke`/`@e2e` tagging convention: 34 spec files retagged (62 smoke / 376 e2e / smoke ⊂ e2e), `frontend/scripts/check-playwright-tags.sh` + `playwright_tag_check` step inside the existing `frontend-playwright` CI job, smoke-then-e2e split via new `test:smoke` + `test:e2e:tags` npm scripts

**Key design call — no new required-check names:** both new CI steps live INSIDE existing jobs (`backend-unit`, `frontend-playwright`). This avoids the Wave 1 branch-protection foot-gun where renaming required check names caused the merge to need manual branch-protection edits.

## Worker DAG

```
feat/quality-v1-wave-2 ── W-A (#268, docs)     ──┐
                       ── W-B (#269, gate)     ──┼── feat/quality-v1-wave-2 (this PR)
                       ── W-C (#270, playwright) ─┘
```

All three workers ran fully in parallel — disjoint file ownership, with the sole shared file (`ci.yml`) touched in different jobs so the 3-way merge was conflict-free.

## Verification (local)

- `backend && python -m pytest -m unit -q` — **1037 passed, 10 skipped, 466 deselected** (parity + 18 new tdd_red gate tests)
- `backend && python -m pytest tests/test_check_tdd_red.py -q` — **18 passed**
- `backend && python -m scripts.check_tdd_red --diff-base origin/main` — **OK** (scanned 2 changed .py files, no markers)
- `frontend && bash scripts/check-playwright-tags.sh` — **OK — 34 spec file(s) tagged**
- `frontend && npx playwright test --grep @smoke --list` — 62 tests across 4 spec files
- `frontend && npx playwright test --grep @e2e --list` — 376 tests across 34 spec files

## Release positioning

Platform-lane milestone progress only. **No SemVer tag.** Milestone #27 (Quality v1) stays open — Wave 3 (#271 pilot) is the next milestone-closing wave.

## Test plan

- [x] All 3 worker branches pushed to origin
- [x] All 3 merged into `feat/quality-v1-wave-2` with clean 3-way merge (no conflicts)
- [x] Local backend unit suite: 1037 passed
- [x] Local tdd_red gate self-scan: OK
- [x] Local Playwright tag check: 34 specs tagged
- [ ] CI green (`backend-unit` + `backend-integration` + `frontend-checks`; `frontend-playwright` is shakedown until 2026-05-25)
- [ ] Phase 5 code review
- [ ] Phase 5.5 CodeRabbit triage
- [ ] Phase 6 release-manager merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)