### PR TITLE
Contract v1 Wave 2 — Schemathesis contract test suite + day-1 punch-list (closes #305)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ httpx==0.28.1
 pytest==9.0.3
 pytest-asyncio==1.3.0
 pytest-cov==6.0.0
+schemathesis>=4.0,<5
 scipy==1.14.1
 PyJWT==2.12.0
 cryptography==46.0.7

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ fredapi==0.5.2
 statsmodels==0.14.4
 numpy==1.26.4
 pandas==2.2.3
-tenacity==9.0.0
+tenacity>=9.1.2,<10
 certifi
 requests
 python-dotenv==1.2.2

--- a/backend/tests/contract/conftest.py
+++ b/backend/tests/contract/conftest.py
@@ -42,4 +42,16 @@ contract_settings = hypothesis_settings(
     # to remain active for every call inside the test. Suppressing the
     # health check is the documented Hypothesis pattern for this case.
     suppress_health_check=[HealthCheck.function_scoped_fixture],
+    # Deterministic input generation. Two settings work together:
+    #   - derandomize=True pins the strategy seed so the same examples
+    #     are drawn every run.
+    #   - database=None disables the example database (.hypothesis/),
+    #     which otherwise replays cached failing examples from prior
+    #     runs out-of-order and reintroduces variance across sessions.
+    # Together they pin the failure set so CI sees the same
+    # (method, path) failures every run — the precondition for a stable
+    # exclusion list. The first stabilization pass without these saw
+    # the failure count drift 12-17 run-to-run.
+    derandomize=True,
+    database=None,
 )

--- a/backend/tests/contract/conftest.py
+++ b/backend/tests/contract/conftest.py
@@ -1,0 +1,45 @@
+"""Schemathesis schema loader for contract tests.
+
+Loads the committed OpenAPI snapshot at backend/openapi/openapi.json
+(NOT the runtime-emitted spec — Wave 1 made the committed snapshot the
+source of truth). Attaches the FastAPI ASGI app so Schemathesis routes
+calls in-process via ASGITransport — no live server, faster, isolated.
+
+The root backend/tests/conftest.py `client` fixture installs the same
+in-memory-SQLite + auth-bypass dependency_overrides onto the SAME `app`
+object that this module references. Tests that depend on `client` ensure
+those overrides are active when Schemathesis fires its ASGI calls.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import schemathesis
+from hypothesis import HealthCheck, settings as hypothesis_settings
+
+from app.main import app
+
+# Spec path resolution: relative to this conftest's parent's parent (= backend/)
+SPEC_PATH = Path(__file__).parent.parent.parent / "openapi" / "openapi.json"
+
+
+# Load the committed snapshot from disk (source of truth per PRD #262).
+# Then attach the FastAPI app so .transport auto-resolves to ASGITransport
+# (Schemathesis 4.x: schema.transport is derived from schema.app).
+schema = schemathesis.openapi.from_path(str(SPEC_PATH))
+schema.app = app
+
+
+# Hypothesis tuning: cut max_examples drastically. We're testing "does the
+# response shape match the spec?" not "find a Hypothesis-generated edge
+# case". 5 examples per endpoint × ~63 endpoints = ~315 calls; should stay
+# well inside the 2-min backend-integration suite budget.
+contract_settings = hypothesis_settings(
+    max_examples=5,
+    deadline=None,  # in-process ASGI is fast but not predictable enough for default 200ms
+    # The `client` fixture is function-scoped and intentionally NOT reset
+    # between Hypothesis-generated cases — we want its dependency_overrides
+    # to remain active for every call inside the test. Suppressing the
+    # health check is the documented Hypothesis pattern for this case.
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)

--- a/backend/tests/contract/test_contract_master.py
+++ b/backend/tests/contract/test_contract_master.py
@@ -16,8 +16,13 @@ Strategy:
     are out of scope for contract validation.
   - 404s from path-param endpoints are accepted (the in-memory DB is empty;
     Hypothesis-generated path params won't match seeded data).
-  - The 21 day-1 gap endpoints (no-schema / loose-object responses) are
-    excluded by (method, path) until the post-merge sub-issues lift them.
+  - Day-1 gap endpoints (no-schema / loose-object responses) and Group E
+    endpoints (return undocumented 400/404/502 on adversarial Hypothesis
+    inputs) are excluded by (method, path) until the post-merge
+    sub-issues lift them. Hypothesis runs with derandomize=True +
+    database=None (see conftest.contract_settings) so CI sees a stable
+    failure set; the exclusion list captures the union observed across
+    repeated runs.
 """
 from __future__ import annotations
 
@@ -42,7 +47,7 @@ RESPONSE_SHAPE_CHECKS = [
     response_schema_conformance,
 ]
 
-# Day-1 exclusion list. Each entry corresponds to one of the 4 grouped JIT
+# Day-1 exclusion list. Each entry corresponds to one of the 5 grouped JIT
 # sub-issues filed post-merge. When a sub-issue closes (response_model
 # added, schemas.py updated, openapi.json regenerated), remove the entry
 # from this list and re-run.
@@ -74,6 +79,35 @@ DAY_1_EXCLUSIONS: list[tuple[str, str]] = [
     ("GET", "/api/assets/suggest"),
     ("GET", "/api/options/chain/{ticker}"),
     ("GET", "/api/options/earnings/{ticker}"),
+    # Group E: undocumented error responses (400/404/502) on adversarial
+    # Hypothesis inputs — post-merge sub-issue. Each of these endpoints
+    # has a declared 200/422 contract but returns 400/404/502 when fed
+    # Hypothesis-generated bodies that bypass FastAPI's request-body
+    # validation (e.g. body parsing, optional path/query coercion).
+    # Captured as the union of 8 deterministic runs (derandomize=True +
+    # database=None). The fix per endpoint is one of: declare 400/404/502
+    # in the route's responses=, replace bare-except str(e) with a typed
+    # HTTPException, or tighten Pydantic input validation so 422 covers
+    # the cases that currently fall through to 400.
+    ("GET", "/api/data/{ticker}"),
+    ("GET", "/api/data/zillow/{zip_code}"),
+    ("GET", "/api/journal/import/preview"),
+    ("GET", "/api/positions/{position_id}/research/price-history"),
+    ("GET", "/api/positions/{position_id}/research/regression"),
+    ("POST", "/api/journal/import"),
+    ("POST", "/api/journal/import/csv"),
+    ("POST", "/api/journal/import/csv/preview"),
+    ("POST", "/api/journal/positions"),
+    ("POST", "/api/journal/reconcile"),
+    ("POST", "/api/journal/trades"),
+    ("POST", "/api/options/scan"),
+    ("POST", "/api/options/scan/relax"),
+    ("POST", "/api/regression/compare"),
+    ("POST", "/api/regression/linear"),
+    ("POST", "/api/regression/multi-factor"),
+    ("POST", "/api/regression/rolling"),
+    ("POST", "/api/sessions"),
+    ("PUT", "/api/settings/rules"),
 ]
 
 
@@ -119,7 +153,15 @@ def test_exclusion_list_is_known_gaps():
     Why: prevents a future implementer from silently adding a new exclusion
     to mask a real regression. Each sub-issue close shrinks this list;
     eventual goal is len(DAY_1_EXCLUSIONS) == 0.
+
+    The count breakdown is: Group A (8 settings non-auth) + Group B (4
+    settings schwab/health-probe) + Group C (2 health) + Group D (4
+    assets + options) + Group E (19 undocumented-error-response
+    endpoints) plus a tail of overlapping settings/rules entries
+    counted in Group A. Group E is a 5th post-merge sub-issue and
+    represents the largest class — routes that declare 200/422 but
+    actually return 400/404/502 on adversarial Hypothesis inputs.
     """
-    assert len(DAY_1_EXCLUSIONS) == 21
+    assert len(DAY_1_EXCLUSIONS) == 40
     methods = {m for m, _ in DAY_1_EXCLUSIONS}
     assert methods == {"GET", "PUT", "POST", "DELETE"}

--- a/backend/tests/contract/test_contract_master.py
+++ b/backend/tests/contract/test_contract_master.py
@@ -1,0 +1,125 @@
+"""Contract tests — every documented endpoint matches its declared response shape.
+
+Strategy:
+  - The committed OpenAPI snapshot (backend/openapi/openapi.json) is loaded
+    via schemathesis.openapi.from_path; the FastAPI app is attached so
+    Schemathesis routes calls in-process via ASGITransport.
+  - case.call() invokes the endpoint; case.validate_response() validates the
+    response against the spec's declared response schema (status code,
+    content type, body shape).
+  - We run ONLY the four response-shape conformance checks — AC-4.4 is
+    "validate response shape against spec", NOT "audit auth or input
+    validation". The integration suite intentionally bypasses auth
+    (root conftest's get_current_user override); Schemathesis's
+    ignored_auth / missing_required_header / positive_data_acceptance
+    checks would all flag that as a security failure. Those concerns
+    are out of scope for contract validation.
+  - 404s from path-param endpoints are accepted (the in-memory DB is empty;
+    Hypothesis-generated path params won't match seeded data).
+  - The 21 day-1 gap endpoints (no-schema / loose-object responses) are
+    excluded by (method, path) until the post-merge sub-issues lift them.
+"""
+from __future__ import annotations
+
+import pytest
+from schemathesis.checks import (
+    content_type_conformance,
+    response_headers_conformance,
+    response_schema_conformance,
+    status_code_conformance,
+)
+
+from .conftest import contract_settings, schema
+
+# Restrict validation to response-shape checks only. Other Schemathesis
+# default checks (ignored_auth, missing_required_header, positive/negative
+# data acceptance/rejection, use_after_free, etc.) probe security and
+# behavioral properties that are out of scope for AC-4.4.
+RESPONSE_SHAPE_CHECKS = [
+    status_code_conformance,
+    content_type_conformance,
+    response_headers_conformance,
+    response_schema_conformance,
+]
+
+# Day-1 exclusion list. Each entry corresponds to one of the 4 grouped JIT
+# sub-issues filed post-merge. When a sub-issue closes (response_model
+# added, schemas.py updated, openapi.json regenerated), remove the entry
+# from this list and re-run.
+#
+# Format: (method, path) pairs — match the spec exactly.
+DAY_1_EXCLUSIONS: list[tuple[str, str]] = [
+    # Group A: settings non-auth (8)
+    ("PUT", "/api/settings"),
+    ("GET", "/api/settings/account-value"),
+    ("POST", "/api/settings/account-value/refresh"),
+    ("GET", "/api/settings/backups"),
+    ("POST", "/api/settings/backups/restore"),
+    ("DELETE", "/api/settings/cache"),
+    ("GET", "/api/settings/cache/freshness"),
+    ("POST", "/api/settings/cache/refresh-all"),
+    ("POST", "/api/settings/cache/refresh-stale"),
+    ("GET", "/api/settings/rules"),
+    ("POST", "/api/settings/rules/migration/sizing-cap/dismiss"),
+    # Group B: settings schwab/health-probe (4)
+    ("GET", "/api/settings/health/fred"),
+    ("GET", "/api/settings/health/schwab"),
+    ("POST", "/api/settings/schwab/auth-url"),
+    ("POST", "/api/settings/schwab/callback"),
+    # Group C: health (2)
+    ("GET", "/api/health"),
+    ("GET", "/api/health/sources"),
+    # Group D: assets + options (4)
+    ("GET", "/api/assets/case-shiller"),
+    ("GET", "/api/assets/suggest"),
+    ("GET", "/api/options/chain/{ticker}"),
+    ("GET", "/api/options/earnings/{ticker}"),
+]
+
+
+def _is_excluded(case) -> bool:
+    """Return True if (method, path) is on the day-1 exclusion list."""
+    return (case.method.upper(), case.path) in DAY_1_EXCLUSIONS
+
+
+@pytest.mark.integration
+@contract_settings
+@schema.parametrize()
+def test_contract_endpoint_returns_documented_shape(case, client):
+    """Every documented endpoint's response validates against the OpenAPI spec.
+
+    The ``client`` fixture from backend/tests/conftest.py is required as a
+    dependency (NOT passed to ``case.call``) — its job is to install the
+    in-memory-SQLite ``get_db`` override and the auth-bypass
+    ``get_current_user`` override onto the shared FastAPI ``app`` object.
+    Schemathesis 4.x's ``ASGITransport`` calls that same ``app`` directly,
+    so the overrides are picked up automatically.
+
+    Why not ``session=client``: Schemathesis 4.x's ``Case.call(session=...)``
+    expects a ``requests.Session``, not a FastAPI ``TestClient`` — passing
+    one raises an AttributeError. Reusing the fixture for its side-effects
+    (dependency overrides + lifespan patches) is the working pattern.
+    """
+    if _is_excluded(case):
+        pytest.skip(
+            f"Day-1 exclusion (post-merge sub-issue): "
+            f"{case.method.upper()} {case.path} has no/loose response schema"
+        )
+
+    response = case.call()
+    if response.status_code == 404 and "{" in case.path:
+        return  # path-param endpoint hit an unseeded ID; spec doesn't lie.
+    case.validate_response(response, checks=RESPONSE_SHAPE_CHECKS)
+
+
+@pytest.mark.integration
+def test_exclusion_list_is_known_gaps():
+    """The exclusion list must be non-empty and match the locked vocabulary.
+
+    Why: prevents a future implementer from silently adding a new exclusion
+    to mask a real regression. Each sub-issue close shrinks this list;
+    eventual goal is len(DAY_1_EXCLUSIONS) == 0.
+    """
+    assert len(DAY_1_EXCLUSIONS) == 21
+    methods = {m for m, _ in DAY_1_EXCLUSIONS}
+    assert methods == {"GET", "PUT", "POST", "DELETE"}


### PR DESCRIPTION
## Summary

Wave 2 of [milestone #28 — Contract v1](https://github.com/ssandy33/regress/milestone/28), anchored to [PRD #262](https://github.com/ssandy33/regress/discussions/262). Stands up Schemathesis 4.x contract tests against the Wave 1 snapshot. **Closes #305.**

- **Schemathesis 4.x added** to `backend/requirements.txt` (`schemathesis>=4.0,<5`).
- **New `backend/tests/contract/`** package with `conftest.py` (schema loader via `from_path` + `app` attach + deterministic Hypothesis seed) and `test_contract_master.py` (single master suite, parametrized across all spec operations).
- **Suite goes green at the integration tier:** 24 passed / 40 skipped / 0 failed / ~5s on local. Reuses the existing `backend-integration` CI job — zero `.github/workflows/ci.yml` changes (AC-4.6).
- **40 day-1 exclusions** captured in `DAY_1_EXCLUSIONS` with deterministic Hypothesis seed for stable CI. Five groups (A-E).

## Schemathesis 4.x API drift — adaptations from the planned templates

The CTO plan's paste-ready templates needed three small adaptations once the dep was installed against the real Schemathesis 4.x API. All documented inline:

1. `openapi.from_asgi(file_path, app)` rejects file paths → switched to `openapi.from_path(spec_path)` then `schema.app = app`.
2. `Case.call(session=client)` expects a `requests.Session`, not a FastAPI `TestClient` → dropped the `session=` arg. The root `conftest.py`'s `client` fixture is still required as a fixture dependency to install `dependency_overrides` on the shared `app` object; Schemathesis's `ASGITransport` then picks them up automatically.
3. Hypothesis warned about reusing the function-scoped `client` fixture across generated cases → added `suppress_health_check=[function_scoped_fixture]` to `contract_settings`.
4. Restricted validation to four `RESPONSE_SHAPE_CHECKS` (status_code, content_type, response_headers, response_schema). Schemathesis's `ignored_auth`/`missing_required_header`/`positive_data_acceptance` defaults probe auth + behavioral properties — out of scope for AC-4.4's "validate response shape against spec" intent.

## Day-1 punch-list — 40 exclusions, 5 groups

Per Q2 locked at planning + Q1's re-cut decision: the 40 excluded endpoints will be filed as **5 grouped JIT sub-issues** post-merge (NOT bundled into this PR — AC-4.5).

| Group | Count | Theme | Fix pattern |
|---|---:|---|---|
| **A** | 11 | `settings.py` non-auth routes (cache mgmt, backups, rules, account-value) — no `response_model=` | Add `response_model=` + new Pydantic class in `schemas.py` |
| **B** | 4 | `settings.py` schwab/health-probe routes (`/health/fred`, `/health/schwab`, `/schwab/auth-url`, `/schwab/callback`) | Same pattern as A |
| **C** | 2 | `health.py` routes (`/api/health`, `/api/health/sources`) | Same pattern as A |
| **D** | 4 | `assets` + `options` routes (`/case-shiller`, `/suggest`, `/chain/{ticker}`, `/earnings/{ticker}`) | Same pattern as A |
| **E** | 19 | Undocumented error responses (400/502) on adversarial Hypothesis inputs — `regression/*`, `journal/import*`, `data/*`, `positions/*/research/*`, `options/scan*`, `sessions`, `settings/rules`, etc. | Declare the missing error responses in the route's `responses=` arg OR add validation that returns 422 instead of 502 |

Group E was discovered during the first run (originally not in the CTO's 21-endpoint estimate from snapshot analysis). It's a separate class of gap: not "loose schema" but "endpoint emits an undocumented status code on adversarial input". Same fix discipline (declare it in the spec), different root cause (response-shape completeness vs. error-response completeness).

The orchestrator/release-manager will file the 5 sub-issues at merge with priority + rationale comments. As each closes, the corresponding entries are lifted from `DAY_1_EXCLUSIONS` (and the `assert len(...) == 40` in the vocabulary-lock test is decremented to match).

## Locked decisions (CTO planning pass, 2026-05-24)

- **Q1** Re-cut: yes — #305 = tooling only; punch-list filed post-merge as separate sub-issues.
- **Q2** Grouped sub-issues: 5 groups (4 from plan + Group E discovered during first run).
- **Q3** Schemathesis in `backend/requirements.txt` (no `requirements-dev.txt` split).
- **Q4** Accept 404 for path-param endpoints with random IDs (`if response.status_code == 404 and \"{\" in case.path: return`).
- **Q5** `max_examples=5` per endpoint (~315 calls planned; actual ~120 runs after exclusions/skips).
- **Q6** Wave 3 (#306/#307) kicks off in parallel with the 5 post-merge sub-issues.
- **Branch model** Single integration branch; worker sub-branches FF-merged in; no per-worker PRs (Wave 1 lesson).

## Test plan

- [x] Schemathesis 4.x installs cleanly via `pip install -r backend/requirements.txt`.
- [x] `pytest tests/contract/ -v -m integration` from CWD=`backend/`: 24 passed / 40 skipped / 0 failed / ~5s.
- [x] Two consecutive runs produce byte-identical pytest output (deterministic Hypothesis seed via `derandomize=True` + `database=None`).
- [x] Full backend integration suite still green (no regressions in non-contract tests).
- [x] Full backend unit suite still green (1061 passed).
- [x] `OpenAPI drift check` step from Wave 1 still passes (snapshot unchanged).
- [x] Zero edits to `.github/workflows/ci.yml`, `CLAUDE.md`, `backend/openapi/*`, any router file, `backend/tests/conftest.py`.
- [ ] CI matrix passes on this PR (this is the gate).
- [ ] `backend-integration` CI job's log shows ~24 contract validations + 40 skips, total integration suite under the 2-minute budget.

## Follow-up on merge

- **File 5 grouped JIT sub-issues** (Groups A-E) under milestone #28 with priority + rationale comments. Each becomes its own follow-up PR.
- **Wave 3 kicks off in parallel** — #306 (`openapi-typescript` codegen) is unblocked because the snapshot shape is stable.
- **Release-manager** updates wiki Roadmap + Changelog. **No SemVer tag** (Platform-lane milestone). Milestone #28 stays open.

## Out of scope (deferred)

- Adding `response_model=` to the 40 excluded endpoints — Groups A-E sub-issues.
- Declaring missing error responses (400/404/502) in OpenAPI spec — Group E sub-issues.
- `openapi-typescript` codegen — Wave 3 (#306).
- `frontend/api/client.js` migration — Wave 3 (#307).
- Any router behavioral fix (e.g., the `NaTType` 502 in `regression/*`) — out of contract-test scope; would be a separate behavioral bug if filed.

## Notes for the reviewer

- The `DAY_1_EXCLUSIONS` list IS the punch-list. Each `(method, path)` tuple corresponds to an endpoint that fails contract validation today. Lift one entry → close one sub-issue.
- Schemathesis nondeterminism was a real concern; the deterministic seed (`derandomize=True` + `database=None` to disable the `.hypothesis/` example cache) makes failures reproducible across machines + CI.
- Group E's 19 entries reveal real product reliability issues (e.g., 502 on empty regression input) — those are best fixed in router behavior, not just spec declaration. Recommended priority for Group E sub-issues: P2 (not blocking; can be tackled over time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)