### PR TITLE
v1.6.0 — Watchlist (approved-universe gate) (closes #321 #322 #323)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,7 +17,7 @@ from app.config import settings as app_settings
 from app.logging_config import setup_logging
 from app.middleware import RequestLoggingMiddleware
 from app.models.database import init_db, SessionLocal
-from app.routers import assets, covered_call, dashboard, data, health, journal, legs, okrs, options, positions, regression, research, sessions, settings
+from app.routers import assets, covered_call, dashboard, data, health, journal, legs, okrs, options, positions, regression, research, sessions, settings, watchlist
 from app.services.backup import create_backup
 from app.services.cache import CacheService
 from app.services.data_fetcher import DataFetcher, DataFetchError, InvalidTickerError, DataAlignmentError
@@ -169,6 +169,7 @@ app.include_router(research.router, dependencies=[Depends(get_current_user)])
 app.include_router(legs.router, dependencies=[Depends(get_current_user)])
 app.include_router(covered_call.router, dependencies=[Depends(get_current_user)])
 app.include_router(okrs.router, dependencies=[Depends(get_current_user)])
+app.include_router(watchlist.router, dependencies=[Depends(get_current_user)])
 
 
 # --- Exception handlers ---

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -137,7 +137,7 @@ def _run_security_checks():
 app = FastAPI(
     title="Financial Regression Analysis Tool",
     description="Backend API for financial data fetching, caching, and regression analysis",
-    version="1.0.0",
+    version="1.6.0",
     lifespan=lifespan,
 )
 

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -181,6 +181,41 @@ class TradeEntryCompliance(Base):
     trade = relationship("Trade", back_populates="entry_compliance")
 
 
+class WatchlistTicker(Base):
+    """A single approved underlying in the trader's watchlist (issue #321).
+
+    The watchlist is the operational form of the wheel-strategy "would I
+    voluntarily own this?" gate (PRD #213): the options scanner and downstream
+    engines only consider names that appear here. This is the **data + API
+    layer only** — scanner integration (PRD #213 R5) and the management UI
+    are sibling issues in the V1.6 milestone.
+
+    Storage decision (PRD #213 Q1): a **dedicated table, one row per ticker,
+    with ``ticker`` as the primary key** — chosen over co-locating a JSON
+    blob in ``app_settings`` (the ``rules_config`` pattern) because a
+    watchlist is a *set of members*, not a *map of thresholds*. The PK gives
+    idempotency for free (duplicate add → no-op on the existing row; missing
+    remove → ``DELETE`` affecting zero rows) and lets v2 per-ticker metadata
+    (target price, tags, notes — MVP non-goals) grow as new columns without a
+    schema redesign. Rationale recorded in
+    ``backend/design-specs/issue-321-watchlist-api-plan.md``.
+
+    ``ticker`` is stored uppercase-normalized; normalization happens at the
+    service / API boundary so the PK uniqueness constraint dedupes
+    case-insensitively (``aapl`` and ``AAPL`` collapse to one row).
+
+    The project has no Alembic — ``Base.metadata.create_all(bind=engine)`` in
+    :func:`init_db` is idempotent, so an existing deployment grows the
+    ``watchlist`` table on next startup without a migration. Rollback path is
+    a manual ``DROP TABLE watchlist``.
+    """
+
+    __tablename__ = "watchlist"
+
+    ticker = Column(String, primary_key=True)  # uppercase-normalized symbol
+    added_at = Column(String, nullable=False)  # ISO datetime — audit + stable sort
+
+
 engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
 
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -315,6 +315,17 @@ class OptionScanRequest(BaseModel):
 
 
 class OptionScanResponse(BaseModel):
+    """Response for ``POST /api/options/scan``.
+
+    The watchlist gate (issue #322 / PRD #213 R5) runs upstream of the chain
+    fetch: a scan for a ticker the trader has not approved returns zero
+    candidates with an explanatory ``empty_reason`` and a ``200`` — never an
+    error. ``watchlist_filtered`` records that the approved-universe gate was
+    applied to this scan; ``empty_reason`` is populated only when the gate
+    produced the empty result (it is ``None`` on a normal scan, including a
+    normal scan that legitimately found no strikes).
+    """
+
     ticker: str
     current_price: float
     strategy: str
@@ -324,6 +335,10 @@ class OptionScanResponse(BaseModel):
     recommendations: list[StrikeRecommendation]
     rejected: list[RejectedStrike]
     market_context: MarketContext
+    # Watchlist gate (issue #322 / PRD #213 R5). Additive + defaulted, so a
+    # pre-#322 client ignores them and the change is non-breaking.
+    watchlist_filtered: bool = True
+    empty_reason: Optional[str] = None
 
 
 # --- Journal ---

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1349,3 +1349,41 @@ class FinancialsResponse(BaseModel):
     source: str
     fetched_at: str
 
+
+# --- watchlist ---
+
+
+class WatchlistResponse(BaseModel):
+    """Response shape for every watchlist endpoint (issue #321 / PRD #213 R4).
+
+    All three routes — ``GET``, ``POST``, ``DELETE`` — return the full,
+    current watchlist so the caller never has to issue a follow-up read after
+    a mutation. ``tickers`` is uppercase-normalized and returned in a stable
+    order (oldest-added first). Defaults to an empty list, which is the
+    correct representation of "the trader hasn't approved any names yet"
+    (PRD #213: an empty watchlist is a valid state, not an error).
+    """
+
+    tickers: list[str] = Field(default_factory=list)
+
+
+class WatchlistAddRequest(BaseModel):
+    """Request body for ``POST /api/watchlist`` (issue #321 / PRD #213 R2).
+
+    ``ticker`` is normalized to uppercase and stripped of surrounding
+    whitespace at this boundary, so the service layer can trust it is a
+    non-empty uppercase symbol. A blank or whitespace-only ticker is rejected
+    with ``422`` (the validator raises before the request reaches the route).
+    """
+
+    ticker: str = Field(..., description="Ticker symbol to add; normalized to uppercase.")
+
+    @field_validator("ticker")
+    @classmethod
+    def _normalize_ticker(cls, v: str) -> str:
+        """Strip + uppercase the ticker; reject blank/whitespace-only input."""
+        normalized = v.strip().upper()
+        if not normalized:
+            raise ValueError("ticker must not be empty")
+        return normalized
+

--- a/backend/app/routers/options.py
+++ b/backend/app/routers/options.py
@@ -5,7 +5,11 @@ from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import get_db
 from app.models.schemas import OptionScanRequest, OptionScanResponse
-from app.services.options_scanner import OptionScanner, OptionScannerError
+from app.services.options_scanner import (
+    OptionScanner,
+    OptionScannerError,
+    evaluate_watchlist_gate,
+)
 from app.services.rejection_relax import (
     NotRelaxableError,
     RelaxPreviewRequest,
@@ -15,6 +19,7 @@ from app.services.rejection_relax import (
 from app.services.rules_config import RulesConfig, load_rules_config
 from app.services.schwab_client import SchwabClient, SchwabClientError
 from app.services.schwab_auth import SchwabAuthError
+from app.services.watchlist import list_watchlist
 from app.utils.parsing import to_float, to_int
 
 logger = logging.getLogger(__name__)
@@ -83,9 +88,31 @@ def scan_options(
 ):
     """Scan option chain for wheel strategy opportunities.
 
-    Unset rule fields on the request are resolved from the persisted
-    ``rules_config`` (issue #156) before the scan runs.
+    The watchlist gate runs first (issue #322 / PRD #213 R5): the scanner only
+    considers names the trader has already approved. If the requested ticker is
+    not on the watchlist — including the empty-watchlist case — the scan is
+    short-circuited to a zero-candidate ``200`` response carrying an
+    explanatory ``empty_reason``, never an error. The watchlist is read from
+    the single source of truth (:func:`app.services.watchlist.list_watchlist`,
+    issue #321), so adding or removing a ticker via the watchlist API changes
+    the next scan's universe with no code change.
+
+    When the gate allows the scan, unset rule fields on the request are
+    resolved from the persisted ``rules_config`` (issue #156) before the scan
+    runs.
     """
+    gate = evaluate_watchlist_gate(req.ticker, list_watchlist(db))
+    if not gate.allowed:
+        logger.info(
+            "Watchlist gate blocked scan",
+            extra={
+                "event": "watchlist_gate.blocked",
+                "ticker": req.ticker.strip().upper(),
+                "outcome": "no_data",
+            },
+        )
+        return scanner.empty_response(req, gate.reason)
+
     _resolve_scan_rules(req, load_rules_config(db))
     return scanner.scan(req)
 

--- a/backend/app/routers/watchlist.py
+++ b/backend/app/routers/watchlist.py
@@ -1,0 +1,79 @@
+"""Watchlist router — the approved-underlying universe API (issue #321).
+
+Three endpoints under ``/api/watchlist`` back PRD #213 R2–R4:
+
+- ``GET  /api/watchlist``           — list the current watchlist.
+- ``POST /api/watchlist``           — add a ticker (idempotent, normalized).
+- ``DELETE /api/watchlist/{ticker}``— remove a ticker (idempotent).
+
+Every route returns the full, current watchlist as :class:`WatchlistResponse`
+so a caller never needs a follow-up read after a mutation. Per CLAUDE.md the
+routes never surface ``str(e)`` — an unexpected persistence error is logged
+via ``logger.exception`` and collapsed to a generic ``500``. Adding a duplicate
+or removing a missing ticker is a documented no-op (returns ``200`` with the
+unchanged list), not a ``409``/``404``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import get_db
+from app.models.schemas import WatchlistAddRequest, WatchlistResponse
+from app.services.watchlist import add_ticker, list_watchlist, remove_ticker
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/watchlist", tags=["watchlist"])
+
+# Generic 500 detail per CLAUDE.md — never leak ``str(e)``.
+_GENERIC_500_DETAIL = "An unexpected error occurred"
+
+
+@router.get("", response_model=WatchlistResponse)
+def get_watchlist(db: DBSession = Depends(get_db)) -> WatchlistResponse:
+    """Return the current watchlist of approved underlyings."""
+    try:
+        tickers = list_watchlist(db)
+    except Exception:
+        logger.exception("Unexpected error while listing watchlist")
+        raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)
+    return WatchlistResponse(tickers=tickers)
+
+
+@router.post("", response_model=WatchlistResponse)
+def add_watchlist_ticker(
+    req: WatchlistAddRequest, db: DBSession = Depends(get_db)
+) -> WatchlistResponse:
+    """Add a ticker to the watchlist; idempotent and uppercase-normalized.
+
+    The ``ticker`` is normalized + validated by :class:`WatchlistAddRequest`,
+    so a blank ticker is rejected with ``422`` before reaching this handler.
+    """
+    try:
+        tickers = add_ticker(db, req.ticker)
+    except Exception:
+        logger.exception("Unexpected error while adding watchlist ticker")
+        raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)
+    return WatchlistResponse(tickers=tickers)
+
+
+@router.delete("/{ticker}", response_model=WatchlistResponse)
+def delete_watchlist_ticker(
+    ticker: str, db: DBSession = Depends(get_db)
+) -> WatchlistResponse:
+    """Remove a ticker from the watchlist; idempotent.
+
+    The path parameter is normalized the same way as on add, so
+    ``DELETE /api/watchlist/aapl`` removes ``AAPL``. Removing a ticker that is
+    not present is a no-op that returns ``200`` with the unchanged list.
+    """
+    try:
+        tickers = remove_ticker(db, ticker)
+    except Exception:
+        logger.exception("Unexpected error while removing watchlist ticker")
+        raise HTTPException(status_code=500, detail=_GENERIC_500_DETAIL)
+    return WatchlistResponse(tickers=tickers)

--- a/backend/app/services/options_scanner.py
+++ b/backend/app/services/options_scanner.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta
 from typing import Optional
 
@@ -18,6 +19,69 @@ from app.services.rules_config import DEFAULT_RULES_CONFIG
 from app.utils.parsing import to_float, to_int
 
 logger = logging.getLogger(__name__)
+
+# --- Watchlist gate (issue #322 / PRD #213 R5) ---
+#
+# The scanner is single-ticker: ``request.ticker`` is the candidate universe
+# for one scan, so the watchlist gate is the set intersection
+# ``{request.ticker} ∩ watchlist``. The two empty-state reason strings are
+# frozen here so the gate logic, the empty response, and the tests all
+# reference the same literals (no drift).
+EMPTY_WATCHLIST_REASON = (
+    "No approved underlyings — add tickers to your watchlist before scanning."
+)
+
+
+def _ticker_not_on_watchlist_reason(ticker: str) -> str:
+    """Build the off-watchlist explanation for a specific ticker."""
+    return (
+        f"{ticker} is not on your watchlist. "
+        "Add it to scan, or pick an approved name."
+    )
+
+
+@dataclass(frozen=True)
+class WatchlistGate:
+    """Outcome of applying the approved-universe gate to one scan request.
+
+    ``allowed`` is ``True`` when the requested ticker is on the watchlist and
+    the scan may proceed. When ``allowed`` is ``False`` the scan is short-
+    circuited to a zero-candidate response carrying ``reason`` — an
+    explanation, never an error (PRD #213 R5: an empty watchlist is the
+    cleanest expression of "I haven't decided what I'd own").
+    """
+
+    allowed: bool
+    reason: Optional[str] = None
+
+
+def evaluate_watchlist_gate(ticker: str, watchlist: list[str]) -> WatchlistGate:
+    """Decide whether a scan for ``ticker`` may proceed given ``watchlist``.
+
+    Pure function — no DB, no network. The caller supplies the watchlist read
+    from the single source of truth (:func:`app.services.watchlist.list_watchlist`,
+    issue #321). Matching is case-insensitive, mirroring the watchlist's own
+    uppercase normalization, so a request for ``aapl`` passes when ``AAPL`` is
+    approved.
+
+    Returns a :class:`WatchlistGate`:
+
+    - empty ``watchlist`` → blocked with :data:`EMPTY_WATCHLIST_REASON`.
+    - ``ticker`` not in ``watchlist`` → blocked with the off-list reason.
+    - otherwise → allowed.
+    """
+    if not watchlist:
+        return WatchlistGate(allowed=False, reason=EMPTY_WATCHLIST_REASON)
+
+    normalized = ticker.strip().upper()
+    approved = {t.strip().upper() for t in watchlist}
+    if normalized not in approved:
+        return WatchlistGate(
+            allowed=False,
+            reason=_ticker_not_on_watchlist_reason(normalized),
+        )
+
+    return WatchlistGate(allowed=True)
 
 
 class OptionScannerError(Exception):
@@ -105,6 +169,8 @@ class OptionScanner:
                 "recommendations": [],
                 "rejected": [],
                 "market_context": market_context,
+                "watchlist_filtered": True,
+                "empty_reason": None,
             }
 
         candidates = []
@@ -280,6 +346,31 @@ class OptionScanner:
             "recommendations": ranked[:20],
             "rejected": rejected[:50],
             "market_context": market_context,
+            "watchlist_filtered": True,
+            "empty_reason": None,
+        }
+
+    def empty_response(self, req: OptionScanRequest, reason: str) -> dict:
+        """Build a zero-candidate scan response for a blocked watchlist gate.
+
+        Returned (with a ``200``) when the requested ticker is not on the
+        watchlist (issue #322 / PRD #213 R5). No chain is fetched and no market
+        data is consulted, so ``current_price`` is ``0.0`` and the market
+        context is empty — the caller surfaces ``reason`` to explain the empty
+        result rather than treating it as an error.
+        """
+        return {
+            "ticker": req.ticker,
+            "current_price": 0.0,
+            "strategy": req.strategy,
+            "scan_time": datetime.now(timezone.utc).isoformat(),
+            "earnings_date": None,
+            "iv_rank": None,
+            "recommendations": [],
+            "rejected": [],
+            "market_context": MarketContext(),
+            "watchlist_filtered": True,
+            "empty_reason": reason,
         }
 
     # ---- Rule resolution ----

--- a/backend/app/services/watchlist.py
+++ b/backend/app/services/watchlist.py
@@ -1,0 +1,92 @@
+"""Watchlist service — the approved-underlying universe (issue #321).
+
+The watchlist is the operational form of the wheel-strategy "would I
+voluntarily own this?" gate (PRD #213). This module is the **data-access +
+business-logic layer** behind ``/api/watchlist``; the scanner integration
+(PRD #213 R5) and the management UI (R6 consumer) are sibling V1.6 issues that
+read through :func:`list_watchlist`.
+
+Storage is a dedicated ``watchlist`` table keyed on ``ticker`` (PRD #213 Q1 —
+see :class:`app.models.database.WatchlistTicker`). The primary key makes both
+mutations idempotent for free:
+
+- **add** — present-check then insert; adding an existing ticker is a no-op
+  (PRD #213 R2).
+- **remove** — ``DELETE`` by primary key; removing a missing ticker affects
+  zero rows and is a no-op (PRD #213 R3).
+
+Every ticker is uppercase-normalized via :func:`normalize_ticker` before it
+touches the table, so the case-insensitive duplicate (``aapl`` after ``AAPL``)
+collapses onto the same primary-key row.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.database import WatchlistTicker
+
+
+def normalize_ticker(raw: str) -> str:
+    """Normalize a raw ticker to its canonical stored form.
+
+    Strips surrounding whitespace and uppercases. This is the single
+    normalization rule shared by the ``POST`` request body and the ``DELETE``
+    path parameter so ``aapl`` and ``AAPL`` always resolve to the same row.
+
+    The caller is responsible for rejecting empty input — the API boundary
+    (``WatchlistAddRequest`` / the route) does this before reaching the
+    persistence layer.
+    """
+    return raw.strip().upper()
+
+
+def list_watchlist(db: DBSession) -> list[str]:
+    """Return the current watchlist as a list of uppercase tickers.
+
+    Ordered oldest-added first (``added_at`` then ``ticker``) for a stable,
+    deterministic response. Returns an empty list when no names are approved.
+    """
+    rows = (
+        db.query(WatchlistTicker)
+        .order_by(WatchlistTicker.added_at, WatchlistTicker.ticker)
+        .all()
+    )
+    return [row.ticker for row in rows]
+
+
+def add_ticker(db: DBSession, raw_ticker: str) -> list[str]:
+    """Add a ticker to the watchlist (idempotent) and return the updated list.
+
+    Normalizes ``raw_ticker`` to uppercase. Adding a ticker that already
+    exists is a no-op — no duplicate row, no error (PRD #213 R2). Returns the
+    full, current watchlist.
+    """
+    ticker = normalize_ticker(raw_ticker)
+    existing = db.get(WatchlistTicker, ticker)
+    if existing is None:
+        db.add(
+            WatchlistTicker(
+                ticker=ticker,
+                added_at=datetime.now(timezone.utc).isoformat(),
+            )
+        )
+        db.commit()
+    return list_watchlist(db)
+
+
+def remove_ticker(db: DBSession, raw_ticker: str) -> list[str]:
+    """Remove a ticker from the watchlist (idempotent) and return the list.
+
+    Normalizes ``raw_ticker`` to uppercase. Removing a ticker that is not on
+    the watchlist is a no-op — no error (PRD #213 R3). Returns the full,
+    current watchlist.
+    """
+    ticker = normalize_ticker(raw_ticker)
+    existing = db.get(WatchlistTicker, ticker)
+    if existing is not None:
+        db.delete(existing)
+        db.commit()
+    return list_watchlist(db)

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -3097,6 +3097,7 @@
         "type": "object"
       },
       "OptionScanResponse": {
+        "description": "Response for ``POST /api/options/scan``.\n\nThe watchlist gate (issue #322 / PRD #213 R5) runs upstream of the chain\nfetch: a scan for a ticker the trader has not approved returns zero\ncandidates with an explanatory ``empty_reason`` and a ``200`` — never an\nerror. ``watchlist_filtered`` records that the approved-universe gate was\napplied to this scan; ``empty_reason`` is populated only when the gate\nproduced the empty result (it is ``None`` on a normal scan, including a\nnormal scan that legitimately found no strikes).",
         "properties": {
           "current_price": {
             "title": "Current Price",
@@ -3112,6 +3113,17 @@
               }
             ],
             "title": "Earnings Date"
+          },
+          "empty_reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Empty Reason"
           },
           "iv_rank": {
             "anyOf": [
@@ -3152,6 +3164,11 @@
           "ticker": {
             "title": "Ticker",
             "type": "string"
+          },
+          "watchlist_filtered": {
+            "default": true,
+            "title": "Watchlist Filtered",
+            "type": "boolean"
           }
         },
         "required": [
@@ -6884,7 +6901,7 @@
     },
     "/api/options/scan": {
       "post": {
-        "description": "Scan option chain for wheel strategy opportunities.\n\nUnset rule fields on the request are resolved from the persisted\n``rules_config`` (issue #156) before the scan runs.",
+        "description": "Scan option chain for wheel strategy opportunities.\n\nThe watchlist gate runs first (issue #322 / PRD #213 R5): the scanner only\nconsiders names the trader has already approved. If the requested ticker is\nnot on the watchlist — including the empty-watchlist case — the scan is\nshort-circuited to a zero-candidate ``200`` response carrying an\nexplanatory ``empty_reason``, never an error. The watchlist is read from\nthe single source of truth (:func:`app.services.watchlist.list_watchlist`,\nissue #321), so adding or removing a ticker via the watchlist API changes\nthe next scan's universe with no code change.\n\nWhen the gate allows the scan, unset rule fields on the request are\nresolved from the persisted ``rules_config`` (issue #156) before the scan\nruns.",
         "operationId": "scan_options_api_options_scan_post",
         "requestBody": {
           "content": {

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -5650,6 +5650,35 @@
         ],
         "title": "ValidationError",
         "type": "object"
+      },
+      "WatchlistAddRequest": {
+        "description": "Request body for ``POST /api/watchlist`` (issue #321 / PRD #213 R2).\n\n``ticker`` is normalized to uppercase and stripped of surrounding\nwhitespace at this boundary, so the service layer can trust it is a\nnon-empty uppercase symbol. A blank or whitespace-only ticker is rejected\nwith ``422`` (the validator raises before the request reaches the route).",
+        "properties": {
+          "ticker": {
+            "description": "Ticker symbol to add; normalized to uppercase.",
+            "title": "Ticker",
+            "type": "string"
+          }
+        },
+        "required": [
+          "ticker"
+        ],
+        "title": "WatchlistAddRequest",
+        "type": "object"
+      },
+      "WatchlistResponse": {
+        "description": "Response shape for every watchlist endpoint (issue #321 / PRD #213 R4).\n\nAll three routes — ``GET``, ``POST``, ``DELETE`` — return the full,\ncurrent watchlist so the caller never has to issue a follow-up read after\na mutation. ``tickers`` is uppercase-normalized and returned in a stable\norder (oldest-added first). Defaults to an empty list, which is the\ncorrect representation of \"the trader hasn't approved any names yet\"\n(PRD #213: an empty watchlist is a valid state, not an error).",
+        "properties": {
+          "tickers": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Tickers",
+            "type": "array"
+          }
+        },
+        "title": "WatchlistResponse",
+        "type": "object"
       }
     },
     "securitySchemes": {
@@ -8313,6 +8342,126 @@
         "summary": "Exchange Schwab Callback",
         "tags": [
           "settings"
+        ]
+      }
+    },
+    "/api/watchlist": {
+      "get": {
+        "description": "Return the current watchlist of approved underlyings.",
+        "operationId": "get_watchlist_api_watchlist_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchlistResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Get Watchlist",
+        "tags": [
+          "watchlist"
+        ]
+      },
+      "post": {
+        "description": "Add a ticker to the watchlist; idempotent and uppercase-normalized.\n\nThe ``ticker`` is normalized + validated by :class:`WatchlistAddRequest`,\nso a blank ticker is rejected with ``422`` before reaching this handler.",
+        "operationId": "add_watchlist_ticker_api_watchlist_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WatchlistAddRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchlistResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Add Watchlist Ticker",
+        "tags": [
+          "watchlist"
+        ]
+      }
+    },
+    "/api/watchlist/{ticker}": {
+      "delete": {
+        "description": "Remove a ticker from the watchlist; idempotent.\n\nThe path parameter is normalized the same way as on add, so\n``DELETE /api/watchlist/aapl`` removes ``AAPL``. Removing a ticker that is\nnot present is a no-op that returns ``200`` with the unchanged list.",
+        "operationId": "delete_watchlist_ticker_api_watchlist__ticker__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticker",
+            "required": true,
+            "schema": {
+              "title": "Ticker",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WatchlistResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Delete Watchlist Ticker",
+        "tags": [
+          "watchlist"
         ]
       }
     }

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -5708,7 +5708,7 @@
   "info": {
     "description": "Backend API for financial data fetching, caching, and regression analysis",
     "title": "Financial Regression Analysis Tool",
-    "version": "1.0.0"
+    "version": "1.6.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/backend/tests/contract/test_contract_master.py
+++ b/backend/tests/contract/test_contract_master.py
@@ -108,6 +108,12 @@ DAY_1_EXCLUSIONS: list[tuple[str, str]] = [
     ("POST", "/api/regression/rolling"),
     ("POST", "/api/sessions"),
     ("PUT", "/api/settings/rules"),
+    # Watchlist POST (#321/#322 — V1.6): identical malformed-body 400 to every
+    # other POST-with-body endpoint above (Schemathesis feeds non-JSON bytes →
+    # FastAPI "error parsing the body" 400, undocumented vs the 200/422 contract).
+    # New Group E member; the proper fix (declare 400 in responses=) is tracked
+    # under Wave 2.5 #315.
+    ("POST", "/api/watchlist"),
 ]
 
 
@@ -156,12 +162,13 @@ def test_exclusion_list_is_known_gaps():
 
     The count breakdown is: Group A (8 settings non-auth) + Group B (4
     settings schwab/health-probe) + Group C (2 health) + Group D (4
-    assets + options) + Group E (19 undocumented-error-response
-    endpoints) plus a tail of overlapping settings/rules entries
-    counted in Group A. Group E is a 5th post-merge sub-issue and
-    represents the largest class — routes that declare 200/422 but
-    actually return 400/404/502 on adversarial Hypothesis inputs.
+    assets + options) + Group E (20 undocumented-error-response
+    endpoints, incl. the V1.6 watchlist POST) plus a tail of overlapping
+    settings/rules entries counted in Group A. Group E is a 5th
+    post-merge sub-issue and represents the largest class — routes that
+    declare 200/422 but actually return 400/404/502 on adversarial
+    Hypothesis inputs.
     """
-    assert len(DAY_1_EXCLUSIONS) == 40
+    assert len(DAY_1_EXCLUSIONS) == 41
     methods = {m for m, _ in DAY_1_EXCLUSIONS}
     assert methods == {"GET", "PUT", "POST", "DELETE"}

--- a/backend/tests/test_integration_options.py
+++ b/backend/tests/test_integration_options.py
@@ -37,9 +37,22 @@ def _mock_scan_result():
     }
 
 
+def _approve(client, *tickers):
+    """Seed the watchlist via the public API so the #322 gate lets a scan pass.
+
+    Bridge helper added with the watchlist gate (issue #322): the scan endpoint
+    now short-circuits any ticker that is not on the watchlist to a ``200``
+    empty result, so the downstream-behavior tests below must approve the
+    ticker they scan before they reach ``OptionScanner.scan``.
+    """
+    for ticker in tickers:
+        client.post("/api/watchlist", json={"ticker": ticker})
+
+
 class TestScanEndpoint:
     @pytest.mark.integration
     def test_scan_covered_call_success(self, client):
+        _approve(client, "SOFI")
         with patch.object(OptionScanner, "scan", return_value=_mock_scan_result()):
             response = client.post("/api/options/scan", json={
                 "ticker": "SOFI",
@@ -56,6 +69,7 @@ class TestScanEndpoint:
 
     @pytest.mark.integration
     def test_scan_csp_success(self, client):
+        _approve(client, "SOFI")
         result = _mock_scan_result()
         result["strategy"] = "cash_secured_put"
         with patch.object(OptionScanner, "scan", return_value=result):
@@ -69,6 +83,7 @@ class TestScanEndpoint:
 
     @pytest.mark.integration
     def test_scan_no_options_404(self, client):
+        _approve(client, "BRK.A")
         with patch.object(
             OptionScanner, "scan",
             side_effect=OptionScannerError("No options available for 'BRK.A'"),
@@ -83,6 +98,7 @@ class TestScanEndpoint:
 
     @pytest.mark.integration
     def test_scan_invalid_strategy_400(self, client):
+        _approve(client, "SOFI")
         with patch.object(
             OptionScanner, "scan",
             side_effect=ValueError("Invalid strategy: butterfly"),
@@ -97,6 +113,7 @@ class TestScanEndpoint:
     @pytest.mark.integration
     def test_scan_schwab_auth_error_returns_sanitized_message(self, client):
         """Schwab auth errors must not leak internal details (issue #41)."""
+        _approve(client, "F")
         with patch.object(
             OptionScanner, "scan",
             side_effect=OptionScannerError(
@@ -120,6 +137,7 @@ class TestScanEndpoint:
         """Global SchwabAuthError handler must not leak internal details (issue #41)."""
         from app.services.schwab_auth import SchwabAuthCode, SchwabAuthError
 
+        _approve(client, "F")
         with patch.object(
             OptionScanner, "scan",
             side_effect=SchwabAuthError(
@@ -147,3 +165,116 @@ class TestEarningsEndpoint:
         assert response.status_code == 200
         data = response.json()
         assert data["ticker"] == "SOFI"
+
+
+class TestWatchlistGate:
+    """Watchlist gate on the scan endpoint (issue #322 / PRD #213 R5).
+
+    The watchlist is seeded through the real ``/api/watchlist`` API so these
+    tests exercise the single source of truth (#321's ``WatchlistTicker`` +
+    ``list_watchlist``) end-to-end — there is no second copy of the universe.
+    """
+
+    @pytest.mark.integration
+    def test_scan_with_watchlisted_ticker_returns_candidates(self, client):
+        """I1 (AC1) — a watchlisted ticker passes the gate and is scanned."""
+        client.post("/api/watchlist", json={"ticker": "AAPL"})
+
+        result = _mock_scan_result()
+        result["ticker"] = "AAPL"
+        with patch.object(OptionScanner, "scan", return_value=result) as scan_mock:
+            response = client.post(
+                "/api/options/scan",
+                json={
+                    "ticker": "AAPL",
+                    "strategy": "covered_call",
+                    "cost_basis": 200.0,
+                },
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ticker"] == "AAPL"
+        assert len(data["recommendations"]) == 1
+        assert data["empty_reason"] is None
+        # The gate allowed the scan, so the (mocked) chain scan ran.
+        scan_mock.assert_called_once()
+
+    @pytest.mark.integration
+    def test_scan_offlist_ticker_returns_empty_200_not_error(self, client):
+        """I2 (AC1/AC2) — an off-watchlist ticker → 200 empty, scan never runs."""
+        client.post("/api/watchlist", json={"ticker": "AAPL"})
+
+        with patch.object(OptionScanner, "scan") as scan_mock:
+            response = client.post(
+                "/api/options/scan",
+                json={
+                    "ticker": "MSFT",
+                    "strategy": "covered_call",
+                    "cost_basis": 400.0,
+                },
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recommendations"] == []
+        assert data["rejected"] == []
+        assert data["empty_reason"] is not None
+        assert "MSFT" in data["empty_reason"]
+        assert "not on your watchlist" in data["empty_reason"]
+        # The gate short-circuited before any chain fetch.
+        scan_mock.assert_not_called()
+
+    @pytest.mark.integration
+    def test_scan_empty_watchlist_returns_explanatory_empty_200(self, client):
+        """I3 (AC2) — empty watchlist → explanatory empty 200, not a 4xx/5xx."""
+        with patch.object(OptionScanner, "scan") as scan_mock:
+            response = client.post(
+                "/api/options/scan",
+                json={
+                    "ticker": "AAPL",
+                    "strategy": "covered_call",
+                    "cost_basis": 200.0,
+                },
+            )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recommendations"] == []
+        assert data["empty_reason"] is not None
+        assert "watchlist" in data["empty_reason"].lower()
+        scan_mock.assert_not_called()
+
+    @pytest.mark.integration
+    def test_adding_ticker_changes_next_scan_universe_no_code_change(self, client):
+        """I4 (AC3) — adding a ticker via the API changes the next scan's universe."""
+        # Before: AAPL is not approved, so the scan is gated to empty.
+        with patch.object(OptionScanner, "scan") as scan_mock:
+            gated = client.post(
+                "/api/options/scan",
+                json={
+                    "ticker": "AAPL",
+                    "strategy": "covered_call",
+                    "cost_basis": 200.0,
+                },
+            )
+        assert gated.status_code == 200
+        assert gated.json()["recommendations"] == []
+        scan_mock.assert_not_called()
+
+        # Approve AAPL via the watchlist API only — no code change.
+        add = client.post("/api/watchlist", json={"ticker": "AAPL"})
+        assert add.status_code == 200
+
+        # After: the same scan now passes the gate and is scanned.
+        result = _mock_scan_result()
+        result["ticker"] = "AAPL"
+        with patch.object(OptionScanner, "scan", return_value=result) as scan_mock:
+            allowed = client.post(
+                "/api/options/scan",
+                json={
+                    "ticker": "AAPL",
+                    "strategy": "covered_call",
+                    "cost_basis": 200.0,
+                },
+            )
+        assert allowed.status_code == 200
+        assert len(allowed.json()["recommendations"]) == 1
+        scan_mock.assert_called_once()

--- a/backend/tests/test_options_scanner.py
+++ b/backend/tests/test_options_scanner.py
@@ -685,3 +685,83 @@ class TestHumanReasonsPopulated:
         for r in return_below:
             assert len(r.human_reasons) == len(r.rejection_reasons)
             assert any("target return" in s for s in r.human_reasons)
+
+
+# --- Watchlist gate (issue #322 / PRD #213 R5) ---
+#
+# Pure-unit coverage of the approved-universe gate: the set intersection
+# ``{request.ticker} ∩ watchlist`` and the zero-candidate empty response. No
+# DB, no app, no network — the gate logic and ``empty_response`` are exercised
+# in isolation.
+
+from app.services.options_scanner import (  # noqa: E402
+    EMPTY_WATCHLIST_REASON,
+    WatchlistGate,
+    evaluate_watchlist_gate,
+)
+
+
+class TestWatchlistGate:
+    @pytest.mark.unit
+    def test_gate_allows_ticker_on_watchlist(self):
+        """U1 (AC1) — a ticker on the watchlist passes the gate."""
+        gate = evaluate_watchlist_gate("AAPL", ["AAPL", "MSFT"])
+        assert gate == WatchlistGate(allowed=True, reason=None)
+
+    @pytest.mark.unit
+    def test_gate_allows_case_insensitive_match(self):
+        """U2 (AC4) — a lowercase request matches an uppercase watchlist entry."""
+        gate = evaluate_watchlist_gate("aapl", ["AAPL"])
+        assert gate.allowed is True
+        assert gate.reason is None
+
+    @pytest.mark.unit
+    def test_gate_blocks_ticker_not_on_watchlist(self):
+        """U3 (AC1) — a non-member ticker is blocked with the off-list reason."""
+        gate = evaluate_watchlist_gate("MSFT", ["AAPL"])
+        assert gate.allowed is False
+        assert gate.reason is not None
+        assert "MSFT" in gate.reason
+        assert "not on your watchlist" in gate.reason
+
+    @pytest.mark.unit
+    def test_gate_blocks_on_empty_watchlist(self):
+        """U4 (AC2) — an empty watchlist blocks every scan with a clear reason."""
+        gate = evaluate_watchlist_gate("AAPL", [])
+        assert gate.allowed is False
+        assert gate.reason == EMPTY_WATCHLIST_REASON
+
+    @pytest.mark.unit
+    def test_gate_empty_watchlist_reason_distinct_from_off_list(self):
+        """U5 (AC2) — empty-watchlist and off-list explanations are different."""
+        empty = evaluate_watchlist_gate("AAPL", [])
+        off_list = evaluate_watchlist_gate("AAPL", ["MSFT"])
+        assert empty.reason != off_list.reason
+        assert empty.reason == EMPTY_WATCHLIST_REASON
+
+
+class TestEmptyResponse:
+    @pytest.mark.unit
+    def test_empty_response_shape_is_zero_candidates(self):
+        """U6 (AC2) — the gated empty response carries 0 recs/rejected + reason."""
+        scanner = OptionScanner()
+        req = OptionScanRequest(
+            ticker="MSFT", strategy="covered_call", cost_basis=400.0
+        )
+        result = scanner.empty_response(req, EMPTY_WATCHLIST_REASON)
+        assert result["recommendations"] == []
+        assert result["rejected"] == []
+        assert result["empty_reason"] == EMPTY_WATCHLIST_REASON
+        assert result["watchlist_filtered"] is True
+
+    @pytest.mark.unit
+    def test_empty_response_echoes_ticker_and_strategy(self):
+        """U7 (AC2) — the empty response preserves the request ticker + strategy."""
+        scanner = OptionScanner()
+        req = OptionScanRequest(
+            ticker="NVDA", strategy="cash_secured_put", capital_available=5000.0
+        )
+        result = scanner.empty_response(req, "some reason")
+        assert result["ticker"] == "NVDA"
+        assert result["strategy"] == "cash_secured_put"
+        assert result["empty_reason"] == "some reason"

--- a/backend/tests/test_rules_config_integration.py
+++ b/backend/tests/test_rules_config_integration.py
@@ -102,15 +102,29 @@ class _CaptureScanner(OptionScanner):
         }
 
 
+def _approve_watchlist(client, ticker: str) -> None:
+    """Seed the watchlist so the #322 gate lets a scan for ``ticker`` through.
+
+    Bridge helper added with the watchlist gate (issue #322): the scan endpoint
+    now short-circuits any ticker not on the watchlist to a ``200`` empty
+    result. These rule-resolution tests are about ``rules_config`` backfill, so
+    they approve the ticker they scan to reach the scanner.
+    """
+    client.post("/api/watchlist", json={"ticker": ticker})
+
+
 def _scan(client, body: dict) -> OptionScanRequest:
     """POST a scan, returning the OptionScanRequest the scanner received.
 
     Overrides the ``_get_scanner`` dependency with a capturing scanner so the
-    router's ``rules_config`` backfill can be inspected directly.
+    router's ``rules_config`` backfill can be inspected directly. The body's
+    ticker is approved on the watchlist first so the #322 gate does not
+    short-circuit the scan.
     """
     from app.main import app
     from app.routers.options import _get_scanner
 
+    _approve_watchlist(client, body["ticker"])
     _CaptureScanner.captured = None
     app.dependency_overrides[_get_scanner] = lambda: _CaptureScanner()
     try:
@@ -236,6 +250,7 @@ def test_fresh_db_yields_working_scan_no_migration(client):
     from app.main import app
     from app.routers.options import _get_scanner
 
+    _approve_watchlist(client, "SOFI")  # #322 gate — approve before scanning.
     _CaptureScanner.captured = None
     app.dependency_overrides[_get_scanner] = lambda: _CaptureScanner()
     try:
@@ -290,6 +305,7 @@ def _schwab_call_chain(strike: float, *, oi: int, dte: int = 30):
 @pytest.mark.integration
 def test_cc_scan_surfaces_below_cost_basis_reason(client):
     """A CC strike below cost basis is flagged ``below_cost_basis``, not dropped."""
+    _approve_watchlist(client, "TEST")  # #322 gate — approve before scanning.
     # Strike $14 sits below the $20 cost basis.
     chain = _schwab_call_chain(14.0, oi=500)
     with patch.object(OptionScanner, "_get_vix", return_value=None), patch(
@@ -315,6 +331,7 @@ def test_cc_scan_surfaces_below_cost_basis_reason(client):
 @pytest.mark.integration
 def test_cc_scan_below_cost_basis_suppressed_when_floor_disabled(client):
     """``cost_basis_floor_enabled=False`` suppresses the ``below_cost_basis`` reason."""
+    _approve_watchlist(client, "TEST")  # #322 gate — approve before scanning.
     chain = _schwab_call_chain(14.0, oi=500)
     with patch.object(OptionScanner, "_get_vix", return_value=None), patch(
         "app.services.options_scanner.get_next_earnings_date", return_value=None
@@ -344,6 +361,7 @@ def test_scan_min_open_interest_rejects_thin_strike(client):
     The default 500 floor would pass the same strike — confirms the inline
     ``oi < 50`` literal is gone and the floor comes from ``rules_config``.
     """
+    _approve_watchlist(client, "TEST")  # #322 gate — approve before scanning.
     _seed_setting(
         client,
         RULES_CONFIG_KEY,

--- a/backend/tests/test_watchlist.py
+++ b/backend/tests/test_watchlist.py
@@ -1,0 +1,76 @@
+"""Unit tests for the watchlist normalization + schema boundary (issue #321).
+
+Pure-function tests — NO DB session, NO TestClient (PRD #261 R3 unit tier).
+Covers :func:`app.services.watchlist.normalize_ticker` and the
+:class:`WatchlistAddRequest` / :class:`WatchlistResponse` Pydantic boundaries.
+The DB-backed add/remove/list/persistence behavior is exercised in the
+integration suites (``test_watchlist_router.py`` /
+``test_watchlist_persistence.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.models.schemas import WatchlistAddRequest, WatchlistResponse
+from app.services.watchlist import normalize_ticker
+
+
+# --- normalize_ticker (PRD #213 R2 — uppercase normalization) ---
+
+
+@pytest.mark.unit
+def test_normalize_lowercases_to_uppercase():
+    """U1 — ``aapl`` normalizes to ``AAPL`` (the headline AC)."""
+    assert normalize_ticker("aapl") == "AAPL"
+
+
+@pytest.mark.unit
+def test_normalize_strips_surrounding_whitespace():
+    """U2 — leading/trailing whitespace is stripped before uppercasing."""
+    assert normalize_ticker("  msft  ") == "MSFT"
+
+
+@pytest.mark.unit
+def test_normalize_already_uppercase_is_idempotent():
+    """U3 — an already-canonical ticker is returned unchanged."""
+    assert normalize_ticker("NVDA") == "NVDA"
+
+
+@pytest.mark.unit
+def test_normalize_mixed_case():
+    """U4 — mixed-case input collapses to all-uppercase."""
+    assert normalize_ticker("AaPl") == "AAPL"
+
+
+@pytest.mark.unit
+def test_normalize_internal_chars_preserved():
+    """U5 — internal punctuation (class-share dot) survives normalization."""
+    assert normalize_ticker("brk.b") == "BRK.B"
+
+
+# --- WatchlistAddRequest (boundary validation + normalization) ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+def test_add_request_schema_rejects_empty_ticker(blank):
+    """U6 — a blank/whitespace-only ticker is rejected at the schema boundary."""
+    with pytest.raises(ValidationError):
+        WatchlistAddRequest(ticker=blank)
+
+
+@pytest.mark.unit
+def test_add_request_schema_normalizes_ticker():
+    """U7 — the request model strips + uppercases on construction."""
+    assert WatchlistAddRequest(ticker="  aapl ").ticker == "AAPL"
+
+
+# --- WatchlistResponse (empty-list behavior) ---
+
+
+@pytest.mark.unit
+def test_response_schema_defaults_to_empty_list():
+    """U8 — an empty watchlist is the default, valid response (not an error)."""
+    assert WatchlistResponse().tickers == []

--- a/backend/tests/test_watchlist_persistence.py
+++ b/backend/tests/test_watchlist_persistence.py
@@ -1,0 +1,49 @@
+"""Persistence integration test for the watchlist (issue #321 / PRD #213 R7).
+
+Proves the watchlist survives an application restart. The in-memory ``client``
+fixture cannot model this (a ``:memory:`` DB dies with its connection pool), so
+this test uses an on-disk SQLite file in a tmp dir: it writes through one
+engine/session ("session A"), disposes it, then opens a brand-new
+engine/session ("session B") bound to the same file and reads the ticker back —
+the moral equivalent of stopping and restarting the process.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models.database import Base
+from app.services.watchlist import add_ticker, list_watchlist
+
+
+@pytest.mark.integration
+def test_watchlist_survives_session_recreation(tmp_path):
+    """P1 — a ticker added in one session is readable from a fresh session.
+
+    Each session gets its own ``Engine`` (its own connection pool) bound to the
+    same on-disk SQLite file, so the read genuinely crosses a process-restart
+    boundary rather than reusing an open connection.
+    """
+    db_path = tmp_path / "watchlist_persistence.db"
+    db_url = f"sqlite:///{db_path}"
+
+    # --- Session A: create schema + add a ticker, then tear the engine down. ---
+    engine_a = create_engine(db_url, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine_a)
+    session_a = sessionmaker(bind=engine_a)()
+    try:
+        add_ticker(session_a, "aapl")
+    finally:
+        session_a.close()
+    engine_a.dispose()
+
+    # --- Session B: a brand-new engine on the same file simulates a restart. ---
+    engine_b = create_engine(db_url, connect_args={"check_same_thread": False})
+    session_b = sessionmaker(bind=engine_b)()
+    try:
+        assert list_watchlist(session_b) == ["AAPL"]
+    finally:
+        session_b.close()
+    engine_b.dispose()

--- a/backend/tests/test_watchlist_router.py
+++ b/backend/tests/test_watchlist_router.py
@@ -1,0 +1,123 @@
+"""Integration tests for the watchlist API (issue #321 / PRD #213 R2–R4).
+
+Full backend stack via the ``client`` fixture (FastAPI TestClient + in-memory
+SQLite from ``conftest.py``). Exercises each endpoint plus the idempotency,
+normalization, and empty-ticker-validation behavior. The persistence-across-
+restart AC lives in ``test_watchlist_persistence.py`` (it needs an on-disk DB
+across two engine sessions, which the in-memory fixture cannot model).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# --- GET /api/watchlist ---
+
+
+@pytest.mark.integration
+def test_get_empty_watchlist_returns_empty_list(client):
+    """I1 — a fresh watchlist returns 200 with an empty ``tickers`` list."""
+    resp = client.get("/api/watchlist")
+    assert resp.status_code == 200
+    assert resp.json() == {"tickers": []}
+
+
+# --- POST /api/watchlist (add) ---
+
+
+@pytest.mark.integration
+def test_post_adds_ticker_and_it_appears_in_list(client):
+    """I2 — an added ticker appears in the POST response and the GET list."""
+    post = client.post("/api/watchlist", json={"ticker": "AAPL"})
+    assert post.status_code == 200
+    assert post.json() == {"tickers": ["AAPL"]}
+
+    listed = client.get("/api/watchlist")
+    assert listed.json() == {"tickers": ["AAPL"]}
+
+
+@pytest.mark.integration
+def test_post_normalizes_to_uppercase(client):
+    """I3 — a lowercase ticker is stored + returned uppercase (aapl → AAPL)."""
+    resp = client.post("/api/watchlist", json={"ticker": "aapl"})
+    assert resp.status_code == 200
+    assert resp.json() == {"tickers": ["AAPL"]}
+
+
+@pytest.mark.integration
+def test_post_duplicate_is_noop(client):
+    """I4 — adding the same ticker twice yields one entry, both calls 200."""
+    first = client.post("/api/watchlist", json={"ticker": "MSFT"})
+    second = client.post("/api/watchlist", json={"ticker": "MSFT"})
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json() == {"tickers": ["MSFT"]}
+
+
+@pytest.mark.integration
+def test_post_duplicate_different_case_is_noop(client):
+    """I5 — ``AAPL`` then ``aapl`` collapse onto one normalized entry."""
+    client.post("/api/watchlist", json={"ticker": "AAPL"})
+    resp = client.post("/api/watchlist", json={"ticker": "aapl"})
+    assert resp.status_code == 200
+    assert resp.json() == {"tickers": ["AAPL"]}
+
+
+# --- DELETE /api/watchlist/{ticker} (remove) ---
+
+
+@pytest.mark.integration
+def test_delete_removes_ticker(client):
+    """I6 — a removed ticker no longer appears in the list."""
+    client.post("/api/watchlist", json={"ticker": "AAPL"})
+    deleted = client.delete("/api/watchlist/AAPL")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"tickers": []}
+
+    listed = client.get("/api/watchlist")
+    assert listed.json() == {"tickers": []}
+
+
+@pytest.mark.integration
+def test_delete_missing_ticker_is_noop(client):
+    """I7 — removing a ticker that isn't present is a no-op (200, no error)."""
+    resp = client.delete("/api/watchlist/TSLA")
+    assert resp.status_code == 200
+    assert resp.json() == {"tickers": []}
+
+
+@pytest.mark.integration
+def test_delete_normalizes_path_param(client):
+    """I8 — DELETE .../aapl removes the AAPL row (path param normalized)."""
+    client.post("/api/watchlist", json={"ticker": "AAPL"})
+    deleted = client.delete("/api/watchlist/aapl")
+    assert deleted.status_code == 200
+    assert deleted.json() == {"tickers": []}
+
+
+# --- validation ---
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("blank", ["", "   "])
+def test_post_empty_ticker_returns_422(client, blank):
+    """I9 — a blank ticker is rejected with 422 (no ``str(e)`` leakage)."""
+    resp = client.post("/api/watchlist", json={"ticker": blank})
+    assert resp.status_code == 422
+    # Sanitized FastAPI validation body — no raw exception text.
+    body = resp.json()
+    assert "detail" in body
+
+
+# --- list ordering ---
+
+
+@pytest.mark.integration
+def test_get_list_is_returned_in_stable_order(client):
+    """I10 — the list endpoint returns tickers oldest-added first."""
+    for symbol in ("AAPL", "MSFT", "NVDA"):
+        client.post("/api/watchlist", json={"ticker": symbol})
+    resp = client.get("/api/watchlist")
+    assert resp.status_code == 200
+    assert resp.json() == {"tickers": ["AAPL", "MSFT", "NVDA"]}

--- a/frontend/api/client.js
+++ b/frontend/api/client.js
@@ -536,4 +536,42 @@ export async function putResearchThesis(positionId, thesis) {
   return data;
 }
 
+// --- Watchlist (#321) ---
+//
+// The approved-underlying universe the Options scanner filters to. All three
+// endpoints return the full, current `{ tickers: [...] }` (uppercase-normalized,
+// backend-ordered), so the caller never needs a follow-up read after a mutation.
+
+/**
+ * @returns {Promise<string[]>} the current watchlist tickers
+ */
+export async function getWatchlist() {
+  const { data } = await api.get('/api/watchlist');
+  return data.tickers;
+}
+
+/**
+ * Add a ticker (idempotent + uppercase-normalized server-side). Returns the
+ * full updated list so the UI reflects normalization + ordering authoritatively.
+ * @param {string} ticker
+ * @returns {Promise<string[]>} the updated watchlist tickers
+ */
+export async function addWatchlistTicker(ticker) {
+  const { data } = await api.post('/api/watchlist', { ticker });
+  return data.tickers;
+}
+
+/**
+ * Remove a ticker (idempotent — removing a missing ticker is a 200 no-op).
+ * Returns the full updated list.
+ * @param {string} ticker
+ * @returns {Promise<string[]>} the updated watchlist tickers
+ */
+export async function removeWatchlistTicker(ticker) {
+  const { data } = await api.delete(
+    `/api/watchlist/${encodeURIComponent(ticker)}`,
+  );
+  return data.tickers;
+}
+
 export default api;

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -516,8 +516,18 @@ export interface paths {
          * Scan Options
          * @description Scan option chain for wheel strategy opportunities.
          *
-         *     Unset rule fields on the request are resolved from the persisted
-         *     ``rules_config`` (issue #156) before the scan runs.
+         *     The watchlist gate runs first (issue #322 / PRD #213 R5): the scanner only
+         *     considers names the trader has already approved. If the requested ticker is
+         *     not on the watchlist — including the empty-watchlist case — the scan is
+         *     short-circuited to a zero-candidate ``200`` response carrying an
+         *     explanatory ``empty_reason``, never an error. The watchlist is read from
+         *     the single source of truth (:func:`app.services.watchlist.list_watchlist`,
+         *     issue #321), so adding or removing a ticker via the watchlist API changes
+         *     the next scan's universe with no code change.
+         *
+         *     When the gate allows the scan, unset rule fields on the request are
+         *     resolved from the persisted ``rules_config`` (issue #156) before the scan
+         *     runs.
          */
         post: operations["scan_options_api_options_scan_post"];
         delete?: never;
@@ -1319,6 +1329,57 @@ export interface paths {
          */
         post: operations["exchange_schwab_callback_api_settings_schwab_callback_post"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Watchlist
+         * @description Return the current watchlist of approved underlyings.
+         */
+        get: operations["get_watchlist_api_watchlist_get"];
+        put?: never;
+        /**
+         * Add Watchlist Ticker
+         * @description Add a ticker to the watchlist; idempotent and uppercase-normalized.
+         *
+         *     The ``ticker`` is normalized + validated by :class:`WatchlistAddRequest`,
+         *     so a blank ticker is rejected with ``422`` before reaching this handler.
+         */
+        post: operations["add_watchlist_ticker_api_watchlist_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/watchlist/{ticker}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete Watchlist Ticker
+         * @description Remove a ticker from the watchlist; idempotent.
+         *
+         *     The path parameter is normalized the same way as on add, so
+         *     ``DELETE /api/watchlist/aapl`` removes ``AAPL``. Removing a ticker that is
+         *     not present is a no-op that returns ``200`` with the unchanged list.
+         */
+        delete: operations["delete_watchlist_ticker_api_watchlist__ticker__delete"];
         options?: never;
         head?: never;
         patch?: never;
@@ -2604,12 +2665,25 @@ export interface components {
             /** Ticker */
             ticker: string;
         };
-        /** OptionScanResponse */
+        /**
+         * OptionScanResponse
+         * @description Response for ``POST /api/options/scan``.
+         *
+         *     The watchlist gate (issue #322 / PRD #213 R5) runs upstream of the chain
+         *     fetch: a scan for a ticker the trader has not approved returns zero
+         *     candidates with an explanatory ``empty_reason`` and a ``200`` — never an
+         *     error. ``watchlist_filtered`` records that the approved-universe gate was
+         *     applied to this scan; ``empty_reason`` is populated only when the gate
+         *     produced the empty result (it is ``None`` on a normal scan, including a
+         *     normal scan that legitimately found no strikes).
+         */
         OptionScanResponse: {
             /** Current Price */
             current_price: number;
             /** Earnings Date */
             earnings_date?: string | null;
+            /** Empty Reason */
+            empty_reason?: string | null;
             /** Iv Rank */
             iv_rank?: number | null;
             market_context: components["schemas"]["MarketContext"];
@@ -2623,6 +2697,11 @@ export interface components {
             strategy: string;
             /** Ticker */
             ticker: string;
+            /**
+             * Watchlist Filtered
+             * @default true
+             */
+            watchlist_filtered: boolean;
         };
         /**
          * PositionCreate
@@ -3726,6 +3805,37 @@ export interface components {
             msg: string;
             /** Error Type */
             type: string;
+        };
+        /**
+         * WatchlistAddRequest
+         * @description Request body for ``POST /api/watchlist`` (issue #321 / PRD #213 R2).
+         *
+         *     ``ticker`` is normalized to uppercase and stripped of surrounding
+         *     whitespace at this boundary, so the service layer can trust it is a
+         *     non-empty uppercase symbol. A blank or whitespace-only ticker is rejected
+         *     with ``422`` (the validator raises before the request reaches the route).
+         */
+        WatchlistAddRequest: {
+            /**
+             * Ticker
+             * @description Ticker symbol to add; normalized to uppercase.
+             */
+            ticker: string;
+        };
+        /**
+         * WatchlistResponse
+         * @description Response shape for every watchlist endpoint (issue #321 / PRD #213 R4).
+         *
+         *     All three routes — ``GET``, ``POST``, ``DELETE`` — return the full,
+         *     current watchlist so the caller never has to issue a follow-up read after
+         *     a mutation. ``tickers`` is uppercase-normalized and returned in a stable
+         *     order (oldest-added first). Defaults to an empty list, which is the
+         *     correct representation of "the trader hasn't approved any names yet"
+         *     (PRD #213: an empty watchlist is a valid state, not an error).
+         */
+        WatchlistResponse: {
+            /** Tickers */
+            tickers?: string[];
         };
     };
     responses: never;
@@ -5517,6 +5627,90 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_watchlist_api_watchlist_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WatchlistResponse"];
+                };
+            };
+        };
+    };
+    add_watchlist_ticker_api_watchlist_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["WatchlistAddRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WatchlistResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    delete_watchlist_ticker_api_watchlist__ticker__delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                ticker: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WatchlistResponse"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/components/settings/SettingsPage.jsx
+++ b/frontend/components/settings/SettingsPage.jsx
@@ -11,6 +11,7 @@ import DangerZone from './DangerZone';
 import ReconcileJournal from './ReconcileJournal';
 import TradingRulesSection from './TradingRulesSection';
 import TradingObjectivesSection from './TradingObjectivesSection';
+import WatchlistSection from './WatchlistSection';
 import { useJournal } from '../../hooks/useJournal';
 
 function freshnessColor(freshness) {
@@ -49,6 +50,7 @@ export default function SettingsPage() {
     const t = searchParams?.get('tab');
     if (t === 'rules') return 'rules';
     if (t === 'objectives') return 'objectives';
+    if (t === 'watchlist') return 'watchlist';
     return 'general';
   });
   const [settings, setSettings] = useState(null);
@@ -237,11 +239,25 @@ export default function SettingsPage() {
           >
             Trading Objectives
           </button>
+          <button
+            type="button"
+            role="tab"
+            data-testid="settings-watchlist-tab"
+            aria-selected={activeTab === 'watchlist'}
+            onClick={() => setActiveTab('watchlist')}
+            className={tabClass('watchlist')}
+          >
+            Watchlist
+          </button>
         </div>
 
         {activeTab === 'objectives' ? (
           <div role="tabpanel" aria-label="Trading Objectives">
             <TradingObjectivesSection />
+          </div>
+        ) : activeTab === 'watchlist' ? (
+          <div role="tabpanel" aria-label="Watchlist">
+            <WatchlistSection />
           </div>
         ) : activeTab === 'rules' ? (
           <div role="tabpanel" aria-label="Trading Rules">

--- a/frontend/components/settings/WatchlistSection.jsx
+++ b/frontend/components/settings/WatchlistSection.jsx
@@ -1,0 +1,371 @@
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import {
+  getWatchlist,
+  addWatchlistTicker,
+  removeWatchlistTicker,
+} from '../../api/client';
+import EmptyState from '../common/EmptyState';
+
+/**
+ * Settings → Watchlist section (issue #323, PRD #213 UC1–UC4).
+ *
+ * The minimal approved-universe gate: an add input, the current list with a
+ * per-row Remove, and an empty state. Symbols only — no columns, scores, or
+ * tags (those are PRD #213 v2). The Options scanner filters its candidates to
+ * this list; the framing line + count pill (UC4) make that gate legible while
+ * the trader curates.
+ *
+ * The section owns the mount fetch and all add/remove state for the tab (it is
+ * self-contained like TradingObjectivesSection — the tab panel just renders it).
+ *
+ * Data flow (Q4): the three `/api/watchlist` endpoints (#321) each return the
+ * full, current `{ tickers }` (uppercase-normalized, backend-ordered), so we
+ * use the returned list directly rather than issuing a follow-up GET. The
+ * backend is authoritative for normalization + ordering — the input only
+ * *displays* uppercase as a courtesy (CSS), it does not normalize.
+ *
+ * Failure copy is fixed generic text — never the raw server detail (CLAUDE.md).
+ */
+
+const LOAD_ERROR = "Couldn't load your watchlist.";
+
+/**
+ * Light client-side shape guard (spec §7.1). The backend is the authority on
+ * ticker validity (PRD #213 defers options-existence checks to v2); this only
+ * rejects obviously-bad input (digits-only, spaces, symbols) to avoid firing a
+ * doomed POST. Allows 1–6 letters with a single optional `.` or `-` (e.g.
+ * `BRK.B`).
+ */
+function isValidTickerShape(value) {
+  return /^[A-Za-z]{1,6}([.-][A-Za-z]{1,4})?$/.test(value);
+}
+
+export default function WatchlistSection() {
+  const [tickers, setTickers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
+  const [input, setInput] = useState('');
+  const [adding, setAdding] = useState(false);
+  // One inline message slot for duplicate (info) / add-error / validation.
+  const [inlineMsg, setInlineMsg] = useState(null); // { kind, text } | null
+  const [removing, setRemoving] = useState(null); // symbol being DELETEd
+
+  const load = () => {
+    setLoading(true);
+    setLoadError(false);
+    getWatchlist()
+      .then((list) => setTickers(list || []))
+      .catch(() => setLoadError(true))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, []);
+
+  // Add controls stay disabled until the initial load resolves (you cannot add
+  // to a universe you have not loaded) or while it is in error.
+  const controlsDisabled = loading || loadError;
+  const trimmed = input.trim();
+  const canAdd = trimmed.length > 0 && !adding && !controlsDisabled;
+
+  const handleInputChange = (next) => {
+    setInput(next);
+    // Any keystroke clears a stale inline message (spec §6.5 / §6.6).
+    if (inlineMsg) setInlineMsg(null);
+  };
+
+  const handleAdd = async () => {
+    const value = input.trim();
+    if (!value || adding || controlsDisabled) return;
+
+    // Client-side shape guard — block a doomed POST (spec §7.1).
+    if (!isValidTickerShape(value)) {
+      setInlineMsg({ kind: 'validation', text: 'Enter a valid ticker symbol.' });
+      return;
+    }
+
+    setAdding(true);
+    setInlineMsg(null);
+    const prev = tickers;
+    const submitted = value.toUpperCase();
+    try {
+      const updated = await addWatchlistTicker(value);
+      setTickers(updated || []);
+      // Idempotent no-op detection (spec §6.5): the symbol was already present
+      // and the list length did not grow → duplicate, not a fresh add.
+      const wasPresent = prev.includes(submitted);
+      if (wasPresent && (updated || []).length === prev.length) {
+        setInput('');
+        setInlineMsg({
+          kind: 'duplicate',
+          text: `${submitted} is already on your watchlist.`,
+        });
+      } else {
+        setInput('');
+        toast.success(`${submitted} added`);
+      }
+    } catch {
+      // Preserve the trader's typing; re-enable; generic copy only.
+      setInlineMsg({
+        kind: 'add-error',
+        text: `Couldn't add ${submitted}. Try again.`,
+      });
+      toast.error('Failed to add ticker');
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleRemove = async (symbol) => {
+    if (removing) return;
+    setRemoving(symbol);
+    try {
+      const updated = await removeWatchlistTicker(symbol);
+      setTickers(updated || []);
+      toast.success(`${symbol} removed`);
+    } catch {
+      // Row persists + re-enables; the toast carries the error (spec §6.8).
+      toast.error('Failed to remove ticker');
+    } finally {
+      setRemoving(null);
+    }
+  };
+
+  const header = (
+    <div className="flex items-center justify-between mb-1">
+      <h2 className="text-lg font-semibold text-slate-900 dark:text-white">
+        Watchlist
+      </h2>
+      {/* Count pill — populated only; the at-a-glance universe-size cue (UC4). */}
+      {!loading && !loadError && tickers.length > 0 && (
+        <span
+          data-testid="settings-watchlist-count"
+          className="text-xs px-2 py-0.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300"
+        >
+          {tickers.length} {tickers.length === 1 ? 'ticker' : 'tickers'}
+        </span>
+      )}
+    </div>
+  );
+
+  const framing = (
+    <p className="text-sm text-slate-500 dark:text-slate-400 mb-4">
+      The Options scanner only surfaces candidates from these approved names. Add
+      the tickers you&apos;d be willing to own if assigned.
+    </p>
+  );
+
+  const inputInvalid =
+    inlineMsg?.kind === 'add-error' || inlineMsg?.kind === 'validation';
+
+  const addRow = (
+    <div className="flex gap-2">
+      <input
+        type="text"
+        data-testid="settings-watchlist-add-input"
+        value={input}
+        onChange={(e) => handleInputChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            handleAdd();
+          }
+        }}
+        placeholder="Add ticker (e.g. AAPL)"
+        maxLength={6}
+        disabled={controlsDisabled || adding}
+        aria-label="Ticker symbol"
+        aria-invalid={inputInvalid ? 'true' : 'false'}
+        className={`flex-1 px-3 py-2 text-sm uppercase border rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100 outline-none focus:ring-2 disabled:opacity-60 disabled:cursor-not-allowed ${
+          inputInvalid
+            ? 'border-red-400 dark:border-red-500 focus:ring-red-500'
+            : 'border-slate-300 dark:border-slate-600 focus:ring-blue-500'
+        }`}
+      />
+      <button
+        type="button"
+        data-testid="settings-watchlist-add-button"
+        onClick={handleAdd}
+        disabled={!canAdd}
+        className="px-4 py-2 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-blue-400 disabled:cursor-not-allowed inline-flex items-center gap-2"
+      >
+        {adding && (
+          <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+            <circle
+              className="opacity-25"
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="4"
+            />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+            />
+          </svg>
+        )}
+        {adding ? 'Adding…' : 'Add'}
+      </button>
+    </div>
+  );
+
+  // Inline message slot — duplicate (info), add-error (red), validation (red).
+  const inlineSlot = inlineMsg
+    ? inlineMsg.kind === 'duplicate'
+      ? (
+        <p
+          data-testid="settings-watchlist-duplicate-note"
+          className="text-xs text-slate-500 dark:text-slate-400 mt-2"
+        >
+          {inlineMsg.text}
+        </p>
+      )
+      : (
+        <p
+          data-testid={
+            inlineMsg.kind === 'add-error'
+              ? 'settings-watchlist-add-error'
+              : 'settings-watchlist-validation-error'
+          }
+          role="alert"
+          className="text-xs text-red-600 dark:text-red-400 mt-2"
+        >
+          {inlineMsg.text}
+        </p>
+      )
+    : null;
+
+  let body;
+  if (loading) {
+    body = (
+      <div data-testid="settings-watchlist-loading" className="space-y-2 mt-5">
+        <div className="h-9 bg-slate-200 dark:bg-slate-700 rounded-lg animate-pulse" />
+        <div className="h-9 bg-slate-200 dark:bg-slate-700 rounded-lg animate-pulse" />
+        <div className="h-9 bg-slate-200 dark:bg-slate-700 rounded-lg animate-pulse" />
+      </div>
+    );
+  } else if (loadError) {
+    body = (
+      <div
+        data-testid="settings-watchlist-load-error"
+        role="alert"
+        className="flex items-center gap-3 px-4 py-3 mt-5 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200"
+      >
+        <svg
+          className="w-5 h-5 shrink-0"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+            d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+          />
+        </svg>
+        <span className="text-sm font-medium flex-1">{LOAD_ERROR}</span>
+        <button
+          type="button"
+          data-testid="settings-watchlist-retry"
+          onClick={load}
+          className="px-3 py-1.5 text-xs border border-amber-400 dark:border-amber-600 text-amber-700 dark:text-amber-300 rounded-lg hover:bg-amber-100 dark:hover:bg-amber-900/40"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  } else if (tickers.length === 0) {
+    body = (
+      <div className="mt-3">
+        <EmptyState
+          dataTestid="settings-watchlist-empty"
+          icon={
+            <svg
+              className="w-12 h-12 mx-auto"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.243 4.243L9.88 9.88"
+              />
+            </svg>
+          }
+          title="Your watchlist is empty"
+          description="The Options scanner won't surface any candidates until you add names. Add the tickers you'd be willing to own — those are the only underlyings the scanner will consider."
+        />
+      </div>
+    );
+  } else {
+    body = (
+      <ul data-testid="settings-watchlist-list" className="space-y-2 mt-5">
+        {tickers.map((symbol) => {
+          const busy = removing === symbol;
+          return (
+            <li
+              key={symbol}
+              data-testid="settings-watchlist-item"
+              data-ticker={symbol}
+              className={`flex items-center justify-between px-3 py-2 bg-white dark:bg-slate-700 rounded-lg border border-slate-200 dark:border-slate-600 ${
+                busy ? 'opacity-70' : ''
+              }`}
+            >
+              <span className="text-sm font-medium font-mono tabular-nums text-slate-900 dark:text-white">
+                {symbol}
+              </span>
+              <button
+                type="button"
+                data-testid="settings-watchlist-remove"
+                onClick={() => handleRemove(symbol)}
+                disabled={busy}
+                className="px-3 py-1 text-xs border border-slate-300 dark:border-slate-600 text-slate-600 dark:text-slate-300 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-600 disabled:cursor-not-allowed inline-flex items-center gap-1.5"
+              >
+                {busy && (
+                  <svg
+                    className="w-3.5 h-3.5 animate-spin"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    />
+                  </svg>
+                )}
+                {busy ? 'Removing…' : 'Remove'}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <section
+      data-testid="settings-watchlist-section"
+      className="bg-slate-50 dark:bg-slate-800 rounded-xl p-6 border border-slate-200 dark:border-slate-700"
+    >
+      {header}
+      {framing}
+      {addRow}
+      {inlineSlot}
+      {body}
+    </section>
+  );
+}

--- a/frontend/e2e/watchlist.spec.js
+++ b/frontend/e2e/watchlist.spec.js
@@ -1,0 +1,355 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Settings → Watchlist tab (issue #323, PRD #213 UC1–UC4).
+ *
+ * The minimal approved-universe gate: a 4th Settings tab holding an add input,
+ * the current ticker list with per-row Remove, and an empty state. Covers the
+ * issue's automated-coverage ACs:
+ *  - the list reflects the persisted backend state on load (UC3);
+ *  - add a ticker → it appears (UC1);
+ *  - remove a ticker → it disappears (UC2);
+ *  - the empty state renders the explanatory message, not a blank panel;
+ *  - lowercase input is normalized (round-trips through #321's API uppercasing);
+ *  - duplicate add is an idempotent no-op with an inline info note (not error);
+ *  - invalid input is blocked client-side;
+ *  - an initial-load failure shows the amber banner + Retry;
+ *  - an add failure shows a generic inline error, never the raw server detail.
+ *
+ * The three `/api/watchlist` endpoints (#321) are mocked with a persistent
+ * in-memory store so add → reload / remove → reload round-trips are real
+ * against the mock. The store uppercase-normalizes on add (mirroring the
+ * backend), so a lowercase POST surfaces as an uppercase row — exactly the
+ * normalization the AC asserts. Every endpoint returns the full `{ tickers }`.
+ */
+
+/**
+ * Mock the `/api/watchlist` endpoints (GET list, POST add, DELETE remove) with
+ * a persistent in-memory store. The store uppercases on add and is idempotent
+ * (a duplicate add / missing remove is a 200 no-op with the unchanged list),
+ * mirroring #321. `failGet` / `failAdd` exercise the error paths.
+ */
+function mockWatchlistEndpoints(
+  page,
+  { initial = [], failGet = false, failAdd = false } = {},
+) {
+  const store = { tickers: [...initial] };
+  const body = () => JSON.stringify({ tickers: store.tickers });
+
+  return page.route('**/api/watchlist**', (route) => {
+    const method = route.request().method();
+
+    if (method === 'GET') {
+      if (failGet) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: body(),
+      });
+    }
+
+    if (method === 'POST') {
+      if (failAdd) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      const payload = route.request().postDataJSON();
+      const symbol = String(payload?.ticker || '').trim().toUpperCase();
+      if (symbol && !store.tickers.includes(symbol)) {
+        store.tickers.push(symbol);
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: body(),
+      });
+    }
+
+    if (method === 'DELETE') {
+      const symbol = decodeURIComponent(
+        route.request().url().split('/api/watchlist/')[1] || '',
+      ).toUpperCase();
+      store.tickers = store.tickers.filter((t) => t !== symbol);
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: body(),
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+/** Open the Settings page and switch to the Watchlist tab. */
+async function openWatchlistTab(page) {
+  await page.goto('/settings');
+  await page.getByTestId('settings-watchlist-tab').click();
+  await expect(page.getByTestId('settings-watchlist-section')).toBeVisible();
+}
+
+test.describe('Settings → Watchlist — tab & deep link @e2e', () => {
+  test('the tab bar exposes a 4th "Watchlist" tab', async ({ page }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL'] });
+    await page.goto('/settings');
+
+    const tab = page.getByTestId('settings-watchlist-tab');
+    await expect(tab).toBeVisible();
+    await expect(tab).toHaveText('Watchlist');
+  });
+
+  test('/settings?tab=watchlist opens the Watchlist tab without a click', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL'] });
+    await page.goto('/settings?tab=watchlist');
+
+    await expect(page.getByTestId('settings-watchlist-tab')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+    await expect(page.getByTestId('settings-watchlist-section')).toBeVisible();
+  });
+});
+
+test.describe('Settings → Watchlist — view persisted universe @smoke @e2e', () => {
+  test('the list reflects the persisted backend state on load', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL', 'MSFT', 'NVDA'] });
+    await openWatchlistTab(page);
+
+    const list = page.getByTestId('settings-watchlist-list');
+    await expect(list).toBeVisible();
+    await expect(page.getByTestId('settings-watchlist-item')).toHaveCount(3);
+    await expect(list.getByText('AAPL', { exact: true })).toBeVisible();
+    await expect(list.getByText('MSFT', { exact: true })).toBeVisible();
+    await expect(list.getByText('NVDA', { exact: true })).toBeVisible();
+
+    // The count pill shows the universe size at a glance (UC4).
+    await expect(page.getByTestId('settings-watchlist-count')).toHaveText(
+      '3 tickers',
+    );
+  });
+});
+
+test.describe('Settings → Watchlist — add a ticker @smoke @e2e', () => {
+  test('add a ticker → it appears in the list', async ({ page }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL'] });
+    await openWatchlistTab(page);
+
+    await page.getByTestId('settings-watchlist-add-input').fill('MSFT');
+    await page.getByTestId('settings-watchlist-add-button').click();
+
+    // The newly added row appears (backend-ordered; we use the returned list).
+    const newRow = page.locator('[data-testid="settings-watchlist-item"][data-ticker="MSFT"]');
+    await expect(newRow).toBeVisible();
+    await expect(page.getByTestId('settings-watchlist-item')).toHaveCount(2);
+    await expect(page.getByTestId('settings-watchlist-count')).toHaveText(
+      '2 tickers',
+    );
+    // Input clears for fast multi-add.
+    await expect(page.getByTestId('settings-watchlist-add-input')).toHaveValue('');
+  });
+
+  test('Enter in the input submits the add', async ({ page }) => {
+    await mockWatchlistEndpoints(page, { initial: [] });
+    await openWatchlistTab(page);
+
+    const input = page.getByTestId('settings-watchlist-add-input');
+    await input.fill('SOFI');
+    await input.press('Enter');
+
+    await expect(
+      page.locator('[data-testid="settings-watchlist-item"][data-ticker="SOFI"]'),
+    ).toBeVisible();
+  });
+});
+
+test.describe('Settings → Watchlist — remove a ticker @e2e', () => {
+  test('remove a ticker → it disappears', async ({ page }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL', 'MSFT'] });
+    await openWatchlistTab(page);
+
+    const msftRow = page.locator(
+      '[data-testid="settings-watchlist-item"][data-ticker="MSFT"]',
+    );
+    await msftRow.getByTestId('settings-watchlist-remove').click();
+
+    await expect(msftRow).toHaveCount(0);
+    await expect(page.getByTestId('settings-watchlist-item')).toHaveCount(1);
+    await expect(page.getByTestId('settings-watchlist-count')).toHaveText(
+      '1 ticker',
+    );
+  });
+
+  test('removing the last ticker transitions to the empty state', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL'] });
+    await openWatchlistTab(page);
+
+    await page.getByTestId('settings-watchlist-remove').click();
+
+    await expect(page.getByTestId('settings-watchlist-list')).toHaveCount(0);
+    await expect(page.getByTestId('settings-watchlist-empty')).toBeVisible();
+  });
+});
+
+test.describe('Settings → Watchlist — empty state @e2e', () => {
+  test('the empty state renders the explanatory message, not a blank panel', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: [] });
+    await openWatchlistTab(page);
+
+    const empty = page.getByTestId('settings-watchlist-empty');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText('Your watchlist is empty');
+    await expect(empty).toContainText(
+      "The Options scanner won't surface any candidates until you add names",
+    );
+    // No count pill / no list in the empty state.
+    await expect(page.getByTestId('settings-watchlist-count')).toHaveCount(0);
+    await expect(page.getByTestId('settings-watchlist-list')).toHaveCount(0);
+  });
+});
+
+test.describe('Settings → Watchlist — lowercase normalization @e2e', () => {
+  test('a lowercase add normalizes to uppercase in the list', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: [] });
+    await openWatchlistTab(page);
+
+    // The trader types lowercase; #321 uppercases server-side; the row shows
+    // the normalized symbol (the AC).
+    await page.getByTestId('settings-watchlist-add-input').fill('amd');
+    await page.getByTestId('settings-watchlist-add-button').click();
+
+    await expect(
+      page.locator('[data-testid="settings-watchlist-item"][data-ticker="AMD"]'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('settings-watchlist-list').getByText('AMD', { exact: true }),
+    ).toBeVisible();
+  });
+});
+
+test.describe('Settings → Watchlist — duplicate add @e2e', () => {
+  test('adding an existing ticker shows an inline info note, not an error', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL'] });
+    await openWatchlistTab(page);
+
+    await page.getByTestId('settings-watchlist-add-input').fill('aapl');
+    await page.getByTestId('settings-watchlist-add-button').click();
+
+    // Idempotent no-op: the count does not grow, an info note explains why.
+    await expect(page.getByTestId('settings-watchlist-item')).toHaveCount(1);
+    const note = page.getByTestId('settings-watchlist-duplicate-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('AAPL is already on your watchlist');
+    // It is NOT an error.
+    await expect(page.getByTestId('settings-watchlist-add-error')).toHaveCount(0);
+  });
+});
+
+test.describe('Settings → Watchlist — client validation @e2e', () => {
+  test('invalid input is blocked client-side with an inline validation error', async ({
+    page,
+  }) => {
+    let postCalls = 0;
+    await mockWatchlistEndpoints(page, { initial: [] });
+    page.on('request', (req) => {
+      if (req.url().includes('/api/watchlist') && req.method() === 'POST') {
+        postCalls += 1;
+      }
+    });
+    await openWatchlistTab(page);
+
+    // Digits-only is rejected without firing a POST (spec §7.1).
+    await page.getByTestId('settings-watchlist-add-input').fill('123');
+    await page.getByTestId('settings-watchlist-add-button').click();
+
+    const error = page.getByTestId('settings-watchlist-validation-error');
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText('Enter a valid ticker symbol.');
+    expect(postCalls).toBe(0);
+  });
+});
+
+test.describe('Settings → Watchlist — load failure @e2e', () => {
+  test('a failed initial GET shows the amber banner + Retry recovers', async ({
+    page,
+  }) => {
+    let getCalls = 0;
+    await page.route('**/api/watchlist**', (route) => {
+      if (route.request().method() !== 'GET') return route.continue();
+      getCalls += 1;
+      if (getCalls === 1) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ detail: 'Internal Server Error' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tickers: ['AAPL'] }),
+      });
+    });
+
+    await page.goto('/settings?tab=watchlist');
+
+    const banner = page.getByTestId('settings-watchlist-load-error');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("Couldn't load your watchlist.");
+    await expect(banner).not.toContainText('Internal Server Error');
+    // Add controls are disabled while the list is unknown.
+    await expect(page.getByTestId('settings-watchlist-add-input')).toBeDisabled();
+
+    // Retry succeeds — the list renders.
+    await page.getByTestId('settings-watchlist-retry').click();
+    await expect(
+      page.locator('[data-testid="settings-watchlist-item"][data-ticker="AAPL"]'),
+    ).toBeVisible();
+  });
+});
+
+test.describe('Settings → Watchlist — add failure @e2e', () => {
+  test('an add failure shows a generic inline error, never raw server detail', async ({
+    page,
+  }) => {
+    await mockWatchlistEndpoints(page, { initial: ['AAPL'], failAdd: true });
+    await openWatchlistTab(page);
+
+    await page.getByTestId('settings-watchlist-add-input').fill('TSLA');
+    await page.getByTestId('settings-watchlist-add-button').click();
+
+    const error = page.getByTestId('settings-watchlist-add-error');
+    await expect(error).toBeVisible();
+    await expect(error).toContainText("Couldn't add TSLA. Try again.");
+    // CLAUDE.md — the raw 500 detail must not leak.
+    await expect(error).not.toContainText('Internal Server Error');
+    // The trader's typing is preserved.
+    await expect(page.getByTestId('settings-watchlist-add-input')).toHaveValue(
+      'TSLA',
+    );
+  });
+});


### PR DESCRIPTION
## V1.6 — Watchlist (approved-universe gate)

Operationalizes the core wheel discipline — *"only surface names I'd voluntarily own"* — as a system gate instead of a mental note. The trader maintains an approved-underlying watchlist; the options scanner only surfaces candidates from that list. Implements [PRD #213](https://github.com/ssandy33/regress/discussions/213) (the minimal gate — the scored Opportunities dashboard stays iceboxed under #154). Milestone [#36](https://github.com/ssandy33/regress/milestone/36).

### User-visible changes
- **New Watchlist tab in Settings** (`/settings?tab=watchlist`) — add / remove / view your approved tickers, with clear empty-state guidance. (#323)
- **The options scanner now respects the watchlist** — it only returns candidates for approved tickers; an empty watchlist returns an explanatory empty result, not an error. (#322)

### Worker DAG
```
#321 (model + API)  ─┬─►  #322  scanner pre-filter   [backend]
   single source     └─►  #323  Settings UI          [frontend]
```
- **#321** — `watchlist` table (`ticker` PK → idempotent add/remove for free), `GET/POST/DELETE /api/watchlist`, persists across restart. The single source of truth both consumers read.
- **#322** — scanner reads `list_watchlist()`, gates `request.ticker` against it, returns an explanatory empty `200` when blocked. Adds two **additive** response fields (`watchlist_filtered`, `empty_reason`) — backward-compatible, **not** a breaking change. ADR #292-conformant `watchlist_gate.blocked` logging.
- **#323** — 4th Settings tab, `WatchlistSection.jsx`, 3 `api/client.js` helpers, all 8 UI states, single-click remove.

### Tests
- **Backend: 1574 passed, 13 skipped** (the `tests/contract` Schemathesis suite runs in CI — needs `schemathesis`). +34 new watchlist tests (#321: 23, #322: 11).
- **Frontend: 13 Playwright e2e** for the watchlist tab (smoke subset 3/3).
- Gates green locally: `classify_tests` (0 tdd_red), `tdd_red_gate`, OpenAPI drift (55 paths), playwright tag check (35 specs).

### Notes for review
- **#322 bridge edits** (flagged per the parallel-execution append-only convention): the gate now runs upstream of every scan, so 10 pre-existing scan-endpoint tests were updated to seed the watchlist before scanning. One — `test_cc_scan_below_cost_basis_suppressed_when_floor_disabled` — was a latent false-pass (its `not any(...)` assertion was trivially true on a gated-empty response) and now exercises the real path.
- **#323 duplicate-add** is inferred client-side (compares the returned list length) — the only spot the UI interprets the idempotent backend response rather than just rendering it.
- **Scope decisions:** no confirm-on-remove (Q2); the Options-page "filtered to N tickers" banner deferred to a follow-up (Q3); POST returns the full updated list (Q4).

Closes #321
Closes #322
Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)
