### PR TITLE
QA environment — same-VPS second compose stack at qa. subdomain (closes #330)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,13 @@ ALLOWED_USERS=
 # Production deployment (used by docker-compose.prod.yml)
 DOMAIN=regression.yourdomain.com
 
+# QA environment (issue #330): the prod stack now joins a shared external
+# Docker network `caddy_net` so the prod Caddy can reverse-proxy the QA stack
+# (qa-backend / qa-frontend) for the qa.${DOMAIN} site block. Create it once on
+# the box: `docker network create caddy_net`. The QA stack uses its OWN env file
+# — see deploy/qa/.env.template and deploy/qa/README.md. No QA-specific var is
+# needed here; qa.{$DOMAIN} derives from DOMAIN above.
+
 # Optional: basic auth (leave empty for open access)
 BASIC_AUTH_USER=
 BASIC_AUTH_PASS=

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ DOMAIN=regression.yourdomain.com
 # (qa-backend / qa-frontend) for the qa.${DOMAIN} site block. Create it once on
 # the box: `docker network create caddy_net`. The QA stack uses its OWN env file
 # — see deploy/qa/.env.template and deploy/qa/README.md. No QA-specific var is
-# needed here; qa.{$DOMAIN} derives from DOMAIN above.
+# needed here; the QA hostname is qa.${DOMAIN} (rendered in Caddy as qa.{$DOMAIN}).
 
 # Optional: basic auth (leave empty for open access)
 BASIC_AUTH_USER=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,22 @@ jobs:
           path: backend/coverage-integration.xml
           if-no-files-found: ignore
 
+  # Issue #330: validate the QA compose file structurally. `docker compose
+  # config -q` parses + schema-validates docker-compose.qa.yml, so a malformed
+  # QA compose fails CI here (the dynamic mirror of the static assertions in
+  # backend/tests/test_qa_compose_config.py). The DOMAIN env is set so the
+  # ${DOMAIN} interpolation in NEXTAUTH_URL resolves during validation.
+  qa-compose-validate:
+    name: QA compose validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate QA compose file
+        env:
+          DOMAIN: regression.example.com
+        run: docker compose -f docker-compose.qa.yml config -q
+
   frontend-checks:
     name: Frontend checks (lint + build)
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
             git fetch origin main
             git reset --hard origin/main
             mkdir -p data data/backups
+            # docker-compose.prod.yml declares caddy_net as external (issue
+            # #330) — `up -d` fails if it doesn't exist on the box yet.
+            docker network create caddy_net 2>/dev/null || true
             if git diff --name-only "$OLD_HEAD" HEAD | grep -q "deploy/Caddyfile"; then
               echo "Caddyfile changed — clearing Caddy TLS cache to force cert re-issuance"
               docker compose -f docker-compose.prod.yml rm -sf caddy

--- a/backend/scripts/qa_snapshot.py
+++ b/backend/scripts/qa_snapshot.py
@@ -1,0 +1,72 @@
+"""QA DB-snapshot selection helper (issue #330).
+
+The QA refresh script (``deploy/qa-refresh-db.sh``) seeds the QA SQLite volume
+from the newest prod backup snapshot written by ``deploy/backup.sh``
+(``backups/regression_tool_<timestamp>.db``). The snapshot-selection logic
+lives here as a pure function so it is unit-testable without docker or a real
+volume — the shell script is a thin wrapper that shells out to
+``python -m scripts.qa_snapshot <backup_dir>`` and uses the printed path.
+
+The restore itself is intentionally an *in-place overwrite* of the single
+``regression_tool.db`` file inside the QA volume — it never accumulates copies
+(the box runs disk-constrained). Re-running is idempotent: the same snapshot
+selection yields the same source, and the copy clobbers rather than appends.
+
+Usage::
+
+    python -m scripts.qa_snapshot /root/regress/backups
+    # prints the absolute path of the newest regression_tool_*.db, or exits 1
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SNAPSHOT_GLOB = "regression_tool_*.db"
+
+
+def select_newest_snapshot(backup_dir: str | Path) -> Path:
+    """Return the newest ``regression_tool_*.db`` snapshot in ``backup_dir``.
+
+    "Newest" is by filesystem mtime (the timestamp embedded in the filename is
+    monotonic with mtime in practice, but mtime is the authoritative ordering
+    and is robust to clock-format changes in ``backup.sh``).
+
+    Raises:
+        FileNotFoundError: if ``backup_dir`` does not exist or contains no
+            matching snapshot. The caller (shell script) surfaces this as a
+            clear "no snapshot found — run deploy/backup.sh first" error.
+    """
+    directory = Path(backup_dir)
+    if not directory.is_dir():
+        raise FileNotFoundError(f"Backup directory does not exist: {directory}")
+
+    snapshots = sorted(
+        directory.glob(SNAPSHOT_GLOB),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    if not snapshots:
+        raise FileNotFoundError(
+            f"No {SNAPSHOT_GLOB} snapshot found in {directory} "
+            "— run deploy/backup.sh first."
+        )
+    return snapshots[0].resolve()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print("usage: python -m scripts.qa_snapshot <backup_dir>", file=sys.stderr)
+        return 2
+    try:
+        print(select_newest_snapshot(args[0]))
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/backend/tests/test_qa_compose_config.py
+++ b/backend/tests/test_qa_compose_config.py
@@ -1,0 +1,296 @@
+"""Tests for the QA environment configuration (issue #330).
+
+Validates the structure of ``docker-compose.qa.yml``, the QA ``deploy/Caddyfile``
+site block, and the snapshot-selection helper used by ``deploy/qa-refresh-db.sh``.
+These are static-config / pure-logic assertions — there is no FastAPI app, no
+TestClient, no DB session, and no network — so they are ``@pytest.mark.unit``.
+
+Following the established pattern in ``test_observability_configs.py``, the
+compose file is parsed directly with PyYAML rather than shelling out to
+``docker compose config`` (the docker CLI is not available in the unit-test
+runner). The CI ``qa-compose-validate`` step in ``.github/workflows/ci.yml``
+runs ``docker compose -f docker-compose.qa.yml config -q`` as the live
+schema-validation gate (the dynamic mirror of these static assertions).
+
+Live infrastructure ACs that cannot run in CI are recorded as skipped tests with
+a rationale (DNS, TLS issuance, OAuth-app registration, on-VPS refresh run,
+degraded-mode smoke) so the AC↔verification mapping stays complete.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEPLOY_DIR = REPO_ROOT / "deploy"
+QA_COMPOSE_FILE = REPO_ROOT / "docker-compose.qa.yml"
+PROD_COMPOSE_FILE = REPO_ROOT / "docker-compose.prod.yml"
+CADDYFILE = DEPLOY_DIR / "Caddyfile"
+
+# Documented QA memory cap (4 GB box, comfortable tier). Sum of per-service
+# limits must not exceed this. See the PR body / plan Resource Budget.
+QA_MEMORY_CAP_MB = 576
+
+
+def _mem_limit_to_mb(value: str) -> int:
+    """Parse a compose memory limit string (e.g. '384M', '1G') to MB."""
+    value = value.strip().upper()
+    if value.endswith("G"):
+        return int(float(value[:-1]) * 1024)
+    if value.endswith("M"):
+        return int(float(value[:-1]))
+    # Bare bytes
+    return int(value) // (1024 * 1024)
+
+
+@pytest.fixture
+def qa_config() -> dict:
+    """Load and parse docker-compose.qa.yml."""
+    return yaml.safe_load(QA_COMPOSE_FILE.read_text())
+
+
+@pytest.fixture
+def prod_config() -> dict:
+    """Load and parse docker-compose.prod.yml."""
+    return yaml.safe_load(PROD_COMPOSE_FILE.read_text())
+
+
+@pytest.fixture
+def caddyfile_content() -> str:
+    """Load the Caddyfile content."""
+    return CADDYFILE.read_text()
+
+
+class TestQaComposeServices:
+    """Service-set and per-service env invariants of the QA compose."""
+
+    @pytest.mark.unit
+    def test_qa_compose_parses_and_has_backend_frontend_only(self, qa_config: dict) -> None:
+        """QA defines exactly backend + frontend — no loki/grafana/caddy."""
+        assert set(qa_config["services"].keys()) == {"backend", "frontend"}
+
+    @pytest.mark.unit
+    def test_qa_compose_no_host_port_mappings(self, qa_config: dict) -> None:
+        """QA exposes no host ports (reached only via prod Caddy)."""
+        for svc in qa_config["services"].values():
+            assert "ports" not in svc
+
+    @pytest.mark.unit
+    def test_qa_compose_volumes_are_qa_prefixed(self, qa_config: dict) -> None:
+        """Top-level volume is qa_-prefixed; no bare prod-style sqlite_data."""
+        assert "qa_sqlite_data" in qa_config["volumes"]
+        assert "sqlite_data" not in qa_config["volumes"]
+
+    @pytest.mark.unit
+    def test_qa_compose_backend_mounts_qa_volume(self, qa_config: dict) -> None:
+        """Backend mounts the qa_sqlite_data volume at /app/data."""
+        volumes = qa_config["services"]["backend"]["volumes"]
+        assert "qa_sqlite_data:/app/data" in volumes
+
+    @pytest.mark.unit
+    def test_qa_compose_memory_limits_set_on_all_services(self, qa_config: dict) -> None:
+        """Every service has deploy.resources.limits.memory; sum <= cap."""
+        total = 0
+        for svc in qa_config["services"].values():
+            mem = svc["deploy"]["resources"]["limits"]["memory"]
+            total += _mem_limit_to_mb(mem)
+        assert total <= QA_MEMORY_CAP_MB
+
+    @pytest.mark.unit
+    def test_qa_compose_omits_schwab_encryption_key(self, qa_config: dict) -> None:
+        """Schwab vars absent — QA runs in degraded (no-Schwab) mode."""
+        env = qa_config["services"]["backend"]["environment"]
+        env_keys = {item.split("=", 1)[0] for item in env}
+        assert "SCHWAB_ENCRYPTION_KEY" not in env_keys
+
+    @pytest.mark.unit
+    def test_qa_compose_no_loki_logging_driver(self, qa_config: dict) -> None:
+        """Neither service uses the loki log driver (QA has no Loki)."""
+        for svc in qa_config["services"].values():
+            logging_block = svc.get("logging", {})
+            assert logging_block.get("driver") != "loki"
+
+    @pytest.mark.unit
+    def test_qa_compose_axiom_dataset_is_qa(self, qa_config: dict) -> None:
+        """Backend routes Axiom logs to the dedicated regression-tool-qa dataset."""
+        env = qa_config["services"]["backend"]["environment"]
+        dataset_line = next(e for e in env if e.startswith("AXIOM_DATASET="))
+        assert "regression-tool-qa" in dataset_line
+
+    @pytest.mark.unit
+    def test_qa_compose_nextauth_url_is_qa_subdomain(self, qa_config: dict) -> None:
+        """Frontend NEXTAUTH_URL targets the qa. subdomain."""
+        env = qa_config["services"]["frontend"]["environment"]
+        url_line = next(e for e in env if e.startswith("NEXTAUTH_URL="))
+        assert "qa." in url_line.split("=", 1)[1]
+
+    @pytest.mark.unit
+    def test_qa_compose_frontend_api_origin_targets_qa_backend(self, qa_config: dict) -> None:
+        """Frontend talks to qa-backend, not the prod backend alias."""
+        env = qa_config["services"]["frontend"]["environment"]
+        origin_line = next(e for e in env if e.startswith("INTERNAL_API_ORIGIN="))
+        assert "qa-backend" in origin_line
+
+
+class TestQaComposeNetwork:
+    """Shared external caddy_net wiring."""
+
+    @pytest.mark.unit
+    def test_qa_compose_joins_external_caddy_net(self, qa_config: dict) -> None:
+        """caddy_net is declared external and both services attach to it."""
+        net = qa_config["networks"]["caddy_net"]
+        assert net["external"] is True
+        for name in ("backend", "frontend"):
+            assert "caddy_net" in qa_config["services"][name]["networks"]
+
+    @pytest.mark.unit
+    def test_qa_compose_service_aliases(self, qa_config: dict) -> None:
+        """Services publish the qa-backend / qa-frontend aliases on caddy_net."""
+        backend_net = qa_config["services"]["backend"]["networks"]["caddy_net"]
+        frontend_net = qa_config["services"]["frontend"]["networks"]["caddy_net"]
+        assert "qa-backend" in backend_net["aliases"]
+        assert "qa-frontend" in frontend_net["aliases"]
+
+
+class TestProdComposeNetwork:
+    """The prod compose must also join caddy_net so its Caddy can reach QA."""
+
+    @pytest.mark.unit
+    def test_prod_compose_declares_external_caddy_net(self, prod_config: dict) -> None:
+        """Prod declares caddy_net as an external network."""
+        assert prod_config["networks"]["caddy_net"]["external"] is True
+
+    @pytest.mark.unit
+    def test_prod_caddy_joins_caddy_net(self, prod_config: dict) -> None:
+        """The prod caddy service attaches to caddy_net to route to QA."""
+        assert "caddy_net" in prod_config["services"]["caddy"]["networks"]
+
+
+class TestQaCaddyfile:
+    """QA site block in the shared Caddyfile."""
+
+    @pytest.mark.unit
+    def test_caddyfile_has_qa_site_block(self, caddyfile_content: str) -> None:
+        """A qa.{$DOMAIN} site block exists."""
+        assert "qa.{$DOMAIN} {" in caddyfile_content
+
+    @pytest.mark.unit
+    def test_qa_block_routes_to_qa_aliases(self, caddyfile_content: str) -> None:
+        """The QA block reverse-proxies to qa-backend / qa-frontend."""
+        qa_start = caddyfile_content.index("qa.{$DOMAIN} {")
+        qa_block = caddyfile_content[qa_start:]
+        assert "qa-backend:8000" in qa_block
+        assert "qa-frontend:8080" in qa_block
+
+    @pytest.mark.unit
+    def test_qa_block_has_no_grafana_handler(self, caddyfile_content: str) -> None:
+        """QA block has no /grafana handler (QA has no Grafana)."""
+        qa_start = caddyfile_content.index("qa.{$DOMAIN} {")
+        qa_block = caddyfile_content[qa_start:]
+        assert "/grafana" not in qa_block
+
+    @pytest.mark.unit
+    def test_qa_block_has_no_basic_auth_placeholder(self, caddyfile_content: str) -> None:
+        """QA block omits the BASIC_AUTH placeholder (prod-only injection)."""
+        qa_start = caddyfile_content.index("qa.{$DOMAIN} {")
+        qa_block = caddyfile_content[qa_start:]
+        assert "BASIC_AUTH_BLOCK" not in qa_block
+
+    @pytest.mark.unit
+    def test_prod_caddy_block_unchanged(self, caddyfile_content: str) -> None:
+        """The prod {$DOMAIN} block still proxies to backend/frontend, not qa-*."""
+        # The prod block is the leading site block, before the QA section
+        # header comment. Slicing on that sentinel avoids matching the literal
+        # "{$DOMAIN} {" that also appears inside "qa.{$DOMAIN} {".
+        prod_block = caddyfile_content.split("# QA site block", 1)[0]
+        assert prod_block.startswith("{$DOMAIN} {")
+        assert "backend:8000" in prod_block
+        assert "frontend:8080" in prod_block
+        assert "qa-backend" not in prod_block
+        assert "qa-frontend" not in prod_block
+
+
+class TestQaSnapshotSelection:
+    """Pure-logic tests for the refresh-script snapshot selection helper."""
+
+    @pytest.mark.unit
+    def test_qa_refresh_db_selects_newest_snapshot(self, tmp_path: Path) -> None:
+        """select_newest_snapshot picks the most recently modified snapshot."""
+        from scripts.qa_snapshot import select_newest_snapshot
+
+        old = tmp_path / "regression_tool_20260101_000000.db"
+        new = tmp_path / "regression_tool_20260201_000000.db"
+        old.write_bytes(b"old")
+        new.write_bytes(b"new")
+        # Force a clear mtime ordering regardless of write order.
+        import os
+
+        os.utime(old, (1000, 1000))
+        os.utime(new, (2000, 2000))
+
+        assert select_newest_snapshot(tmp_path) == new.resolve()
+
+    @pytest.mark.unit
+    def test_qa_refresh_db_idempotent_overwrite(self, tmp_path: Path) -> None:
+        """Re-selecting yields the same single snapshot (no duplication)."""
+        from scripts.qa_snapshot import select_newest_snapshot
+
+        snap = tmp_path / "regression_tool_20260201_000000.db"
+        snap.write_bytes(b"data")
+
+        first = select_newest_snapshot(tmp_path)
+        second = select_newest_snapshot(tmp_path)
+        assert first == second == snap.resolve()
+        # Only one snapshot present — selection never created copies.
+        assert len(list(tmp_path.glob("regression_tool_*.db"))) == 1
+
+    @pytest.mark.unit
+    def test_qa_refresh_db_no_snapshot_raises(self, tmp_path: Path) -> None:
+        """Empty backup dir raises a clear FileNotFoundError."""
+        from scripts.qa_snapshot import select_newest_snapshot
+
+        with pytest.raises(FileNotFoundError):
+            select_newest_snapshot(tmp_path)
+
+    @pytest.mark.unit
+    def test_qa_refresh_db_missing_dir_raises(self, tmp_path: Path) -> None:
+        """Nonexistent backup dir raises a clear FileNotFoundError."""
+        from scripts.qa_snapshot import select_newest_snapshot
+
+        with pytest.raises(FileNotFoundError):
+            select_newest_snapshot(tmp_path / "does-not-exist")
+
+
+class TestQaManualInfraACs:
+    """Live-infra ACs that cannot run in CI — recorded as skipped per CLAUDE.md.
+
+    These keep the AC↔verification mapping complete. They are verified manually
+    on the VPS and documented in deploy/qa/README.md; the run-log is pasted into
+    the PR description.
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.skip(reason="M1: DNS A record qa.<domain> is external infra — verify with `dig qa.<domain>`.")
+    def test_qa_dns_a_record_resolves(self) -> None:  # pragma: no cover
+        ...
+
+    @pytest.mark.unit
+    @pytest.mark.skip(reason="M2: qa.<domain> auto-TLS depends on live Caddy + DNS — verify with `curl -I https://qa.<domain>`.")
+    def test_qa_serves_valid_tls_cert(self) -> None:  # pragma: no cover
+        ...
+
+    @pytest.mark.unit
+    @pytest.mark.skip(reason="M3: GitHub OAuth app registration is a manual console step — cannot register in CI.")
+    def test_qa_github_oauth_app_login(self) -> None:  # pragma: no cover
+        ...
+
+    @pytest.mark.unit
+    @pytest.mark.skip(reason="M4: qa-refresh-db.sh end-to-end needs the real prod volume + docker on the VPS — run-log pasted into PR.")
+    def test_qa_refresh_db_live_run(self) -> None:  # pragma: no cover
+        ...
+
+    @pytest.mark.unit
+    @pytest.mark.skip(reason="M5: degraded-mode (no-Schwab) live smoke — verify with `curl https://qa.<domain>/api/health` post-deploy.")
+    def test_qa_starts_in_degraded_mode(self) -> None:  # pragma: no cover
+        ...

--- a/backend/tests/test_qa_compose_config.py
+++ b/backend/tests/test_qa_compose_config.py
@@ -90,11 +90,13 @@ class TestQaComposeServices:
 
     @pytest.mark.unit
     def test_qa_compose_memory_limits_set_on_all_services(self, qa_config: dict) -> None:
-        """Every service has deploy.resources.limits.memory; sum <= cap."""
+        """Each service carries its documented cap (backend 384M, frontend 192M); sum <= cap."""
+        expected_mb = {"backend": 384, "frontend": 192}
         total = 0
-        for svc in qa_config["services"].values():
-            mem = svc["deploy"]["resources"]["limits"]["memory"]
-            total += _mem_limit_to_mb(mem)
+        for name, svc in qa_config["services"].items():
+            mem = _mem_limit_to_mb(svc["deploy"]["resources"]["limits"]["memory"])
+            assert mem == expected_mb[name]
+            total += mem
         assert total <= QA_MEMORY_CAP_MB
 
     @pytest.mark.unit

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -63,3 +63,55 @@
 		}
 	}
 }
+
+# QA site block (issue #330). Same prod Caddy terminates TLS for qa.{$DOMAIN}
+# and reverse-proxies to the QA stack (docker-compose.qa.yml) across the shared
+# external caddy_net using the qa-backend / qa-frontend service aliases.
+#
+# Intentionally NO /grafana handler and NO basic-auth placeholder here: QA has
+# no Grafana, and caddy-entrypoint.sh only injects BASIC_AUTH into the prod
+# block's placeholder, so QA stays open by design. TLS for qa.{$DOMAIN} requires
+# the qa. DNS A record to resolve to the VPS IP before this block is deployed
+# (otherwise ACME issuance fails for QA only; the prod block is unaffected).
+qa.{$DOMAIN} {
+	# Compression
+	encode gzip
+
+	# Security headers (same set as the prod block; CSP is owned by Next.js)
+	header {
+		X-Frame-Options "DENY"
+		X-Content-Type-Options "nosniff"
+		X-XSS-Protection "1; mode=block"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		Permissions-Policy "camera=(), microphone=(), geolocation=()"
+		Strict-Transport-Security "max-age=31536000; includeSubDomains"
+		-Server
+	}
+
+	# NextAuth routes — handled by the QA frontend, not the backend
+	handle /api/auth/* {
+		reverse_proxy qa-frontend:8080 {
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto {scheme}
+		}
+	}
+
+	# API reverse proxy
+	handle /api/* {
+		reverse_proxy qa-backend:8000 {
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto {scheme}
+		}
+	}
+
+	# Frontend reverse proxy
+	handle {
+		reverse_proxy qa-frontend:8080 {
+			header_up X-Real-IP {remote_host}
+			header_up X-Forwarded-For {remote_host}
+			header_up X-Forwarded-Proto {scheme}
+		}
+	}
+}

--- a/deploy/LOGGING.md
+++ b/deploy/LOGGING.md
@@ -31,6 +31,26 @@ The regression_tool backend supports optional centralized logging via [Axiom](ht
 
 Unset `AXIOM_API_TOKEN` and restart. Behavior reverts to stdout-only — no Axiom code is exercised, no background thread is started.
 
+## QA dataset (issue #330)
+
+The QA stack (`docker-compose.qa.yml`) is the QA distinguisher for observability:
+it reuses the **same** `AXIOM_API_TOKEN` as prod but routes every event to a
+**dedicated dataset**, `AXIOM_DATASET=regression-tool-qa`, so prod and QA logs
+never interleave. This is a zero-code-change distinguisher — `AXIOM_DATASET` is
+already env-driven.
+
+| | Prod | QA |
+|---|---|---|
+| `AXIOM_DATASET` | `regression-tool` | `regression-tool-qa` |
+| Compose file | `docker-compose.prod.yml` | `docker-compose.qa.yml` |
+| Container stdout | Loki driver → Loki/Grafana | default json-file (`docker logs qa-backend`) |
+
+QA has **no Loki/Grafana** — the loki log driver is a host-wide plugin pointing
+at `localhost:3100`, which QA doesn't run. The QA compose therefore omits the
+`logging:` block entirely and uses Docker's default `json-file` driver. Axiom
+carries the structured logs; `docker logs qa-backend` is the local fallback.
+Create the `regression-tool-qa` dataset in the Axiom UI before first QA deploy.
+
 ## How it works
 
 - `backend/app/logging_axiom.py` implements `AxiomHandler`, a `logging.Handler` subclass.

--- a/deploy/qa-deploy.sh
+++ b/deploy/qa-deploy.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================
+# QA environment — deploy / redeploy the QA stack (issue #330)
+# ============================================================
+# First-time or repeat deploy of the QA stack (project: regress-qa). Run
+# manually over SSH from the QA clone at /root/regress-qa — there is no CI for
+# QA.
+#
+# Prerequisites (see deploy/qa/README.md):
+#   - qa.<domain> DNS A record resolves to the VPS IP
+#   - /root/regress-qa/.env created from deploy/qa/.env.template (QA OAuth app,
+#     fresh NEXTAUTH_SECRET, AXIOM_DATASET=regression-tool-qa, no Schwab key)
+#   - The prod stack has been deployed at least once with the qa.{$DOMAIN}
+#     Caddy block + caddy_net attachment (so the prod Caddy can route to QA)
+#
+# Usage:
+#   bash deploy/qa-deploy.sh
+
+APP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_DIR"
+
+COMPOSE="docker compose -p regress-qa -f docker-compose.qa.yml"
+
+echo "=== QA stack deploy ==="
+echo ""
+
+# --------------------------------------------------
+# 1. Ensure the shared external network exists
+# --------------------------------------------------
+echo ">>> Ensuring caddy_net exists..."
+docker network create caddy_net 2>/dev/null || true
+echo ""
+
+# --------------------------------------------------
+# 2. Pull latest QA code
+# --------------------------------------------------
+echo ">>> Pulling latest changes..."
+git pull
+echo ""
+
+# --------------------------------------------------
+# 3. Build and start the QA stack
+# --------------------------------------------------
+echo ">>> Building and starting QA containers..."
+$COMPOSE up -d --build
+echo ""
+
+# --------------------------------------------------
+# 4. Wait for services to become healthy (mirrors deploy.sh step 11)
+# --------------------------------------------------
+echo ">>> Waiting for QA services to become healthy..."
+sleep 10
+
+MAX_RETRIES=12
+RETRY_COUNT=0
+while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+    if $COMPOSE ps | grep -q "unhealthy\|starting"; then
+        echo "  Waiting for services... ($(( RETRY_COUNT + 1 ))/${MAX_RETRIES})"
+        sleep 10
+        RETRY_COUNT=$(( RETRY_COUNT + 1 ))
+    else
+        break
+    fi
+done
+echo ""
+
+# --------------------------------------------------
+# 5. Status
+# --------------------------------------------------
+echo ">>> QA container status:"
+$COMPOSE ps
+echo ""
+
+echo "=========================================="
+echo ""
+echo "  QA stack started. Once DNS + prod Caddy are in place it serves at"
+echo "  https://qa.\${DOMAIN}"
+echo ""
+echo "=========================================="
+echo ""
+echo "Next steps:"
+echo "  Seed QA DB:  bash deploy/qa-refresh-db.sh"
+echo "  Verify:      curl -I https://qa.<domain> && curl https://qa.<domain>/api/health"
+echo "  Logs:        docker compose -p regress-qa -f docker-compose.qa.yml logs -f"
+echo ""

--- a/deploy/qa-deploy.sh
+++ b/deploy/qa-deploy.sh
@@ -53,16 +53,20 @@ echo ""
 echo ">>> Waiting for QA services to become healthy..."
 sleep 10
 
+# Success is BOTH services reporting (healthy) — not merely the absence of
+# "unhealthy|starting" output. A container that exited or is restart-looping
+# must fail the deploy, not print a false green.
+EXPECTED_HEALTHY=2
 MAX_RETRIES=12
 RETRY_COUNT=0
 while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
-    if $COMPOSE ps | grep -q "unhealthy\|starting"; then
-        echo "  Waiting for services... ($(( RETRY_COUNT + 1 ))/${MAX_RETRIES})"
-        sleep 10
-        RETRY_COUNT=$(( RETRY_COUNT + 1 ))
-    else
+    HEALTHY_COUNT=$($COMPOSE ps | grep -c "(healthy)" || true)
+    if [ "$HEALTHY_COUNT" -ge "$EXPECTED_HEALTHY" ]; then
         break
     fi
+    echo "  Waiting for services... ($(( RETRY_COUNT + 1 ))/${MAX_RETRIES})"
+    sleep 10
+    RETRY_COUNT=$(( RETRY_COUNT + 1 ))
 done
 echo ""
 
@@ -72,6 +76,13 @@ echo ""
 echo ">>> QA container status:"
 $COMPOSE ps
 echo ""
+
+HEALTHY_COUNT=$($COMPOSE ps | grep -c "(healthy)" || true)
+if [ "$HEALTHY_COUNT" -lt "$EXPECTED_HEALTHY" ]; then
+    echo "ERROR: QA deploy failed — only ${HEALTHY_COUNT}/${EXPECTED_HEALTHY} services are healthy." >&2
+    echo "       Inspect with: $COMPOSE ps && $COMPOSE logs --tail=100" >&2
+    exit 1
+fi
 
 echo "=========================================="
 echo ""

--- a/deploy/qa-refresh-db.sh
+++ b/deploy/qa-refresh-db.sh
@@ -76,23 +76,34 @@ echo ">>> Stopping qa-backend..."
 $COMPOSE stop backend
 echo ""
 
+# From here on qa-backend is down. Restart it on ANY exit so a failed restore
+# can't leave QA offline; the happy path clears the trap before its own restart.
+trap '$COMPOSE start backend || true' EXIT
+
 # --------------------------------------------------
 # 4. Overwrite the DB in the QA volume via a throwaway alpine container
 #    (same volume-access pattern as deploy/backup.sh). In-place, no temp copies.
 # --------------------------------------------------
 echo ">>> Restoring snapshot into $QA_VOLUME (in place)..."
 SNAP_BASENAME="$(basename "$SOURCE_SNAPSHOT")"
+# chown to the qa-backend runtime user (1000:1000 in docker-compose.qa.yml) —
+# the copy runs as root, and a root-owned DB breaks the backend's first write.
+# Stale -wal/-shm sidecars from the previous DB are removed so SQLite can't
+# replay an old WAL against the freshly restored file.
 docker run --rm \
     -v "$RESOLVED_VOLUME":/data \
     -v "$(cd "$(dirname "$SOURCE_SNAPSHOT")" && pwd)":/snapshot:ro \
     alpine:latest \
-    sh -c "cp /snapshot/'$SNAP_BASENAME' /data/regression_tool.db"
+    sh -c "rm -f /data/regression_tool.db-wal /data/regression_tool.db-shm \
+        && cp /snapshot/'$SNAP_BASENAME' /data/regression_tool.db \
+        && chown 1000:1000 /data/regression_tool.db"
 echo ""
 
 # --------------------------------------------------
 # 5. Restart qa-backend (re-opens the fresh DB)
 # --------------------------------------------------
 echo ">>> Restarting qa-backend..."
+trap - EXIT
 $COMPOSE start backend
 echo ""
 

--- a/deploy/qa-refresh-db.sh
+++ b/deploy/qa-refresh-db.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================
+# QA environment — on-demand DB refresh (issue #330)
+# ============================================================
+# Seeds the QA SQLite volume from the newest prod backup snapshot written by
+# deploy/backup.sh (../regress/backups/regression_tool_<timestamp>.db).
+#
+# The restore is an IN-PLACE overwrite of the single regression_tool.db inside
+# the QA volume — it never accumulates copies (the box runs disk-constrained).
+# Re-running is idempotent.
+#
+# Usage (on the VPS, from the QA clone at /root/regress-qa):
+#   bash deploy/qa-refresh-db.sh
+#
+# Overrides:
+#   BACKUP_DIR=/path/to/backups  bash deploy/qa-refresh-db.sh
+#   SNAPSHOT=/path/to/snap.db    bash deploy/qa-refresh-db.sh   # skip selection
+
+APP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_DIR"
+
+COMPOSE="docker compose -p regress-qa -f docker-compose.qa.yml"
+
+# Prod backups live alongside the prod clone (../regress/backups by default).
+BACKUP_DIR="${BACKUP_DIR:-$APP_DIR/../regress/backups}"
+
+# Fully-qualified QA volume name. NOTE: must match `regress-qa_qa_sqlite_data`
+# exactly — a bare `grep sqlite_data` would also match the prod volume
+# `regress_sqlite_data` and risk clobbering prod (see plan risk #5).
+QA_VOLUME="regress-qa_qa_sqlite_data"
+
+echo "=== QA DB refresh ==="
+echo ""
+
+# --------------------------------------------------
+# 1. Select the source snapshot
+# --------------------------------------------------
+if [ -n "${SNAPSHOT:-}" ]; then
+    SOURCE_SNAPSHOT="$SNAPSHOT"
+    if [ ! -f "$SOURCE_SNAPSHOT" ]; then
+        echo "ERROR: SNAPSHOT override not found: $SOURCE_SNAPSHOT" >&2
+        exit 1
+    fi
+else
+    echo ">>> Selecting newest snapshot in $BACKUP_DIR ..."
+    # Pure-Python selection (unit-tested via backend/scripts/qa_snapshot.py).
+    SOURCE_SNAPSHOT="$(cd "$APP_DIR/backend" && python -m scripts.qa_snapshot "$BACKUP_DIR")" || {
+        echo "ERROR: no snapshot found. Run deploy/backup.sh on prod first." >&2
+        exit 1
+    }
+fi
+
+SNAP_SIZE=$(du -h "$SOURCE_SNAPSHOT" | cut -f1)
+SNAP_TIME=$(date -r "$SOURCE_SNAPSHOT" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "unknown")
+echo "    Source:    $SOURCE_SNAPSHOT"
+echo "    Size:      $SNAP_SIZE"
+echo "    Modified:  $SNAP_TIME"
+echo ""
+
+# --------------------------------------------------
+# 2. Resolve the QA volume exactly (collision-safe)
+# --------------------------------------------------
+RESOLVED_VOLUME=$(docker volume ls -q | grep -x "$QA_VOLUME" || true)
+if [ -z "$RESOLVED_VOLUME" ]; then
+    echo "ERROR: QA volume '$QA_VOLUME' not found. Deploy the QA stack first" >&2
+    echo "       (bash deploy/qa-deploy.sh)." >&2
+    exit 1
+fi
+
+# --------------------------------------------------
+# 3. Stop qa-backend for a clean SQLite copy (WAL/lock safety)
+# --------------------------------------------------
+echo ">>> Stopping qa-backend..."
+$COMPOSE stop backend
+echo ""
+
+# --------------------------------------------------
+# 4. Overwrite the DB in the QA volume via a throwaway alpine container
+#    (same volume-access pattern as deploy/backup.sh). In-place, no temp copies.
+# --------------------------------------------------
+echo ">>> Restoring snapshot into $QA_VOLUME (in place)..."
+SNAP_BASENAME="$(basename "$SOURCE_SNAPSHOT")"
+docker run --rm \
+    -v "$RESOLVED_VOLUME":/data \
+    -v "$(cd "$(dirname "$SOURCE_SNAPSHOT")" && pwd)":/snapshot:ro \
+    alpine:latest \
+    sh -c "cp /snapshot/'$SNAP_BASENAME' /data/regression_tool.db"
+echo ""
+
+# --------------------------------------------------
+# 5. Restart qa-backend (re-opens the fresh DB)
+# --------------------------------------------------
+echo ">>> Restarting qa-backend..."
+$COMPOSE start backend
+echo ""
+
+echo "=== QA DB refresh complete ==="
+echo "    Restored from: $SOURCE_SNAPSHOT ($SNAP_SIZE, $SNAP_TIME)"
+echo "    Into volume:   $QA_VOLUME -> /app/data/regression_tool.db"
+echo ""

--- a/deploy/qa/.env.template
+++ b/deploy/qa/.env.template
@@ -1,0 +1,55 @@
+# ============================================================
+# QA environment template (issue #330)
+# ============================================================
+# Copy this to /root/regress-qa/.env on the VPS and fill in the QA-specific
+# values. NEVER commit a filled-in copy — placeholders only.
+#
+#   cp deploy/qa/.env.template /root/regress-qa/.env
+#   chmod 600 /root/regress-qa/.env
+#
+# QA is a throwaway pre-production stack. It runs in degraded (no-Schwab) mode:
+# there is intentionally NO SCHWAB_ENCRYPTION_KEY / SCHWAB_APP_* here.
+
+# --- Domain ---
+# The base domain. The QA stack is served at qa.${DOMAIN} by the prod Caddy.
+# Use the SAME value as the prod .env so the qa.{$DOMAIN} Caddy block resolves.
+DOMAIN=regression.yourdomain.com
+
+# --- Data sources (reused from prod, free tiers) ---
+# FRED economic data key.
+FRED_API_KEY=
+
+# Alpha Vantage earnings-calendar key. NOTE: the free tier is 25 req/day and is
+# SHARED with prod (same key). A QA soak that hammers earnings can exhaust prod's
+# daily quota — see deploy/qa/README.md.
+ALPHA_VANTAGE_API_KEY=
+
+# --- Authentication (QA GitHub OAuth app — DEDICATED, not the prod app) ---
+# Register a SEPARATE GitHub OAuth app for QA at
+# https://github.com/settings/developers
+#   Homepage URL:    https://qa.${DOMAIN}
+#   Callback URL:    https://qa.${DOMAIN}/api/auth/callback/github
+# Reusing the prod GITHUB_ID would send the OAuth callback to the prod domain.
+GITHUB_ID=
+GITHUB_SECRET=
+
+# QA NextAuth secret — generate a FRESH one (do not reuse prod's):
+#   openssl rand -base64 32
+NEXTAUTH_SECRET=
+
+# QA NextAuth URL — must be the qa. subdomain over HTTPS.
+NEXTAUTH_URL=https://qa.regression.yourdomain.com
+
+# Comma-separated GitHub usernames allowed to log in (empty = any authenticated).
+ALLOWED_USERS=
+
+# --- Observability (Axiom) ---
+# Reuse the same Axiom API token as prod, but route QA events to a DEDICATED
+# dataset so prod and QA logs never interleave. This is the QA distinguisher —
+# AXIOM_DATASET is already env-driven, so no backend code changes.
+AXIOM_API_TOKEN=
+AXIOM_DATASET=regression-tool-qa
+
+# --- Optional ---
+# Slack webhook for QA alerts (leave empty to disable).
+SLACK_WEBHOOK_URL=

--- a/deploy/qa/README.md
+++ b/deploy/qa/README.md
@@ -1,0 +1,163 @@
+# QA Environment (issue #330)
+
+A second Docker Compose project (`regress-qa`) on the **same VPS** as prod,
+served at `qa.<domain>`. QA runs only `backend` + `frontend` — no Caddy, no
+Loki, no Grafana. The **existing prod Caddy** terminates TLS for `qa.<domain>`
+and reverse-proxies to the QA containers across a shared external Docker network
+(`caddy_net`) using the `qa-backend` / `qa-frontend` aliases.
+
+QA data is an on-demand restore of a prod backup snapshot. Observability is
+Axiom-only, routed to a dedicated dataset (`AXIOM_DATASET=regression-tool-qa`);
+`docker logs qa-backend` (json-file driver) is the fallback.
+
+This is the same-VPS precursor to #324 — every artifact here is forward-portable
+to a dedicated host.
+
+---
+
+## Architecture at a glance
+
+| Component | Prod (`regress`) | QA (`regress-qa`) |
+|---|---|---|
+| Compose file | `docker-compose.prod.yml` | `docker-compose.qa.yml` |
+| App dir on box | `/root/regress` | `/root/regress-qa` |
+| Caddy | ✅ owns ports 80/443 | ❌ reuses prod Caddy |
+| Loki + Grafana | ✅ | ❌ |
+| TLS for | `<domain>` | `qa.<domain>` (via prod Caddy) |
+| Volume | `regress_sqlite_data` | `regress-qa_qa_sqlite_data` |
+| Axiom dataset | `regression-tool` | `regression-tool-qa` |
+| Schwab | ✅ | ❌ degraded mode |
+| Memory cap | backend 512M / frontend 256M | backend 384M / frontend 192M |
+
+The only genuinely shared component is Caddy. Everything else is namespaced
+under `qa-` / `qa_` + the `regress-qa` project prefix, so no collision is
+possible.
+
+---
+
+## ⚠️ Two prod-impact warnings — read before deploying
+
+1. **Adding the `qa.<domain>` Caddy block wipes ALL TLS certs on the next prod
+   deploy.** `.github/workflows/deploy.yml` does, on *any* `deploy/Caddyfile`
+   diff: `docker compose rm -sf caddy` + `docker volume rm regress_caddy_data`.
+   So the first prod deploy after the QA block lands **re-issues every cert
+   (prod + qa)**. Do it during low traffic, and make sure the `qa.<domain>` DNS
+   A record already resolves so Caddy can issue the QA cert on first boot.
+   Repeated re-issuance hits Let's Encrypt rate limits.
+
+2. **Don't `docker network rm caddy_net` while either stack is up.** It is an
+   `external: true` network — neither stack auto-creates it, and removing it
+   with active endpoints errors. Create it once (below) and leave it.
+
+---
+
+## First-time setup (operator, on the VPS, in order)
+
+1. **Create the DNS A record** `qa.<domain>` → VPS IP (`5.78.124.155`). Wait
+   for it to resolve:
+
+   ```bash
+   dig +short qa.<domain>
+   ```
+
+2. **Register a dedicated GitHub OAuth app for QA**
+   (<https://github.com/settings/developers>):
+   - Homepage URL: `https://qa.<domain>`
+   - Authorization callback URL: `https://qa.<domain>/api/auth/callback/github`
+   - Copy the Client ID + Secret. Do **not** reuse the prod app — its callback
+     points at the prod domain.
+
+3. **Create the shared external network** (once):
+
+   ```bash
+   docker network create caddy_net
+   ```
+
+4. **Clone the repo to `/root/regress-qa`** and create its `.env`:
+
+   ```bash
+   git clone <repo-url> /root/regress-qa
+   cp /root/regress-qa/deploy/qa/.env.template /root/regress-qa/.env
+   chmod 600 /root/regress-qa/.env
+   # then edit .env: QA OAuth creds, a FRESH NEXTAUTH_SECRET (openssl rand -base64 32),
+   # reused FRED/AV/Axiom token, AXIOM_DATASET=regression-tool-qa, NO Schwab key.
+   ```
+
+5. **Deploy prod once** to activate the `qa.{$DOMAIN}` Caddy block + the
+   `caddy_net` attachment (⚠️ see warning #1 — this re-issues certs; DNS must
+   already be in place):
+
+   ```bash
+   cd /root/regress && bash deploy/update.sh
+   ```
+
+6. **Deploy the QA stack:**
+
+   ```bash
+   cd /root/regress-qa && bash deploy/qa-deploy.sh
+   ```
+
+7. **Seed the QA DB** from the latest prod snapshot (run `deploy/backup.sh` on
+   prod first if there's no recent snapshot):
+
+   ```bash
+   cd /root/regress-qa && bash deploy/qa-refresh-db.sh
+   ```
+
+8. **Verify:**
+
+   ```bash
+   curl -I https://qa.<domain>            # valid auto-TLS cert
+   curl https://qa.<domain>/api/health    # ok in degraded (no-Schwab) mode
+   # then log into QA via the QA OAuth app
+   ```
+
+---
+
+## Routine operations
+
+**Refresh the QA DB from the latest prod snapshot** (idempotent, in-place
+overwrite — never accumulates copies):
+
+```bash
+cd /root/regress-qa && bash deploy/qa-refresh-db.sh
+# Overrides:
+#   BACKUP_DIR=/path/to/backups bash deploy/qa-refresh-db.sh
+#   SNAPSHOT=/path/to/snap.db   bash deploy/qa-refresh-db.sh
+```
+
+**Update QA to the latest code:**
+
+```bash
+cd /root/regress-qa && bash deploy/qa-deploy.sh
+```
+
+**Logs** (Axiom dataset `regression-tool-qa`, or local):
+
+```bash
+docker compose -p regress-qa -f docker-compose.qa.yml logs -f
+docker logs qa-backend
+```
+
+**Tear down QA** (prod untouched; add `-v` to also drop the QA volume):
+
+```bash
+cd /root/regress-qa && docker compose -p regress-qa -f docker-compose.qa.yml down
+```
+
+---
+
+## Notes / caveats
+
+- **Shared Alpha Vantage key (25 req/day).** QA reuses prod's AV key. A QA soak
+  that hammers earnings endpoints can exhaust prod's daily quota. Don't soak
+  earnings-heavy flows on QA during prod-critical windows.
+- **Degraded mode.** QA has no `SCHWAB_ENCRYPTION_KEY`; the app runs in its
+  existing no-Schwab degraded mode. Live quotes/Schwab features are unavailable
+  on QA by design.
+- **External-network ordering.** On a full prod `down`, `caddy_net` survives
+  because QA still references it. If both stacks are down, recreate it with
+  `docker network create caddy_net` before bringing either back up.
+- **Forward-compatibility (#324).** The compose file, env template, and refresh
+  script are written to port cleanly to a dedicated QA host: only the Caddy
+  routing and the `caddy_net` sharing are same-VPS-specific.

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -16,6 +16,13 @@ echo ">>> Pulling latest changes..."
 git pull
 echo ""
 
+# Ensure the shared external caddy_net exists before `up -d` (issue #330).
+# The prod compose now declares caddy_net as external; without this guard a
+# prod-only operator would hit a "network not found" error. Idempotent.
+echo ">>> Ensuring caddy_net exists..."
+docker network create caddy_net 2>/dev/null || true
+echo ""
+
 # Rebuild containers
 echo ">>> Building containers..."
 docker compose -f docker-compose.prod.yml build

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,12 @@ services:
       - BASIC_AUTH_USER=${BASIC_AUTH_USER:-}
       - BASIC_AUTH_PASS=${BASIC_AUTH_PASS:-}
     entrypoint: /entrypoint.sh
+    # Joins the shared external caddy_net so this prod Caddy can reverse-proxy
+    # the QA stack (qa-backend / qa-frontend aliases) for the qa.{$DOMAIN} site
+    # block. See docker-compose.qa.yml and deploy/qa/README.md (issue #330).
+    networks:
+      - default
+      - caddy_net
     depends_on:
       frontend:
         condition: service_healthy
@@ -95,6 +101,9 @@ services:
       - AXIOM_DATASET=${AXIOM_DATASET:-regression-tool}
     volumes:
       - sqlite_data:/app/data
+    networks:
+      - default
+      - caddy_net
     logging:
       driver: loki
       options:
@@ -128,6 +137,9 @@ services:
       - GITHUB_SECRET=${GITHUB_SECRET:-}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-}
       - ALLOWED_USERS=${ALLOWED_USERS:-}
+    networks:
+      - default
+      - caddy_net
     logging:
       driver: loki
       options:
@@ -146,6 +158,18 @@ services:
       resources:
         limits:
           memory: 256M
+
+networks:
+  # Implicit project network, kept for intra-prod service DNS
+  # (caddy -> backend/frontend, grafana -> loki, etc.).
+  default:
+  # Shared cross-stack network the QA stack (docker-compose.qa.yml) also joins,
+  # so this prod Caddy can resolve qa-backend / qa-frontend. Declared external:
+  # neither stack auto-creates it. Create once on the box with
+  # `docker network create caddy_net` (deploy/qa-deploy.sh and deploy/update.sh
+  # both create it defensively). See deploy/qa/README.md (issue #330).
+  caddy_net:
+    external: true
 
 volumes:
   sqlite_data:

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -1,0 +1,97 @@
+# QA stack (issue #330) — second compose project `regress-qa` on the same VPS.
+#
+# Runs ONLY backend + frontend. No Caddy, no Loki, no Grafana, no host ports:
+# the existing prod Caddy terminates TLS for qa.{$DOMAIN} and reverse-proxies
+# here across the shared external caddy_net via the qa-backend / qa-frontend
+# aliases.
+#
+# Deploy with the regress-qa project name so volumes/containers are namespaced
+# (qa_ prefix + regress-qa_ project prefix => no collision with prod regress_*):
+#   docker compose -p regress-qa -f docker-compose.qa.yml up -d --build
+# (deploy/qa-deploy.sh wraps this.)
+#
+# Observability: Axiom only, routed to the dedicated dataset
+# AXIOM_DATASET=regression-tool-qa (zero backend code change). Container stdout
+# uses Docker's default json-file driver (`docker logs qa-backend`), NOT the
+# loki driver — QA has no Loki/Grafana, and the loki driver is a host-wide
+# plugin that would error on push without a Loki endpoint.
+services:
+  backend:
+    build: ./backend
+    container_name: qa-backend
+    # Run as the non-root appuser (UID/GID 1000) created in backend/Dockerfile.
+    user: "1000:1000"
+    env_file:
+      - path: ./backend/.env
+        required: false
+    environment:
+      - FRED_API_KEY=${FRED_API_KEY}
+      - DATABASE_URL=sqlite:///./data/regression_tool.db
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-}
+      - ALLOWED_USERS=${ALLOWED_USERS:-}
+      - SLACK_WEBHOOK_URL=${SLACK_WEBHOOK_URL:-}
+      # No SCHWAB_ENCRYPTION_KEY in QA — QA runs in degraded (no-Schwab) mode.
+      - AXIOM_API_TOKEN=${AXIOM_API_TOKEN:-}
+      - AXIOM_DATASET=${AXIOM_DATASET:-regression-tool-qa}
+    volumes:
+      - qa_sqlite_data:/app/data
+    networks:
+      caddy_net:
+        aliases:
+          - qa-backend
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/health')"]
+      interval: 30s
+      timeout: 15s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          # 4 GB box, comfortable tier (verified ~1.9Gi available). Hard cap —
+          # an OOM-killed QA container restarts and never starves prod.
+          memory: 384M
+
+  frontend:
+    build: ./frontend
+    container_name: qa-frontend
+    # Run as the non-root node user (UID/GID 1000) from the Node base image.
+    user: "1000:1000"
+    environment:
+      - HOSTNAME=0.0.0.0
+      - INTERNAL_API_ORIGIN=http://qa-backend:8000
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-}
+      - GITHUB_ID=${GITHUB_ID:-}
+      - GITHUB_SECRET=${GITHUB_SECRET:-}
+      - NEXTAUTH_URL=${NEXTAUTH_URL:-https://qa.${DOMAIN}}
+      - ALLOWED_USERS=${ALLOWED_USERS:-}
+    networks:
+      caddy_net:
+        aliases:
+          - qa-frontend
+    healthcheck:
+      test: ["CMD", "node", "-e", "const http = require('http'); http.get('http://127.0.0.1:8080/', (r) => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 192M
+
+networks:
+  # Shared cross-stack network the prod stack (docker-compose.prod.yml) also
+  # joins, so the prod Caddy resolves qa-backend / qa-frontend. external: true —
+  # neither stack auto-creates it. Create once with `docker network create
+  # caddy_net` (deploy/qa-deploy.sh does this defensively).
+  caddy_net:
+    external: true
+
+volumes:
+  # Real volume name under -p regress-qa is `regress-qa_qa_sqlite_data`
+  # (referenced by deploy/qa-refresh-db.sh). Double-namespaced => no collision
+  # with prod's `regress_sqlite_data`.
+  qa_sqlite_data:

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -26,6 +26,7 @@ services:
         required: false
     environment:
       - FRED_API_KEY=${FRED_API_KEY}
+      - ALPHA_VANTAGE_API_KEY=${ALPHA_VANTAGE_API_KEY:-}
       - DATABASE_URL=sqlite:///./data/regression_tool.db
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-}
       - ALLOWED_USERS=${ALLOWED_USERS:-}


### PR DESCRIPTION
## Summary

Closes #330.

Stands up a second Docker Compose project (`regress-qa`) on the **existing** VPS, served at `qa.<domain>`. QA runs only `backend` + `frontend` — no Caddy, no Loki, no Grafana, no host ports. The **existing prod Caddy** terminates TLS for `qa.<domain>` via a new site block and reaches the QA containers across a shared external Docker network (`caddy_net`) using stable aliases (`qa-backend`, `qa-frontend`). QA data is an on-demand restore of a prod backup snapshot. Observability is Axiom-only, routed to a dedicated dataset (`AXIOM_DATASET=regression-tool-qa`) — a zero-code-change distinguisher — with `docker logs` (json-file driver) as the fallback.

The only genuinely shared, ports-80/443-owning component is Caddy; everything else is namespaced under `qa-` / `qa_` + the `regress-qa` project prefix, so no collision is possible.

### Resolved decisions baked in
- **Memory tier:** 4 GB box (verified 3.7Gi total, ~1.9Gi available) → comfortable tier: `qa-backend 384M` + `qa-frontend 192M` = **576M**.
- **Axiom:** dedicated dataset `regression-tool-qa` via the env-driven `AXIOM_DATASET` — zero backend code changes.
- **Disk (78% full, 8.1 GB free):** `qa-refresh-db.sh` restores **in place** — overwrites the single `regression_tool.db` in the QA volume, never accumulates snapshot copies.

### Files
**Modified:** `docker-compose.prod.yml` (declare external `caddy_net`, attach caddy/backend/frontend), `deploy/Caddyfile` (add `qa.{$DOMAIN}` block — no grafana/basic-auth in it), `deploy/update.sh` (defensive `caddy_net` create guard), `.env.example`, `deploy/LOGGING.md`, `.github/workflows/ci.yml` (`qa-compose-validate` step).
**Created:** `docker-compose.qa.yml`, `deploy/qa/.env.template`, `deploy/qa-refresh-db.sh`, `deploy/qa-deploy.sh`, `deploy/qa/README.md`, `backend/scripts/qa_snapshot.py`, `backend/tests/test_qa_compose_config.py`.

**No route/schema changes** — OpenAPI snapshot unchanged, no regen needed.

## Tests

- `backend/tests/test_qa_compose_config.py` — 23 unit assertions (compose service set, qa_-prefixed volume, memory caps ≤ 576M, no Schwab key, no loki driver, qa Axiom dataset, qa NextAuth URL, external caddy_net + aliases, prod compose joins caddy_net, Caddyfile qa block routes to qa-* with no grafana/basic-auth, prod block unchanged, snapshot-selection newest/idempotent/error paths) + 5 manual-infra ACs as skipped tests (DNS, TLS, OAuth app, live refresh run, degraded-mode smoke).
- Full backend unit suite: **1102 passed, 15 skipped**. Classifier: OK (no `tdd_red`). OpenAPI drift: clean.
- `docker compose -f docker-compose.qa.yml config -q` validates locally; mirrored as the CI `qa-compose-validate` job.

## ⚠️ Manual rollout steps (operator, on the VPS, in order)

Full runbook in `deploy/qa/README.md`. Sequence:

1. **Create DNS A record** `qa.<domain>` → `5.78.124.155`. Wait for `dig +short qa.<domain>` to resolve.
2. **Register a dedicated GitHub OAuth app for QA** — Homepage `https://qa.<domain>`, callback `https://qa.<domain>/api/auth/callback/github`. Do **not** reuse the prod app (its callback points at the prod domain).
3. **Create the shared external network once:** `docker network create caddy_net`.
4. **Clone to `/root/regress-qa`** and create `.env` from `deploy/qa/.env.template` (QA OAuth creds, a **fresh** `NEXTAUTH_SECRET`, reused FRED/AV/Axiom token, `AXIOM_DATASET=regression-tool-qa`, **no Schwab key**). Also create the `regression-tool-qa` dataset in the Axiom UI.
5. **Deploy prod once** to activate the Caddy block + `caddy_net` attachment — see the cert-wipe warning below; do it during low traffic with DNS already in place.
6. `bash deploy/qa-deploy.sh` — builds and starts the QA stack on `caddy_net`.
7. `bash deploy/qa-refresh-db.sh` — seed QA DB from the latest prod snapshot (run `deploy/backup.sh` on prod first if no recent snapshot exists).
8. Verify: `curl -I https://qa.<domain>` (valid cert), `curl https://qa.<domain>/api/health` (ok in degraded mode), log into QA via the QA OAuth app.
9. Paste the `qa-refresh-db.sh` run-log into this PR (AC requirement).

## 🚨 Prod-Caddy cert re-issuance risk (highest-impact)

`.github/workflows/deploy.yml` does, on **any** `deploy/Caddyfile` diff: `docker compose rm -sf caddy` + `docker volume rm regress_caddy_data`. Adding the `qa.<domain>` site block **is** a Caddyfile change, so the **first prod deploy after this PR merges will wipe and re-issue ALL certs (prod + qa).** Mitigations: (a) deploy intentionally during low traffic; (b) ensure the `qa.<domain>` DNS A record exists **before** that deploy so Caddy can issue the QA cert on first boot. Repeated re-issuance hits Let's Encrypt rate limits — and a Caddyfile *revert* has the same cost.

## Deviations from the plan

- **Test layer/runner:** the plan proposed `docker compose config` **integration** tests; I followed the established codebase convention (`backend/tests/test_observability_configs.py`) — parse the YAML directly with PyYAML as `@pytest.mark.unit` (no docker CLI in the unit runner, no DB session). The plan's intent (assert QA compose structural invariants) is preserved, and the live `docker compose config -q` schema gate is the new CI `qa-compose-validate` job. The snapshot-selection unit tests are unit-tested via the extracted `backend/scripts/qa_snapshot.py` helper, exactly as the plan's Test List anticipated.
- `shellcheck` is not installed in this environment; shell scripts were validated with `bash -n` and follow `set -euo pipefail`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)