### PR TITLE
QA live-rollout fixes: backup volume targeting, Schwab scrub, python3, cross-env traffic bleed (closes #332, #334)

### DIFF
--- a/backend/tests/test_qa_compose_config.py
+++ b/backend/tests/test_qa_compose_config.py
@@ -68,7 +68,7 @@ class TestQaComposeServices:
     @pytest.mark.unit
     def test_qa_compose_parses_and_has_backend_frontend_only(self, qa_config: dict) -> None:
         """QA defines exactly backend + frontend — no loki/grafana/caddy."""
-        assert set(qa_config["services"].keys()) == {"backend", "frontend"}
+        assert set(qa_config["services"].keys()) == {"qa-backend", "qa-frontend"}
 
     @pytest.mark.unit
     def test_qa_compose_no_host_port_mappings(self, qa_config: dict) -> None:
@@ -85,13 +85,13 @@ class TestQaComposeServices:
     @pytest.mark.unit
     def test_qa_compose_backend_mounts_qa_volume(self, qa_config: dict) -> None:
         """Backend mounts the qa_sqlite_data volume at /app/data."""
-        volumes = qa_config["services"]["backend"]["volumes"]
+        volumes = qa_config["services"]["qa-backend"]["volumes"]
         assert "qa_sqlite_data:/app/data" in volumes
 
     @pytest.mark.unit
     def test_qa_compose_memory_limits_set_on_all_services(self, qa_config: dict) -> None:
         """Each service carries its documented cap (backend 384M, frontend 192M); sum <= cap."""
-        expected_mb = {"backend": 384, "frontend": 192}
+        expected_mb = {"qa-backend": 384, "qa-frontend": 192}
         total = 0
         for name, svc in qa_config["services"].items():
             mem = _mem_limit_to_mb(svc["deploy"]["resources"]["limits"]["memory"])
@@ -102,7 +102,7 @@ class TestQaComposeServices:
     @pytest.mark.unit
     def test_qa_compose_omits_schwab_encryption_key(self, qa_config: dict) -> None:
         """Schwab vars absent — QA runs in degraded (no-Schwab) mode."""
-        env = qa_config["services"]["backend"]["environment"]
+        env = qa_config["services"]["qa-backend"]["environment"]
         env_keys = {item.split("=", 1)[0] for item in env}
         assert "SCHWAB_ENCRYPTION_KEY" not in env_keys
 
@@ -116,21 +116,21 @@ class TestQaComposeServices:
     @pytest.mark.unit
     def test_qa_compose_axiom_dataset_is_qa(self, qa_config: dict) -> None:
         """Backend routes Axiom logs to the dedicated regression-tool-qa dataset."""
-        env = qa_config["services"]["backend"]["environment"]
+        env = qa_config["services"]["qa-backend"]["environment"]
         dataset_line = next(e for e in env if e.startswith("AXIOM_DATASET="))
         assert "regression-tool-qa" in dataset_line
 
     @pytest.mark.unit
     def test_qa_compose_nextauth_url_is_qa_subdomain(self, qa_config: dict) -> None:
         """Frontend NEXTAUTH_URL targets the qa. subdomain."""
-        env = qa_config["services"]["frontend"]["environment"]
+        env = qa_config["services"]["qa-frontend"]["environment"]
         url_line = next(e for e in env if e.startswith("NEXTAUTH_URL="))
         assert "qa." in url_line.split("=", 1)[1]
 
     @pytest.mark.unit
     def test_qa_compose_frontend_api_origin_targets_qa_backend(self, qa_config: dict) -> None:
         """Frontend talks to qa-backend, not the prod backend alias."""
-        env = qa_config["services"]["frontend"]["environment"]
+        env = qa_config["services"]["qa-frontend"]["environment"]
         origin_line = next(e for e in env if e.startswith("INTERNAL_API_ORIGIN="))
         assert "qa-backend" in origin_line
 
@@ -143,16 +143,29 @@ class TestQaComposeNetwork:
         """caddy_net is declared external and both services attach to it."""
         net = qa_config["networks"]["caddy_net"]
         assert net["external"] is True
-        for name in ("backend", "frontend"):
+        for name in ("qa-backend", "qa-frontend"):
             assert "caddy_net" in qa_config["services"][name]["networks"]
 
     @pytest.mark.unit
     def test_qa_compose_service_aliases(self, qa_config: dict) -> None:
         """Services publish the qa-backend / qa-frontend aliases on caddy_net."""
-        backend_net = qa_config["services"]["backend"]["networks"]["caddy_net"]
-        frontend_net = qa_config["services"]["frontend"]["networks"]["caddy_net"]
+        backend_net = qa_config["services"]["qa-backend"]["networks"]["caddy_net"]
+        frontend_net = qa_config["services"]["qa-frontend"]["networks"]["caddy_net"]
         assert "qa-backend" in backend_net["aliases"]
         assert "qa-frontend" in frontend_net["aliases"]
+
+    @pytest.mark.unit
+    def test_qa_service_names_do_not_collide_with_prod(
+        self, qa_config: dict, prod_config: dict
+    ) -> None:
+        """No QA service shares a name with any prod service (issue #334).
+
+        Compose adds each service's NAME as an implicit DNS alias on every
+        attached network. When QA's services were named backend/frontend,
+        they answered to prod's service names on the shared caddy_net and
+        prod's Caddy round-robined live traffic into the QA stack.
+        """
+        assert not set(qa_config["services"]) & set(prod_config["services"])
 
 
 class TestProdComposeNetwork:
@@ -167,6 +180,19 @@ class TestProdComposeNetwork:
     def test_prod_caddy_joins_caddy_net(self, prod_config: dict) -> None:
         """The prod caddy service attaches to caddy_net to route to QA."""
         assert "caddy_net" in prod_config["services"]["caddy"]["networks"]
+
+    @pytest.mark.unit
+    def test_prod_app_services_not_on_caddy_net(self, prod_config: dict) -> None:
+        """Only prod caddy joins the shared network (issue #334).
+
+        Prod backend/frontend stay off caddy_net so their implicit
+        service-name aliases can never be resolved by (or collide with)
+        anything on the shared network; Caddy reaches them over the
+        project-default network.
+        """
+        for name in ("backend", "frontend"):
+            networks = prod_config["services"][name].get("networks") or []
+            assert "caddy_net" not in networks
 
 
 class TestQaCaddyfile:

--- a/backend/tests/test_qa_compose_config.py
+++ b/backend/tests/test_qa_compose_config.py
@@ -264,6 +264,45 @@ class TestQaSnapshotSelection:
             select_newest_snapshot(tmp_path / "does-not-exist")
 
 
+class TestOpsScriptInvariants:
+    """Text invariants on deploy scripts for the #332 rollout fixes."""
+
+    @pytest.mark.unit
+    def test_backup_sh_targets_exact_prod_volume(self) -> None:
+        """backup.sh resolves the prod volume by exact name, not a loose grep.
+
+        With the QA stack deployed, `grep sqlite_data | head -1` matches
+        `regress-qa_qa_sqlite_data` first (`-` sorts before `_`) and would
+        silently back up the QA database (#332).
+        """
+        content = (DEPLOY_DIR / "backup.sh").read_text()
+        assert 'PROD_VOLUME="regress_sqlite_data"' in content
+        assert 'grep -qx "$PROD_VOLUME"' in content
+        assert "grep sqlite_data | head -1" not in content
+
+    @pytest.mark.unit
+    def test_qa_refresh_db_scrubs_all_encrypted_setting_keys(self) -> None:
+        """qa-refresh-db.sh scrubs every ENCRYPTED_SETTING_KEYS row post-restore.
+
+        QA has no SCHWAB_ENCRYPTION_KEY; the backend's fail-closed startup
+        check refuses to boot while these rows exist (#332). The script's
+        DELETE must cover the canonical key list from app.services.encryption
+        so the two can't drift.
+        """
+        from app.services.encryption import ENCRYPTED_SETTING_KEYS
+
+        content = (DEPLOY_DIR / "qa-refresh-db.sh").read_text()
+        assert "DELETE FROM app_settings" in content
+        for key in ENCRYPTED_SETTING_KEYS:
+            assert f"'{key}'" in content
+
+    @pytest.mark.unit
+    def test_qa_refresh_db_uses_python3_on_host(self) -> None:
+        """Host-side snapshot selection calls python3 — the VPS has no bare python (#332)."""
+        content = (DEPLOY_DIR / "qa-refresh-db.sh").read_text()
+        assert "python3 -m scripts.qa_snapshot" in content
+
+
 class TestQaManualInfraACs:
     """Live-infra ACs that cannot run in CI — recorded as skipped per CLAUDE.md.
 

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -26,9 +26,19 @@ echo ""
 echo ">>> Copying SQLite database..."
 CONTAINER_NAME=$(docker compose -f docker-compose.prod.yml ps -q backend 2>/dev/null || true)
 
+# Fully-qualified prod volume name (issue #332). A loose `grep sqlite_data`
+# also matches the QA stack's `regress-qa_qa_sqlite_data` — which sorts FIRST
+# (`-` < `_`), so `head -1` would silently back up the QA database instead.
+PROD_VOLUME="regress_sqlite_data"
+if ! docker volume ls -q | grep -qx "$PROD_VOLUME"; then
+    echo "ERROR: prod volume '$PROD_VOLUME' not found — refusing to guess." >&2
+    docker compose -f docker-compose.prod.yml start backend
+    exit 1
+fi
+
 # Use a temporary container to access the volume
 docker run --rm \
-    -v "$(docker volume ls -q | grep sqlite_data | head -1)":/data \
+    -v "$PROD_VOLUME":/data \
     -v "$BACKUP_DIR":/backup \
     alpine:latest \
     cp /data/regression_tool.db "/backup/${BACKUP_FILE}" 2>/dev/null || {

--- a/deploy/qa-refresh-db.sh
+++ b/deploy/qa-refresh-db.sh
@@ -46,7 +46,8 @@ if [ -n "${SNAPSHOT:-}" ]; then
 else
     echo ">>> Selecting newest snapshot in $BACKUP_DIR ..."
     # Pure-Python selection (unit-tested via backend/scripts/qa_snapshot.py).
-    SOURCE_SNAPSHOT="$(cd "$APP_DIR/backend" && python -m scripts.qa_snapshot "$BACKUP_DIR")" || {
+    # python3 explicitly — the VPS has no bare `python` (issue #332).
+    SOURCE_SNAPSHOT="$(cd "$APP_DIR/backend" && python3 -m scripts.qa_snapshot "$BACKUP_DIR")" || {
         echo "ERROR: no snapshot found. Run deploy/backup.sh on prod first." >&2
         exit 1
     }
@@ -100,7 +101,28 @@ docker run --rm \
 echo ""
 
 # --------------------------------------------------
-# 5. Restart qa-backend (re-opens the fresh DB)
+# 5. Scrub Schwab tokens from the restored snapshot (issue #332)
+# --------------------------------------------------
+# Prod snapshots carry encrypted Schwab tokens in app_settings. QA has no
+# SCHWAB_ENCRYPTION_KEY by design, and the backend's fail-closed startup check
+# (app/main.py _run_security_checks) refuses to boot when tokens exist without
+# the key — so an unscrubbed restore puts qa-backend in a restart loop. The
+# key list mirrors ENCRYPTED_SETTING_KEYS in app/services/encryption.py.
+echo ">>> Scrubbing Schwab tokens (QA runs without SCHWAB_ENCRYPTION_KEY)..."
+$COMPOSE run --rm --no-deps backend python -c "
+import sqlite3
+conn = sqlite3.connect('/app/data/regression_tool.db')
+cur = conn.execute(
+    \"DELETE FROM app_settings WHERE key IN \"
+    \"('schwab_access_token','schwab_refresh_token','schwab_app_key','schwab_app_secret')\"
+)
+conn.commit()
+print(f'    Scrubbed {cur.rowcount} Schwab token row(s)')
+"
+echo ""
+
+# --------------------------------------------------
+# 6. Restart qa-backend (re-opens the fresh DB)
 # --------------------------------------------------
 echo ">>> Restarting qa-backend..."
 trap - EXIT

--- a/deploy/qa-refresh-db.sh
+++ b/deploy/qa-refresh-db.sh
@@ -74,12 +74,12 @@ fi
 # 3. Stop qa-backend for a clean SQLite copy (WAL/lock safety)
 # --------------------------------------------------
 echo ">>> Stopping qa-backend..."
-$COMPOSE stop backend
+$COMPOSE stop qa-backend
 echo ""
 
 # From here on qa-backend is down. Restart it on ANY exit so a failed restore
 # can't leave QA offline; the happy path clears the trap before its own restart.
-trap '$COMPOSE start backend || true' EXIT
+trap '$COMPOSE start qa-backend || true' EXIT
 
 # --------------------------------------------------
 # 4. Overwrite the DB in the QA volume via a throwaway alpine container
@@ -109,7 +109,7 @@ echo ""
 # the key — so an unscrubbed restore puts qa-backend in a restart loop. The
 # key list mirrors ENCRYPTED_SETTING_KEYS in app/services/encryption.py.
 echo ">>> Scrubbing Schwab tokens (QA runs without SCHWAB_ENCRYPTION_KEY)..."
-$COMPOSE run --rm --no-deps backend python -c "
+$COMPOSE run --rm --no-deps qa-backend python -c "
 import sqlite3
 conn = sqlite3.connect('/app/data/regression_tool.db')
 cur = conn.execute(
@@ -126,7 +126,7 @@ echo ""
 # --------------------------------------------------
 echo ">>> Restarting qa-backend..."
 trap - EXIT
-$COMPOSE start backend
+$COMPOSE start qa-backend
 echo ""
 
 echo "=== QA DB refresh complete ==="

--- a/deploy/qa/README.md
+++ b/deploy/qa/README.md
@@ -1,7 +1,7 @@
 # QA Environment (issue #330)
 
 A second Docker Compose project (`regress-qa`) on the **same VPS** as prod,
-served at `qa.<domain>`. QA runs only `backend` + `frontend` — no Caddy, no
+served at `qa.<domain>`. QA runs only `qa-backend` + `qa-frontend` — no Caddy, no
 Loki, no Grafana. The **existing prod Caddy** terminates TLS for `qa.<domain>`
 and reverse-proxies to the QA containers across a shared external Docker network
 (`caddy_net`) using the `qa-backend` / `qa-frontend` aliases.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -101,9 +101,10 @@ services:
       - AXIOM_DATASET=${AXIOM_DATASET:-regression-tool}
     volumes:
       - sqlite_data:/app/data
-    networks:
-      - default
-      - caddy_net
+    # NOT on caddy_net (issue #334): only the prod Caddy joins the shared
+    # network — it reaches this service over the project-default network.
+    # Keeping prod services off caddy_net stops their implicit service-name
+    # DNS aliases from colliding with the QA stack's on the shared network.
     logging:
       driver: loki
       options:
@@ -137,9 +138,7 @@ services:
       - GITHUB_SECRET=${GITHUB_SECRET:-}
       - NEXTAUTH_URL=${NEXTAUTH_URL:-}
       - ALLOWED_USERS=${ALLOWED_USERS:-}
-    networks:
-      - default
-      - caddy_net
+    # NOT on caddy_net — see the backend service note (issue #334).
     logging:
       driver: loki
       options:

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -16,7 +16,11 @@
 # loki driver — QA has no Loki/Grafana, and the loki driver is a host-wide
 # plugin that would error on push without a Loki endpoint.
 services:
-  backend:
+  # Service names are qa-prefixed ON PURPOSE (issue #334): Compose adds each
+  # service's NAME as an implicit DNS alias on every attached network. Naming
+  # these `backend`/`frontend` made them answer to prod's service names on the
+  # shared caddy_net, and prod Caddy round-robined live traffic into QA.
+  qa-backend:
     build: ./backend
     container_name: qa-backend
     # Run as the non-root appuser (UID/GID 1000) created in backend/Dockerfile.
@@ -54,7 +58,7 @@ services:
           # an OOM-killed QA container restarts and never starves prod.
           memory: 384M
 
-  frontend:
+  qa-frontend:
     build: ./frontend
     container_name: qa-frontend
     # Run as the non-root node user (UID/GID 1000) from the Node base image.


### PR DESCRIPTION
## Summary

Three ops-script bugs surfaced during the live QA rollout on the VPS today (post-v1.6.2). All three are fixed with regression tests.

### 1. `backup.sh` would back up the QA database instead of prod (data integrity)
Now that the QA volume exists, `docker volume ls -q | grep sqlite_data | head -1` matches `regress-qa_qa_sqlite_data` first (`-` sorts before `_`). Fixed with an exact-name match + a refuse-to-guess guard that restarts the backend and exits 1 if the prod volume isn't found. **Until this merges, don't run `backup.sh` on the box.**

### 2. `qa-refresh-db.sh` bricked qa-backend (observed live)
Prod snapshots carry encrypted Schwab tokens in `app_settings`; the backend's fail-closed startup check raises `EncryptionKeyMissing` when they exist without `SCHWAB_ENCRYPTION_KEY` — QA's intended degraded mode. The restore now scrubs the four `ENCRYPTED_SETTING_KEYS` rows before restarting. (Also stops prod's encrypted secrets living in the QA volume.) The live QA env was recovered manually with the same DELETE.

### 3. Bare `python` → `python3`
The VPS has no `python` binary; snapshot auto-selection failed (worked around live with `SNAPSHOT=`).

## Tests
- `test_backup_sh_targets_exact_prod_volume` — exact volume name + guard present, loose grep gone
- `test_qa_refresh_db_scrubs_all_encrypted_setting_keys` — imports `ENCRYPTED_SETTING_KEYS` from `app.services.encryption` so the script's DELETE and the canonical key list cannot drift
- `test_qa_refresh_db_uses_python3_on_host`

26 passed, 5 skipped in the file; scripts pass `bash -n`.

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)