### PR TITLE
Deploy: tag-to-ship promotion model (main→QA, release→prod)

### DIFF
--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -1,0 +1,74 @@
+name: _deploy-ssh
+
+# Reusable SSH deploy. Called by deploy.yml for both the QA and production
+# stacks (same VPS, separate compose projects). The caller decides which git
+# ref, directory, and compose file to use — this workflow just runs it.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "GitHub Environment name (qa | production)"
+        required: true
+        type: string
+      deploy_dir:
+        description: "Working-tree dir on the box (~/regress-qa | ~/regress)"
+        required: true
+        type: string
+      compose_file:
+        description: "Compose file to build/up (docker-compose.qa.yml | docker-compose.prod.yml)"
+        required: true
+        type: string
+      git_ref:
+        description: "Git ref to check out (origin/main | a release tag)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}     # production can require a manual approval gate
+    concurrency:
+      group: deploy-${{ inputs.environment }}   # never two deploys racing the same stack
+      cancel-in-progress: false
+    steps:
+      - name: Deploy via SSH
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            mkdir -p ~/.ssh
+            echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+            chmod 600 ~/.ssh/deploy_key
+            ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+              -i ~/.ssh/deploy_key \
+              ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} 'bash -s' <<'ENDSSH'
+            set -e
+            cd ${{ inputs.deploy_dir }}
+            OLD_HEAD=$(git rev-parse HEAD)
+            git fetch origin --tags --prune
+            git reset --hard ${{ inputs.git_ref }}
+            mkdir -p data data/backups
+            # docker-compose declares caddy_net as external (issue #330) —
+            # `up -d` fails if it doesn't exist on the box yet.
+            docker network create caddy_net 2>/dev/null || true
+            if git diff --name-only "$OLD_HEAD" HEAD | grep -q "deploy/Caddyfile"; then
+              echo "Caddyfile changed — clearing Caddy TLS cache to force cert re-issuance"
+              docker compose -f ${{ inputs.compose_file }} rm -sf caddy
+              PROJECT_NAME=$(basename "$(pwd)")
+              docker volume rm "${PROJECT_NAME}_caddy_data" || true
+            fi
+            docker compose -f ${{ inputs.compose_file }} build --no-cache
+            docker compose -f ${{ inputs.compose_file }} up -d
+            docker compose -f ${{ inputs.compose_file }} restart caddy
+            docker compose -f ${{ inputs.compose_file }} ps
+            docker image prune -f
+            ENDSSH
+            SSH_EXIT=$?
+            rm -f ~/.ssh/deploy_key
+            exit $SSH_EXIT

--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -23,6 +23,13 @@ on:
         description: "Git ref to check out (origin/main | a release tag)"
         required: true
         type: string
+    secrets:
+      DEPLOY_SSH_KEY:
+        required: true
+      DEPLOY_USER:
+        required: true
+      DEPLOY_HOST:
+        required: true
 
 permissions:
   contents: read
@@ -35,6 +42,12 @@ jobs:
       group: deploy-${{ inputs.environment }}   # never two deploys racing the same stack
       cancel-in-progress: false
     steps:
+      - name: Guard against empty git ref
+        run: |
+          if [ -z "${{ inputs.git_ref }}" ]; then
+            echo "::error::git_ref is empty — refusing to deploy. For a manual production deploy, supply an explicit tag/ref via the 'ref' input."
+            exit 1
+          fi
       - name: Deploy via SSH
         uses: nick-fields/retry@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,13 @@
-name: Deploy to Production
+name: Deploy
+
+# Promotion model (matches ado-pulse):
+#   merge to main ............... → QA   (qa.regression.shawnjsandy.com, tracks main HEAD)
+#   publish a -rc prerelease .... → QA   (validate the exact RC tag before promoting)
+#   publish a full release ...... → PROD (regression.shawnjsandy.com, the exact release tag)
+#   workflow_dispatch ........... → break-glass deploy to either stack
+#
+# Prod no longer auto-deploys on merge. Prod only moves when you publish a
+# GitHub Release — the release IS the deploy gate.
 
 permissions:
   contents: read
@@ -6,51 +15,50 @@ permissions:
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target stack"
+        type: choice
+        options: [qa, production]
+        default: qa
+      ref:
+        description: "Git ref/tag to deploy (blank = origin/main)"
+        type: string
+        default: ""
 
 jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
-  deploy:
+  # main HEAD, an RC prerelease, or a manual qa dispatch → QA stack
+  deploy-qa:
     needs: [ci]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy via SSH
-        uses: nick-fields/retry@v4
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_wait_seconds: 30
-          command: |
-            mkdir -p ~/.ssh
-            echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
-            chmod 600 ~/.ssh/deploy_key
-            ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
-              -i ~/.ssh/deploy_key \
-              ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} 'bash -s' <<'ENDSSH'
-            set -e
-            cd ~/regress
-            OLD_HEAD=$(git rev-parse HEAD)
-            git fetch origin main
-            git reset --hard origin/main
-            mkdir -p data data/backups
-            # docker-compose.prod.yml declares caddy_net as external (issue
-            # #330) — `up -d` fails if it doesn't exist on the box yet.
-            docker network create caddy_net 2>/dev/null || true
-            if git diff --name-only "$OLD_HEAD" HEAD | grep -q "deploy/Caddyfile"; then
-              echo "Caddyfile changed — clearing Caddy TLS cache to force cert re-issuance"
-              docker compose -f docker-compose.prod.yml rm -sf caddy
-              PROJECT_NAME=$(basename "$(pwd)")
-              docker volume rm "${PROJECT_NAME}_caddy_data" || true
-            fi
-            docker compose -f docker-compose.prod.yml build --no-cache
-            docker compose -f docker-compose.prod.yml up -d
-            docker compose -f docker-compose.prod.yml restart caddy
-            docker compose -f docker-compose.prod.yml ps
-            docker image prune -f
-            ENDSSH
-            SSH_EXIT=$?
-            rm -f ~/.ssh/deploy_key
-            exit $SSH_EXIT
+    if: >
+      github.event_name == 'push' ||
+      (github.event_name == 'release' && github.event.release.prerelease == true) ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'qa')
+    uses: ./.github/workflows/_deploy-ssh.yml
+    secrets: inherit
+    with:
+      environment: qa
+      deploy_dir: ~/regress-qa
+      compose_file: docker-compose.qa.yml
+      git_ref: ${{ github.event.release.tag_name || inputs.ref || 'origin/main' }}
+
+  # a full (non-RC) GitHub Release, or a manual production dispatch → PROD stack
+  deploy-prod:
+    needs: [ci]
+    if: >
+      (github.event_name == 'release' && github.event.release.prerelease == false) ||
+      (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
+    uses: ./.github/workflows/_deploy-ssh.yml
+    secrets: inherit
+    with:
+      environment: production
+      deploy_dir: ~/regress
+      compose_file: docker-compose.prod.yml
+      git_ref: ${{ github.event.release.tag_name || inputs.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,10 @@ jobs:
       (github.event_name == 'release' && github.event.release.prerelease == true) ||
       (github.event_name == 'workflow_dispatch' && inputs.environment == 'qa')
     uses: ./.github/workflows/_deploy-ssh.yml
-    secrets: inherit
+    secrets:
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
     with:
       environment: qa
       deploy_dir: ~/regress-qa
@@ -56,7 +59,10 @@ jobs:
       (github.event_name == 'release' && github.event.release.prerelease == false) ||
       (github.event_name == 'workflow_dispatch' && inputs.environment == 'production')
     uses: ./.github/workflows/_deploy-ssh.yml
-    secrets: inherit
+    secrets:
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
     with:
       environment: production
       deploy_dir: ~/regress


### PR DESCRIPTION
## What

Adopts the **ado-pulse promotion model** for deploys. Today `push: main` deploys straight to **prod**; this changes it so:

| Trigger | Deploys to | Ref |
|---|---|---|
| merge to `main` | **QA** (`~/regress-qa`, `docker-compose.qa.yml`) | `origin/main` |
| publish `vX.Y.Z-rc.N` (prerelease) | **QA** | the RC tag |
| publish `vX.Y.Z` (full release) | **PROD** (`~/regress`, `docker-compose.prod.yml`) | the release tag |
| `workflow_dispatch` | either (input) | your ref |

## How

- New reusable `_deploy-ssh.yml` — the SSH+compose deploy, parameterized by `environment` / `deploy_dir` / `compose_file` / `git_ref`. Keeps the existing `<<'ENDSSH'` quoted-heredoc form, adds per-env `concurrency` + a GitHub `environment:` gate.
- `deploy.yml` becomes an orchestrator that routes by trigger. Prod now `git reset --hard <release-tag>` instead of `origin/main` — **the release is the deploy gate**.

## Behavior change ⚠️

After merge, **pushing to `main` no longer deploys to prod** — it deploys to QA. Prod only moves when a GitHub Release is published. This is intentional (gated prod), but it's a hard switch.

## Follow-ups / notes

- **Reusable-workflow availability:** the `push: main` run resolves `_deploy-ssh.yml` from the same ref, so it's live the moment this lands on `main`.
- **Optional prod approval gate:** create a GitHub Environment named `production` with a required reviewer → prod deploys pause for one-click approval. Wired but inert until the Environment exists.
- **First QA run** assumes `~/regress-qa` is a git clone with `origin` set (established in #330–#334).
- `[needs-test]` the first live run to confirm the heredoc + input substitution behaves on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)