### PR TITLE
v1.6.4 — Deploy hardening

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -110,9 +110,12 @@ def get_schwab_credentials() -> tuple[str, str]:
                 .first()
             )
             enc_key = get_encryption_key()
-            if key_entry:
+            # Per-field, env-wins precedence (#221): only consult the DB row
+            # for a half the env did NOT already supply. A stale ``app_settings``
+            # row must never clobber an env-supplied credential.
+            if not app_key and key_entry:
                 app_key = decrypt_value(key_entry.value) if enc_key else key_entry.value
-            if secret_entry:
+            if not app_secret and secret_entry:
                 app_secret = (
                     decrypt_value(secret_entry.value) if enc_key else secret_entry.value
                 )

--- a/backend/app/services/watchlist.py
+++ b/backend/app/services/watchlist.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import WatchlistTicker
@@ -63,17 +64,28 @@ def add_ticker(db: DBSession, raw_ticker: str) -> list[str]:
     Normalizes ``raw_ticker`` to uppercase. Adding a ticker that already
     exists is a no-op — no duplicate row, no error (PRD #213 R2). Returns the
     full, current watchlist.
+
+    The insert is **atomic**: the present-check is only a cheap fast-path, and
+    the ``IntegrityError`` catch is what makes the add correct under
+    concurrency (#326). Two callers can both pass ``db.get(...) is None`` and
+    race to a second ``INSERT`` on the ``ticker`` primary key; the loser's
+    ``IntegrityError`` is caught and rolled back to the idempotent no-op
+    instead of surfacing as a generic 500.
     """
     ticker = normalize_ticker(raw_ticker)
     existing = db.get(WatchlistTicker, ticker)
     if existing is None:
-        db.add(
-            WatchlistTicker(
-                ticker=ticker,
-                added_at=datetime.now(timezone.utc).isoformat(),
+        try:
+            db.add(
+                WatchlistTicker(
+                    ticker=ticker,
+                    added_at=datetime.now(timezone.utc).isoformat(),
+                )
             )
-        )
-        db.commit()
+            db.commit()
+        except IntegrityError:
+            # Already present (concurrent add raced us) — idempotent no-op.
+            db.rollback()
     return list_watchlist(db)
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -109,12 +109,13 @@ class TestGetSchwabCredentials:
 
     @pytest.mark.unit
     def test_get_schwab_credentials_partial_env(self, db_session_factory):
-        """Only one env var set — falls through to the DB fallback path.
+        """Env key set + DB rows for both — the env key wins per-field (#221).
 
         ``get_schwab_credentials`` only short-circuits when *both* env vars
-        are set. With one missing, it enters the DB branch, and any DB row
-        found overwrites the corresponding value — including the half that
-        was supplied via env. This documents the actual two-tier behavior.
+        are set. With one missing it enters the DB branch, but the fix makes
+        resolution **per-field, env-wins**: an env-supplied half is never
+        clobbered by a stale ``app_settings`` row. Here the env key survives
+        and only the missing secret is filled from the DB.
         """
         _seed(
             db_session_factory,
@@ -128,8 +129,52 @@ class TestGetSchwabCredentials:
             mock_settings.schwab_app_secret = ""
             enc_settings.schwab_encryption_key = TEST_KEY
             app_key, app_secret = get_schwab_credentials()
-        # Both DB rows present — both halves are taken from the DB.
+        # Env key wins; only the empty secret half is filled from the DB.
+        assert app_key == "env_key"
+        assert app_secret == "db_secret"
+
+    @pytest.mark.unit
+    def test_partial_env_secret_set_db_both(self, db_session_factory):
+        """Env *secret* set + DB rows for both — env secret wins (#221).
+
+        Symmetric to ``test_get_schwab_credentials_partial_env``: the
+        env-supplied secret survives and only the missing key is filled
+        from the DB.
+        """
+        _seed(
+            db_session_factory,
+            schwab_app_key=encrypt_value("db_key", key=TEST_KEY),
+            schwab_app_secret=encrypt_value("db_secret", key=TEST_KEY),
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = ""
+            mock_settings.schwab_app_secret = "env_secret"
+            enc_settings.schwab_encryption_key = TEST_KEY
+            app_key, app_secret = get_schwab_credentials()
         assert app_key == "db_key"
+        assert app_secret == "env_secret"
+
+    @pytest.mark.unit
+    def test_partial_env_no_conflicting_db_row(self, db_session_factory):
+        """Env key set, only a DB *secret* row present — env key preserved (#221).
+
+        No DB key row exists to (incorrectly) clobber the env-supplied key,
+        and the missing secret half is filled from its DB row.
+        """
+        _seed(
+            db_session_factory,
+            schwab_app_secret=encrypt_value("db_secret", key=TEST_KEY),
+        )
+        with patch("app.config.settings") as mock_settings, patch(
+            "app.models.database.SessionLocal", db_session_factory
+        ), patch("app.services.encryption.settings") as enc_settings:
+            mock_settings.schwab_app_key = "env_key"
+            mock_settings.schwab_app_secret = ""
+            enc_settings.schwab_encryption_key = TEST_KEY
+            app_key, app_secret = get_schwab_credentials()
+        assert app_key == "env_key"
         assert app_secret == "db_secret"
 
     @pytest.mark.unit

--- a/backend/tests/test_watchlist_router.py
+++ b/backend/tests/test_watchlist_router.py
@@ -10,6 +10,35 @@ across two engine sessions, which the in-memory fixture cannot model).
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import Base, WatchlistTicker
+from app.services.watchlist import add_ticker, list_watchlist
+
+
+@pytest.fixture()
+def db_session():
+    """In-memory SQLite session for direct service-level watchlist tests.
+
+    Mirrors the conftest ``client`` fixture's engine setup but yields a raw
+    session so the atomic-add tests (#326) can drive ``add_ticker`` directly
+    and exercise the ``IntegrityError`` path the concurrency race triggers.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    TestSessionLocal = sessionmaker(bind=engine)
+    db = TestSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
 
 
 # --- GET /api/watchlist ---
@@ -114,10 +143,77 @@ def test_post_empty_ticker_returns_422(client, blank):
 
 
 @pytest.mark.integration
-def test_get_list_is_returned_in_stable_order(client):
-    """I10 — the list endpoint returns tickers oldest-added first."""
-    for symbol in ("AAPL", "MSFT", "NVDA"):
-        client.post("/api/watchlist", json={"ticker": symbol})
-    resp = client.get("/api/watchlist")
-    assert resp.status_code == 200
-    assert resp.json() == {"tickers": ["AAPL", "MSFT", "NVDA"]}
+def test_get_list_is_returned_in_stable_order(db_session):
+    """I10 — the list endpoint returns tickers oldest-added first (#326 nit).
+
+    Rewritten off the router path to seed **distinct** ``added_at`` values so
+    the assertion genuinely proves insertion-order sort. The original
+    three-rapid-POST version could share an identical ``added_at`` and pass by
+    the alphabetical (``AAPL < MSFT < NVDA``) tiebreaker accident rather than
+    by true oldest-first ordering. Here the rows are inserted in reverse
+    alphabetical order with increasing timestamps, so an alpha-only sort would
+    fail and only an ``added_at``-primary sort produces the expected list.
+    """
+    db_session.add_all(
+        [
+            WatchlistTicker(ticker="NVDA", added_at="2026-01-01T00:00:00+00:00"),
+            WatchlistTicker(ticker="MSFT", added_at="2026-01-02T00:00:00+00:00"),
+            WatchlistTicker(ticker="AAPL", added_at="2026-01-03T00:00:00+00:00"),
+        ]
+    )
+    db_session.commit()
+    assert list_watchlist(db_session) == ["NVDA", "MSFT", "AAPL"]
+
+
+# --- add_ticker atomicity (#326 — present-check-then-insert race) ---
+
+
+@pytest.mark.integration
+def test_add_ticker_duplicate_integrityerror_is_noop(db_session):
+    """A pre-existing row + a forced insert path is an idempotent no-op (#326).
+
+    Simulates the concurrency race: two callers both pass the present-check
+    and race to ``INSERT`` the same primary key. We pre-insert the row, then
+    bypass the fast-path present-check so ``add_ticker`` attempts the insert
+    and trips the ``ticker`` PK ``IntegrityError`` — which must be caught,
+    rolled back, and collapsed to the documented no-op (returns the unchanged
+    list, never raises). This exercises the exact code path the race triggers;
+    genuinely concurrent two-thread racing is not deterministically assertable
+    in-process (per the Wave 3 pilot lesson on not faking concurrency).
+    """
+    db_session.add(
+        WatchlistTicker(ticker="AAPL", added_at="2026-01-01T00:00:00+00:00")
+    )
+    db_session.commit()
+
+    # Force the insert path even though the row exists: patch the fast-path
+    # present-check to report "absent" so the service reaches the INSERT.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(db_session, "get", lambda *a, **k: None)
+        result = add_ticker(db_session, "AAPL")
+
+    # No raise; the unchanged single-entry list is returned.
+    assert result == ["AAPL"]
+    assert list_watchlist(db_session) == ["AAPL"]
+
+
+@pytest.mark.integration
+def test_add_ticker_atomic_no_check_then_insert_gap(db_session):
+    """The success path commits exactly one row; re-adding does not raise (#326).
+
+    Proves the happy path is unchanged (one row committed) and that a second
+    ``add_ticker`` of the same ticker is an idempotent no-op even when the
+    insert is attempted — the atomic ``try/except IntegrityError`` guard, not
+    the present-check, is what makes the duplicate safe.
+    """
+    first = add_ticker(db_session, "msft")
+    assert first == ["MSFT"]
+    assert db_session.query(WatchlistTicker).count() == 1
+
+    # Force the insert path on the duplicate add — must not raise.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(db_session, "get", lambda *a, **k: None)
+        second = add_ticker(db_session, "msft")
+
+    assert second == ["MSFT"]
+    assert db_session.query(WatchlistTicker).count() == 1

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -146,8 +146,16 @@ services:
         loki-retries: "3"
         loki-batch-size: "400"
         loki-external-labels: "job=regression-tool,service=frontend"
+    # Probe /auth/signin directly (issue #232). The old probe hit `/`, which
+    # returns a 307 redirect (< 400) the instant Next.js is *listening* — so a
+    # fully-broken app reported healthy (the v1.0.0 #229 outage). /auth/signin
+    # is a real rendered page, is middleware-excluded so it never redirects,
+    # and renders in both auth-on and auth-off deployments; a 200 proves the
+    # render pipeline produced HTML, not just a redirect header. This is a
+    # container-layer AC validated via the QA-stack healthy/unhealthy/auth-
+    # redirect cycle (not the pytest/Playwright pyramid); see PR #232 body.
     healthcheck:
-      test: ["CMD", "node", "-e", "const http = require('http'); http.get('http://127.0.0.1:8080/', (r) => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
+      test: ["CMD", "node", "-e", "const http = require('http'); http.get('http://127.0.0.1:8080/auth/signin', (r) => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -75,8 +75,16 @@ services:
       caddy_net:
         aliases:
           - qa-frontend
+    # Probe /auth/signin directly (issue #232) — kept identical to
+    # docker-compose.prod.yml so QA is the validation harness for this change.
+    # The old probe hit `/`, whose 307 redirect (< 400) passed the instant
+    # Next.js was listening, so a broken app reported healthy. /auth/signin is
+    # a real rendered, middleware-excluded page that renders in both auth-on
+    # and auth-off deployments; a 200 proves the render pipeline produced HTML.
+    # Container-layer AC validated via the QA healthy/unhealthy/auth-redirect
+    # cycle (not the pytest/Playwright pyramid); see PR #232 body.
     healthcheck:
-      test: ["CMD", "node", "-e", "const http = require('http'); http.get('http://127.0.0.1:8080/', (r) => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
+      test: ["CMD", "node", "-e", "const http = require('http'); http.get('http://127.0.0.1:8080/auth/signin', (r) => process.exit(r.statusCode < 400 ? 0 : 1)).on('error', () => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/app/auth/signin/SignInForm.jsx
+++ b/frontend/app/auth/signin/SignInForm.jsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useSearchParams } from "next/navigation";
+
+/**
+ * Client-side sign-in form. Renders the GitHub OAuth button only when the
+ * provider is configured; otherwise shows a self-explanatory not-configured
+ * message instead of a button that would hand off to GitHub with an empty
+ * client_id and fail into a GitHub 404 (issue #335).
+ *
+ * `githubConfigured` is computed server-side in the page wrapper (it reads
+ * GITHUB_ID/GITHUB_SECRET, which are server-only env vars) and passed down as
+ * a non-secret boolean.
+ */
+export default function SignInForm({ githubConfigured }) {
+  const searchParams = useSearchParams();
+  const callbackUrl = searchParams.get("callbackUrl") || "/";
+
+  if (!githubConfigured) {
+    return (
+      <div
+        className="mt-8 rounded-lg border border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 p-4 text-center"
+        data-testid="github-not-configured"
+      >
+        <p className="text-sm font-medium text-amber-800 dark:text-amber-200">
+          GitHub OAuth is not configured for this environment
+        </p>
+        <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+          Set GITHUB_ID and GITHUB_SECRET to enable sign-in.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-8 space-y-4">
+      <button
+        onClick={() => signIn("github", { callbackUrl })}
+        className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+        </svg>
+        Sign in with GitHub
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/auth/signin/page.jsx
+++ b/frontend/app/auth/signin/page.jsx
@@ -1,29 +1,23 @@
-"use client";
-
 import { Suspense } from "react";
-import { signIn } from "next-auth/react";
-import { useSearchParams } from "next/navigation";
 
-function SignInForm() {
-  const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
+import SignInForm from "./SignInForm";
 
-  return (
-    <div className="mt-8 space-y-4">
-      <button
-        onClick={() => signIn("github", { callbackUrl })}
-        className="w-full flex items-center justify-center gap-3 px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg shadow-sm bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-      >
-        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-        </svg>
-        Sign in with GitHub
-      </button>
-    </div>
-  );
-}
-
+/**
+ * Sign-in page (server component).
+ *
+ * Reads the server-only GITHUB_ID/GITHUB_SECRET env vars and passes a
+ * non-secret `githubConfigured` boolean down to the client `SignInForm`.
+ * When the provider is half-configured (NEXTAUTH_SECRET set but the GitHub
+ * creds blank — the QA default), the form renders a self-explanatory
+ * "not configured" message instead of a button that would 404 on GitHub
+ * with an empty client_id (issue #335). The middleware enforcement gate,
+ * which keys on NEXTAUTH_SECRET alone, is unchanged.
+ */
 export default function SignInPage() {
+  const githubConfigured = Boolean(
+    process.env.GITHUB_ID && process.env.GITHUB_SECRET,
+  );
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
       <div className="max-w-md w-full space-y-8 p-8">
@@ -37,7 +31,7 @@ export default function SignInPage() {
         </div>
 
         <Suspense>
-          <SignInForm />
+          <SignInForm githubConfigured={githubConfigured} />
         </Suspense>
 
         <p className="text-center text-xs text-gray-500 dark:text-gray-500 mt-6">

--- a/frontend/auth.js
+++ b/frontend/auth.js
@@ -8,6 +8,22 @@ const allowedUsers = process.env.ALLOWED_USERS
       .filter(Boolean)
   : [];
 
+// Operator-facing startup warning (issue #335): NEXTAUTH_SECRET alone enables
+// the middleware auth gate, so the sign-in page renders — but without GITHUB_ID
+// /GITHUB_SECRET the GitHub button would hand off with an empty client_id and
+// 404 on GitHub. Surface the half-configured state in the logs so it is
+// self-explanatory rather than a silent failure. The in-page message (see
+// app/auth/signin) handles the end-user side.
+if (
+  process.env.NEXTAUTH_SECRET &&
+  !(process.env.GITHUB_ID && process.env.GITHUB_SECRET)
+) {
+  console.warn(
+    "[auth] NEXTAUTH_SECRET is set but GITHUB_ID/GITHUB_SECRET are missing — " +
+      "GitHub sign-in is disabled until both are configured (issue #335).",
+  );
+}
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
   trustHost: true,
   providers: [

--- a/frontend/e2e/auth-flow.spec.js
+++ b/frontend/e2e/auth-flow.spec.js
@@ -164,3 +164,53 @@ test.describe('Issue #80: NEXTAUTH_SECRET-only auth enablement @smoke @e2e', () 
     expect(partialWarnings).toHaveLength(0);
   });
 });
+
+/**
+ * Issue #335 — half-configured GitHub OAuth on the sign-in page.
+ *
+ * When NEXTAUTH_SECRET is set but GITHUB_ID/GITHUB_SECRET are blank (the QA
+ * default before a dedicated OAuth app is registered), the sign-in page used
+ * to render a "Sign in with GitHub" button that handed off to github.com with
+ * an empty client_id and 404'd. The fix renders a self-explanatory
+ * "GitHub OAuth is not configured for this environment" message instead, and
+ * never renders the button in that state.
+ *
+ * Whether GITHUB_ID is set is fixed at dev-server startup, so this spec
+ * branches on the rendered state rather than forcing an env: it asserts the
+ * not-configured message and the GitHub button are mutually exclusive and that
+ * exactly one of them renders. To exercise the not-configured branch
+ * deterministically, run the dev server with a blank GITHUB_ID + a set
+ * NEXTAUTH_SECRET.
+ *
+ * AC2 (startup warning when NEXTAUTH_SECRET set + creds empty) is a
+ * server-process log line emitted at module load, not cleanly assertable from
+ * Playwright's browser context — verified via the container log on the QA
+ * stack instead. Documented here per CLAUDE.md's manual-AC convention.
+ */
+test.describe('Sign-in GitHub-config state @smoke @e2e', () => {
+  test('renders exactly one of the GitHub button or the not-configured notice', async ({ page }) => {
+    await page.goto('/auth/signin');
+    await page.waitForLoadState('networkidle');
+
+    const button = page.getByRole('button', { name: /sign in with github/i });
+    const notice = page.getByTestId('github-not-configured');
+
+    const buttonVisible = await button.isVisible().catch(() => false);
+    const noticeVisible = await notice.isVisible().catch(() => false);
+
+    // Mutually exclusive: exactly one of the two states is rendered.
+    expect(buttonVisible).not.toBe(noticeVisible);
+
+    if (noticeVisible) {
+      // Not-configured branch: the message is shown and the button is absent.
+      await expect(notice).toContainText(
+        /GitHub OAuth is not configured for this environment/i
+      );
+      await expect(button).toHaveCount(0);
+    } else {
+      // Configured branch: the working button renders unchanged (#335 AC4).
+      await expect(button).toBeVisible();
+      await expect(notice).toHaveCount(0);
+    }
+  });
+});

--- a/frontend/e2e/auth-flow.spec.js
+++ b/frontend/e2e/auth-flow.spec.js
@@ -65,6 +65,14 @@ test.describe('Sign-in page @smoke @e2e', () => {
   test('shows GitHub sign-in button', async ({ page }) => {
     await page.goto('/auth/signin');
     await page.waitForLoadState('networkidle');
+    // #335: the button only renders when GitHub OAuth is configured. When it
+    // isn't (e.g. CI with no GITHUB_ID), the not-configured notice renders
+    // instead — that mutual exclusion is covered by the 'Sign-in GitHub-config
+    // state' spec below. Skip here so this baseline assertion runs only in the
+    // configured state and doesn't fail on a correctly-degraded sign-in page.
+    if (await page.getByTestId('github-not-configured').isVisible().catch(() => false)) {
+      test.skip(true, 'GitHub OAuth not configured — button intentionally hidden (#335)');
+    }
     await expect(page.getByRole('button', { name: /sign in with github/i })).toBeVisible();
   });
 


### PR DESCRIPTION
## v1.6.4 — Deploy hardening

Single integration PR for the **Deploy hardening** milestone. Four issues, four commits (one per issue), all off `main`.

`closes #221 #326 #335 #232`

> **Multi-issue close caveat (Release Model):** GitHub's squash-merge auto-closes only ONE of these on merge. After merge, the remaining three get a manual audit-trail close of the form `Closed by PR #<this>, shipped in v1.6.4: <release URL>`.

---

## ⚠️ POST-MERGE GATE — #232 QA validation (prod-deploy-behavior change)

**#232 changes the signal Docker uses to decide the frontend is healthy.** It can only be fully validated against a live container-up healthcheck cycle, which is done on the **QA stack** after merge — NOT in this PR's CI. Before promoting to prod, validate the full matrix on QA:

1. Deploy the changed `docker-compose.qa.yml`; confirm `docker compose ps` shows the frontend **healthy** when the app renders.
2. Break the app (stop the frontend container); confirm the healthcheck flips to **unhealthy** within `interval × retries`.
3. Confirm the auth-redirect path (`NEXTAUTH_SECRET` set) does **not** produce a false negative.

**Mitigation / revert boundary:** #232 is its own commit (`c074dd8`) — if the new probe flaps a working prod frontend, `git revert c074dd8` cleanly backs out only the healthcheck change. A too-strict probe could mark a working frontend unhealthy, so watch the first prod deploy's `docker compose ps` health state.

Scope guard: a server-side HTTP probe proves the served HTML is a real page, NOT client hydration — #229-class hydration failures remain out of scope (that's the CI e2e lane).

---

## Fixes

### #221 — Schwab credential env-wins precedence (`fbf986a`)
`get_schwab_credentials()` only short-circuited when *both* env vars were set; with exactly one set, it fell into the DB-fallback branch where unconditional assignments let a stale `app_settings` row clobber the env-supplied half. Now per-field, env-wins: the DB is consulted only for a half the env didn't supply. Mirrors `get_fred_api_key` / `get_slack_webhook_url`. Backend-only; 3 unit tests (rewrote `partial_env` to assert the fix + symmetric + no-conflicting-row cases).

### #326 — watchlist `add_ticker` atomicity (`b2e4226`)
Present-check-then-insert had a race window: two concurrent adds of the same new ticker could both pass `db.get(...) is None` and race to a second `INSERT` on the PK, raising `IntegrityError` that the router collapsed to a 500. Wrapped the insert in `try/except IntegrityError: db.rollback()` → idempotent no-op. ORM-portable (no dialect-specific `ON CONFLICT`). 2 new service-level integration tests + rewrote the order-coupled `test_get_list_is_returned_in_stable_order` (bridge edit) to seed distinct `added_at` in reverse-alpha order so it proves true insertion-order sort.

### #335 — half-configured GitHub OAuth on sign-in (`064b1cf`)
With `NEXTAUTH_SECRET` set but `GITHUB_ID`/`GITHUB_SECRET` blank (the QA default), the sign-in page rendered a "Sign in with GitHub" button that handed off with an empty `client_id` and 404'd. Fix (CTO Option A): `page.jsx` becomes a server component reading the server-only creds and passing a non-secret `githubConfigured` boolean to the new client `SignInForm`; when false it renders a "GitHub OAuth is not configured for this environment" notice instead of the dead button. Added an operator-facing startup warning in `auth.js`. The middleware enforcement gate (keyed on `NEXTAUTH_SECRET` alone) is unchanged (AC3). Treated as a display-bug hotfix — no designer pass. Playwright `@smoke @e2e` test (branch-adaptive, mutually-exclusive button/notice); verified locally in both branches (blank creds → notice + startup warning emitted; creds set → button, all existing sign-in tests green).

### #232 — frontend healthcheck probes `/auth/signin` (`c074dd8`)
See the post-merge gate above. Old probe hit `/` (a 307 redirect, `< 400`) so it passed the instant Next.js was listening — a dead app reported healthy (#229). New probe hits `/auth/signin` directly: a real rendered, middleware-excluded page that returns 200 in both auth-on/off deployments. Applied identically to `docker-compose.prod.yml` and `docker-compose.qa.yml`.

---

## Test results
- **Backend:** `cd backend && python -m pytest` → **1632 passed, 59 skipped**. Classifier ✅, `tdd_red` gate ✅ (no surviving markers in changed files), OpenAPI snapshot ✅ (no route-shape changes, no drift).
- **Frontend:** Playwright `auth-flow.spec.js` sign-in suite + new #335 config-state test run locally and green in both the not-configured and configured env branches; tag check ✅. The #232 container healthcheck cycle is the QA post-merge gate above (container-layer AC, not in the pytest/Playwright pyramid).

Do not merge yet — leaving for CodeRabbit + human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)