### PR TITLE
Hotfix: grant packages: write to deploy.yml ci job (fixes Deploy startup_failure)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,15 @@ jobs:
   ci:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
+    # A called reusable workflow's GITHUB_TOKEN permissions are CAPPED by the
+    # caller. ci.yml's build-and-push-images job (SUB-1) needs `packages: write`
+    # to push images to GHCR; the workflow-level default above is only
+    # `contents: read`, so without this grant the called job's request exceeds
+    # the cap and the whole Deploy run fails at startup (zero jobs). Grant the
+    # ci call exactly what it needs — least privilege, scoped to this job.
+    permissions:
+      contents: read
+      packages: write
 
   # main HEAD, an RC prerelease, or a manual qa dispatch → QA stack
   deploy-qa:

--- a/backend/tests/test_deploy_pull_config.py
+++ b/backend/tests/test_deploy_pull_config.py
@@ -206,6 +206,21 @@ class TestDeploySshPullByDigest:
         assert "group: deploy-${{ inputs.environment }}" in deploy_ssh_text
 
     @pytest.mark.unit
+    def test_deploy_ci_job_grants_packages_write(self) -> None:
+        """The `ci` reusable-workflow call must grant packages: write.
+
+        Regression guard for the Deploy startup_failure after #345: a called
+        reusable workflow's GITHUB_TOKEN permissions are capped by the caller, so
+        ci.yml's build-and-push-images job (which needs packages: write to push
+        to GHCR) is rejected at graph-build time unless the `ci` job in deploy.yml
+        grants it. Workflow-level default is only contents: read.
+        """
+        config = yaml.safe_load(DEPLOY_WORKFLOW.read_text())
+        ci_perms = config["jobs"]["ci"]["permissions"]
+        assert ci_perms["packages"] == "write"
+        assert ci_perms["contents"] == "read"
+
+    @pytest.mark.unit
     def test_deploy_yml_threads_digests_to_both_paths(self) -> None:
         """deploy.yml threads pinned digests to QA + prod deploy calls.
 


### PR DESCRIPTION
## Problem

The Deploy workflow **startup-failed** on the merge commit of #345 (run [27493049419](https://github.com/ssandy33/regress/actions/runs/27493049419)) — zero jobs, ~1s, "workflow file issue".

## Root cause

`deploy.yml`'s `ci` job calls `ci.yml` as a reusable workflow. #345 (SUB-1) added a `build-and-push-images` job to `ci.yml` with job-level `permissions: packages: write`. **A called reusable workflow's `GITHUB_TOKEN` permissions are capped by the caller.** `deploy.yml`'s only grant was `contents: read`, so the called job's `packages: write` request exceeded the cap and was rejected at graph-build time → `startup_failure`.

Invisible on PR #345 because **Deploy only runs on push-to-main / release, never on PRs** — the first push to `main` was its first execution.

## Fix

Grant the `ci` reusable-workflow call `packages: write` at the job level (least privilege, scoped to that call). Plus a regression test (`test_deploy_ci_job_grants_packages_write`).

## Note

Merging this triggers the **first real image-pinned Deploy run** — the QA-first cutover (build+push to GHCR → QA pulls by digest). `GHCR_PULL_TOKEN` is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)