### PR TITLE
v1.7.0 — Covered Call decision support (#318, #319, #320)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -1151,12 +1151,52 @@ class BtcEconomics(BaseModel):
     pricing_source: Literal["live", "stub", "unavailable"]
 
 
+class BtcAnalysisScenario(BaseModel):
+    """One assign-vs-buy-to-close scenario row (issue #319).
+
+    All money figures are whole-position dollars (per-share × contracts × 100)
+    to match the economics block convention. ``delta = btc_and_hold -
+    let_assign``; ``winner`` is ``"btc"`` when ``delta > 0``, ``"assign"`` when
+    ``delta < 0``, ``"tie"`` at exact breakeven.
+    """
+
+    underlying: float  # S_e — underlying at this expiration scenario
+    label: str  # "−10%" | "Flat" | "+5%" | "+10%"
+    let_assign: float  # K × n × 100  (whole-position $)
+    btc_and_hold: float  # (S_e − O) × n × 100  (whole-position $)
+    delta: float  # btc_and_hold − let_assign (signed; >0 ⇒ BTC wins)
+    winner: Literal["btc", "assign", "tie"]
+
+
+class BtcAnalysis(BaseModel):
+    """BTC decision-math block: decomposition, breakeven, scenarios (issue #319).
+
+    ``available`` gates the panel: ``False`` when neither a live option mid nor
+    an underlying price is resolvable. When ``available`` is ``True`` but the
+    option mid is missing (illiquid strike / greek-null), ``intrinsic`` is still
+    populated while ``extrinsic`` / ``btc_breakeven`` / ``scenarios`` degrade to
+    null / empty. Per-share figures (intrinsic / extrinsic / option_mid) are NOT
+    scaled; the scenario dollars ARE (× contracts × 100).
+    """
+
+    available: bool
+    intrinsic: Optional[float] = None
+    extrinsic: Optional[float] = None
+    extrinsic_pct_of_mid: Optional[float] = None
+    option_mid: Optional[float] = None
+    btc_breakeven: Optional[float] = None
+    underlying: Optional[float] = None
+    breakeven_delta: Optional[float] = None
+    scenarios: list[BtcAnalysisScenario] = Field(default_factory=list)
+
+
 class BtcDetailResponse(BaseModel):
     """Top-level response for ``GET /api/positions/{id}/legs/{legId}/btc``.
 
     Composes the leg identity, the §R6 rule-monitor verdict + audit (reused
     verbatim from :func:`app.services.rule_monitor.evaluate_leg_rules` via
-    ``derive_open_legs``), and the buy-to-close economics block. A 404 with
+    ``derive_open_legs``), the buy-to-close economics block, and the BTC
+    decision-math analysis block (issue #319). A 404 with
     ``{"detail": "Leg not found"}`` is returned for an unknown / closed leg.
     """
 
@@ -1164,6 +1204,7 @@ class BtcDetailResponse(BaseModel):
     leg: BtcLeg
     verdict: DASHBOARD_VERDICT
     economics: BtcEconomics
+    analysis: BtcAnalysis
     triggered_rules: list[DashboardRuleEvaluation] = Field(default_factory=list)
     disclaimer: Optional[str] = None
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -513,6 +513,11 @@ class PositionResponse(BaseModel):
     notes: Optional[str] = None
     total_premiums: float
     adjusted_cost_basis: float
+    # Per-share basis (issue #320): round(total / shares, 4), null when
+    # shares == 0. Mirrors the covered-call/action-engine convention
+    # (covered_call.py:276) so per-share rounding has a single source of truth.
+    broker_cost_basis_per_share: Optional[float] = None
+    adjusted_cost_basis_per_share: Optional[float] = None
     min_compliant_cc_strike: float
     trades: list[TradeResponse] = []
 
@@ -779,6 +784,11 @@ class DashboardPositionRow(BaseModel):
     # cost-basis cell ("line 1: broker; line 2: adjusted, muted").
     # Optional because cash-secured-put rows have no broker basis yet.
     broker_cost_basis: Optional[float] = None
+    # New in v1.7.0 (#320) — per-share basis so the cost-basis cell aligns
+    # 1:1 with the per-share Current column. round(total / shares, 4); null
+    # when shares == 0 (cash-secured rows render "cash-secured", not a divide).
+    broker_cost_basis_per_share: Optional[float] = None
+    adjusted_cost_basis_per_share: Optional[float] = None
 
 
 class DashboardMoneyness(BaseModel):

--- a/backend/app/services/btc_detail.py
+++ b/backend/app/services/btc_detail.py
@@ -32,7 +32,7 @@ from typing import Any
 from sqlalchemy.orm import Session as DBSession
 
 from app.services import journal
-from app.services.dashboard_legs import build_option_mark_index, derive_open_legs
+from app.services.dashboard_legs import build_option_leg_index, derive_open_legs
 from app.services.rules_config import load_rules_config
 from app.services.schwab_client import SchwabClient
 
@@ -166,8 +166,12 @@ def build_btc_detail(
         float(current_price_raw) if current_price_raw is not None else None
     )
     chain = client.get_option_chain(ticker)
-    marks = build_option_mark_index(
-        {ticker: chain} if isinstance(chain, dict) else {}
+    # Richer per-leg index carrying delta (issue #318) — same shared path as the
+    # dashboard, so the BTC screen sees the identical delta. Spot is threaded
+    # for the Black-Scholes delta fallback on illiquid strikes.
+    marks = build_option_leg_index(
+        {ticker: chain} if isinstance(chain, dict) else {},
+        spots_by_ticker={ticker: current_price},
     )
 
     open_legs = derive_open_legs(

--- a/backend/app/services/btc_detail.py
+++ b/backend/app/services/btc_detail.py
@@ -48,6 +48,17 @@ DISCLAIMER_TEXT: str = (
     "exclude commissions; the decision to buy to close is yours."
 )
 
+# Scenario grid (issue #319, Decision 1): fixed offsets of the current
+# underlying S — one down, one flat, two up. Strike-independent so it does not
+# degenerate for deep-ITM legs (where S ≫ K). Order down→up matches the spec
+# table. Swap this one line to revisit the grid.
+SCENARIO_OFFSETS: list[tuple[float, str]] = [
+    (-0.10, "−10%"),
+    (0.0, "Flat"),
+    (0.05, "+5%"),
+    (0.10, "+10%"),
+]
+
 # Maps the position's derived strategy label to the human context phrase used
 # in the leg header sub-line. Unknown strategies fall back to "position".
 _STRATEGY_LABEL: dict[str, str] = {
@@ -115,6 +126,120 @@ def _build_economics(leg: dict) -> dict[str, Any]:
         "est_pl_if_closed": est_pl_if_closed,
         "pricing_as_of": datetime.now(timezone.utc).isoformat(),
         "pricing_source": "live",
+    }
+
+
+def _degraded_analysis() -> dict[str, Any]:
+    """Full-degrade analysis body — neither a live mid nor an underlying price."""
+    return {
+        "available": False,
+        "intrinsic": None,
+        "extrinsic": None,
+        "extrinsic_pct_of_mid": None,
+        "option_mid": None,
+        "btc_breakeven": None,
+        "underlying": None,
+        "breakeven_delta": None,
+        "scenarios": [],
+    }
+
+
+def _build_analysis(leg: dict, current_price: float | None) -> dict[str, Any]:
+    """Compute the BTC decision-math block for one leg (issue #319).
+
+    Pure function — no I/O, never raises on bad input (a thrown exception would
+    500 the whole page). Reads only ``leg["type"]`` / ``leg["strike"]`` /
+    ``leg["current_mid"]`` / ``leg["quantity"]`` and the live underlying
+    ``current_price``. Consumes no option delta/greek — the decomposition,
+    breakeven, and scenarios are all expressible in S, K, O, n.
+
+    Degrade gates:
+
+    - No underlying ``S`` → ``available: False`` (intrinsic is uncomputable
+      without ``S``), regardless of the mid.
+    - ``S`` present, mid ``O`` missing → greek-null: intrinsic computable,
+      extrinsic / breakeven / scenarios null. ``available: True``.
+    - Both present → fully populated.
+
+    Per-share figures (intrinsic / extrinsic / option_mid) are NOT scaled; the
+    scenario dollars use the same ``× contracts × 100`` scaling as
+    :func:`_build_economics` so the figures are directly comparable.
+    """
+    current_mid = leg.get("current_mid")  # per-share, None ⇒ no live mark
+    strike_raw = leg.get("strike")
+
+    # Can't compute intrinsic without the underlying or the strike.
+    if current_price is None or strike_raw is None:
+        return _degraded_analysis()
+
+    s = float(current_price)
+    k = float(strike_raw)
+    is_put = leg.get("type") == "put"
+    intrinsic = max(0.0, (k - s) if is_put else (s - k))
+
+    # Greek-null: underlying live, option mid missing (illiquid strike).
+    # Intrinsic still computes; everything that needs O degrades.
+    if current_mid is None:
+        return {
+            "available": True,
+            "intrinsic": round(intrinsic, 2),
+            "extrinsic": None,
+            "extrinsic_pct_of_mid": None,
+            "option_mid": None,
+            "btc_breakeven": None,
+            "underlying": round(s, 2),
+            "breakeven_delta": None,
+            "scenarios": [],
+        }
+
+    o = float(current_mid)
+    # Clamp negative extrinsic (stale mid drives O < intrinsic) to 0 — a valid
+    # "no time value left" reading for deep-ITM at expiry. We do NOT flip
+    # available false on a clamp (Decision 2).
+    extrinsic = max(0.0, o - intrinsic)
+    extrinsic_pct_of_mid = round(extrinsic / o, 4) if o != 0 else None
+
+    btc_breakeven = k + o  # = S + extrinsic
+    breakeven_delta = s - btc_breakeven
+
+    contracts = int(leg.get("quantity") or 1)
+    scale = contracts * 100
+    let_assign = round(k * scale, 2)
+    scenarios: list[dict[str, Any]] = []
+    for offset, label in SCENARIO_OFFSETS:
+        # Round the scenario underlying to the displayed price first, then
+        # derive the dollar figures from it — so the table's BTC+hold / Δ
+        # columns reconcile with the underlying shown in the same row.
+        s_e = round(s * (1.0 + offset), 2)
+        btc_and_hold = round((s_e - o) * scale, 2)
+        delta = round(btc_and_hold - let_assign, 2)
+        if delta > 0:
+            winner = "btc"
+        elif delta < 0:
+            winner = "assign"
+        else:
+            winner = "tie"
+        scenarios.append(
+            {
+                "underlying": round(s_e, 2),
+                "label": label,
+                "let_assign": let_assign,
+                "btc_and_hold": btc_and_hold,
+                "delta": delta,
+                "winner": winner,
+            }
+        )
+
+    return {
+        "available": True,
+        "intrinsic": round(intrinsic, 2),
+        "extrinsic": round(extrinsic, 2),
+        "extrinsic_pct_of_mid": extrinsic_pct_of_mid,
+        "option_mid": round(o, 2),
+        "btc_breakeven": round(btc_breakeven, 2),
+        "underlying": round(s, 2),
+        "breakeven_delta": round(breakeven_delta, 2),
+        "scenarios": scenarios,
     }
 
 
@@ -188,6 +313,7 @@ def build_btc_detail(
         return None
 
     economics = _build_economics(leg)
+    analysis = _build_analysis(leg, current_price)
     verdict = leg.get("verdict") or "hold"
     state = "no-rule-triggered" if verdict == "hold" else "populated"
 
@@ -196,6 +322,7 @@ def build_btc_detail(
         "leg": _reshape_leg(leg, position),
         "verdict": verdict,
         "economics": economics,
+        "analysis": analysis,
         "triggered_rules": leg.get("triggered_rules") or [],
         "disclaimer": DISCLAIMER_TEXT,
     }

--- a/backend/app/services/btc_detail.py
+++ b/backend/app/services/btc_detail.py
@@ -172,10 +172,18 @@ def _build_analysis(leg: dict, current_price: float | None) -> dict[str, Any]:
     if current_price is None or strike_raw is None:
         return _degraded_analysis()
 
+    # Gate puts out of the covered-call decision math (v1.7.0 is CC-scoped).
+    # The breakeven / let-assign / BTC-and-hold equations below are
+    # call-specific (btc_breakeven = K + O, let_assign = K·n·100, etc.); they
+    # produce misleading numbers for a short put. Until put equations exist,
+    # return the not-applicable shape so the panel never displays call-math
+    # for a put. Gate after the S/K degrade check, before any call computation.
+    if leg.get("type") == "put":
+        return _degraded_analysis()
+
     s = float(current_price)
     k = float(strike_raw)
-    is_put = leg.get("type") == "put"
-    intrinsic = max(0.0, (k - s) if is_put else (s - k))
+    intrinsic = max(0.0, s - k)
 
     # Greek-null: underlying live, option mid missing (illiquid strike).
     # Intrinsic still computes; everything that needs O degrades.

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -23,7 +23,7 @@ from app.services import journal as journal_service
 from app.services.action_engine import compute_next_actions
 from app.services.alpha_vantage_client import get_cached_next_earnings_date
 from app.services.dashboard_legs import (
-    build_option_mark_index,
+    build_option_leg_index,
     derive_open_legs,
     parse_iso_to_utc,
 )
@@ -683,7 +683,9 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         open_leg_tickers, schwab_configured=schwab_configured
     )
     schwab_failed = schwab_failed or chains_failed
-    option_marks = build_option_mark_index(option_chains)
+    # Richer per-leg index carrying delta (issue #318). Spot is threaded so the
+    # Black-Scholes delta fallback can run on illiquid strikes.
+    option_marks = build_option_leg_index(option_chains, spots_by_ticker=quotes_by_ticker)
 
     # Legs derive purely from in-memory data + the quote/mark maps. Earnings
     # lookup is cache-hit-only — the request path must not block on AV.

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -320,6 +320,16 @@ def _build_position_rows(
                 # Broker basis is surfaced so the Positions card can render
                 # the dual-line "broker / adjusted" cost-basis cell (#151).
                 "broker_cost_basis": position.get("broker_cost_basis"),
+                # Per-share basis (#320) — the card renders these so the
+                # cost-basis cell aligns with the per-share Current column.
+                # Already computed (and shares==0 → null guarded) by the
+                # journal producer; thread them straight through.
+                "broker_cost_basis_per_share": position.get(
+                    "broker_cost_basis_per_share"
+                ),
+                "adjusted_cost_basis_per_share": position.get(
+                    "adjusted_cost_basis_per_share"
+                ),
             }
         )
     # Sort by notional desc (None last), then ticker asc.

--- a/backend/app/services/dashboard_legs.py
+++ b/backend/app/services/dashboard_legs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Iterable, Literal
 
+from app.services.greeks import calculate_greeks
 from app.services.rule_monitor import evaluate_leg_rules
 from app.utils.parsing import to_float
 
@@ -29,6 +30,25 @@ DecisionTag = Literal["roll-or-assign", "manage", "watch", "hold"]
 AssignmentRisk = Literal["high", "watch", "low"]
 SuggestedAction = Literal["roll", "close", "hold", "manage"]
 ProfitTargetState = Literal["captured_50", "in_progress", "underwater", "unknown"]
+
+# Depth-of-ITM signal for assignment risk (issue #318). A separate axis from the
+# acute-timing (DTE) floor — see compute_assignment_risk.
+AssignmentDepth = Literal["deep", "moderate", "shallow", "unknown"]
+DeltaSource = Literal["market", "calculated"]
+
+# Schwab uses a |value| >= 999 sentinel to mean "greek not available". Mirrors
+# the null-out pattern in app.services.options_scanner.
+_DELTA_SENTINEL = 999.0
+
+# Depth thresholds (frozen — issue #318 contract freeze). Delta is the primary
+# signal; moneyness-% (distance_pct) is the degrade when delta is null.
+_DEPTH_DELTA_DEEP = 0.80
+_DEPTH_DELTA_MODERATE = 0.60
+_DEPTH_MONEYNESS_DEEP = 0.10
+_DEPTH_MONEYNESS_MODERATE = 0.05
+
+# Risk-bucket severity ordering for the independent-max combine (Decision 2).
+_RISK_SEVERITY: dict[AssignmentRisk, int] = {"low": 0, "watch": 1, "high": 2}
 
 # Maps the four existing decision-tag buckets to the V0.5 suggested-action
 # vocabulary. Spec §14.5 locks this mapping; "close" is intentionally absent
@@ -134,27 +154,144 @@ def compute_decision_tag(
     return "hold"
 
 
+def resolve_leg_delta(
+    raw_delta: float | None,
+    spot: float | None,
+    strike: float,
+    dte: int,
+    iv: float | None,
+    option_type: Literal["put", "call"],
+) -> tuple[float | None, DeltaSource | None]:
+    """Resolve a leg's signed option delta and its provenance.
+
+    Single source of truth for delta on the shared leg path (issue #318 / #319),
+    mirroring the sentinel + Black-Scholes fallback in
+    :mod:`app.services.options_scanner`.
+
+    Resolution order:
+
+    - A Schwab ``|delta| >= 999`` sentinel is treated as missing.
+    - A present, non-sentinel delta is returned with ``source="market"``.
+    - A missing delta with a usable IV and a positive spot is computed via
+      :func:`app.services.greeks.calculate_greeks` (``source="calculated"``).
+    - Otherwise ``(None, None)`` — the caller degrades to the moneyness-%
+      depth fallback.
+
+    Args:
+        raw_delta: ``contract.get("delta")`` off the Schwab chain node.
+        spot: Underlying price; required for the Black-Scholes fallback.
+        strike: Option strike.
+        dte: Days to expiration.
+        iv: Implied volatility as a decimal (``contract.volatility / 100``).
+        option_type: ``"put"`` or ``"call"``.
+
+    Returns:
+        ``(delta, source)`` where ``source ∈ {"market", "calculated", None}``.
+        Put delta is negative — callers compare on ``abs(delta)``.
+    """
+    if raw_delta is not None and abs(raw_delta) >= _DELTA_SENTINEL:
+        raw_delta = None
+    if raw_delta is not None:
+        return raw_delta, "market"
+    if iv and spot and spot > 0:
+        calc = calculate_greeks(
+            spot=spot,
+            strike=strike,
+            dte=dte,
+            iv=iv,
+            contract_type="CALL" if option_type == "call" else "PUT",
+        )
+        if calc["delta"] is not None:
+            return calc["delta"], "calculated"
+    return None, None
+
+
+def classify_depth(
+    delta: float | None,
+    distance_pct: float | None,
+) -> AssignmentDepth:
+    """Classify depth-of-ITM from delta (primary) or moneyness-% (fallback).
+
+    Delta is the market's own probability-of-finishing-ITM estimate, so it is
+    the precise depth signal; moneyness-% is the coarser degrade when delta is
+    null. Thresholds are frozen by the issue #318 contract:
+
+    - ``abs(delta) >= 0.80`` → ``"deep"``
+    - ``abs(delta) >= 0.60`` → ``"moderate"``
+    - ``delta`` present and ``< 0.60`` → ``"shallow"``
+    - ``delta`` null, ``distance_pct >= 0.10`` → ``"deep"`` (fallback)
+    - ``delta`` null, ``distance_pct >= 0.05`` → ``"moderate"`` (fallback)
+    - ``delta`` null, ``distance_pct < 0.05`` → ``"shallow"`` (fallback)
+    - both null (no live signal at all) → ``"unknown"``
+
+    ``abs(delta)`` is used because short puts carry a negative delta; depth is
+    direction-agnostic ("how far ITM"). This is a pure classifier — moneyness
+    state (ITM/OTM) gating happens upstream in :func:`compute_assignment_risk`.
+    """
+    if delta is not None:
+        magnitude = abs(delta)
+        if magnitude >= _DEPTH_DELTA_DEEP:
+            return "deep"
+        if magnitude >= _DEPTH_DELTA_MODERATE:
+            return "moderate"
+        return "shallow"
+    if distance_pct is not None:
+        if distance_pct >= _DEPTH_MONEYNESS_DEEP:
+            return "deep"
+        if distance_pct >= _DEPTH_MONEYNESS_MODERATE:
+            return "moderate"
+        return "shallow"
+    return "unknown"
+
+
 def compute_assignment_risk(
     dte: int,
     moneyness_state: str | None,
+    depth: AssignmentDepth = "unknown",
 ) -> AssignmentRisk:
     """Classify the short option's assignment risk into three buckets.
 
-    Per spec §14.5:
-    - ``dte <= 7 AND ITM``  → ``"high"`` (acute risk; review today)
+    Two independent escalation axes are combined by "take the higher risk"
+    (issue #318, Decision 2):
+
+    **Acute-timing axis** (preserves the original spec §14.5 behavior):
+
+    - ``dte <= 7 AND ITM``  → ``"high"`` (review today)
     - ``dte <= 14 AND ITM`` → ``"watch"`` (watch the next 1–2 sessions)
     - otherwise             → ``"low"``
 
+    **Depth axis** (new — escalates a deep-ITM leg regardless of DTE):
+
+    - ``depth == "deep"``     → ``"high"``
+    - ``depth == "moderate"`` → ``"watch"``
+    - ``depth in {"shallow", "unknown"}`` → ``"low"``
+
+    The final bucket is ``max(timing, depth)`` on ``high > watch > low``.
+    ``depth`` defaults to ``"unknown"`` so every legacy caller stays
+    behavior-identical (the result collapses to the timing axis).
+
     Non-ITM legs and legs with unknown moneyness (no live price) collapse to
-    ``"low"`` so the dashboard never flags a risk it cannot justify.
+    ``"low"`` — both axes are gated on ITM so the dashboard never flags a risk
+    it cannot justify.
     """
     if moneyness_state != "ITM":
         return "low"
+
     if dte <= 7:
-        return "high"
-    if dte <= 14:
-        return "watch"
-    return "low"
+        timing_bucket: AssignmentRisk = "high"
+    elif dte <= 14:
+        timing_bucket = "watch"
+    else:
+        timing_bucket = "low"
+
+    if depth == "deep":
+        depth_bucket: AssignmentRisk = "high"
+    elif depth == "moderate":
+        depth_bucket = "watch"
+    else:
+        depth_bucket = "low"
+
+    return max(timing_bucket, depth_bucket, key=_RISK_SEVERITY.__getitem__)
 
 
 def compute_suggested_action(decision_tag: DecisionTag) -> SuggestedAction:
@@ -305,29 +442,43 @@ def derive_leg_economics(
     }
 
 
-def build_option_mark_index(
+def build_option_leg_index(
     chains_by_ticker: dict[str, dict],
-) -> dict[tuple, float]:
-    """Flatten raw Schwab option-chain responses into a flat mid-price index.
+    spots_by_ticker: dict[str, float | None] | None = None,
+) -> dict[tuple, dict]:
+    """Flatten raw Schwab option chains into a per-leg ``{mid, delta}`` index.
 
-    Schwab ``callExpDateMap`` / ``putExpDateMap`` are nested two levels deep:
+    This is the richer sibling of :func:`build_option_mark_index` — the
+    **shared, reusable** leg index consumed by the dashboard and BTC-detail
+    paths (issue #318) and by the BTC decision math (issue #319). Schwab
+    ``callExpDateMap`` / ``putExpDateMap`` are nested two levels deep:
     ``{exp_key: {strike_str: [contract, ...]}}`` where ``exp_key`` looks like
-    ``"2026-06-26:38"`` (expiration date plus DTE). This helper flattens them
-    into ``{(ticker, type, round(strike, 4), exp_date): mid}`` so a leg can be
-    matched with a single dict lookup.
+    ``"2026-06-26:38"`` (expiration date plus DTE). Each entry is flattened to
+    ``{(ticker, type, round(strike, 4), exp_date): {"mid", "delta", ...}}`` so a
+    leg matches with a single dict lookup.
 
-    The mid is ``contract["mark"]`` when present, otherwise ``(bid + ask) / 2``
-    (mirrors :mod:`app.services.options_scanner`). Entries with a falsy mid are
-    skipped — a leg with no usable mark degrades to ``unknown`` rather than a
-    misleading 0.
+    Value shape (frozen — issue #318 contract):
+
+    - ``mid``: ``contract["mark"]`` when present, else ``(bid + ask) / 2``
+      (mirrors :mod:`app.services.options_scanner`). Falsy mids are skipped.
+    - ``delta``: signed live delta with the Schwab ``>= 999`` sentinel nulled
+      and a Black-Scholes fallback when the chain omits it but IV + spot are
+      present (see :func:`resolve_leg_delta`). ``None`` when unresolvable.
+    - ``delta_source``: ``"market"`` | ``"calculated"`` | ``None``.
+
+    ``spots_by_ticker`` supplies the per-ticker underlying price needed for the
+    Black-Scholes delta fallback (the chain node does not carry spot). When a
+    spot is missing the fallback simply cannot run → delta stays ``None``.
 
     The function is tolerant of malformed nodes: a single bad contract,
     missing key, or non-dict entry is skipped and never aborts the index.
     """
-    index: dict[tuple, float] = {}
+    spots_by_ticker = spots_by_ticker or {}
+    index: dict[tuple, dict] = {}
     for ticker, chain in (chains_by_ticker or {}).items():
         if not isinstance(chain, dict):
             continue
+        spot = spots_by_ticker.get(ticker)
         for option_type, map_key in (("call", "callExpDateMap"), ("put", "putExpDateMap")):
             exp_date_map = chain.get(map_key)
             if not isinstance(exp_date_map, dict):
@@ -351,8 +502,42 @@ def build_option_mark_index(
                     mid = to_float(contract.get("mark")) or round((bid + ask) / 2, 4)
                     if not mid:
                         continue
-                    index[(ticker, option_type, round(strike, 4), exp_date)] = mid
+                    vol_raw = to_float(contract.get("volatility"), None)
+                    iv = vol_raw / 100.0 if vol_raw else None
+                    dte = compute_dte(exp_date)
+                    delta, delta_source = resolve_leg_delta(
+                        raw_delta=to_float(contract.get("delta"), None),
+                        spot=spot,
+                        strike=strike,
+                        dte=dte,
+                        iv=iv,
+                        option_type=option_type,  # type: ignore[arg-type]
+                    )
+                    index[(ticker, option_type, round(strike, 4), exp_date)] = {
+                        "mid": mid,
+                        "delta": delta,
+                        "delta_source": delta_source,
+                    }
     return index
+
+
+def build_option_mark_index(
+    chains_by_ticker: dict[str, dict],
+) -> dict[tuple, float]:
+    """Flatten raw Schwab option chains into a flat mid-price index.
+
+    Thin, back-compatible wrapper over :func:`build_option_leg_index` that
+    projects out the float ``mid`` so the legacy callers
+    (:mod:`app.services.covered_call` and the mark-index tests) stay byte
+    compatible. New callers that also need delta should use
+    :func:`build_option_leg_index` directly.
+
+    Returns ``{(ticker, type, round(strike, 4), exp_date): mid}``.
+    """
+    return {
+        key: entry["mid"]
+        for key, entry in build_option_leg_index(chains_by_ticker).items()
+    }
 
 
 def compute_earnings_in_window(
@@ -459,14 +644,33 @@ def derive_open_legs(
                 round(strike, 4),
                 str(trade["expiration"])[:10],
             )
-            current_mid = option_marks.get(mark_key)
+            # The index may be the legacy float-mid map
+            # (``build_option_mark_index``) or the richer ``{mid, delta}`` map
+            # (``build_option_leg_index``). Normalize both to (mid, delta).
+            entry = option_marks.get(mark_key)
+            if isinstance(entry, dict):
+                current_mid = entry.get("mid")
+                current_delta = entry.get("delta")
+                delta_source = entry.get("delta_source")
+            else:
+                current_mid = entry
+                current_delta = None
+                delta_source = None
             profit_target_status = build_profit_target_status(
                 premium=trade.get("premium"),
                 current_mid=current_mid,
                 dte=dte,
                 profit_review_pct=profit_review_pct,
             )
-            assignment_risk = compute_assignment_risk(dte, moneyness_state)
+            distance_pct = moneyness["distance_pct"] if moneyness else None
+            assignment_depth = (
+                classify_depth(current_delta, distance_pct)
+                if moneyness_state == "ITM"
+                else "unknown"
+            )
+            assignment_risk = compute_assignment_risk(
+                dte, moneyness_state, depth=assignment_depth
+            )
             # §R6 rule-monitor verdict layer (issue #240). Pure — derives the
             # verdict from values already on this leg; no I/O, no DB.
             verdict, verdict_label, reasoning, triggered_rules = evaluate_leg_rules(
@@ -496,6 +700,13 @@ def derive_open_legs(
                     # by the BTC detail endpoint (issue #244). The dashboard
                     # ignores this key, so it cannot regress #240.
                     "current_mid": current_mid,
+                    # Shared delta interface (issue #318 / #319). `delta` and
+                    # `delta_source` are the fields #319's BTC decision math
+                    # consumes off this identical leg path; `assignment_depth`
+                    # is #318-local metadata behind the risk bucket.
+                    "delta": current_delta,
+                    "delta_source": delta_source,
+                    "assignment_depth": assignment_depth,
                     "profit_target_status": profit_target_status,
                     "assignment_risk": assignment_risk,
                     "suggested_action": compute_suggested_action(decision_tag),

--- a/backend/app/services/journal.py
+++ b/backend/app/services/journal.py
@@ -45,6 +45,19 @@ def compute_min_cc_strike(adjusted_basis: float, shares: int) -> float:
     return round((adjusted_basis / shares) * 1.10, 2)
 
 
+def compute_per_share_basis(total: float, shares: int) -> float | None:
+    """Per-share cost basis = ``round(total / shares, 4)`` (issue #320).
+
+    Returns ``None`` when ``shares <= 0`` so the Positions table renders an
+    em-dash instead of dividing by zero. Mirrors the covered-call /
+    action-engine rounding convention (``covered_call.py:276``) so per-share
+    basis has a single source of truth.
+    """
+    if shares <= 0:
+        return None
+    return round(total / shares, 4)
+
+
 def _build_trade_response(trade: Trade) -> dict:
     """Build a TradeResponse dict from a Trade ORM object."""
     return {
@@ -97,6 +110,18 @@ def _build_position_response(position: Position) -> dict:
             adjusted_cost_basis, position.shares
         )
 
+    # Issue #320: per-share basis so the Positions table reads against the
+    # per-share Current column / candidate strikes without head-math. Divide
+    # total / shares and round to 4 decimals — identical to the covered-call /
+    # action-engine convention (covered_call.py:276). Null when shares == 0 so
+    # the display layer renders an em-dash instead of $0.00 / Infinity.
+    broker_cost_basis_per_share = compute_per_share_basis(
+        position.broker_cost_basis, position.shares
+    )
+    adjusted_cost_basis_per_share = compute_per_share_basis(
+        adjusted_cost_basis, position.shares
+    )
+
     return {
         "id": position.id,
         "ticker": position.ticker,
@@ -109,6 +134,8 @@ def _build_position_response(position: Position) -> dict:
         "notes": position.notes,
         "total_premiums": total_premiums,
         "adjusted_cost_basis": adjusted_cost_basis,
+        "broker_cost_basis_per_share": broker_cost_basis_per_share,
+        "adjusted_cost_basis_per_share": adjusted_cost_basis_per_share,
         "min_compliant_cc_strike": min_compliant_cc_strike,
         "trades": [_build_trade_response(t) for t in trades],
     }

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -121,9 +121,154 @@
         "title": "Body_import_csv_preview_api_journal_import_csv_preview_post",
         "type": "object"
       },
-      "BtcDetailResponse": {
-        "description": "Top-level response for ``GET /api/positions/{id}/legs/{legId}/btc``.\n\nComposes the leg identity, the §R6 rule-monitor verdict + audit (reused\nverbatim from :func:`app.services.rule_monitor.evaluate_leg_rules` via\n``derive_open_legs``), and the buy-to-close economics block. A 404 with\n``{\"detail\": \"Leg not found\"}`` is returned for an unknown / closed leg.",
+      "BtcAnalysis": {
+        "description": "BTC decision-math block: decomposition, breakeven, scenarios (issue #319).\n\n``available`` gates the panel: ``False`` when neither a live option mid nor\nan underlying price is resolvable. When ``available`` is ``True`` but the\noption mid is missing (illiquid strike / greek-null), ``intrinsic`` is still\npopulated while ``extrinsic`` / ``btc_breakeven`` / ``scenarios`` degrade to\nnull / empty. Per-share figures (intrinsic / extrinsic / option_mid) are NOT\nscaled; the scenario dollars ARE (× contracts × 100).",
         "properties": {
+          "available": {
+            "title": "Available",
+            "type": "boolean"
+          },
+          "breakeven_delta": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Breakeven Delta"
+          },
+          "btc_breakeven": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Btc Breakeven"
+          },
+          "extrinsic": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extrinsic"
+          },
+          "extrinsic_pct_of_mid": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Extrinsic Pct Of Mid"
+          },
+          "intrinsic": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Intrinsic"
+          },
+          "option_mid": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Option Mid"
+          },
+          "scenarios": {
+            "items": {
+              "$ref": "#/components/schemas/BtcAnalysisScenario"
+            },
+            "title": "Scenarios",
+            "type": "array"
+          },
+          "underlying": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Underlying"
+          }
+        },
+        "required": [
+          "available"
+        ],
+        "title": "BtcAnalysis",
+        "type": "object"
+      },
+      "BtcAnalysisScenario": {
+        "description": "One assign-vs-buy-to-close scenario row (issue #319).\n\nAll money figures are whole-position dollars (per-share × contracts × 100)\nto match the economics block convention. ``delta = btc_and_hold -\nlet_assign``; ``winner`` is ``\"btc\"`` when ``delta > 0``, ``\"assign\"`` when\n``delta < 0``, ``\"tie\"`` at exact breakeven.",
+        "properties": {
+          "btc_and_hold": {
+            "title": "Btc And Hold",
+            "type": "number"
+          },
+          "delta": {
+            "title": "Delta",
+            "type": "number"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "let_assign": {
+            "title": "Let Assign",
+            "type": "number"
+          },
+          "underlying": {
+            "title": "Underlying",
+            "type": "number"
+          },
+          "winner": {
+            "enum": [
+              "btc",
+              "assign",
+              "tie"
+            ],
+            "title": "Winner",
+            "type": "string"
+          }
+        },
+        "required": [
+          "underlying",
+          "label",
+          "let_assign",
+          "btc_and_hold",
+          "delta",
+          "winner"
+        ],
+        "title": "BtcAnalysisScenario",
+        "type": "object"
+      },
+      "BtcDetailResponse": {
+        "description": "Top-level response for ``GET /api/positions/{id}/legs/{legId}/btc``.\n\nComposes the leg identity, the §R6 rule-monitor verdict + audit (reused\nverbatim from :func:`app.services.rule_monitor.evaluate_leg_rules` via\n``derive_open_legs``), the buy-to-close economics block, and the BTC\ndecision-math analysis block (issue #319). A 404 with\n``{\"detail\": \"Leg not found\"}`` is returned for an unknown / closed leg.",
+        "properties": {
+          "analysis": {
+            "$ref": "#/components/schemas/BtcAnalysis"
+          },
           "disclaimer": {
             "anyOf": [
               {
@@ -172,7 +317,8 @@
           "state",
           "leg",
           "verdict",
-          "economics"
+          "economics",
+          "analysis"
         ],
         "title": "BtcDetailResponse",
         "type": "object"

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -1538,6 +1538,17 @@
             "title": "Adjusted Cost Basis",
             "type": "number"
           },
+          "adjusted_cost_basis_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adjusted Cost Basis Per Share"
+          },
           "broker_cost_basis": {
             "anyOf": [
               {
@@ -1548,6 +1559,17 @@
               }
             ],
             "title": "Broker Cost Basis"
+          },
+          "broker_cost_basis_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Broker Cost Basis Per Share"
           },
           "current_price": {
             "anyOf": [
@@ -3246,9 +3268,31 @@
             "title": "Adjusted Cost Basis",
             "type": "number"
           },
+          "adjusted_cost_basis_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adjusted Cost Basis Per Share"
+          },
           "broker_cost_basis": {
             "title": "Broker Cost Basis",
             "type": "number"
+          },
+          "broker_cost_basis_per_share": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Broker Cost Basis Per Share"
           },
           "closed_at": {
             "anyOf": [

--- a/backend/tests/test_btc_detail_endpoint.py
+++ b/backend/tests/test_btc_detail_endpoint.py
@@ -334,6 +334,71 @@ def test_btc_detail_404_for_position_leg_mismatch(client):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Analysis block (issue #319) — decomposition / breakeven / scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_btc_detail_response_carries_analysis_block(client):
+    """The analysis block wires through end-to-end with correct decomposition."""
+    _seed_position(client)
+    # S = 16.29 (quote), K = 15.0, O = 1.93 → intrinsic 1.29, extrinsic 0.64.
+    _seed_trade(client, strike=15.0)
+    chain = _chain(15.0, 1.93)
+    with _patch_schwab(quote_price=16.29, chain=chain):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 200, resp.text
+    analysis = resp.json()["analysis"]
+    assert analysis["available"] is True
+    assert analysis["intrinsic"] == 1.29  # max(0, 16.29 - 15.0)
+    assert analysis["extrinsic"] == 0.64  # 1.93 - 1.29
+    assert analysis["option_mid"] == 1.93
+    assert analysis["underlying"] == 16.29
+    assert analysis["extrinsic_pct_of_mid"] is not None
+
+
+@pytest.mark.integration
+def test_btc_detail_analysis_scenarios_have_four_rows(client):
+    _seed_position(client)
+    _seed_trade(client, strike=15.0)
+    with _patch_schwab(quote_price=16.29, chain=_chain(15.0, 1.93)):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    scenarios = resp.json()["analysis"]["scenarios"]
+    assert len(scenarios) == 4
+    assert [s["label"] for s in scenarios] == ["−10%", "Flat", "+5%", "+10%"]
+    # Each row carries the assign-vs-BTC comparison fields.
+    for s in scenarios:
+        assert s["winner"] in {"btc", "assign", "tie"}
+        assert s["delta"] == round(s["btc_and_hold"] - s["let_assign"], 2)
+
+
+@pytest.mark.integration
+def test_btc_detail_analysis_breakeven_matches_strike_plus_mid(client):
+    _seed_position(client)
+    _seed_trade(client, strike=15.0)
+    with _patch_schwab(quote_price=16.29, chain=_chain(15.0, 1.93)):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    analysis = resp.json()["analysis"]
+    assert analysis["btc_breakeven"] == 16.93  # 15.0 + 1.93
+    assert analysis["breakeven_delta"] == -0.64  # 16.29 - 16.93
+
+
+@pytest.mark.integration
+def test_btc_detail_analysis_available_false_when_no_mark(client):
+    """No option mark AND no underlying → analysis degrades to available:false."""
+    _seed_position(client)
+    _seed_trade(client)
+    # No mark for the contract and no live quote price.
+    with _patch_schwab(quote_price=None, chain={}):
+        resp = client.get("/api/positions/pos-ford/legs/leg-ford-15c/btc")
+    assert resp.status_code == 200
+    analysis = resp.json()["analysis"]
+    assert analysis["available"] is False
+    assert analysis["intrinsic"] is None
+    assert analysis["scenarios"] == []
+
+
 @pytest.mark.integration
 def test_btc_detail_500_uses_generic_detail_on_quote_failure(client):
     _seed_position(client)

--- a/backend/tests/test_btc_detail_service.py
+++ b/backend/tests/test_btc_detail_service.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import pytest
 
 from app.services.btc_detail import (
+    SCENARIO_OFFSETS,
+    _build_analysis,
     _build_economics,
     _moneyness_label,
     _position_label,
@@ -149,3 +151,166 @@ class TestMoneynessLabel:
     def test_unknown_when_no_moneyness(self):
         assert _moneyness_label({"moneyness": None}) == "Unknown"
         assert _moneyness_label({}) == "Unknown"
+
+
+class TestBuildAnalysis:
+    """BTC decision-math block (issue #319). Pure-function unit tests — no DB,
+    no app, no Schwab. Computes from S (underlying), K (strike), O (mid), n.
+    """
+
+    @staticmethod
+    def _call_leg(strike=14.5, mid=1.93, quantity=1):
+        return {
+            "type": "call",
+            "strike": strike,
+            "current_mid": mid,
+            "quantity": quantity,
+        }
+
+    @pytest.mark.unit
+    def test_intrinsic_extrinsic_split_itm_call(self):
+        # F 14.5C, S=16.29, O=1.93 → intrinsic 1.79, extrinsic 0.14.
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        assert a["available"] is True
+        assert a["intrinsic"] == 1.79
+        assert a["extrinsic"] == 0.14
+
+    @pytest.mark.unit
+    def test_intrinsic_zero_for_otm_call(self):
+        # S below strike → call intrinsic 0; extrinsic is the whole mid.
+        a = _build_analysis(self._call_leg(strike=20.0, mid=0.50), current_price=16.29)
+        assert a["intrinsic"] == 0.0
+        assert a["extrinsic"] == 0.50
+
+    @pytest.mark.unit
+    def test_intrinsic_extrinsic_split_itm_put(self):
+        # Deep-ITM put: K=20, S=16 → intrinsic max(0, 20-16)=4.0.
+        leg = {"type": "put", "strike": 20.0, "current_mid": 4.30, "quantity": 1}
+        a = _build_analysis(leg, current_price=16.0)
+        assert a["intrinsic"] == 4.0
+        assert a["extrinsic"] == 0.30
+
+    @pytest.mark.unit
+    def test_extrinsic_pct_of_mid_is_ratio(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        # 0.14 / 1.93 ≈ 0.0725.
+        assert a["extrinsic_pct_of_mid"] == pytest.approx(0.0725, abs=1e-4)
+
+    @pytest.mark.unit
+    def test_extrinsic_pct_null_when_mid_zero(self):
+        a = _build_analysis(self._call_leg(strike=14.5, mid=0.0), current_price=16.29)
+        # O == 0 → division guard yields null; breakeven K+0 still valid.
+        assert a["extrinsic_pct_of_mid"] is None
+        assert a["btc_breakeven"] == 14.5
+
+    @pytest.mark.unit
+    def test_negative_extrinsic_clamps_to_zero(self):
+        # Stale mid below intrinsic (O=1.50 < intrinsic 1.79) → clamp to 0.
+        a = _build_analysis(self._call_leg(mid=1.50), current_price=16.29)
+        assert a["extrinsic"] == 0.0
+        # Still available — a clamp is not a degrade (Decision 2).
+        assert a["available"] is True
+
+    @pytest.mark.unit
+    def test_btc_breakeven_is_strike_plus_mid(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        assert a["btc_breakeven"] == 16.43  # 14.5 + 1.93
+
+    @pytest.mark.unit
+    def test_breakeven_delta_is_signed_underlying_minus_breakeven(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        # 16.29 - 16.43 = -0.14 (below breakeven).
+        assert a["breakeven_delta"] == -0.14
+
+    @pytest.mark.unit
+    def test_scenario_grid_has_four_rows_one_down_one_flat_two_up(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        labels = [s["label"] for s in a["scenarios"]]
+        assert labels == ["−10%", "Flat", "+5%", "+10%"]
+        assert len(a["scenarios"]) == 4
+
+    @pytest.mark.unit
+    def test_scenario_let_assign_is_strike_times_n_times_100(self):
+        a = _build_analysis(self._call_leg(quantity=2), current_price=16.29)
+        # 14.5 × 2 × 100 = 2900, constant across scenarios.
+        for s in a["scenarios"]:
+            assert s["let_assign"] == 2900.0
+
+    @pytest.mark.unit
+    def test_scenario_btc_and_hold_and_delta_math(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        flat = next(s for s in a["scenarios"] if s["label"] == "Flat")
+        # (16.29 - 1.93) × 1 × 100 = 1436.00; Δ = 1436 - 1450 = -14.
+        assert flat["btc_and_hold"] == 1436.0
+        assert flat["delta"] == -14.0
+
+    @pytest.mark.unit
+    def test_scenario_winner_btc_when_delta_positive(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        up = next(s for s in a["scenarios"] if s["label"] == "+5%")
+        assert up["delta"] > 0
+        assert up["winner"] == "btc"
+
+    @pytest.mark.unit
+    def test_scenario_winner_tie_at_exact_breakeven(self):
+        # Construct a leg whose +10% scenario lands exactly at breakeven.
+        # Want S_e = K + O at offset +0.10 → S × 1.10 = K + O.
+        # Pick S=10, O=1 → K+O = S×1.10 = 11 → K = 10. intrinsic max(0,10-10)=0,
+        # extrinsic = 1, breakeven 11; +10% S_e = 11.0 → delta 0 → tie.
+        leg = {"type": "call", "strike": 10.0, "current_mid": 1.0, "quantity": 1}
+        a = _build_analysis(leg, current_price=10.0)
+        up = next(s for s in a["scenarios"] if s["label"] == "+10%")
+        assert up["delta"] == 0.0
+        assert up["winner"] == "tie"
+
+    @pytest.mark.unit
+    def test_canonical_F_14_5C_fixture_matches_spec(self):
+        a = _build_analysis(self._call_leg(), current_price=16.29)
+        assert a["intrinsic"] == 1.79
+        assert a["extrinsic"] == 0.14
+        assert a["extrinsic_pct_of_mid"] == pytest.approx(0.0725, abs=1e-4)
+        assert a["option_mid"] == 1.93
+        assert a["btc_breakeven"] == 16.43
+        assert a["underlying"] == 16.29
+        assert a["breakeven_delta"] == -0.14
+        deltas = {s["label"]: s["delta"] for s in a["scenarios"]}
+        assert deltas["−10%"] == -177.0
+        assert deltas["Flat"] == -14.0
+        assert deltas["+5%"] == 67.0
+        assert deltas["+10%"] == 149.0
+
+    @pytest.mark.unit
+    def test_available_false_when_no_mid_and_no_price(self):
+        leg = {"type": "call", "strike": 14.5, "current_mid": None, "quantity": 1}
+        a = _build_analysis(leg, current_price=None)
+        assert a["available"] is False
+        assert a["intrinsic"] is None
+        assert a["scenarios"] == []
+
+    @pytest.mark.unit
+    def test_greek_null_intrinsic_only_when_mid_missing(self):
+        # Underlying live, option mid missing → intrinsic only, rest null.
+        leg = {"type": "call", "strike": 14.5, "current_mid": None, "quantity": 1}
+        a = _build_analysis(leg, current_price=16.29)
+        assert a["available"] is True
+        assert a["intrinsic"] == 1.79
+        assert a["extrinsic"] is None
+        assert a["btc_breakeven"] is None
+        assert a["breakeven_delta"] is None
+        assert a["scenarios"] == []
+
+    @pytest.mark.unit
+    def test_does_not_raise_on_null_quantity(self):
+        # Null quantity must default to 1 contract, not crash scenario scaling.
+        leg = {"type": "call", "strike": 14.5, "current_mid": 1.93, "quantity": None}
+        a = _build_analysis(leg, current_price=16.29)
+        assert a["scenarios"][0]["let_assign"] == 1450.0  # 14.5 × 1 × 100
+
+    @pytest.mark.unit
+    def test_scenario_offsets_constant_is_frozen(self):
+        assert SCENARIO_OFFSETS == [
+            (-0.10, "−10%"),
+            (0.0, "Flat"),
+            (0.05, "+5%"),
+            (0.10, "+10%"),
+        ]

--- a/backend/tests/test_btc_detail_service.py
+++ b/backend/tests/test_btc_detail_service.py
@@ -183,12 +183,17 @@ class TestBuildAnalysis:
         assert a["extrinsic"] == 0.50
 
     @pytest.mark.unit
-    def test_intrinsic_extrinsic_split_itm_put(self):
-        # Deep-ITM put: K=20, S=16 → intrinsic max(0, 20-16)=4.0.
+    def test_put_leg_returns_not_applicable_not_call_math(self):
+        # BRIDGE EDIT (CodeRabbit triage, v1.7.0): this test previously asserted
+        # put intrinsic/extrinsic (max(0, K-S)). The decision math is now
+        # covered-call-only — put legs are gated to the not-applicable shape so
+        # the call-specific breakeven/scenario equations never run for a put.
+        # See test_put_leg_is_gated_out_of_cc_decision_math for the full assert.
         leg = {"type": "put", "strike": 20.0, "current_mid": 4.30, "quantity": 1}
         a = _build_analysis(leg, current_price=16.0)
-        assert a["intrinsic"] == 4.0
-        assert a["extrinsic"] == 0.30
+        assert a["available"] is False
+        assert a["intrinsic"] is None
+        assert a["extrinsic"] is None
 
     @pytest.mark.unit
     def test_extrinsic_pct_of_mid_is_ratio(self):
@@ -314,3 +319,28 @@ class TestBuildAnalysis:
             (0.05, "+5%"),
             (0.10, "+10%"),
         ]
+
+    @pytest.mark.unit
+    def test_put_leg_is_gated_out_of_cc_decision_math(self):
+        # v1.7.0 decision math is covered-call-only. A short put must NOT get
+        # the call-specific breakeven / let-assign / BTC-and-hold equations —
+        # those produce misleading numbers for a put. The service returns the
+        # not-applicable (degraded) shape so the panel never shows call-math.
+        leg = {"type": "put", "strike": 20.0, "current_mid": 4.30, "quantity": 1}
+        a = _build_analysis(leg, current_price=16.0)
+        assert a["available"] is False
+        # No call-style figures — all decision-math fields are null/empty.
+        assert a["intrinsic"] is None
+        assert a["extrinsic"] is None
+        assert a["btc_breakeven"] is None
+        assert a["breakeven_delta"] is None
+        assert a["scenarios"] == []
+
+    @pytest.mark.unit
+    def test_put_leg_gate_matches_full_degrade_shape(self):
+        # The put gate reuses the exact full-degrade shape — no new fields, so
+        # no schema change / openapi regen is required.
+        from app.services.btc_detail import _degraded_analysis
+
+        put_leg = {"type": "put", "strike": 20.0, "current_mid": 4.30, "quantity": 1}
+        assert _build_analysis(put_leg, current_price=16.0) == _degraded_analysis()

--- a/backend/tests/test_dashboard_legs.py
+++ b/backend/tests/test_dashboard_legs.py
@@ -6,8 +6,10 @@ import pytest
 
 from app.models.schemas import DashboardOpenLeg
 from app.services.dashboard_legs import (
+    build_option_leg_index,
     build_option_mark_index,
     build_profit_target_status,
+    classify_depth,
     compute_assignment_risk,
     compute_decision_tag,
     compute_dte,
@@ -16,6 +18,7 @@ from app.services.dashboard_legs import (
     compute_suggested_action,
     derive_leg_economics,
     derive_open_legs,
+    resolve_leg_delta,
 )
 
 
@@ -1469,3 +1472,397 @@ class TestDashboardOpenLegQuantity:
         assert qty3["quantity"] == 3
         assert qty3["pnl_dollars"] == pytest.approx(qty1["pnl_dollars"] * 3)
         assert qty3["cost_to_close"] == pytest.approx(qty1["cost_to_close"] * 3)
+
+
+# ---------------------------------------------------------------------------
+# Issue #318 — assignment-risk depth-awareness
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLegDelta:
+    """Single source of truth for delta resolution (AC6 — #319-facing)."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("raw", [999.0, -999.0, 1000.0, -1500.0])
+    def test_nulls_999_sentinel(self, raw):
+        # Schwab sentinel |delta| >= 999 means "not available" → treated as
+        # missing; with no IV/spot to fall back on, returns (None, None).
+        delta, source = resolve_leg_delta(
+            raw_delta=raw, spot=None, strike=15.0, dte=20, iv=None, option_type="call"
+        )
+        assert delta is None
+        assert source is None
+
+    @pytest.mark.unit
+    def test_market_delta_passthrough(self):
+        delta, source = resolve_leg_delta(
+            raw_delta=-0.42, spot=14.0, strike=15.0, dte=20, iv=0.35, option_type="put"
+        )
+        assert delta == -0.42
+        assert source == "market"
+
+    @pytest.mark.unit
+    def test_blackscholes_fallback(self):
+        # No market delta but IV + positive spot present → calculate it.
+        delta, source = resolve_leg_delta(
+            raw_delta=None, spot=20.0, strike=15.0, dte=20, iv=0.40, option_type="call"
+        )
+        assert source == "calculated"
+        assert delta is not None
+        # Deep-ITM call → delta near 1.
+        assert 0.9 <= delta <= 1.0
+
+    @pytest.mark.unit
+    def test_no_iv_returns_none(self):
+        delta, source = resolve_leg_delta(
+            raw_delta=None, spot=20.0, strike=15.0, dte=20, iv=None, option_type="call"
+        )
+        assert delta is None
+        assert source is None
+
+    @pytest.mark.unit
+    def test_no_spot_returns_none(self):
+        # IV present but no spot → Black-Scholes cannot run.
+        delta, source = resolve_leg_delta(
+            raw_delta=None, spot=None, strike=15.0, dte=20, iv=0.40, option_type="call"
+        )
+        assert delta is None
+        assert source is None
+
+
+class TestClassifyDepth:
+    """Pure depth classifier: delta primary, moneyness-% fallback (#318)."""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "delta,expected",
+        [
+            (0.93, "deep"),
+            (0.80, "deep"),  # boundary — >= 0.80
+            (-0.85, "deep"),  # short put, negative delta → abs()
+            (0.79, "moderate"),
+            (0.60, "moderate"),  # boundary — >= 0.60
+            (-0.65, "moderate"),
+            (0.59, "shallow"),
+            (0.30, "shallow"),
+            (0.0, "shallow"),
+        ],
+    )
+    def test_delta_thresholds(self, delta, expected):
+        assert classify_depth(delta, distance_pct=None) == expected
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "distance_pct,expected",
+        [
+            (0.12, "deep"),
+            (0.10, "deep"),  # boundary — >= 0.10
+            (0.07, "moderate"),
+            (0.05, "moderate"),  # boundary — >= 0.05
+            (0.04, "shallow"),
+            (0.0, "shallow"),
+        ],
+    )
+    def test_moneyness_fallback_when_delta_null(self, distance_pct, expected):
+        assert classify_depth(None, distance_pct=distance_pct) == expected
+
+    @pytest.mark.unit
+    def test_delta_wins_over_moneyness(self):
+        # When delta is present it is the signal — moneyness-% is ignored.
+        assert classify_depth(0.30, distance_pct=0.50) == "shallow"
+
+    @pytest.mark.unit
+    def test_both_null_is_unknown(self):
+        assert classify_depth(None, distance_pct=None) == "unknown"
+
+
+class TestAssignmentRiskDepth:
+    """compute_assignment_risk depth axis + independent-max (#318)."""
+
+    # AC1 — deep-ITM past 14 DTE escalates above Low (the F reproduction).
+    @pytest.mark.unit
+    def test_deep_itm_call_past_14dte_is_high(self):
+        # delta 0.93, 17 DTE, ITM → "high" (timing would say "low").
+        assert compute_assignment_risk(17, "ITM", depth="deep") == "high"
+
+    @pytest.mark.unit
+    def test_deep_itm_via_moneyness_fallback_escalates(self):
+        # In the no-delta path classify_depth gives "deep" from 12% ITM; the
+        # classifier sees depth="deep" at 20 DTE → "high".
+        assert classify_depth(None, distance_pct=0.12) == "deep"
+        assert compute_assignment_risk(20, "ITM", depth="deep") == "high"
+
+    # AC2 — moderate depth escalates to Watch (not High).
+    @pytest.mark.unit
+    def test_moderate_delta_itm_is_watch(self):
+        # delta 0.65 → moderate; 25 DTE ITM → "watch".
+        assert classify_depth(0.65, distance_pct=None) == "moderate"
+        assert compute_assignment_risk(25, "ITM", depth="moderate") == "watch"
+
+    @pytest.mark.unit
+    def test_moderate_moneyness_fallback_is_watch(self):
+        # delta None, 6% ITM → moderate; 25 DTE → "watch".
+        assert classify_depth(None, distance_pct=0.06) == "moderate"
+        assert compute_assignment_risk(25, "ITM", depth="moderate") == "watch"
+
+    # AC3 — shallow / unknown depth preserves today's behavior.
+    @pytest.mark.unit
+    def test_shallow_delta_itm_past_14dte_stays_low(self):
+        # delta 0.30 → shallow; 20 DTE ITM → "low" (matches pre-#318).
+        assert compute_assignment_risk(20, "ITM", depth="shallow") == "low"
+
+    @pytest.mark.unit
+    def test_unknown_depth_falls_back_to_dte_axis(self):
+        # depth "unknown" (the default), 17 DTE ITM → "low" (today's behavior).
+        assert compute_assignment_risk(17, "ITM", depth="unknown") == "low"
+        assert compute_assignment_risk(17, "ITM") == "low"  # default param
+
+    # AC4 — DTE timing axis still wins when more urgent than depth.
+    @pytest.mark.unit
+    def test_shallow_delta_near_expiry_stays_high(self):
+        # delta 0.30 → shallow, but 3 DTE ITM → timing floor "high" survives.
+        assert compute_assignment_risk(3, "ITM", depth="shallow") == "high"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "dte,depth,expected",
+        [
+            # (timing_bucket, depth_bucket) → max on high > watch > low.
+            (3, "shallow", "high"),   # high vs low → high
+            (3, "deep", "high"),      # high vs high → high
+            (10, "shallow", "watch"), # watch vs low → watch
+            (10, "deep", "high"),     # watch vs high → high
+            (10, "moderate", "watch"),# watch vs watch → watch
+            (20, "shallow", "low"),   # low vs low → low
+            (20, "moderate", "watch"),# low vs watch → watch
+            (20, "deep", "high"),     # low vs high → high
+        ],
+    )
+    def test_independent_max_takes_higher_bucket(self, dte, depth, expected):
+        assert compute_assignment_risk(dte, "ITM", depth=depth) == expected
+
+    # AC5 — not-ITM / no-price never flags risk.
+    @pytest.mark.unit
+    @pytest.mark.parametrize("state", ["OTM", "ATM"])
+    def test_otm_with_high_delta_stays_low(self, state):
+        # Moneyness gates first — a deep depth signal cannot escalate a non-ITM
+        # leg. (In practice derive_open_legs passes depth="unknown" off-ITM, but
+        # the classifier must itself never escalate a non-ITM leg.)
+        assert compute_assignment_risk(3, state, depth="deep") == "low"
+
+    @pytest.mark.unit
+    def test_no_live_price_depth_unknown_stays_low(self):
+        # moneyness None (no live price) → "low" regardless of depth.
+        assert compute_assignment_risk(3, None, depth="deep") == "low"
+
+
+class TestBuildOptionLegIndex:
+    """Richer {mid, delta} leg index — the shared #318/#319 path (AC6)."""
+
+    @pytest.mark.unit
+    def test_carries_mid_and_delta(self):
+        chain = {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "240.0": [
+                        {"strikePrice": 240.0, "mark": 3.10, "delta": 0.88}
+                    ],
+                }
+            }
+        }
+        index = build_option_leg_index({"AAPL": chain})
+        entry = index[("AAPL", "call", 240.0, "2026-06-26")]
+        assert entry["mid"] == pytest.approx(3.10)
+        assert entry["delta"] == pytest.approx(0.88)
+        assert entry["delta_source"] == "market"
+
+    @pytest.mark.unit
+    def test_nulls_999_delta_sentinel(self):
+        chain = {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "240.0": [
+                        {"strikePrice": 240.0, "mark": 3.10, "delta": -999.0}
+                    ],
+                }
+            }
+        }
+        index = build_option_leg_index({"AAPL": chain})
+        entry = index[("AAPL", "call", 240.0, "2026-06-26")]
+        assert entry["delta"] is None
+        assert entry["delta_source"] is None
+
+    @pytest.mark.unit
+    def test_blackscholes_fallback_threads_spot(self):
+        # No market delta but IV present + spot threaded → calculated delta.
+        exp = (date.today() + timedelta(days=30)).isoformat()
+        chain = {
+            "callExpDateMap": {
+                f"{exp}:30": {
+                    "15.0": [
+                        {"strikePrice": 15.0, "mark": 5.10, "volatility": 40.0}
+                    ],
+                }
+            }
+        }
+        index = build_option_leg_index(
+            {"F": chain}, spots_by_ticker={"F": 20.0}
+        )
+        entry = index[("F", "call", 15.0, exp)]
+        assert entry["delta_source"] == "calculated"
+        assert entry["delta"] is not None
+
+    @pytest.mark.unit
+    def test_no_spot_leaves_delta_none(self):
+        # IV present but no spot threaded → fallback cannot run → delta None.
+        exp = (date.today() + timedelta(days=30)).isoformat()
+        chain = {
+            "callExpDateMap": {
+                f"{exp}:30": {
+                    "15.0": [
+                        {"strikePrice": 15.0, "mark": 5.10, "volatility": 40.0}
+                    ],
+                }
+            }
+        }
+        index = build_option_leg_index({"F": chain})
+        entry = index[("F", "call", 15.0, exp)]
+        assert entry["delta"] is None
+        assert entry["delta_source"] is None
+
+
+class TestBuildOptionMarkIndexBackCompat:
+    """The legacy float-mid wrapper stays byte-compatible (AC6)."""
+
+    @pytest.mark.unit
+    def test_still_returns_float_mid(self):
+        chain = {
+            "callExpDateMap": {
+                "2026-06-26:38": {
+                    "240.0": [
+                        {"strikePrice": 240.0, "mark": 3.10, "delta": 0.88}
+                    ],
+                }
+            }
+        }
+        index = build_option_mark_index({"AAPL": chain})
+        value = index[("AAPL", "call", 240.0, "2026-06-26")]
+        assert isinstance(value, float)
+        assert value == pytest.approx(3.10)
+
+
+class TestDeriveOpenLegsDepth:
+    """derive_open_legs threads delta + depth onto the leg dict (#318/#319)."""
+
+    def _position(self, ticker: str, position_id: str, trades: list[dict]) -> dict:
+        return {"id": position_id, "ticker": ticker, "trades": trades}
+
+    @pytest.mark.unit
+    def test_emits_delta_and_depth(self):
+        positions = [
+            self._position(
+                "F",
+                "pos-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2099-12-31",
+                        "premium": 0.40,
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        # Deep-ITM short call (price 20 > strike 15), delta 0.93 from the chain.
+        marks = {
+            ("F", "call", 15.0, "2099-12-31"): {
+                "mid": 5.10,
+                "delta": 0.93,
+                "delta_source": "market",
+            }
+        }
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"F": 20.0},
+            today=date(2026, 5, 5),
+            option_marks=marks,
+        )
+        leg = legs[0]
+        assert leg["delta"] == pytest.approx(0.93)
+        assert leg["delta_source"] == "market"
+        assert leg["assignment_depth"] == "deep"
+        # current_mid stays a plain float — load-bearing for #319.
+        assert leg["current_mid"] == pytest.approx(5.10)
+        assert isinstance(leg["current_mid"], float)
+
+    @pytest.mark.unit
+    def test_deep_itm_call_far_dte_reports_high(self):
+        # The F reproduction in pure form: deep-ITM short call far past 14 DTE
+        # must report assignment_risk "high" instead of flooring to "low".
+        positions = [
+            self._position(
+                "F",
+                "pos-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2026-05-22",  # 17 DTE from 2026-05-05
+                        "premium": 0.40,
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        marks = {
+            ("F", "call", 15.0, "2026-05-22"): {
+                "mid": 5.10,
+                "delta": 0.93,
+                "delta_source": "market",
+            }
+        }
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"F": 20.0},
+            today=date(2026, 5, 5),
+            option_marks=marks,
+        )
+        assert legs[0]["dte"] == 17
+        assert legs[0]["assignment_risk"] == "high"
+
+    @pytest.mark.unit
+    def test_legacy_float_mark_index_still_works(self):
+        # A plain float-mid index (the build_option_mark_index shape) must still
+        # produce a valid leg with delta None and depth from moneyness-%.
+        positions = [
+            self._position(
+                "F",
+                "pos-1",
+                [
+                    {
+                        "id": "t1",
+                        "trade_type": "sell_call",
+                        "strike": 15.0,
+                        "expiration": "2026-05-22",
+                        "premium": 0.40,
+                        "closed_at": None,
+                    }
+                ],
+            )
+        ]
+        # price 17 vs strike 15 → ~13.3% ITM → moneyness-% fallback "deep".
+        marks = {("F", "call", 15.0, "2026-05-22"): 2.10}
+        legs = derive_open_legs(
+            positions,
+            quotes_by_ticker={"F": 17.0},
+            today=date(2026, 5, 5),
+            option_marks=marks,
+        )
+        leg = legs[0]
+        assert leg["current_mid"] == pytest.approx(2.10)
+        assert leg["delta"] is None
+        assert leg["assignment_depth"] == "deep"
+        assert leg["assignment_risk"] == "high"

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -930,3 +930,123 @@ def test_schwab_pill_error_field_absent_when_schwab_not_configured(
     assert schwab["valid"] is False
     assert schwab["error"] is None
 
+
+
+# ---------------------------------------------------------------------------
+# Issue #318 — assignment-risk depth-awareness (deep-ITM past 14 DTE)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_dashboard_leg_deep_itm_call_reports_high(client, monkeypatch):
+    """AC1 — a deep-ITM short call past 14 DTE reports assignment_risk "high".
+
+    The F reproduction: pre-fix this floored to "low" because 17 DTE is outside
+    the 14-day Watch window. The chain carries a 0.93 delta → depth "deep" →
+    independent-max escalates the leg to "high".
+    """
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+    # Price 20 > strike 15 → ITM short call.
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 20.0},
+    )
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        lambda self, ticker, *a, **kw: {
+            "callExpDateMap": {
+                "2026-05-22:17": {
+                    "15.0": [{"strikePrice": 15.0, "mark": 5.10, "delta": 0.93}],
+                }
+            }
+        },
+    )
+    today = datetime(2026, 5, 5, tzinfo=timezone.utc).date()
+    monkeypatch.setattr(
+        "app.services.dashboard.date",
+        type("D", (), {"today": staticmethod(lambda: today)}),
+    )
+
+    pid = _seed_position(client, ticker="F", shares=100, broker_cost_basis=1500.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_call",
+        strike=15.0,
+        expiration="2026-05-22",  # 17 DTE — past the 14-day timing floor
+        premium=0.40,
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["open_legs"], "expected at least one open leg"
+    leg = data["open_legs"][0]
+    assert leg["dte"] == 17
+    assert leg["assignment_risk"] == "high"
+
+
+@pytest.mark.integration
+def test_dashboard_leg_delta_threads_from_chain(client, monkeypatch):
+    """AC6 — the chain's delta surfaces on the derived dashboard leg.
+
+    Proves the shared build_option_leg_index -> derive_open_legs wiring through
+    the full service stack: a delta seeded on the chain node reaches the leg
+    dict (the field #319 consumes), and current_mid stays a plain float.
+
+    Asserted on the internal leg dict (captured via a spy on the real
+    derive_open_legs), not the HTTP payload — per the #318 plan the wire shape
+    is intentionally unchanged, so DashboardResponse strips these leg-internal
+    fields. #319 will promote them onto the response model when it needs them.
+    """
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 20.0},
+    )
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_option_chain",
+        lambda self, ticker, *a, **kw: {
+            "callExpDateMap": {
+                "2026-05-22:17": {
+                    "15.0": [{"strikePrice": 15.0, "mark": 5.10, "delta": 0.91}],
+                }
+            }
+        },
+    )
+    today = datetime(2026, 5, 5, tzinfo=timezone.utc).date()
+    monkeypatch.setattr(
+        "app.services.dashboard.date",
+        type("D", (), {"today": staticmethod(lambda: today)}),
+    )
+
+    # Spy on the real derive_open_legs to capture the un-stripped leg dicts.
+    captured: list[dict] = []
+    real_derive = dashboard_service.derive_open_legs
+
+    def _spy(*args, **kwargs):
+        legs = real_derive(*args, **kwargs)
+        captured.extend(legs)
+        return legs
+
+    monkeypatch.setattr("app.services.dashboard.derive_open_legs", _spy)
+
+    pid = _seed_position(client, ticker="F", shares=100, broker_cost_basis=1500.0)
+    _seed_trade(
+        client,
+        pid,
+        trade_type="sell_call",
+        strike=15.0,
+        expiration="2026-05-22",
+        premium=0.40,
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    assert captured, "expected derive_open_legs to yield at least one leg"
+    leg = captured[0]
+    assert leg["delta"] == pytest.approx(0.91)
+    assert leg["delta_source"] == "market"
+    assert leg["assignment_depth"] == "deep"
+    assert leg["current_mid"] == pytest.approx(5.10)
+    assert isinstance(leg["current_mid"], float)

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -562,6 +562,20 @@ def test_dashboard_payload_schema_v05_keys(client, monkeypatch):
 
 
 @pytest.mark.integration
+def test_dashboard_position_row_includes_per_share_basis(client, monkeypatch):
+    """Issue #320: dashboard rows carry per-share basis for the cost cell."""
+    _patch_status(monkeypatch, schwab_configured=False, fred_key="")
+    _seed_position(client, ticker="AAPL", shares=100, broker_cost_basis=2856.0)
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    row = next(r for r in resp.json()["positions"] if r["ticker"] == "AAPL")
+    assert row["broker_cost_basis_per_share"] == 28.56
+    # No trades → adjusted total == broker total → same per-share value.
+    assert row["adjusted_cost_basis_per_share"] == 28.56
+
+
+@pytest.mark.integration
 def test_dashboard_scanner_card_when_no_open_legs(client, monkeypatch):
     """`journal.no_open_legs` emits even when there are zero positions."""
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")

--- a/backend/tests/test_integration_journal_api.py
+++ b/backend/tests/test_integration_journal_api.py
@@ -602,3 +602,32 @@ def test_update_position_ignores_strategy_field(client):
     assert resp.status_code == 200
     # Seeded label persists because recomputer was not invoked from PUT.
     assert resp.json()["strategy"] == "csp"
+
+
+# --- Issue #320: per-share cost basis surfaces on the positions endpoint ---
+
+
+@pytest.mark.integration
+def test_position_response_includes_per_share_basis(client):
+    """The positions endpoint emits round(total / shares, 4) per-share fields."""
+    _create_position(client, shares=100, broker_cost_basis=2856.0)
+    resp = client.get("/api/journal/positions")
+    assert resp.status_code == 200
+    pos = resp.json()["positions"][0]
+    assert pos["broker_cost_basis_per_share"] == 28.56
+    # No trades → adjusted == broker total, so adjusted per-share matches.
+    assert pos["adjusted_cost_basis_per_share"] == 28.56
+
+
+@pytest.mark.integration
+def test_position_response_adjusted_per_share_nets_premiums(client):
+    """Adjusted per-share reflects premium-reduced basis, divided by shares."""
+    pos = _create_position(client, shares=100, broker_cost_basis=5000.0).json()
+    # sell_put premium 1.50 × 1 contract × 100 = 150 gross premium collected.
+    _create_trade(client, pos["id"], premium=1.50, quantity=1)
+    resp = client.get(f"/api/journal/positions/{pos['id']}")
+    assert resp.status_code == 200
+    data = resp.json()
+    # adjusted total = 5000 - 150 = 4850 → /100 = 48.50/sh.
+    assert data["broker_cost_basis_per_share"] == 50.0
+    assert data["adjusted_cost_basis_per_share"] == 48.5

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -256,6 +256,17 @@ def test_build_position_response_still_computes_for_positive_shares(db_session, 
 
 
 # --- Issue #320: per-share basis on the built position response ---
+#
+# Classification note (CodeRabbit triage): the two tests below call
+# `_build_position_response` directly with a DB session (no TestClient). They
+# are correctly `@pytest.mark.integration`, not `@pytest.mark.unit`: per
+# CLAUDE.md's Wave 3 precedent, any test that touches a real DB session is
+# integration-tier (the "no DB session" disqualifier in PRD #261/R3). The happy
+# path also has a real TestClient endpoint test in test_integration_journal_api.py;
+# these are the producer-level integration tests for `_build_position_response`
+# itself. The shares==0 null path is endpoint-unreachable — PositionCreate
+# rejects 0 shares with a 422 — so a true endpoint test for it is impossible;
+# exercising the producer directly is the only way to cover that branch.
 
 
 @pytest.mark.integration

--- a/backend/tests/test_journal_service.py
+++ b/backend/tests/test_journal_service.py
@@ -12,6 +12,7 @@ from app.services.journal import (
     clear_all_journal_data,
     compute_adjusted_basis,
     compute_min_cc_strike,
+    compute_per_share_basis,
     compute_total_premiums,
     delete_position,
 )
@@ -61,6 +62,40 @@ def test_compute_total_premiums_empty():
 def test_compute_adjusted_basis():
     """broker_cost_basis 5000, premiums 350 -> 4650."""
     assert compute_adjusted_basis(5000.0, 350.0) == 4650.0
+
+
+# --- Issue #320: per-share cost basis ---
+
+
+@pytest.mark.unit
+def test_compute_per_share_basis_divides_and_rounds():
+    """round(total / shares, 4) — the covered-call/action-engine convention."""
+    assert compute_per_share_basis(2856.0, 100) == 28.56
+
+
+@pytest.mark.unit
+def test_compute_per_share_basis_rounds_to_four_decimals():
+    """Non-terminating quotient is rounded to 4 decimals, not truncated."""
+    # 2632.10 / 100 = 26.321 exactly; pick a divisor that needs rounding.
+    assert compute_per_share_basis(1000.0, 3) == 333.3333
+
+
+@pytest.mark.unit
+def test_compute_per_share_basis_shares_zero_returns_none():
+    """shares == 0 → None (display renders an em-dash, never a divide)."""
+    assert compute_per_share_basis(2856.0, 0) is None
+
+
+@pytest.mark.unit
+def test_compute_per_share_basis_negative_shares_returns_none():
+    """shares < 0 (data corruption) → None, no negative per-share leaks out."""
+    assert compute_per_share_basis(2856.0, -100) is None
+
+
+@pytest.mark.unit
+def test_compute_per_share_basis_zero_total():
+    """A zero total with real shares is a legitimate $0.00/sh, not None."""
+    assert compute_per_share_basis(0.0, 100) == 0.0
 
 
 @pytest.mark.unit
@@ -218,6 +253,54 @@ def test_build_position_response_still_computes_for_positive_shares(db_session, 
     assert "compute_min_cc_strike called with shares=" not in caplog.text
     # 10_000 / 100 * 1.10 = 110.0
     assert result["min_compliant_cc_strike"] == 110.0
+
+
+# --- Issue #320: per-share basis on the built position response ---
+
+
+@pytest.mark.integration
+def test_build_position_response_emits_per_share_basis(db_session):
+    """Producer divides total/shares for both broker and adjusted basis."""
+    from app.services.journal import _build_position_response
+
+    pos = Position(
+        id=str(uuid.uuid4()),
+        ticker="MSFT",
+        shares=100,
+        broker_cost_basis=2856.0,
+        status="open",
+        strategy="csp",
+        opened_at="2025-01-01T00:00:00Z",
+    )
+    db_session.add(pos)
+    db_session.commit()
+
+    result = _build_position_response(pos)
+    # No trades → adjusted total == broker total → same per-share value.
+    assert result["broker_cost_basis_per_share"] == 28.56
+    assert result["adjusted_cost_basis_per_share"] == 28.56
+
+
+@pytest.mark.integration
+def test_build_position_response_per_share_basis_null_when_zero_shares(db_session):
+    """shares == 0 → per-share fields are None (no divide-by-zero)."""
+    from app.services.journal import _build_position_response
+
+    closed = Position(
+        id=str(uuid.uuid4()),
+        ticker="AAPL",
+        shares=0,
+        broker_cost_basis=0.0,
+        status="closed",
+        strategy="csp",
+        opened_at="2025-01-01T00:00:00Z",
+    )
+    db_session.add(closed)
+    db_session.commit()
+
+    result = _build_position_response(closed)
+    assert result["broker_cost_basis_per_share"] is None
+    assert result["adjusted_cost_basis_per_share"] is None
 
 
 @pytest.mark.unit

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -1449,15 +1449,74 @@ export interface components {
             file: string;
         };
         /**
+         * BtcAnalysis
+         * @description BTC decision-math block: decomposition, breakeven, scenarios (issue #319).
+         *
+         *     ``available`` gates the panel: ``False`` when neither a live option mid nor
+         *     an underlying price is resolvable. When ``available`` is ``True`` but the
+         *     option mid is missing (illiquid strike / greek-null), ``intrinsic`` is still
+         *     populated while ``extrinsic`` / ``btc_breakeven`` / ``scenarios`` degrade to
+         *     null / empty. Per-share figures (intrinsic / extrinsic / option_mid) are NOT
+         *     scaled; the scenario dollars ARE (× contracts × 100).
+         */
+        BtcAnalysis: {
+            /** Available */
+            available: boolean;
+            /** Breakeven Delta */
+            breakeven_delta?: number | null;
+            /** Btc Breakeven */
+            btc_breakeven?: number | null;
+            /** Extrinsic */
+            extrinsic?: number | null;
+            /** Extrinsic Pct Of Mid */
+            extrinsic_pct_of_mid?: number | null;
+            /** Intrinsic */
+            intrinsic?: number | null;
+            /** Option Mid */
+            option_mid?: number | null;
+            /** Scenarios */
+            scenarios?: components["schemas"]["BtcAnalysisScenario"][];
+            /** Underlying */
+            underlying?: number | null;
+        };
+        /**
+         * BtcAnalysisScenario
+         * @description One assign-vs-buy-to-close scenario row (issue #319).
+         *
+         *     All money figures are whole-position dollars (per-share × contracts × 100)
+         *     to match the economics block convention. ``delta = btc_and_hold -
+         *     let_assign``; ``winner`` is ``"btc"`` when ``delta > 0``, ``"assign"`` when
+         *     ``delta < 0``, ``"tie"`` at exact breakeven.
+         */
+        BtcAnalysisScenario: {
+            /** Btc And Hold */
+            btc_and_hold: number;
+            /** Delta */
+            delta: number;
+            /** Label */
+            label: string;
+            /** Let Assign */
+            let_assign: number;
+            /** Underlying */
+            underlying: number;
+            /**
+             * Winner
+             * @enum {string}
+             */
+            winner: "btc" | "assign" | "tie";
+        };
+        /**
          * BtcDetailResponse
          * @description Top-level response for ``GET /api/positions/{id}/legs/{legId}/btc``.
          *
          *     Composes the leg identity, the §R6 rule-monitor verdict + audit (reused
          *     verbatim from :func:`app.services.rule_monitor.evaluate_leg_rules` via
-         *     ``derive_open_legs``), and the buy-to-close economics block. A 404 with
+         *     ``derive_open_legs``), the buy-to-close economics block, and the BTC
+         *     decision-math analysis block (issue #319). A 404 with
          *     ``{"detail": "Leg not found"}`` is returned for an unknown / closed leg.
          */
         BtcDetailResponse: {
+            analysis: components["schemas"]["BtcAnalysis"];
             /** Disclaimer */
             disclaimer?: string | null;
             economics: components["schemas"]["BtcEconomics"];

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -2040,8 +2040,12 @@ export interface components {
         DashboardPositionRow: {
             /** Adjusted Cost Basis */
             adjusted_cost_basis: number;
+            /** Adjusted Cost Basis Per Share */
+            adjusted_cost_basis_per_share?: number | null;
             /** Broker Cost Basis */
             broker_cost_basis?: number | null;
+            /** Broker Cost Basis Per Share */
+            broker_cost_basis_per_share?: number | null;
             /** Current Price */
             current_price?: number | null;
             /** Id */
@@ -2737,8 +2741,12 @@ export interface components {
         PositionResponse: {
             /** Adjusted Cost Basis */
             adjusted_cost_basis: number;
+            /** Adjusted Cost Basis Per Share */
+            adjusted_cost_basis_per_share?: number | null;
             /** Broker Cost Basis */
             broker_cost_basis: number;
+            /** Broker Cost Basis Per Share */
+            broker_cost_basis_per_share?: number | null;
             /** Closed At */
             closed_at?: string | null;
             /** Id */

--- a/frontend/components/btc/BtcDetailView.jsx
+++ b/frontend/components/btc/BtcDetailView.jsx
@@ -229,7 +229,7 @@ function EconomicsTile({ testId, label, value, valueClass }) {
   );
 }
 
-function BtcEconomicsPanel({ economics, analysis, verdict }) {
+function BtcEconomicsPanel({ economics, analysis }) {
   const pricingLive = economics.pricing_source === 'live';
   const captured = economics.captured_pct;
   // The honest decision signal that replaces the misleading "% premium
@@ -533,13 +533,20 @@ function BtcAnalysisPanel({ analysis }) {
                 <span
                   data-testid="btc-analysis-breakeven-delta"
                   className={`tabular-nums font-medium ${
-                    analysis.breakeven_delta < 0
+                    analysis.breakeven_delta === 0
+                      ? 'text-slate-700 dark:text-slate-200'
+                      : analysis.breakeven_delta < 0
                       ? 'text-red-700 dark:text-red-300'
                       : 'text-emerald-700 dark:text-emerald-300'
                   }`}
                 >
                   ({formatSignedDollar(analysis.breakeven_delta)}{' '}
-                  {analysis.breakeven_delta < 0 ? 'below' : 'above'} breakeven)
+                  {analysis.breakeven_delta === 0
+                    ? 'at breakeven'
+                    : analysis.breakeven_delta < 0
+                    ? 'below breakeven'
+                    : 'above breakeven'}
+                  )
                 </span>
               </p>
               <p
@@ -587,9 +594,15 @@ function BtcAnalysisPanel({ analysis }) {
                 <tbody>
                   {analysis.scenarios.map((s, i) => {
                     const btcWins = s.winner === 'btc';
+                    const isTie = s.winner === 'tie';
                     const deltaClass = btcWins
                       ? 'text-emerald-700 dark:text-emerald-300 font-medium'
                       : 'text-slate-700 dark:text-slate-200';
+                    const winnerLabel = isTie
+                      ? 'Tie'
+                      : btcWins
+                      ? 'BTC wins'
+                      : 'Assign wins';
                     return (
                       <tr
                         key={s.label}
@@ -617,7 +630,7 @@ function BtcAnalysisPanel({ analysis }) {
                             btcWins ? 'text-emerald-700 dark:text-emerald-300' : ''
                           }`}
                         >
-                          {btcWins ? 'BTC wins' : 'Assign wins'}
+                          {winnerLabel}
                         </td>
                       </tr>
                     );
@@ -659,11 +672,7 @@ export default function BtcDetailView({ data }) {
     <div className="space-y-4">
       <LegHeader leg={leg} verdict={verdict} />
       <RecommendedActionBlock data={data} />
-      <BtcEconomicsPanel
-        economics={economics}
-        analysis={analysis}
-        verdict={verdict}
-      />
+      <BtcEconomicsPanel economics={economics} analysis={analysis} />
       <BtcAnalysisPanel analysis={analysis} />
       <RuleAuditPanel rules={rules} verdict={verdict} />
 

--- a/frontend/components/btc/BtcDetailView.jsx
+++ b/frontend/components/btc/BtcDetailView.jsx
@@ -444,36 +444,67 @@ function AnalysisFigure({ testId, label, value, valueClass, note }) {
 
 const ANALYSIS_HEADING = 'BTC Analysis — let assign vs. buy to close';
 
-function BtcAnalysisPanel({ analysis }) {
+function BtcAnalysisPanel({ analysis, optionType }) {
   if (!analysis) return null;
 
-  // Three render states: full-degrade (available === false), greek-null
-  // (available, but no option mid → intrinsic-only), and populated.
-  const degraded = analysis.available === false;
-  const greekNull = !degraded && analysis.option_mid === null;
-  const populated = !degraded && !greekNull;
+  // Put legs are gated out of the covered-call decision math (v1.7.0 is
+  // CC-scoped). The backend returns the degraded analysis shape for a put,
+  // which is indistinguishable from a pricing-degrade on the wire — so we use
+  // the leg's option_type to render an honest "covered-call-only" affordance
+  // instead of "pricing unavailable", which would read as a data error.
+  const isPut = optionType === 'P';
+
+  // Render states: put-not-applicable (CC-only), full-degrade
+  // (available === false), greek-null (available, but no option mid →
+  // intrinsic-only), and populated.
+  const degraded = !isPut && analysis.available === false;
+  const greekNull = !isPut && !degraded && analysis.option_mid === null;
+  const populated = !isPut && !degraded && !greekNull;
+
+  let degradeAttr;
+  if (isPut) degradeAttr = 'put-not-applicable';
+  else if (greekNull) degradeAttr = 'greek-null';
 
   return (
     <div
       data-testid="btc-analysis"
-      data-degrade={greekNull ? 'greek-null' : undefined}
+      data-degrade={degradeAttr}
       className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
     >
       <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
         <h3 className="text-base font-semibold text-slate-900 dark:text-white">
           {ANALYSIS_HEADING}
         </h3>
-        {(degraded || greekNull) && (
+        {(degraded || greekNull || isPut) && (
           <span
             data-testid="btc-analysis-degraded-badge"
             className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400"
           >
-            {greekNull ? 'Option mid missing' : 'Pricing unavailable'}
+            {isPut
+              ? 'Covered-call only'
+              : greekNull
+              ? 'Option mid missing'
+              : 'Pricing unavailable'}
           </span>
         )}
       </div>
 
       <div className="p-4 space-y-5">
+        {isPut ? (
+          // Put legs: the assign-vs-BTC decision math is covered-call-only in
+          // v1.7.0. Show an honest not-applicable affordance rather than the
+          // call-math decomposition (which would be wrong for a short put) or
+          // the "pricing unavailable" copy (which would read as a data error).
+          <p
+            data-testid="btc-analysis-put-na"
+            className="text-sm text-slate-500 dark:text-slate-400 max-w-prose"
+          >
+            Decision math is covered-call-only right now. This is a put leg, so
+            the let-assign vs. buy-to-close comparison isn&apos;t shown. The rule
+            audit below still applies.
+          </p>
+        ) : (
+          <>
         {/* Section 1 — decomposition trio */}
         <div className={`grid grid-cols-3 gap-4 ${degraded ? 'opacity-60' : ''}`}>
           <AnalysisFigure
@@ -650,6 +681,8 @@ function BtcAnalysisPanel({ analysis }) {
               : 'Decomposition, breakeven, and scenarios need a live option mark and underlying price. They’ll appear once pricing reconnects.'}
           </p>
         )}
+          </>
+        )}
       </div>
     </div>
   );
@@ -673,7 +706,7 @@ export default function BtcDetailView({ data }) {
       <LegHeader leg={leg} verdict={verdict} />
       <RecommendedActionBlock data={data} />
       <BtcEconomicsPanel economics={economics} analysis={analysis} />
-      <BtcAnalysisPanel analysis={analysis} />
+      <BtcAnalysisPanel analysis={analysis} optionType={leg.option_type} />
       <RuleAuditPanel rules={rules} verdict={verdict} />
 
       <footer

--- a/frontend/components/btc/BtcDetailView.jsx
+++ b/frontend/components/btc/BtcDetailView.jsx
@@ -229,17 +229,16 @@ function EconomicsTile({ testId, label, value, valueClass }) {
   );
 }
 
-function BtcEconomicsPanel({ economics, verdict }) {
+function BtcEconomicsPanel({ economics, analysis, verdict }) {
   const pricingLive = economics.pricing_source === 'live';
   const captured = economics.captured_pct;
-  // The % captured tile reads emerald when the leg cleared the user's
-  // profit-take threshold (verdict tells us, no threshold parsing needed).
-  const pctClass =
-    verdict === 'profit_take_review' && captured !== null && captured !== undefined
-      ? 'text-emerald-700 dark:text-emerald-300'
-      : pricingLive
-        ? 'text-slate-900 dark:text-white'
-        : 'text-slate-400 dark:text-slate-500';
+  // The honest decision signal that replaces the misleading "% premium
+  // captured" tile in the BTC detail context (issue #319). Comes from the
+  // analysis decomposition, NOT captured_pct.
+  const extrinsicPct = analysis?.extrinsic_pct_of_mid;
+  const extrinsicPctClass = pricingLive
+    ? 'text-slate-900 dark:text-white'
+    : 'text-slate-400 dark:text-slate-500';
   const estPl = economics.est_pl_if_closed;
   let estPlClass = 'text-slate-400 dark:text-slate-500';
   if (estPl !== null && estPl !== undefined) {
@@ -296,10 +295,10 @@ function BtcEconomicsPanel({ economics, verdict }) {
             value={formatDollar(economics.credit_received)}
           />
           <EconomicsTile
-            testId="btc-detail-economics-tile-pct-captured"
-            label="% premium captured"
-            value={formatPct(economics.captured_pct)}
-            valueClass={pctClass}
+            testId="btc-detail-economics-tile-extrinsic-pct"
+            label="Extrinsic % of mid"
+            value={formatPct(extrinsicPct)}
+            valueClass={extrinsicPctClass}
           />
           <EconomicsTile
             testId="btc-detail-economics-tile-est-pl"
@@ -308,9 +307,20 @@ function BtcEconomicsPanel({ economics, verdict }) {
             valueClass={estPlClass}
           />
         </div>
+        {captured !== null && captured !== undefined && (
+          <p
+            data-testid="btc-detail-economics-captured-raw-note"
+            className="text-xs text-slate-400 dark:text-slate-500 mt-3"
+          >
+            Premium captured (raw):{' '}
+            <span className="tabular-nums">{formatPct(captured)}</span> —
+            distorted by intrinsic value on deep-ITM legs; see BTC Analysis
+            below.
+          </p>
+        )}
         <p
           data-testid="btc-detail-economics-caption"
-          className="text-xs text-slate-500 dark:text-slate-400 mt-3"
+          className="text-xs text-slate-500 dark:text-slate-400 mt-1"
         >
           {caption}
         </p>
@@ -407,18 +417,254 @@ function RuleAuditPanel({ rules, verdict }) {
   );
 }
 
+// --- BtcAnalysisPanel (issue #319) -----------------------------------------
+
+// Section 1 figure (decomposition trio) — smaller than EconomicsTile, 3-up.
+function AnalysisFigure({ testId, label, value, valueClass, note }) {
+  return (
+    <div data-testid={testId}>
+      <div className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">
+        {label}
+      </div>
+      <div
+        className={`text-2xl font-semibold tabular-nums mt-1 ${
+          valueClass || 'text-slate-900 dark:text-white'
+        }`}
+      >
+        {value}
+      </div>
+      {note && (
+        <div className="text-[11px] text-slate-400 dark:text-slate-500 mt-0.5">
+          {note}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const ANALYSIS_HEADING = 'BTC Analysis — let assign vs. buy to close';
+
+function BtcAnalysisPanel({ analysis }) {
+  if (!analysis) return null;
+
+  // Three render states: full-degrade (available === false), greek-null
+  // (available, but no option mid → intrinsic-only), and populated.
+  const degraded = analysis.available === false;
+  const greekNull = !degraded && analysis.option_mid === null;
+  const populated = !degraded && !greekNull;
+
+  return (
+    <div
+      data-testid="btc-analysis"
+      data-degrade={greekNull ? 'greek-null' : undefined}
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800"
+    >
+      <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700 flex items-center justify-between">
+        <h3 className="text-base font-semibold text-slate-900 dark:text-white">
+          {ANALYSIS_HEADING}
+        </h3>
+        {(degraded || greekNull) && (
+          <span
+            data-testid="btc-analysis-degraded-badge"
+            className="px-2 py-0.5 rounded-full text-[11px] font-medium bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400"
+          >
+            {greekNull ? 'Option mid missing' : 'Pricing unavailable'}
+          </span>
+        )}
+      </div>
+
+      <div className="p-4 space-y-5">
+        {/* Section 1 — decomposition trio */}
+        <div className={`grid grid-cols-3 gap-4 ${degraded ? 'opacity-60' : ''}`}>
+          <AnalysisFigure
+            testId="btc-analysis-intrinsic"
+            label="Intrinsic value"
+            value={formatDollar(analysis.intrinsic)}
+            valueClass={
+              analysis.intrinsic === null || analysis.intrinsic === undefined
+                ? 'text-slate-400 dark:text-slate-500'
+                : undefined
+            }
+          />
+          <AnalysisFigure
+            testId="btc-analysis-extrinsic"
+            label="Extrinsic (time) value"
+            value={formatDollar(analysis.extrinsic)}
+            valueClass={
+              analysis.extrinsic === null || analysis.extrinsic === undefined
+                ? 'text-slate-400 dark:text-slate-500'
+                : undefined
+            }
+            note={greekNull ? 'Needs option mid' : undefined}
+          />
+          <AnalysisFigure
+            testId="btc-analysis-extrinsic-pct"
+            label="Extrinsic % of mid"
+            value={formatPct(analysis.extrinsic_pct_of_mid)}
+            valueClass={
+              analysis.extrinsic_pct_of_mid === null ||
+              analysis.extrinsic_pct_of_mid === undefined
+                ? 'text-slate-400 dark:text-slate-500'
+                : undefined
+            }
+          />
+        </div>
+
+        {/* Sections 2 + 3 — only when fully populated */}
+        {populated ? (
+          <>
+            <div className="border-t border-slate-100 dark:border-slate-700/50 pt-4">
+              <p
+                data-testid="btc-analysis-breakeven"
+                className="text-sm text-slate-800 dark:text-slate-100"
+              >
+                <span className="font-semibold">
+                  BTC breakeven at expiration:{' '}
+                  <span className="tabular-nums">
+                    {formatDollar(analysis.btc_breakeven)}
+                  </span>
+                </span>
+                <span className="text-slate-500 dark:text-slate-400">
+                  {' · '}Underlying{' '}
+                  <span className="tabular-nums">
+                    {formatDollar(analysis.underlying)}
+                  </span>{' '}
+                </span>
+                <span
+                  data-testid="btc-analysis-breakeven-delta"
+                  className={`tabular-nums font-medium ${
+                    analysis.breakeven_delta < 0
+                      ? 'text-red-700 dark:text-red-300'
+                      : 'text-emerald-700 dark:text-emerald-300'
+                  }`}
+                >
+                  ({formatSignedDollar(analysis.breakeven_delta)}{' '}
+                  {analysis.breakeven_delta < 0 ? 'below' : 'above'} breakeven)
+                </span>
+              </p>
+              <p
+                data-testid="btc-analysis-guidance"
+                className="text-sm text-slate-600 dark:text-slate-300 mt-2 max-w-prose"
+              >
+                The stock must rise above your BTC breakeven (
+                <span className="font-medium tabular-nums">
+                  {formatDollar(analysis.btc_breakeven)}
+                </span>
+                ) by expiration for buying to close to beat letting the shares
+                get called away. That&apos;s{' '}
+                <span className="font-medium tabular-nums">
+                  {formatDollar(analysis.extrinsic)}
+                </span>{' '}
+                of remaining time value the stock has to clear. Below breakeven,
+                letting it assign keeps more.
+              </p>
+            </div>
+
+            <div className="border-t border-slate-100 dark:border-slate-700/50 pt-4">
+              <table
+                data-testid="btc-analysis-scenario-table"
+                className="w-full text-sm"
+              >
+                <thead>
+                  <tr className="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400 border-b border-slate-200 dark:border-slate-700">
+                    <th scope="col" className="text-left font-medium pb-2">
+                      Underlying @ exp
+                    </th>
+                    <th scope="col" className="text-left font-medium pb-2">
+                      Let assign
+                    </th>
+                    <th scope="col" className="text-left font-medium pb-2">
+                      BTC + hold
+                    </th>
+                    <th scope="col" className="text-left font-medium pb-2">
+                      Δ (BTC − assign)
+                    </th>
+                    <th scope="col" className="text-left font-medium pb-2">
+                      Winner
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {analysis.scenarios.map((s, i) => {
+                    const btcWins = s.winner === 'btc';
+                    const deltaClass = btcWins
+                      ? 'text-emerald-700 dark:text-emerald-300 font-medium'
+                      : 'text-slate-700 dark:text-slate-200';
+                    return (
+                      <tr
+                        key={s.label}
+                        data-testid={`btc-analysis-scenario-row-${i}`}
+                        className="text-slate-700 dark:text-slate-200 border-b border-slate-100 dark:border-slate-700/50 last:border-b-0"
+                      >
+                        <td className="py-2 tabular-nums">
+                          {formatDollar(s.underlying)}{' '}
+                          <span className="text-slate-400">({s.label})</span>
+                        </td>
+                        <td className="py-2 tabular-nums">
+                          {formatDollar(s.let_assign)}
+                        </td>
+                        <td className="py-2 tabular-nums">
+                          {formatDollar(s.btc_and_hold)}
+                        </td>
+                        <td
+                          data-testid={`btc-analysis-scenario-delta-${i}`}
+                          className={`py-2 tabular-nums ${deltaClass}`}
+                        >
+                          {formatSignedDollar(s.delta)}
+                        </td>
+                        <td
+                          className={`py-2 ${
+                            btcWins ? 'text-emerald-700 dark:text-emerald-300' : ''
+                          }`}
+                        >
+                          {btcWins ? 'BTC wins' : 'Assign wins'}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-3">
+                Net dollars per scenario, pre-commission. Δ &gt; 0 means buying
+                to close beats letting assign at that price.
+              </p>
+            </div>
+          </>
+        ) : (
+          <p className="text-sm text-slate-500 dark:text-slate-400 border-t border-slate-100 dark:border-slate-700/50 pt-4">
+            {greekNull
+              ? 'The option chain returned no mark for this strike, so breakeven and the assign-vs-BTC scenarios can’t be computed. Intrinsic value is shown from the live underlying.'
+              : 'Decomposition, breakeven, and scenarios need a live option mark and underlying price. They’ll appear once pricing reconnects.'}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // --- BtcDetailView ---------------------------------------------------------
 
 export default function BtcDetailView({ data }) {
   if (!data || !data.leg) return null;
-  const { leg, verdict, economics, triggered_rules: rules = [], disclaimer } =
-    data;
+  const {
+    leg,
+    verdict,
+    economics,
+    analysis,
+    triggered_rules: rules = [],
+    disclaimer,
+  } = data;
 
   return (
     <div className="space-y-4">
       <LegHeader leg={leg} verdict={verdict} />
       <RecommendedActionBlock data={data} />
-      <BtcEconomicsPanel economics={economics} verdict={verdict} />
+      <BtcEconomicsPanel
+        economics={economics}
+        analysis={analysis}
+        verdict={verdict}
+      />
+      <BtcAnalysisPanel analysis={analysis} />
       <RuleAuditPanel rules={rules} verdict={verdict} />
 
       <footer

--- a/frontend/components/dashboard/DashboardPositionsCard.jsx
+++ b/frontend/components/dashboard/DashboardPositionsCard.jsx
@@ -106,8 +106,13 @@ function CostBasisCell({ position }) {
       <span className="text-slate-700 dark:text-slate-200">cash-secured</span>
     );
   }
-  const broker = position.broker_cost_basis;
-  const adjusted = position.adjusted_cost_basis;
+  // Issue #320: per-share basis (with a muted /sh affordance) so this cell
+  // aligns 1:1 with the per-share Current column. The currency number keeps
+  // tabular-nums; /sh and adj. are muted non-tabular suffixes. Backend sends
+  // null when shares == 0, but the cspOnly branch above already short-circuits
+  // those rows, so null here only happens on incomplete data → em-dash.
+  const broker = position.broker_cost_basis_per_share;
+  const adjusted = position.adjusted_cost_basis_per_share;
   return (
     <div className="flex flex-col items-end">
       {/*
@@ -116,19 +121,37 @@ function CostBasisCell({ position }) {
         in the DOM so screen readers read broker then adjusted on desktop
         (AC: "semantic markup so screen readers read both").
       */}
-      <span className="hidden lg:inline tabular-nums text-slate-900 dark:text-white">
-        {broker == null ? '—' : formatCurrency(broker)}
+      <span
+        className="hidden lg:inline text-slate-900 dark:text-white"
+        data-testid="dashboard-position-broker-basis"
+      >
+        {broker == null ? (
+          '—'
+        ) : (
+          <>
+            <span className="tabular-nums">{formatCurrency(broker)}</span>
+            <span className="text-xs text-slate-400 dark:text-slate-500 ml-1">/sh</span>
+          </>
+        )}
       </span>
       <span
-        className="tabular-nums text-xs lg:text-xs text-slate-500 dark:text-slate-400"
+        className="text-xs lg:text-xs text-slate-500 dark:text-slate-400"
         data-testid="dashboard-position-adjusted-basis"
       >
-        <span className="lg:hidden tabular-nums text-sm text-slate-700 dark:text-slate-200">
-          {adjusted == null ? '—' : formatCurrency(adjusted)}
-        </span>
-        <span className="hidden lg:inline">
-          {adjusted == null ? '—' : `${formatCurrency(adjusted)} adj.`}
-        </span>
+        {adjusted == null ? (
+          '—'
+        ) : (
+          <>
+            <span className="lg:hidden text-sm text-slate-700 dark:text-slate-200">
+              <span className="tabular-nums">{formatCurrency(adjusted)}</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500 ml-1">/sh</span>
+            </span>
+            <span className="hidden lg:inline">
+              <span className="tabular-nums">{formatCurrency(adjusted)}</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500 ml-1">/sh adj.</span>
+            </span>
+          </>
+        )}
       </span>
     </div>
   );

--- a/frontend/components/journal/PositionsTable.jsx
+++ b/frontend/components/journal/PositionsTable.jsx
@@ -5,6 +5,29 @@ function formatCurrency(value) {
   return `$${Number(value).toFixed(2)}`;
 }
 
+/**
+ * Per-share basis cell (issue #320). Renders the per-share value with a muted
+ * non-tabular `/sh` affordance so it can't be misread as a total. The currency
+ * number keeps `tabular-nums` so digits align with the other right-aligned
+ * columns. `value == null` (shares === 0, backend sends null) renders an
+ * em-dash — never `$0.00` / Infinity.
+ */
+function PerShareBasis({ value, testid }) {
+  if (value == null) {
+    return (
+      <span data-testid={testid} className="text-slate-400 dark:text-slate-500">
+        —
+      </span>
+    );
+  }
+  return (
+    <span data-testid={testid}>
+      <span className="tabular-nums">{formatCurrency(value)}</span>
+      <span className="text-xs text-slate-400 dark:text-slate-500 ml-1">/sh</span>
+    </span>
+  );
+}
+
 function StatusBadge({ status }) {
   const isOpen = status === 'open';
   return (
@@ -144,9 +167,19 @@ export default function PositionsTable({
             >
               <td className="px-4 py-3 font-medium text-slate-900 dark:text-white">{pos.ticker}</td>
               <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">{pos.shares}</td>
-              <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">{formatCurrency(pos.broker_cost_basis)}</td>
+              <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">
+                <PerShareBasis
+                  value={pos.broker_cost_basis_per_share}
+                  testid="position-broker-basis-per-share"
+                />
+              </td>
               <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">{formatCurrency(pos.total_premiums)}</td>
-              <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">{formatCurrency(pos.adjusted_cost_basis)}</td>
+              <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">
+                <PerShareBasis
+                  value={pos.adjusted_cost_basis_per_share}
+                  testid="position-adjusted-basis-per-share"
+                />
+              </td>
               <td className="px-4 py-3 text-right text-slate-700 dark:text-slate-300">{formatCurrency(pos.min_compliant_cc_strike)}</td>
               <td className="px-4 py-3 text-center"><StatusBadge status={pos.status} /></td>
               <td className="px-4 py-3 text-right">

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -107,8 +107,46 @@ function populatedPayload(overrides = {}) {
       pricing_source: 'live',
       ...overrides.economics,
     },
+    analysis:
+      overrides.analysis !== undefined ? overrides.analysis : analysisBlock(),
     triggered_rules: overrides.triggered_rules || triggeredRules(verdict),
     disclaimer: DISCLAIMER,
+  };
+}
+
+// Canonical F 14.5C analysis block (issue #319): S=16.29, K=14.5, O=1.93 →
+// intrinsic 1.79, extrinsic 0.14, ext% 7%, breakeven 16.43, delta −0.14.
+function analysisBlock(overrides = {}) {
+  return {
+    available: true,
+    intrinsic: 1.79,
+    extrinsic: 0.14,
+    extrinsic_pct_of_mid: 0.0725,
+    option_mid: 1.93,
+    btc_breakeven: 16.43,
+    underlying: 16.29,
+    breakeven_delta: -0.14,
+    scenarios: [
+      { underlying: 14.66, label: '−10%', let_assign: 1450.0, btc_and_hold: 1273.0, delta: -177.0, winner: 'assign' },
+      { underlying: 16.29, label: 'Flat', let_assign: 1450.0, btc_and_hold: 1436.0, delta: -14.0, winner: 'assign' },
+      { underlying: 17.1, label: '+5%', let_assign: 1450.0, btc_and_hold: 1517.0, delta: 67.0, winner: 'btc' },
+      { underlying: 17.92, label: '+10%', let_assign: 1450.0, btc_and_hold: 1599.0, delta: 149.0, winner: 'btc' },
+    ],
+    ...overrides,
+  };
+}
+
+function degradedAnalysisBlock() {
+  return {
+    available: false,
+    intrinsic: null,
+    extrinsic: null,
+    extrinsic_pct_of_mid: null,
+    option_mid: null,
+    btc_breakeven: null,
+    underlying: null,
+    breakeven_delta: null,
+    scenarios: [],
   };
 }
 
@@ -130,6 +168,7 @@ function pricingUnavailablePayload() {
       pricing_as_of: null,
       pricing_source: 'unavailable',
     },
+    analysis: degradedAnalysisBlock(),
   });
 }
 
@@ -245,9 +284,12 @@ test.describe('BTC detail screen — route + states @e2e', () => {
     await expect(
       page.getByTestId('btc-detail-economics-tile-credit'),
     ).toContainText('$38.34');
+    // BRIDGE EDIT (issue #319): the 4th tile "% premium captured"
+    // (btc-detail-economics-tile-pct-captured) was replaced by the honest
+    // "Extrinsic % of mid" tile. The old assertion is removed here.
     await expect(
-      page.getByTestId('btc-detail-economics-tile-pct-captured'),
-    ).toContainText('59%');
+      page.getByTestId('btc-detail-economics-tile-extrinsic-pct'),
+    ).toContainText('7%');
     await expect(
       page.getByTestId('btc-detail-economics-tile-est-pl'),
     ).toContainText('+$22.62');
@@ -532,5 +574,116 @@ test.describe('BTC detail — journal close-leg pre-fill (issue #244) @e2e', () 
     // The journal opens on the position; no form auto-opens, no error.
     await expect(page.getByTestId('trade-history')).toBeVisible();
     await expect(page.getByTestId('trade-entry-form')).toHaveCount(0);
+  });
+});
+
+// --- Tests: BTC Analysis panel (issue #319) --------------------------------
+
+test.describe('BTC Analysis panel — decision math @e2e', () => {
+  test('renders decomposition, breakeven, and ≥4-row scenario table for ITM fixture @e2e', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    const panel = page.getByTestId('btc-analysis');
+    await expect(panel).toBeVisible();
+    // Section 1 — decomposition trio.
+    await expect(page.getByTestId('btc-analysis-intrinsic')).toContainText(
+      '$1.79',
+    );
+    await expect(page.getByTestId('btc-analysis-extrinsic')).toContainText(
+      '$0.14',
+    );
+    await expect(page.getByTestId('btc-analysis-extrinsic-pct')).toContainText(
+      '7%',
+    );
+    // Section 2 — breakeven line.
+    await expect(page.getByTestId('btc-analysis-breakeven')).toContainText(
+      '$16.43',
+    );
+    // Section 3 — ≥4-row scenario table.
+    await expect(
+      page.getByTestId('btc-analysis-scenario-table'),
+    ).toBeVisible();
+    for (let i = 0; i < 4; i += 1) {
+      await expect(
+        page.getByTestId(`btc-analysis-scenario-row-${i}`),
+      ).toBeVisible();
+    }
+    // The up scenarios favor BTC; the down/flat favor assign.
+    await expect(page.getByTestId('btc-analysis-scenario-row-0')).toContainText(
+      'Assign wins',
+    );
+    await expect(page.getByTestId('btc-analysis-scenario-row-2')).toContainText(
+      'BTC wins',
+    );
+  });
+
+  test('breakeven line shows signed delta vs underlying @e2e', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    const delta = page.getByTestId('btc-analysis-breakeven-delta');
+    // Signed (−) + dollar literal + direction word, never NaN.
+    await expect(delta).toContainText('-$0.14');
+    await expect(delta).toContainText('below breakeven');
+  });
+
+  test('guidance copy explains breakeven intuition @e2e', async ({ page }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-analysis-guidance')).toContainText(
+      'must rise above your BTC breakeven',
+    );
+    await expect(page.getByTestId('btc-analysis-guidance')).toContainText(
+      'letting it assign keeps more',
+    );
+  });
+
+  test('4th economics tile shows Extrinsic % of mid; raw %CAPT demoted to footnote @e2e', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, populatedPayload());
+    await openBtcDetail(page);
+
+    // The replaced tile reads the honest extrinsic% signal.
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-extrinsic-pct'),
+    ).toContainText('Extrinsic % of mid');
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-extrinsic-pct'),
+    ).toContainText('7%');
+    // The old misleading tile is gone.
+    await expect(
+      page.getByTestId('btc-detail-economics-tile-pct-captured'),
+    ).toHaveCount(0);
+    // captured_pct survives as a muted, labelled footnote.
+    const note = page.getByTestId('btc-detail-economics-captured-raw-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('Premium captured (raw)');
+    await expect(note).toContainText('59%');
+  });
+
+  test('degraded state shows badge + em-dash, never NaN @e2e', async ({
+    page,
+  }) => {
+    await mockBtcDetail(page, pricingUnavailablePayload());
+    await openBtcDetail(page);
+
+    await expect(page.getByTestId('btc-analysis')).toBeVisible();
+    await expect(
+      page.getByTestId('btc-analysis-degraded-badge'),
+    ).toBeVisible();
+    // Decomposition figures show the em-dash, never NaN.
+    await expect(page.getByTestId('btc-analysis-intrinsic')).toContainText('—');
+    await expect(page.getByTestId('btc-analysis')).not.toContainText('NaN');
+    // No scenario table when unavailable.
+    await expect(
+      page.getByTestId('btc-analysis-scenario-table'),
+    ).toHaveCount(0);
   });
 });

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -686,4 +686,34 @@ test.describe('BTC Analysis panel — decision math @e2e', () => {
       page.getByTestId('btc-analysis-scenario-table'),
     ).toHaveCount(0);
   });
+
+  // Review follow-up (#319): an exact-tie scenario (delta 0, winner 'tie',
+  // breakeven_delta 0) must render "Tie" / "at breakeven", not "Assign wins"
+  // or "above breakeven". The backend emits 'tie' at exact delta === 0.
+  test('renders "Tie" winner + "at breakeven" for an exact-tie scenario @e2e', async ({
+    page,
+  }) => {
+    await mockBtcDetail(
+      page,
+      populatedPayload({
+        analysis: analysisBlock({
+          breakeven_delta: 0,
+          scenarios: [
+            { underlying: 16.43, label: 'Flat', let_assign: 1450.0, btc_and_hold: 1450.0, delta: 0.0, winner: 'tie' },
+            { underlying: 17.1, label: '+5%', let_assign: 1450.0, btc_and_hold: 1517.0, delta: 67.0, winner: 'btc' },
+          ],
+        }),
+      }),
+    );
+    await openBtcDetail(page);
+
+    const tieRow = page.getByTestId('btc-analysis-scenario-row-0');
+    await expect(tieRow).toContainText('Tie');
+    await expect(tieRow).not.toContainText('Assign wins');
+    await expect(tieRow).not.toContainText('BTC wins');
+    // Breakeven line reads neutral "at breakeven" at exact 0, not "above".
+    const delta = page.getByTestId('btc-analysis-breakeven-delta');
+    await expect(delta).toContainText('at breakeven');
+    await expect(delta).not.toContainText('above breakeven');
+  });
 });

--- a/frontend/e2e/btc-detail.spec.js
+++ b/frontend/e2e/btc-detail.spec.js
@@ -716,4 +716,40 @@ test.describe('BTC Analysis panel — decision math @e2e', () => {
     await expect(delta).toContainText('at breakeven');
     await expect(delta).not.toContainText('above breakeven');
   });
+
+  // CodeRabbit triage (v1.7.0): the assign-vs-BTC decision math is
+  // covered-call-only. A put leg must render an honest "covered-call only"
+  // affordance — not the call-math scenario table and not the
+  // "pricing unavailable" copy (which would read as a data error). The backend
+  // returns the degraded analysis shape for a put; the frontend keys off the
+  // leg's option_type to distinguish it.
+  test('put leg renders a covered-call-only affordance, never call-math @e2e', async ({
+    page,
+  }) => {
+    await mockBtcDetail(
+      page,
+      populatedPayload({
+        verdict: 'dte_review',
+        leg: { option_type: 'P', strike: 20.0 },
+        analysis: degradedAnalysisBlock(),
+      }),
+    );
+    await openBtcDetail(page);
+
+    const panel = page.getByTestId('btc-analysis');
+    await expect(panel).toBeVisible();
+    await expect(panel).toHaveAttribute('data-degrade', 'put-not-applicable');
+    await expect(
+      page.getByTestId('btc-analysis-degraded-badge'),
+    ).toContainText('Covered-call only');
+    // The not-applicable message, not the pricing-error copy.
+    await expect(page.getByTestId('btc-analysis-put-na')).toContainText(
+      'covered-call-only',
+    );
+    // No misleading call-style scenario table.
+    await expect(
+      page.getByTestId('btc-analysis-scenario-table'),
+    ).toHaveCount(0);
+    await expect(panel).not.toContainText('NaN');
+  });
 });

--- a/frontend/e2e/dashboard-positions-triage.spec.js
+++ b/frontend/e2e/dashboard-positions-triage.spec.js
@@ -43,6 +43,8 @@ const TRIAGE_POSITIONS = [
     strategy: 'wheel',
     adjusted_cost_basis: 16983.0,
     broker_cost_basis: 17240.0,
+    adjusted_cost_basis_per_share: 169.83,
+    broker_cost_basis_per_share: 172.4,
     current_price: 175.42,
     notional: 17542.0,
     unrealized_pl: 559.0,
@@ -58,6 +60,8 @@ const TRIAGE_POSITIONS = [
     strategy: 'cc',
     adjusted_cost_basis: 11620.0,
     broker_cost_basis: 11755.0,
+    adjusted_cost_basis_per_share: 232.4,
+    broker_cost_basis_per_share: 235.1,
     current_price: 238.8,
     notional: 11940.0,
     unrealized_pl: 320.0,
@@ -73,6 +77,8 @@ const TRIAGE_POSITIONS = [
     strategy: 'holding',
     adjusted_cost_basis: 11707.5,
     broker_cost_basis: 11865.0,
+    adjusted_cost_basis_per_share: 156.1,
+    broker_cost_basis_per_share: 158.2,
     current_price: 162.35,
     notional: 12176.25,
     unrealized_pl: 468.75,
@@ -89,6 +95,8 @@ const TRIAGE_POSITIONS = [
     strategy: 'csp',
     adjusted_cost_basis: 0.0,
     broker_cost_basis: null,
+    adjusted_cost_basis_per_share: null,
+    broker_cost_basis_per_share: null,
     current_price: null,
     notional: null,
     unrealized_pl: null,
@@ -136,16 +144,23 @@ test.describe('Positions triage table @e2e', () => {
     await expect(page.getByTestId('dashboard-position-next-action')).toHaveCount(4);
   });
 
-  test('cost-basis cell renders both broker and adjusted values', async ({ page }) => {
+  // Issue #320 (bridge edit): basis cell now renders PER-SHARE values with a
+  // "/sh" affordance instead of the totals ($17,240 / $16,983). Broker
+  // 17240/100 = $172.40; adjusted 16983/100 = $169.83.
+  test('cost-basis cell renders per-share broker and adjusted values', async ({ page }) => {
     await mockDashboard(page, TRIAGE_PAYLOAD);
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
     const firstRow = page.getByTestId('dashboard-position-row').first();
-    // Broker basis on line 1; adjusted basis with "adj." suffix on line 2.
-    await expect(firstRow).toContainText('$17,240');
-    await expect(firstRow).toContainText('$16,983');
-    await expect(firstRow).toContainText('adj.');
+    const brokerCell = firstRow.getByTestId('dashboard-position-broker-basis');
+    const adjustedCell = firstRow.getByTestId('dashboard-position-adjusted-basis');
+    // Broker basis on line 1; adjusted basis with "/sh adj." suffix on line 2.
+    await expect(brokerCell).toContainText('$172.40');
+    await expect(brokerCell).toContainText('/sh');
+    await expect(adjustedCell).toContainText('$169.83');
+    await expect(adjustedCell).toContainText('/sh');
+    await expect(adjustedCell).toContainText('adj.');
   });
 
   test('%P/L cell renders positive in green and negative in red', async ({ page }) => {
@@ -290,10 +305,16 @@ test.describe('Positions triage table @e2e', () => {
     const firstRow = page.getByTestId('dashboard-position-row').first();
     const adjustedCell = firstRow
       .getByTestId('dashboard-position-adjusted-basis');
-    // On mobile the visible text is the adjusted basis alone (no "adj." suffix).
-    await expect(adjustedCell).toContainText('$16,983');
+    // Issue #320: mobile shows the per-share adjusted basis with "/sh". The
+    // "adj." suffix lives only on the lg:inline span (visually hidden on
+    // mobile but still in the DOM), so we assert the visible per-share value
+    // rather than DOM-absence of "adj.".
+    await expect(adjustedCell).toContainText('$169.83');
+    await expect(adjustedCell).toContainText('/sh');
     // Broker basis is in the DOM (semantic order) but hidden on mobile.
-    await expect(firstRow.locator('text=$17,240').first()).toBeHidden();
+    await expect(
+      firstRow.getByTestId('dashboard-position-broker-basis')
+    ).toBeHidden();
   });
 
   test('CSP row (zero shares) renders "cash-secured" placeholder', async ({ page }) => {

--- a/frontend/e2e/journal.spec.js
+++ b/frontend/e2e/journal.spec.js
@@ -12,6 +12,8 @@ const MOCK_POSITION = {
   notes: null,
   total_premiums: 350.0,
   adjusted_cost_basis: 14650.0,
+  broker_cost_basis_per_share: 150.0,
+  adjusted_cost_basis_per_share: 146.5,
   min_compliant_cc_strike: 161.15,
   trades: [
     {
@@ -121,7 +123,9 @@ test.describe('Journal page @e2e', () => {
 
     const row = page.getByTestId('position-row').first();
     await expect(row).toContainText('$350.00');
-    await expect(row).toContainText('$14650.00');
+    // Issue #320 (bridge edit): Adjusted Basis cell now renders the per-share
+    // value ($14,650 / 100 = $146.50) with a "/sh" affordance, not the total.
+    await expect(row).toContainText('$146.50');
     await expect(row).toContainText('$161.15');
   });
 

--- a/frontend/e2e/positions-per-share-basis.spec.js
+++ b/frontend/e2e/positions-per-share-basis.spec.js
@@ -1,0 +1,187 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Issue #320 — per-share cost basis in the Positions table.
+ *
+ * Asserts the journal PositionsTable and the dashboard PositionsCard render
+ * basis per share (with a "/sh" affordance) instead of totals, and that a
+ * zero-shares row degrades gracefully (journal → em-dash; dashboard →
+ * "cash-secured"). The dashboard cost-basis cell aligns 1:1 with the
+ * per-share Current column — the whole point of the issue.
+ */
+
+// --- Journal PositionsTable -------------------------------------------------
+
+const JOURNAL_POSITION = {
+  id: 'pos-1',
+  ticker: 'AAPL',
+  shares: 100,
+  broker_cost_basis: 15000.0,
+  status: 'open',
+  strategy: 'wheel',
+  opened_at: '2025-01-15T10:00:00Z',
+  closed_at: null,
+  notes: null,
+  total_premiums: 350.0,
+  adjusted_cost_basis: 14650.0,
+  broker_cost_basis_per_share: 150.0,
+  adjusted_cost_basis_per_share: 146.5,
+  min_compliant_cc_strike: 161.15,
+  trades: [],
+};
+
+// Orphaned / closed-out row: zero shares → backend sends null per-share basis.
+const ZERO_SHARE_POSITION = {
+  id: 'pos-2',
+  ticker: 'ZERO',
+  shares: 0,
+  broker_cost_basis: 0.0,
+  status: 'closed',
+  strategy: 'csp',
+  opened_at: '2025-01-15T10:00:00Z',
+  closed_at: '2025-02-15T10:00:00Z',
+  notes: null,
+  total_premiums: 0.0,
+  adjusted_cost_basis: 0.0,
+  broker_cost_basis_per_share: null,
+  adjusted_cost_basis_per_share: null,
+  min_compliant_cc_strike: 0.0,
+  trades: [],
+};
+
+function mockJournal(page, positions) {
+  return page.route('**/api/journal/positions', (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ positions }),
+      });
+    }
+    return route.continue();
+  });
+}
+
+test.describe('Per-share cost basis — journal table @e2e', () => {
+  test('broker + adjusted basis render per-share with /sh affordance @smoke', async ({
+    page,
+  }) => {
+    await mockJournal(page, [JOURNAL_POSITION]);
+    await page.goto('/journal');
+    await page.waitForLoadState('networkidle');
+
+    const broker = page.getByTestId('position-broker-basis-per-share').first();
+    const adjusted = page
+      .getByTestId('position-adjusted-basis-per-share')
+      .first();
+
+    // 15000 / 100 = $150.00; 14650 / 100 = $146.50.
+    await expect(broker).toContainText('$150.00');
+    await expect(broker).toContainText('/sh');
+    await expect(adjusted).toContainText('$146.50');
+    await expect(adjusted).toContainText('/sh');
+  });
+
+  test('zero-shares row renders em-dash, never $0.00 / Infinity', async ({
+    page,
+  }) => {
+    await mockJournal(page, [ZERO_SHARE_POSITION]);
+    await page.goto('/journal');
+    await page.waitForLoadState('networkidle');
+
+    const broker = page.getByTestId('position-broker-basis-per-share').first();
+    const adjusted = page
+      .getByTestId('position-adjusted-basis-per-share')
+      .first();
+
+    await expect(broker).toContainText('—');
+    await expect(adjusted).toContainText('—');
+    await expect(broker).not.toContainText('$');
+    await expect(broker).not.toContainText('Infinity');
+    await expect(adjusted).not.toContainText('$');
+  });
+});
+
+// --- Dashboard PositionsCard ------------------------------------------------
+
+const BASE_STATUS = {
+  schwab: { configured: true, valid: true, expires_at: '2026-12-31T00:00:00Z' },
+  fred: { configured: false },
+};
+
+const BASE_KPIS = {
+  open_positions: 1,
+  open_positions_breakdown: { csp: 0, cc: 0, wheel: 1, holding: 0 },
+  total_premium_collected: 0,
+  largest_risk: null,
+  premium_collected_total: 0,
+  premium_collected_trades: 0,
+  premium_collected_ytd: 0,
+  realized_pl: 0,
+  realized_pl_pct: null,
+  largest_loser: null,
+};
+
+const DASHBOARD_POSITION = {
+  id: 'pos-aapl',
+  ticker: 'AAPL',
+  shares: 100,
+  strategy: 'wheel',
+  adjusted_cost_basis: 16983.0,
+  broker_cost_basis: 17240.0,
+  adjusted_cost_basis_per_share: 169.83,
+  broker_cost_basis_per_share: 172.4,
+  current_price: 175.42,
+  notional: 17542.0,
+  unrealized_pl: 559.0,
+  pl_pct: 0.0329,
+  open_legs_count: 1,
+  wheel_status: 'Wheel',
+  next_suggested_action: 'hold',
+};
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('Per-share cost basis — dashboard card @e2e', () => {
+  test('basis cell renders per-share, aligned with the per-share Current column', async ({
+    page,
+  }) => {
+    await mockDashboard(page, {
+      generated_at: '2026-06-14T13:42:00+00:00',
+      status: BASE_STATUS,
+      kpis: BASE_KPIS,
+      positions: [DASHBOARD_POSITION],
+      open_legs: [],
+      recent_activity: [],
+      data_meta: {
+        is_stale: false,
+        fetched_at: '2026-06-14T13:42:00+00:00',
+        sources_unavailable: [],
+      },
+      next_actions: [],
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const row = page.getByTestId('dashboard-position-row').first();
+    const broker = row.getByTestId('dashboard-position-broker-basis');
+    const adjusted = row.getByTestId('dashboard-position-adjusted-basis');
+
+    // Per-share basis (172.40 / 169.83) reads against the per-share Current
+    // price (175.42) in the adjacent column — no head-math required.
+    await expect(broker).toContainText('$172.40');
+    await expect(broker).toContainText('/sh');
+    await expect(adjusted).toContainText('$169.83');
+    await expect(adjusted).toContainText('/sh');
+    await expect(adjusted).toContainText('adj.');
+    await expect(row).toContainText('$175.42'); // Current column, per-share.
+  });
+});


### PR DESCRIPTION
## v1.7.0 — Covered Call decision support

Single integration PR for milestone **v1.7.0**. Three issues, built in parallel on isolated worktrees off `feat/v1.7.0`, reviewed, and merged in dependency order **#318 → #319 → #320**.

### Issues shipped
- **Closes #318** (bug) — Assignment-risk model was depth-blind: deep-ITM short calls showed "Low" past the 14-DTE window. Now delta-primary depth (`abs(delta)≥0.80` deep, `≥0.60` moderate) with a moneyness-% fallback for illiquid strikes; final bucket = `max(timing, depth)`. The F $14.50C @ 17 DTE / delta ≈ 0.93 case now correctly reads **High**. No API shape change.
- **Closes #319** (enhancement) — New **BTC Analysis panel** on the buy-to-close detail view: intrinsic/extrinsic decomposition, breakeven line, and an assign-vs-close scenario table (fixed −10%/Flat/+5%/+10% offsets). The misleading `-1187%` "% premium captured" tile is demoted ("Extrinsic % of mid" replaces it; raw value kept as a muted footnote) — scoped strictly to the BTC detail view. New `BtcAnalysis`/`BtcAnalysisScenario` schemas (`response_model=`, openapi + TS types regenerated).
- **Closes #320** (enhancement) — Per-share cost basis in the Positions table (both render sites), aligned with the per-share Current column. Additive `broker_cost_basis_per_share` / `adjusted_cost_basis_per_share` on `PositionResponse` (backend division, single source of truth, `round(total/shares, 4)`); `shares == 0` guarded to `—`. Additive-only — no breaking change.

### Carved out (not in this release)
- **#347** — roll-comparison ("close-and-reopen" economics) was split out of #319 as a net-new algorithm; sequenced as a fast-follow, not in v1.7.0.

### Shared contract
#318 and #319 both depend on the option-leg mid/greek path. Frozen contract: `derive_open_legs` preserves `leg["current_mid"]` as a plain float; #318 owns the index refactor (`build_option_leg_index` / `resolve_leg_delta`) and adds `delta`/`delta_source`/`assignment_depth` leg fields; #319 is a pure consumer (zero new fetch). `build_option_mark_index` kept byte-compatible for existing callers.

### Verification
- Backend suite on merged branch: **1775 passed, 64 skipped**.
- Playwright e2e: #319 panel (19 passed incl. tie-state), #320 per-share (25 passed).
- OpenAPI snapshot + `frontend/api/generated/types.ts`: no drift post-merge.
- All three branches passed Phase 5 review (finapp-code-reviewer) clean; #319 review-polish (tie-state render, unused prop) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
