### PR TITLE
v1.7.1 — QA test-data seeding + deterministic stub pricing (#349)

### DIFF
--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -179,6 +179,27 @@ jobs:
               exit 1
             fi
             echo "Smoke gate PASSED: ${FRONTEND_SVC}${SMOKE_PATH} is serving."
+            # QA-only auto-seed (#349): keep QA populated with the 7 v1.7
+            # decision-support archetypes after every deploy so #318/#319/#320
+            # are always acceptance-testable on QA. The seed CLI is idempotent
+            # (tagged delete-then-reseed — non-destructive to manual QA rows)
+            # and its DTE-relative fixtures refresh each run, so time-sensitive
+            # archetypes (e.g. the "Watch ≤14 DTE" leg) stay valid over time.
+            #
+            # Double-guarded against prod: this step only runs when the caller
+            # passed environment=qa, AND `seed-qa` itself hard-blocks
+            # APP_ENV=production before any write. Prod's compose sets
+            # APP_ENV=production and never reaches this branch.
+            if [ "${{ inputs.environment }}" = "qa" ]; then
+              BACKEND_SVC=$(docker compose -f ${{ inputs.compose_file }} config --services | grep -E '(^|-)backend$' | head -1)
+              if [ -z "$BACKEND_SVC" ]; then
+                echo "::error::QA auto-seed: could not resolve a backend service from ${{ inputs.compose_file }} — refusing to mark deploy healthy."
+                exit 1
+              fi
+              echo "QA auto-seed: running 'python -m app.cli seed-qa' in ${BACKEND_SVC}"
+              docker compose -f ${{ inputs.compose_file }} exec -T "$BACKEND_SVC" python -m app.cli seed-qa
+              echo "QA auto-seed: complete."
+            fi
             docker image prune -f
             ENDSSH
             SSH_EXIT=$?

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,6 +1,8 @@
 """CLI commands for the regression tool backend.
 
-Usage: python -m app.cli schwab-auth [--app-key KEY] [--app-secret SECRET]
+Usage:
+    python -m app.cli schwab-auth [--app-key KEY] [--app-secret SECRET]
+    python -m app.cli seed-qa [--dry-run]
 """
 
 import argparse
@@ -129,6 +131,51 @@ def schwab_auth(args):
         print("\nTokens encrypted at rest with SCHWAB_ENCRYPTION_KEY.")
 
 
+def seed_qa_command(args):
+    """Seed the QA database with synthetic v1.7 archetypes (issue #349).
+
+    Hard-blocked on production by ``assert_seed_allowed`` (raises before any
+    write). ``--dry-run`` lists the archetypes and writes nothing. Exits
+    non-zero if any archetype fails to insert, or if the prod guard refuses.
+    """
+    from app.models.database import init_db, SessionLocal
+    from app.services.seed_qa import (
+        SeedGuardError,
+        build_archetypes,
+        seed_qa,
+    )
+
+    if args.dry_run:
+        archetypes = build_archetypes()
+        print("--- seed-qa dry run (no writes) ---\n")
+        for arch in archetypes:
+            print(f"  {arch.key:24s} {arch.ticker:6s} {arch.intended_state}")
+        print(f"\n{len(archetypes)} archetypes would be seeded.")
+        return
+
+    init_db()
+    db = SessionLocal()
+    try:
+        result = seed_qa(db)
+    except SeedGuardError as e:
+        # Sanitized message — the guard's own text is safe (no secrets).
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        db.close()
+
+    print("--- seed-qa complete ---")
+    print(f"  positions seeded: {result.positions_seeded}")
+    print(f"  quote stubs:      {result.quotes_seeded}")
+    print(f"  option marks:     {result.marks_seeded}")
+    if result.failed_archetypes:
+        print(
+            f"  FAILED archetypes: {', '.join(result.failed_archetypes)}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def main():
     parser = argparse.ArgumentParser(prog="app.cli", description="Regression Tool CLI")
     subparsers = parser.add_subparsers(dest="command")
@@ -137,10 +184,20 @@ def main():
     schwab_parser.add_argument("--app-key", default=None, help="Schwab app key")
     schwab_parser.add_argument("--app-secret", default=None, help="Schwab app secret")
 
+    seed_parser = subparsers.add_parser(
+        "seed-qa", help="Seed the QA database with synthetic v1.7 archetypes"
+    )
+    seed_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List the archetypes without writing anything",
+    )
 
     args = parser.parse_args()
     if args.command == "schwab-auth":
         schwab_auth(args)
+    elif args.command == "seed-qa":
+        seed_qa_command(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic_settings import BaseSettings
 
@@ -28,14 +28,16 @@ class Settings(BaseSettings):
     # guard: ``seed-qa`` is hard-blocked when ``app_env == "production"`` so
     # synthetic test data can never be written to the prod database. Defaults
     # to ``"development"`` — prod compose sets ``APP_ENV=production`` explicitly.
-    app_env: str = "development"
+    # Constrained to a Literal so a typo/casing drift fails closed at startup
+    # rather than silently bypassing the seed/stub safety switches (#349).
+    app_env: Literal["development", "qa", "production"] = "development"
 
     # Pricing-source mode (issue #349). ``"live"`` uses the real Schwab
     # market-data client; ``"stub"`` swaps in a deterministic in-DB stub
     # provider for the QA environment (where there is no Schwab feed). Defaults
     # to ``"live"`` and is never overridden in prod compose, so the stub path is
     # unreachable on production by configuration.
-    pricing_mode: str = "live"
+    pricing_mode: Literal["live", "stub"] = "live"
 
     # Axiom centralized logging (optional). When ``axiom_api_token`` is unset
     # the Axiom handler is not attached and behavior is identical to today.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -24,6 +24,19 @@ class Settings(BaseSettings):
     cache_ttl_monthly_days: int = 7
     cors_origins: str = "http://localhost:3000,http://localhost:5173"
 
+    # Deployment-environment discriminator (issue #349). Drives the QA seed
+    # guard: ``seed-qa`` is hard-blocked when ``app_env == "production"`` so
+    # synthetic test data can never be written to the prod database. Defaults
+    # to ``"development"`` — prod compose sets ``APP_ENV=production`` explicitly.
+    app_env: str = "development"
+
+    # Pricing-source mode (issue #349). ``"live"`` uses the real Schwab
+    # market-data client; ``"stub"`` swaps in a deterministic in-DB stub
+    # provider for the QA environment (where there is no Schwab feed). Defaults
+    # to ``"live"`` and is never overridden in prod compose, so the stub path is
+    # unreachable on production by configuration.
+    pricing_mode: str = "live"
+
     # Axiom centralized logging (optional). When ``axiom_api_token`` is unset
     # the Axiom handler is not attached and behavior is identical to today.
     # See ``backend/app/logging_axiom.py`` and ``deploy/LOGGING.md``.

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Column, Float, ForeignKey, Integer, String, Text, create_engine, event
+from sqlalchemy import (
+    Column,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    create_engine,
+    event,
+)
 from sqlalchemy.orm import DeclarativeBase, relationship, sessionmaker
 
 from app.config import settings
@@ -256,6 +266,15 @@ class OptionMarkStub(Base):
     """
 
     __tablename__ = "option_mark_stubs"
+    __table_args__ = (
+        UniqueConstraint(
+            "ticker",
+            "strike",
+            "expiration",
+            "option_type",
+            name="uq_option_mark_stub_leg",
+        ),
+    )
 
     id = Column(String, primary_key=True)  # UUID4
     ticker = Column(String, nullable=False, index=True)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -216,6 +216,56 @@ class WatchlistTicker(Base):
     added_at = Column(String, nullable=False)  # ISO datetime — audit + stable sort
 
 
+class QuoteStub(Base):
+    """Deterministic underlying quote for the QA stub-pricing layer (issue #349).
+
+    Internal table — never a route response model. Seeded and torn down by
+    ``seed-qa`` (cascaded with the synthetic positions). Read only by
+    :class:`app.services.market_client.StubSchwabClient` when
+    ``settings.pricing_mode == "stub"`` (QA only); the prod path never
+    constructs the stub client, so this table stays empty on production.
+
+    One row per ticker (``ticker`` is the primary key). ``last_price`` is the
+    synthetic underlying price returned in the Schwab-shaped quote dict.
+
+    The project has no Alembic — ``Base.metadata.create_all(bind=engine)`` is
+    idempotent, so an existing deployment grows the table on next startup.
+    Rollback path is a manual ``DROP TABLE quote_stubs``.
+    """
+
+    __tablename__ = "quote_stubs"
+
+    ticker = Column(String, primary_key=True)  # underlying symbol
+    last_price = Column(Float, nullable=False)  # synthetic last price
+
+
+class OptionMarkStub(Base):
+    """Deterministic option mark for the QA stub-pricing layer (issue #349).
+
+    Internal table — never a route response model. Seeded and torn down by
+    ``seed-qa``. Read only by :class:`app.services.market_client.StubSchwabClient`
+    when ``settings.pricing_mode == "stub"`` (QA only).
+
+    One row per ``(ticker, strike, expiration, option_type)`` leg. The stub
+    client reassembles these rows into a Schwab-shaped ``callExpDateMap`` /
+    ``putExpDateMap`` chain so ``build_option_leg_index`` parses them unchanged.
+    ``delta`` is nullable: omitting it (and the row entirely) lets an archetype
+    model the "no live option mark" degrade path.
+
+    Rollback path is a manual ``DROP TABLE option_mark_stubs``.
+    """
+
+    __tablename__ = "option_mark_stubs"
+
+    id = Column(String, primary_key=True)  # UUID4
+    ticker = Column(String, nullable=False, index=True)
+    strike = Column(Float, nullable=False)
+    expiration = Column(String, nullable=False)  # YYYY-MM-DD
+    option_type = Column(String, nullable=False)  # "call" | "put"
+    mid = Column(Float, nullable=False)  # synthetic option mid (per-share)
+    delta = Column(Float, nullable=True)  # signed live delta, nullable
+
+
 engine = create_engine(settings.database_url, connect_args={"check_same_thread": False})
 
 

--- a/backend/app/services/btc_detail.py
+++ b/backend/app/services/btc_detail.py
@@ -31,10 +31,19 @@ from typing import Any
 
 from sqlalchemy.orm import Session as DBSession
 
+from app.config import settings
 from app.services import journal
 from app.services.dashboard_legs import build_option_leg_index, derive_open_legs
+from app.services.market_client import get_market_client
 from app.services.rules_config import load_rules_config
-from app.services.schwab_client import SchwabClient
+
+# ``SchwabClient`` is re-exported into this module's namespace as the stable
+# monkeypatch surface the BTC-detail integration tests target
+# (``app.services.btc_detail.SchwabClient.get_quote`` / ``.get_option_chain``).
+# The live quote/chain fetch now goes through :func:`get_market_client` (issue
+# #349), which instantiates this same class object, so patching the method here
+# still intercepts the live calls. Kept as an explicit re-export, not dead code.
+from app.services.schwab_client import SchwabClient  # noqa: F401  (test patch surface)
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +127,10 @@ def _build_economics(leg: dict) -> dict[str, Any]:
     # construction with the dashboard column (spec §10 note 2).
     captured_pct = (leg.get("profit_target_status") or {}).get("captured_pct")
     est_pl_if_closed = round(credit_received - cost_to_close, 2)
+    # Label the source "stub" on the QA stub-pricing path (issue #349) so the
+    # frozen ``pricing_source="stub"`` schema value is finally reachable; "live"
+    # everywhere else. This is the only place the literal is chosen.
+    pricing_source = "stub" if settings.pricing_mode == "stub" else "live"
     return {
         "credit_received": credit_received,
         "current_option_mid": round(float(current_mid), 4),
@@ -125,7 +138,7 @@ def _build_economics(leg: dict) -> dict[str, Any]:
         "captured_pct": captured_pct,
         "est_pl_if_closed": est_pl_if_closed,
         "pricing_as_of": datetime.now(timezone.utc).isoformat(),
-        "pricing_source": "live",
+        "pricing_source": pricing_source,
     }
 
 
@@ -290,7 +303,9 @@ def build_btc_detail(
 
     # Resolve the live price + option chain for THIS position's ticker only.
     # A single quote + single chain — far cheaper than the dashboard fan-out.
-    client = SchwabClient()
+    # The factory returns the live Schwab client (prod default) or the
+    # deterministic stub client on the QA pricing_mode=="stub" path (issue #349).
+    client = get_market_client(db)
     quote = client.get_quote(ticker)
     current_price_raw = quote.get("lastPrice") if isinstance(quote, dict) else None
     if current_price_raw is None and isinstance(quote, dict):

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -17,11 +17,12 @@ from typing import Iterable
 
 from sqlalchemy.orm import Session as DBSession
 
-from app.config import get_fred_api_key
+from app.config import get_fred_api_key, settings
 from app.models.database import CacheEntry, Position, Session as SessionModel, Trade
 from app.services import journal as journal_service
 from app.services.action_engine import compute_next_actions
 from app.services.alpha_vantage_client import get_cached_next_earnings_date
+from app.services.market_client import get_market_client
 from app.services.dashboard_legs import (
     build_option_leg_index,
     derive_open_legs,
@@ -29,7 +30,17 @@ from app.services.dashboard_legs import (
 )
 from app.services.rules_config import load_rules_config
 from app.services.schwab_auth import SchwabAuthError, SchwabTokenManager
-from app.services.schwab_client import SchwabClient, SchwabClientError
+# ``SchwabClient`` is re-exported into this module's namespace as the stable
+# monkeypatch surface the dashboard integration tests target
+# (``app.services.dashboard.SchwabClient.get_quote`` / ``.get_option_chain``).
+# The live quote/chain fetches now go through :func:`get_market_client` (issue
+# #349), which instantiates this same class object, so patching the method here
+# still intercepts the live calls. Kept as an explicit re-export rather than an
+# unused import.
+from app.services.schwab_client import (  # noqa: F401  (test patch surface)
+    SchwabClient,
+    SchwabClientError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +124,7 @@ def _bucket_cache_freshness(db: DBSession) -> dict:
 def _fetch_quotes_parallel(
     tickers: Iterable[str],
     schwab_configured: bool,
+    db: DBSession,
 ) -> tuple[dict[str, float | None], bool]:
     """Fetch live quotes for `tickers` concurrently. Returns
     (price_by_ticker, schwab_failed_flag).
@@ -137,7 +149,9 @@ def _fetch_quotes_parallel(
         return prices, False
 
     schwab_failed = False
-    client = SchwabClient()
+    # Live Schwab client (prod default) or deterministic stub client on the QA
+    # pricing_mode=="stub" path (issue #349). Behavior-neutral on prod.
+    client = get_market_client(db)
 
     def _fetch(ticker: str) -> tuple[str, float | None, bool]:
         try:
@@ -171,6 +185,7 @@ def _fetch_quotes_parallel(
 def _fetch_option_chains_parallel(
     tickers: Iterable[str],
     schwab_configured: bool,
+    db: DBSession,
 ) -> tuple[dict[str, dict], bool]:
     """Fetch raw Schwab option chains for `tickers` concurrently.
 
@@ -199,7 +214,9 @@ def _fetch_option_chains_parallel(
         return chains_by_ticker, False
 
     schwab_failed = False
-    client = SchwabClient()
+    # Live Schwab client (prod default) or deterministic stub client on the QA
+    # pricing_mode=="stub" path (issue #349). Behavior-neutral on prod.
+    client = get_market_client(db)
 
     def _fetch(ticker: str) -> tuple[str, dict | None, bool]:
         try:
@@ -660,6 +677,11 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
 
     # Status block
     schwab_status, schwab_configured = _build_schwab_status()
+    # On the QA stub-pricing path (issue #349) there is no live Schwab feed, so
+    # ``schwab_configured`` is False and the fetch fan-outs would short-circuit.
+    # The stub client serves the deterministic feed instead, so treat the feed
+    # as available whenever pricing_mode=="stub". Prod stays "live" → no change.
+    feed_available = schwab_configured or settings.pricing_mode == "stub"
     fred_status = _build_fred_status()
     cache_status = _bucket_cache_freshness(db)
 
@@ -676,7 +698,7 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
     # Quotes (parallelized; deduped by ticker)
     tickers = [p["ticker"] for p in open_positions]
     quotes_by_ticker, schwab_failed = _fetch_quotes_parallel(
-        tickers, schwab_configured=schwab_configured
+        tickers, schwab_configured=feed_available, db=db
     )
 
     # Option chains for the % CAPT signal — fetched only for positions that
@@ -690,7 +712,7 @@ def build_dashboard_payload(db: DBSession, today: date | None = None) -> dict:
         and not trade.get("closed_at")
     }
     option_chains, chains_failed = _fetch_option_chains_parallel(
-        open_leg_tickers, schwab_configured=schwab_configured
+        open_leg_tickers, schwab_configured=feed_available, db=db
     )
     schwab_failed = schwab_failed or chains_failed
     # Richer per-leg index carrying delta (issue #318). Spot is threaded so the

--- a/backend/app/services/market_client.py
+++ b/backend/app/services/market_client.py
@@ -97,10 +97,10 @@ class StubSchwabClient:
     def get_option_chain(
         self,
         ticker: str,
-        contract_type: str = "ALL",
-        from_date: str | None = None,
-        to_date: str | None = None,
-        strike_count: int | None = None,
+        contract_type: str = "ALL",  # noqa: ARG002 — signature parity with SchwabClient
+        from_date: str | None = None,  # noqa: ARG002
+        to_date: str | None = None,  # noqa: ARG002
+        strike_count: int | None = None,  # noqa: ARG002
     ) -> dict:
         """Return a Schwab-shaped option chain dict from the stub marks table.
 
@@ -154,13 +154,27 @@ def get_market_client(db: DBSession) -> SchwabClient | StubSchwabClient:
     bound to ``db`` (QA only); any other value (including the prod default
     ``"live"``) yields the real :class:`SchwabClient`. ``db`` is accepted
     unconditionally so call sites are uniform; the live client ignores it.
+
+    **Prod-safety guard (defense-in-depth):** stub construction is refused
+    outright when ``app_env == "production"``, regardless of ``pricing_mode``.
+    The configuration invariant (prod never sets ``PRICING_MODE``) is the first
+    line of defense; this guard ensures a single stray prod env override cannot
+    swap real market data for synthetic stub rows. Mirrors the ``seed-qa`` prod
+    guard so the safety is by design, not by convention.
     """
-    if settings.pricing_mode == "stub":
+    if settings.pricing_mode == "stub" and settings.app_env != "production":
         logger.info(
             "market_client.select",
             extra={"event": "market_client.select", "outcome": "success"},
         )
         return StubSchwabClient(db)
+    if settings.pricing_mode == "stub":
+        # pricing_mode=stub requested on production — refuse and fall back to
+        # the live client so prod can never serve synthetic data.
+        logger.warning(
+            "market_client.select",
+            extra={"event": "market_client.select", "outcome": "degraded"},
+        )
     return SchwabClient()
 
 

--- a/backend/app/services/market_client.py
+++ b/backend/app/services/market_client.py
@@ -1,0 +1,141 @@
+"""Market-data provider seam for QA-gated deterministic stub pricing (issue #349).
+
+The dashboard and BTC-detail services need live quotes, option mids, and deltas
+to compute assignment-risk depth (#318) and the buy-to-close decision panel
+(#319). QA has no Schwab feed, so those surfaces collapse to their degraded
+states there — which means the v1.7 acceptance criteria cannot be validated on
+QA before promoting to prod.
+
+This module introduces a thin provider seam: :func:`get_market_client` returns
+the real :class:`app.services.schwab_client.SchwabClient` when
+``settings.pricing_mode == "live"`` (the default, and the only value prod ever
+runs with), or a :class:`StubSchwabClient` reading deterministic values from the
+``quote_stubs`` / ``option_mark_stubs`` tables when ``pricing_mode == "stub"``.
+
+**Prod-safety invariant:** prod compose never sets ``PRICING_MODE``, so
+``settings.pricing_mode`` stays ``"live"`` and :class:`StubSchwabClient` is never
+constructed on production. The stub path is unreachable on prod by configuration,
+not by a runtime check — the seam simply hands back the real client.
+
+The stub client returns Schwab-shaped dicts: ``get_quote`` mirrors
+:meth:`SchwabClient.get_quote` (a ``quote``-node dict with ``lastPrice``), and
+``get_option_chain`` mirrors :meth:`SchwabClient.get_option_chain` (nested
+``callExpDateMap`` / ``putExpDateMap`` with ``mark`` / ``delta`` / ``strikePrice``
+keys). This means every downstream consumer — ``dashboard.py``,
+``dashboard_legs.build_option_leg_index``, ``btc_detail.py`` — is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.config import settings
+from app.models.database import OptionMarkStub, QuoteStub
+from app.services.schwab_client import SchwabClient, SchwabClientError
+
+logger = logging.getLogger(__name__)
+
+
+class StubSchwabClient:
+    """Deterministic, in-DB stand-in for :class:`SchwabClient` (QA only).
+
+    Reads the synthetic ``quote_stubs`` / ``option_mark_stubs`` rows seeded by
+    ``seed-qa`` and returns Schwab-shaped dicts so the dashboard / BTC-detail
+    code paths run identically to the live feed. Constructed only when
+    ``settings.pricing_mode == "stub"`` (never on prod — see module docstring).
+
+    Implements the subset of the :class:`SchwabClient` surface the
+    dashboard/BTC paths call: :meth:`get_quote` and :meth:`get_option_chain`.
+    """
+
+    def __init__(self, db: DBSession) -> None:
+        """Bind the stub client to a request-scoped DB session."""
+        self._db = db
+
+    def get_quote(self, ticker: str) -> dict:
+        """Return a Schwab-shaped quote dict for ``ticker`` from the stub table.
+
+        Mirrors :meth:`SchwabClient.get_quote`: returns a ``quote``-node dict
+        carrying ``lastPrice`` / ``mark``. Raises :class:`SchwabClientError`
+        when no stub row exists (same contract as the live client's no-data
+        case), so the dashboard's per-ticker guard degrades that ticker.
+        """
+        row = self._db.query(QuoteStub).filter(QuoteStub.ticker == ticker).first()
+        if row is None:
+            raise SchwabClientError(f"No stub quote for '{ticker}'")
+        return {"lastPrice": row.last_price, "mark": row.last_price}
+
+    def get_option_chain(
+        self,
+        ticker: str,
+        contract_type: str = "ALL",
+        from_date: str | None = None,
+        to_date: str | None = None,
+        strike_count: int | None = None,
+    ) -> dict:
+        """Return a Schwab-shaped option chain dict from the stub marks table.
+
+        Reassembles ``option_mark_stubs`` rows into the nested
+        ``callExpDateMap`` / ``putExpDateMap`` structure that
+        :func:`app.services.dashboard_legs.build_option_leg_index` parses. The
+        ``contract_type`` / ``*_date`` / ``strike_count`` args are accepted for
+        signature parity with the live client and ignored — the stub returns
+        every seeded leg for the ticker.
+
+        Returns a valid chain with **empty** maps when the ticker has no seeded
+        marks (the "no live option mark" archetype). A real Schwab chain for a
+        tradable ticker still returns a payload — the specific illiquid strike
+        is simply absent — so the leg degrades to ``current_mid=None`` and the
+        BTC panel renders its ``"—"`` sentinel rather than 500-ing the page.
+        """
+        rows = (
+            self._db.query(OptionMarkStub)
+            .filter(OptionMarkStub.ticker == ticker)
+            .all()
+        )
+        call_map: dict[str, dict] = {}
+        put_map: dict[str, dict] = {}
+        for row in rows:
+            target = call_map if row.option_type == "call" else put_map
+            # Schwab keys expirations as "YYYY-MM-DD:DTE"; build_option_leg_index
+            # only reads the date prefix, so a ":0" DTE suffix is a harmless,
+            # parser-compatible filler.
+            exp_key = f"{row.expiration}:0"
+            strike_key = f"{row.strike:.1f}"
+            contract: dict = {
+                "strikePrice": row.strike,
+                "mark": row.mid,
+                "bid": row.mid,
+                "ask": row.mid,
+            }
+            if row.delta is not None:
+                contract["delta"] = row.delta
+            target.setdefault(exp_key, {})[strike_key] = [contract]
+
+        return {
+            "symbol": ticker,
+            "callExpDateMap": call_map,
+            "putExpDateMap": put_map,
+        }
+
+
+def get_market_client(db: DBSession) -> SchwabClient | StubSchwabClient:
+    """Return the live or stub market-data client based on ``pricing_mode``.
+
+    ``settings.pricing_mode == "stub"`` yields a :class:`StubSchwabClient`
+    bound to ``db`` (QA only); any other value (including the prod default
+    ``"live"``) yields the real :class:`SchwabClient`. ``db`` is accepted
+    unconditionally so call sites are uniform; the live client ignores it.
+    """
+    if settings.pricing_mode == "stub":
+        logger.info(
+            "market_client.select",
+            extra={"event": "market_client.select", "outcome": "success"},
+        )
+        return StubSchwabClient(db)
+    return SchwabClient()
+
+
+__all__ = ["StubSchwabClient", "get_market_client"]

--- a/backend/app/services/market_client.py
+++ b/backend/app/services/market_client.py
@@ -51,21 +51,48 @@ class StubSchwabClient:
     """
 
     def __init__(self, db: DBSession) -> None:
-        """Bind the stub client to a request-scoped DB session."""
-        self._db = db
+        """Snapshot the stub tables into memory up-front (issue #349).
+
+        The dashboard fetches quotes and option chains concurrently via a
+        ``ThreadPoolExecutor`` (``dashboard._fetch_quotes_parallel`` /
+        ``_fetch_option_chains_parallel``). A SQLAlchemy ``Session`` and its
+        underlying SQLite connection are NOT thread-safe — querying ``db`` from
+        those worker threads raises ``sqlite3.InterfaceError: bad parameter or
+        other API misuse``, which silently degrades every leg to the no-data
+        path (assignment-risk collapses to ``"low"``). We therefore read every
+        stub row ONCE here, in the constructing thread, into plain in-memory
+        dicts; :meth:`get_quote` / :meth:`get_option_chain` then serve from
+        memory and never touch the session (or ORM-managed objects) again.
+        """
+        self._quotes: dict[str, float] = {
+            row.ticker: row.last_price for row in db.query(QuoteStub).all()
+        }
+        self._marks: dict[str, list[dict]] = {}
+        for row in db.query(OptionMarkStub).all():
+            self._marks.setdefault(row.ticker, []).append(
+                {
+                    "option_type": row.option_type,
+                    "expiration": row.expiration,
+                    "strike": row.strike,
+                    "mid": row.mid,
+                    "delta": row.delta,
+                }
+            )
 
     def get_quote(self, ticker: str) -> dict:
-        """Return a Schwab-shaped quote dict for ``ticker`` from the stub table.
+        """Return a Schwab-shaped quote dict for ``ticker`` from the snapshot.
 
         Mirrors :meth:`SchwabClient.get_quote`: returns a ``quote``-node dict
         carrying ``lastPrice`` / ``mark``. Raises :class:`SchwabClientError`
         when no stub row exists (same contract as the live client's no-data
         case), so the dashboard's per-ticker guard degrades that ticker.
+        Reads only the in-memory snapshot — thread-safe under the parallel
+        fetch fan-out.
         """
-        row = self._db.query(QuoteStub).filter(QuoteStub.ticker == ticker).first()
-        if row is None:
+        last_price = self._quotes.get(ticker)
+        if last_price is None:
             raise SchwabClientError(f"No stub quote for '{ticker}'")
-        return {"lastPrice": row.last_price, "mark": row.last_price}
+        return {"lastPrice": last_price, "mark": last_price}
 
     def get_option_chain(
         self,
@@ -89,29 +116,28 @@ class StubSchwabClient:
         tradable ticker still returns a payload — the specific illiquid strike
         is simply absent — so the leg degrades to ``current_mid=None`` and the
         BTC panel renders its ``"—"`` sentinel rather than 500-ing the page.
+
+        Reads only the in-memory snapshot taken in :meth:`__init__` — safe to
+        call from the parallel-fetch worker threads.
         """
-        rows = (
-            self._db.query(OptionMarkStub)
-            .filter(OptionMarkStub.ticker == ticker)
-            .all()
-        )
+        rows = self._marks.get(ticker, [])
         call_map: dict[str, dict] = {}
         put_map: dict[str, dict] = {}
         for row in rows:
-            target = call_map if row.option_type == "call" else put_map
+            target = call_map if row["option_type"] == "call" else put_map
             # Schwab keys expirations as "YYYY-MM-DD:DTE"; build_option_leg_index
             # only reads the date prefix, so a ":0" DTE suffix is a harmless,
             # parser-compatible filler.
-            exp_key = f"{row.expiration}:0"
-            strike_key = f"{row.strike:.1f}"
+            exp_key = f"{row['expiration']}:0"
+            strike_key = f"{row['strike']:.1f}"
             contract: dict = {
-                "strikePrice": row.strike,
-                "mark": row.mid,
-                "bid": row.mid,
-                "ask": row.mid,
+                "strikePrice": row["strike"],
+                "mark": row["mid"],
+                "bid": row["mid"],
+                "ask": row["mid"],
             }
-            if row.delta is not None:
-                contract["delta"] = row.delta
+            if row["delta"] is not None:
+                contract["delta"] = row["delta"]
             target.setdefault(exp_key, {})[strike_key] = [contract]
 
         return {

--- a/backend/app/services/seed_qa.py
+++ b/backend/app/services/seed_qa.py
@@ -1,0 +1,477 @@
+"""QA test-data seeding + deterministic stub-pricing fixtures (issue #349).
+
+QA (``qa.regression.shawnjsandy.com``) has no positions and no Schwab feed, so
+the v1.7 covered-call decision surfaces (#318 assignment-risk depth, #319 BTC
+panel, #320 per-share basis) cannot be validated there before promoting to prod.
+This module seeds seven synthetic position archetypes — plus the deterministic
+stub-pricing rows that light up the live-feed-dependent surfaces — so every v1.7
+acceptance criterion renders its intended state on QA.
+
+**Prod safety (hard block, no override):** :func:`assert_seed_allowed` raises
+:class:`SeedGuardError` when ``settings.app_env == "production"`` *before any DB
+write*. Prod compose sets ``APP_ENV=production``; the seeder can never write
+synthetic data to the prod database.
+
+**Idempotency (tagged delete-then-reseed):** every seeded position carries a
+``"__seed__:<key>"`` sentinel prefix in its ``notes`` column. Teardown deletes
+only sentinel-tagged positions (cascading to their trades) plus all stub rows,
+so reseeding yields seven positions — not fourteen — and never touches
+manually-added QA state.
+
+**Recomputer bypass (deliberate):** the archetypes pin derived state
+(``shares`` / ``broker_cost_basis`` / ``strategy`` / ``status``) directly on the
+ORM row because the seed validates the *display* features, not the recomputer.
+Calling :func:`recompute_position_state` would overwrite the pinned state. The
+one read-time-derived value, ``adjusted_cost_basis``, is computed by
+``journal.py`` from the seeded trades — so archetype 7 carries real
+premium-bearing trades to make ``adjusted_cost_basis`` differ from broker basis.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session as DBSession
+
+from app.config import settings
+from app.models.database import (
+    OptionMarkStub,
+    Position,
+    QuoteStub,
+    Trade,
+)
+
+logger = logging.getLogger(__name__)
+
+# Sentinel prefix written to a seeded position's ``notes`` column so teardown
+# can find and delete only seeded rows. Frozen contract — the teardown LIKE
+# filter and the tests both reference this literal.
+SEED_TAG_PREFIX: str = "__seed__:"
+
+
+class SeedGuardError(Exception):
+    """Raised when a seed run is attempted against the production environment.
+
+    The guard is a hard block with no override — there is no flag that lets
+    ``seed-qa`` write synthetic data to the prod database.
+    """
+
+
+@dataclass(frozen=True)
+class StubMark:
+    """A single deterministic option mark to seed for an archetype's leg."""
+
+    strike: float
+    expiration: str  # YYYY-MM-DD
+    option_type: str  # "call" | "put"
+    mid: float
+    delta: float | None = None
+
+
+@dataclass(frozen=True)
+class SeedTrade:
+    """A synthetic trade ledger entry for an archetype position."""
+
+    trade_type: str
+    strike: float
+    expiration: str  # YYYY-MM-DD
+    premium: float  # per-share, positive for credits
+    quantity: int = 1
+    fees: float = 0.0
+    closed_at: str | None = None
+    close_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class Archetype:
+    """A frozen synthetic-position fixture (issue #349 contract-freeze source).
+
+    The ``ARCHETYPES`` list below is the single source of truth referenced by
+    both the seeder and the tests. Derived state (``shares`` /
+    ``broker_cost_basis`` / ``strategy`` / ``status``) is pinned directly on the
+    ORM row; the recomputer is deliberately not run (see module docstring).
+    """
+
+    key: str
+    ticker: str
+    shares: int
+    broker_cost_basis: float
+    strategy: str
+    intended_state: str
+    trades: list[SeedTrade] = field(default_factory=list)
+    quote_price: float | None = None
+    marks: list[StubMark] = field(default_factory=list)
+
+
+@dataclass
+class SeedResult:
+    """Outcome of a seed run.
+
+    ``positions_seeded`` counts positions inserted (0 on a dry run).
+    ``quotes_seeded`` / ``marks_seeded`` count stub rows inserted.
+    ``failed_archetypes`` lists archetype keys whose insert raised — a non-empty
+    list drives the CLI's non-zero exit. ``dry_run`` echoes the run mode.
+    """
+
+    positions_seeded: int = 0
+    quotes_seeded: int = 0
+    marks_seeded: int = 0
+    failed_archetypes: list[str] = field(default_factory=list)
+    dry_run: bool = False
+
+    @property
+    def ok(self) -> bool:
+        """True when no archetype failed to insert."""
+        return not self.failed_archetypes
+
+
+def _iso_date_in(days: int, *, now: datetime) -> str:
+    """Return the YYYY-MM-DD date ``days`` from ``now`` (UTC).
+
+    Expirations are computed from ``datetime.now(timezone.utc)`` rather than
+    pinned ISO literals so a DTE-relative archetype keeps its intended
+    near/far-dated state regardless of when the seed runs (Wave 3 date-drift
+    lesson — a pinned literal silently drifts out of its DTE window over time).
+    """
+    return (now + timedelta(days=days)).date().isoformat()
+
+
+def build_archetypes(now: datetime | None = None) -> list[Archetype]:
+    """Construct the seven synthetic archetypes with DTE-relative expirations.
+
+    ``now`` is injectable for deterministic tests; production callers omit it
+    and get ``datetime.now(timezone.utc)``. Returns a fresh list each call (the
+    expirations depend on ``now``), but the *shape* — keys, tickers, strategy,
+    intended state — is frozen.
+
+    Archetype matrix (issue #349 plan §3):
+
+    1. Deep-ITM short call, >14 DTE, δ≈0.90 → #318 **High** (depth axis).
+    2. NTM short call, ≤14 DTE, ITM, δ≈0.55 → #318 **Watch** (timing axis).
+    3. OTM short call, long DTE, δ≈0.25 → #318 **Low**.
+    4. Covered call, normal premium, live stub mark → #319 BTC panel populated,
+       ``pricing_source="stub"``.
+    5. Cash-secured put, 0 shares → #319 covered-call-only N/A gate + #320
+       0-share basis em-dash. No stub marks (CSP is not a covered call).
+    6. Covered call, no live option mark → #319 degraded ``"—"`` sentinel,
+       ``pricing_source="unavailable"`` (quote seeded, mark omitted).
+    7. Multi-share equity, premium-bearing trades → #320 adjusted/sh ≠ broker/sh.
+    """
+    now = now or datetime.now(timezone.utc)
+    far = _iso_date_in(30, now=now)  # > 14 DTE
+    # 10 DTE: inside the ≤14 "watch" timing band but above the ≤7 "high" floor,
+    # so the timing axis yields Watch (the depth axis stays Low at δ≈0.55).
+    near = _iso_date_in(10, now=now)
+    past = _iso_date_in(-30, now=now)  # closed-leg expiration in the past
+
+    return [
+        # 1 — Deep-ITM short call, >14 DTE, δ≈0.90 → High (depth axis).
+        Archetype(
+            key="deep_itm_call",
+            ticker="SEEDA",
+            shares=100,
+            broker_cost_basis=8000.0,
+            strategy="cc",
+            intended_state="#318 assignment risk = High (deep ITM)",
+            trades=[
+                SeedTrade("sell_call", strike=80.0, expiration=far, premium=12.0),
+            ],
+            quote_price=110.0,  # price ≫ strike → deep ITM
+            marks=[
+                StubMark(80.0, far, "call", mid=31.5, delta=0.90),
+            ],
+        ),
+        # 2 — NTM short call, ≤14 DTE, ITM, δ≈0.55 → Watch (timing axis).
+        Archetype(
+            key="ntm_call",
+            ticker="SEEDB",
+            shares=100,
+            broker_cost_basis=5000.0,
+            strategy="cc",
+            intended_state="#318 assignment risk = Watch (near-dated ITM)",
+            trades=[
+                SeedTrade("sell_call", strike=50.0, expiration=near, premium=2.5),
+            ],
+            quote_price=51.0,  # slightly ITM
+            marks=[
+                StubMark(50.0, near, "call", mid=1.6, delta=0.55),
+            ],
+        ),
+        # 3 — OTM short call, long DTE, δ≈0.25 → Low.
+        Archetype(
+            key="otm_call",
+            ticker="SEEDC",
+            shares=100,
+            broker_cost_basis=6000.0,
+            strategy="cc",
+            intended_state="#318 assignment risk = Low (OTM)",
+            trades=[
+                SeedTrade("sell_call", strike=70.0, expiration=far, premium=1.8),
+            ],
+            quote_price=62.0,  # price < strike → OTM
+            marks=[
+                StubMark(70.0, far, "call", mid=1.2, delta=0.25),
+            ],
+        ),
+        # 4 — Covered call, normal premium, live stub mark → BTC panel populated.
+        Archetype(
+            key="btc_populated_cc",
+            ticker="SEEDD",
+            shares=100,
+            broker_cost_basis=4500.0,
+            strategy="cc",
+            intended_state="#319 BTC panel populated, pricing_source=stub",
+            trades=[
+                SeedTrade("sell_call", strike=48.0, expiration=far, premium=2.2),
+            ],
+            quote_price=46.0,  # OTM, mid present → full BTC math
+            marks=[
+                StubMark(48.0, far, "call", mid=1.1, delta=0.30),
+            ],
+        ),
+        # 5 — Cash-secured put, 0 shares → CC-only N/A gate + 0-share basis dash.
+        Archetype(
+            key="csp_zero_shares",
+            ticker="SEEDE",
+            shares=0,
+            broker_cost_basis=0.0,
+            strategy="csp",
+            intended_state="#319 CC-only N/A + #320 0-share basis em-dash",
+            trades=[
+                SeedTrade("sell_put", strike=40.0, expiration=far, premium=1.5),
+            ],
+            quote_price=42.0,  # put is OTM; no marks (CSP ≠ covered call)
+            marks=[],
+        ),
+        # 6 — Covered call, NO live option mark → degraded "—" sentinel.
+        Archetype(
+            key="cc_no_mark",
+            ticker="SEEDF",
+            shares=100,
+            broker_cost_basis=5500.0,
+            strategy="cc",
+            intended_state="#319 degraded '—' sentinel, pricing_source=unavailable",
+            trades=[
+                SeedTrade("sell_call", strike=55.0, expiration=far, premium=2.0),
+            ],
+            quote_price=54.0,  # quote present, mark omitted → greek-null degrade
+            marks=[],
+        ),
+        # 7 — Multi-share equity, premium-bearing trades → adjusted/sh ≠ broker/sh.
+        Archetype(
+            key="equity_adjusted_basis",
+            ticker="SEEDG",
+            shares=100,
+            broker_cost_basis=7000.0,
+            strategy="wheel",
+            intended_state="#320 adjusted/sh ≠ broker/sh (premium-reduced basis)",
+            trades=[
+                # Closed premium-bearing legs reduce adjusted basis below broker.
+                SeedTrade(
+                    "sell_call",
+                    strike=75.0,
+                    expiration=past,
+                    premium=3.0,
+                    closed_at=past + "T00:00:00+00:00",
+                    close_reason="full_expiration",
+                ),
+                SeedTrade(
+                    "sell_call",
+                    strike=72.0,
+                    expiration=past,
+                    premium=2.5,
+                    closed_at=past + "T00:00:00+00:00",
+                    close_reason="full_expiration",
+                ),
+            ],
+            quote_price=78.0,
+            marks=[],
+        ),
+    ]
+
+
+def assert_seed_allowed() -> None:
+    """Hard-block seeding on production (issue #349).
+
+    Raises :class:`SeedGuardError` when ``settings.app_env == "production"``.
+    Called first by :func:`seed_qa`, before any DB read or write, so synthetic
+    data can never reach the prod database. There is no override.
+    """
+    if settings.app_env == "production":
+        logger.warning(
+            "seed_qa.refused",
+            extra={
+                "event": "seed_qa.refused",
+                "outcome": "failed",
+                "app_env": settings.app_env,
+            },
+        )
+        raise SeedGuardError(
+            "QA seeding is blocked on the production environment (APP_ENV=production)."
+        )
+
+
+def _delete_seeded_rows(db: DBSession) -> None:
+    """Delete only sentinel-tagged positions (cascade to trades) + all stub rows.
+
+    Untagged positions — manually added QA state — are preserved. Stub tables
+    are QA-only fixtures owned entirely by the seeder, so they are cleared
+    wholesale. Position deletion goes through the ORM so the
+    ``cascade="all, delete-orphan"`` on ``Position.trades`` removes child trades.
+    """
+    seeded = (
+        db.query(Position)
+        .filter(Position.notes.like(f"{SEED_TAG_PREFIX}%"))
+        .all()
+    )
+    for position in seeded:
+        db.delete(position)
+    db.query(QuoteStub).delete(synchronize_session=False)
+    db.query(OptionMarkStub).delete(synchronize_session=False)
+    db.commit()
+
+
+def _insert_archetype(db: DBSession, archetype: Archetype, *, now: datetime) -> int:
+    """Insert one archetype's position, trades, and stub rows. Returns stub count.
+
+    Pins derived state directly on the ORM row (no recomputer). Tags the
+    position ``notes`` with the seed sentinel. Commits so a later archetype's
+    failure does not roll back an already-inserted archetype. Returns the number
+    of stub rows (quote + marks) written for this archetype.
+    """
+    opened_at = now.replace(microsecond=0).isoformat()
+    position = Position(
+        id=str(uuid.uuid4()),
+        ticker=archetype.ticker,
+        shares=archetype.shares,
+        broker_cost_basis=archetype.broker_cost_basis,
+        status="open",
+        strategy=archetype.strategy,
+        opened_at=opened_at,
+        notes=f"{SEED_TAG_PREFIX}{archetype.key}",
+    )
+    db.add(position)
+    db.flush()  # assign position.id for the trade FK
+
+    for spec in archetype.trades:
+        db.add(
+            Trade(
+                id=str(uuid.uuid4()),
+                position_id=position.id,
+                trade_type=spec.trade_type,
+                strike=spec.strike,
+                expiration=spec.expiration,
+                premium=spec.premium,
+                fees=spec.fees,
+                quantity=spec.quantity,
+                opened_at=opened_at,
+                closed_at=spec.closed_at,
+                close_reason=spec.close_reason,
+            )
+        )
+
+    stub_count = 0
+    if archetype.quote_price is not None:
+        db.add(QuoteStub(ticker=archetype.ticker, last_price=archetype.quote_price))
+        stub_count += 1
+    for mark in archetype.marks:
+        db.add(
+            OptionMarkStub(
+                id=str(uuid.uuid4()),
+                ticker=archetype.ticker,
+                strike=mark.strike,
+                expiration=mark.expiration,
+                option_type=mark.option_type,
+                mid=mark.mid,
+                delta=mark.delta,
+            )
+        )
+        stub_count += 1
+
+    db.commit()
+    return stub_count
+
+
+def seed_qa(db: DBSession, *, dry_run: bool = False) -> SeedResult:
+    """Seed QA with the seven synthetic archetypes + stub-pricing rows.
+
+    Guards against production first, then performs a tagged delete-then-reseed:
+    sentinel-tagged positions and all stub rows are removed, then the seven
+    archetypes are re-inserted. A per-archetype insert failure is collected (its
+    key added to ``SeedResult.failed_archetypes``) and the run continues, so one
+    bad archetype does not abort the rest; the CLI exits non-zero when any
+    failed.
+
+    ``dry_run=True`` performs no writes — it builds the archetype list (to
+    surface construction errors) and returns counts of zero.
+    """
+    assert_seed_allowed()
+    now = datetime.now(timezone.utc)
+    archetypes = build_archetypes(now)
+
+    if dry_run:
+        logger.info(
+            "seed_qa.dry_run",
+            extra={
+                "event": "seed_qa.dry_run",
+                "outcome": "success",
+                "app_env": settings.app_env,
+            },
+        )
+        return SeedResult(dry_run=True)
+
+    _delete_seeded_rows(db)
+
+    result = SeedResult()
+    for archetype in archetypes:
+        try:
+            stub_count = _insert_archetype(db, archetype, now=now)
+        except Exception:
+            db.rollback()
+            logger.exception(
+                "seed_qa.archetype_failed",
+                extra={
+                    "event": "seed_qa.archetype_failed",
+                    "outcome": "failed",
+                    "archetype": archetype.key,
+                },
+            )
+            result.failed_archetypes.append(archetype.key)
+            continue
+        result.positions_seeded += 1
+        # The quote (if any) is the first stub row; the rest are marks.
+        if archetype.quote_price is not None:
+            result.quotes_seeded += 1
+            result.marks_seeded += stub_count - 1
+        else:
+            result.marks_seeded += stub_count
+
+    logger.info(
+        "seed_qa.complete",
+        extra={
+            "event": "seed_qa.complete",
+            "outcome": "success" if result.ok else "degraded",
+            "app_env": settings.app_env,
+            "positions_seeded": result.positions_seeded,
+            "quotes_seeded": result.quotes_seeded,
+            "marks_seeded": result.marks_seeded,
+            "failed_count": len(result.failed_archetypes),
+        },
+    )
+    return result
+
+
+__all__ = [
+    "SEED_TAG_PREFIX",
+    "Archetype",
+    "SeedGuardError",
+    "SeedResult",
+    "SeedTrade",
+    "StubMark",
+    "assert_seed_allowed",
+    "build_archetypes",
+    "seed_qa",
+]

--- a/backend/app/services/seed_qa.py
+++ b/backend/app/services/seed_qa.py
@@ -30,6 +30,7 @@ premium-bearing trades to make ``adjusted_cost_basis`` differ from broker basis.
 from __future__ import annotations
 
 import logging
+import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -409,6 +410,7 @@ def seed_qa(db: DBSession, *, dry_run: bool = False) -> SeedResult:
     surface construction errors) and returns counts of zero.
     """
     assert_seed_allowed()
+    start = time.monotonic()
     now = datetime.now(timezone.utc)
     archetypes = build_archetypes(now)
 
@@ -429,13 +431,15 @@ def seed_qa(db: DBSession, *, dry_run: bool = False) -> SeedResult:
     for archetype in archetypes:
         try:
             stub_count = _insert_archetype(db, archetype, now=now)
-        except Exception:
+        except Exception as exc:
             db.rollback()
             logger.exception(
                 "seed_qa.archetype_failed",
                 extra={
                     "event": "seed_qa.archetype_failed",
                     "outcome": "failed",
+                    "duration_ms": round((time.monotonic() - start) * 1000, 2),
+                    "error_class": type(exc).__name__,
                     "archetype": archetype.key,
                 },
             )
@@ -454,6 +458,7 @@ def seed_qa(db: DBSession, *, dry_run: bool = False) -> SeedResult:
         extra={
             "event": "seed_qa.complete",
             "outcome": "success" if result.ok else "degraded",
+            "duration_ms": round((time.monotonic() - start) * 1000, 2),
             "app_env": settings.app_env,
             "positions_seeded": result.positions_seeded,
             "quotes_seeded": result.quotes_seeded,

--- a/backend/tests/test_seed_qa.py
+++ b/backend/tests/test_seed_qa.py
@@ -1,0 +1,253 @@
+"""Unit tests for the QA seed mechanism (issue #349).
+
+Pure-Python: no DB session, no TestClient, no network. Covers the prod guard,
+the archetype-construction contract, and the stub client's Schwab-shaped output.
+DB-touching behavior (idempotency, dry-run writes, render paths) lives in the
+integration suites.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+from app.services.dashboard_legs import build_option_leg_index, compute_dte
+from app.services.market_client import StubSchwabClient, get_market_client
+from app.services.schwab_client import SchwabClient, SchwabClientError
+from app.services.seed_qa import (
+    SEED_TAG_PREFIX,
+    SeedGuardError,
+    assert_seed_allowed,
+    build_archetypes,
+)
+
+_FIXED_NOW = datetime(2026, 6, 15, tzinfo=timezone.utc)
+
+
+# --- Prod guard (Component 1) ---
+
+
+@pytest.mark.unit
+def test_assert_seed_allowed_blocks_production():
+    """AC: prod guard tested — APP_ENV=production raises SeedGuardError."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "production"
+        with pytest.raises(SeedGuardError):
+            assert_seed_allowed()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("env", ["qa", "development", "test"])
+def test_assert_seed_allowed_permits_non_production(env):
+    """Non-prod environments proceed without raising."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = env
+        assert_seed_allowed() is None
+
+
+# --- Archetype contract (Components 2-3) ---
+
+
+@pytest.mark.unit
+def test_build_archetypes_yields_seven_with_unique_keys():
+    """The frozen archetype list is exactly seven with distinct keys."""
+    archetypes = build_archetypes(_FIXED_NOW)
+    assert len(archetypes) == 7
+    keys = [a.key for a in archetypes]
+    assert len(set(keys)) == 7
+
+
+@pytest.mark.unit
+def test_archetype_expirations_are_dte_relative_not_pinned():
+    """Expirations are computed from ``now`` so they don't drift out of window."""
+    later = _FIXED_NOW + timedelta(days=90)
+    first = {a.key: a for a in build_archetypes(_FIXED_NOW)}
+    second = {a.key: a for a in build_archetypes(later)}
+    # The far-dated leg shifts by 90 days when ``now`` shifts by 90 days.
+    exp_first = first["deep_itm_call"].trades[0].expiration
+    exp_second = second["deep_itm_call"].trades[0].expiration
+    assert exp_first != exp_second
+
+
+@pytest.mark.unit
+def test_archetype_deep_itm_call_derived_state():
+    """Archetype 1: deep-ITM short call, >14 DTE, δ≈0.90 (High depth axis)."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["deep_itm_call"]
+    assert arch.strategy == "cc"
+    assert arch.shares == 100
+    leg = arch.trades[0]
+    assert leg.trade_type == "sell_call"
+    # price ≫ strike → deep ITM.
+    assert arch.quote_price > leg.strike
+    assert compute_dte(leg.expiration, today=_FIXED_NOW.date()) > 14
+    assert arch.marks[0].delta == 0.90
+
+
+@pytest.mark.unit
+def test_archetype_ntm_call_derived_state():
+    """Archetype 2: near-the-money short call, ≤14 DTE, ITM (Watch timing axis)."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["ntm_call"]
+    assert arch.strategy == "cc"
+    leg = arch.trades[0]
+    assert arch.quote_price > leg.strike  # ITM
+    assert compute_dte(leg.expiration, today=_FIXED_NOW.date()) <= 14
+    assert 0.5 <= arch.marks[0].delta < 0.6
+
+
+@pytest.mark.unit
+def test_archetype_otm_call_derived_state():
+    """Archetype 3: OTM short call, long DTE, low delta (Low)."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["otm_call"]
+    leg = arch.trades[0]
+    assert arch.quote_price < leg.strike  # OTM
+    assert arch.marks[0].delta < 0.6
+
+
+@pytest.mark.unit
+def test_archetype_btc_populated_has_mark():
+    """Archetype 4: covered call with a live stub mark (BTC panel populated)."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["btc_populated_cc"]
+    assert arch.strategy == "cc"
+    assert arch.quote_price is not None
+    assert len(arch.marks) == 1
+    assert arch.marks[0].mid > 0
+
+
+@pytest.mark.unit
+def test_archetype_csp_zero_shares_derived_state():
+    """Archetype 5: cash-secured put, 0 shares, 0 basis, no marks."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["csp_zero_shares"]
+    assert arch.strategy == "csp"
+    assert arch.shares == 0
+    assert arch.broker_cost_basis == 0.0
+    assert arch.trades[0].trade_type == "sell_put"
+    assert arch.marks == []  # CSP is not a covered call → no stub marks
+
+
+@pytest.mark.unit
+def test_archetype_cc_no_mark_omits_marks():
+    """Archetype 6: covered call with a quote but no option mark (degraded)."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["cc_no_mark"]
+    assert arch.strategy == "cc"
+    assert arch.quote_price is not None  # quote present
+    assert arch.marks == []  # mark omitted → "—" degrade path
+
+
+@pytest.mark.unit
+def test_archetype_equity_adjusted_basis_has_premium_trades():
+    """Archetype 7: equity with premium-bearing trades so adjusted ≠ broker."""
+    arch = {a.key: a for a in build_archetypes(_FIXED_NOW)}["equity_adjusted_basis"]
+    assert arch.shares == 100
+    assert arch.broker_cost_basis > 0
+    assert len(arch.trades) >= 2
+    assert all(t.premium > 0 for t in arch.trades)
+
+
+@pytest.mark.unit
+def test_seed_tag_prefix_is_frozen():
+    """The teardown sentinel prefix is the frozen contract literal."""
+    assert SEED_TAG_PREFIX == "__seed__:"
+
+
+# --- Stub pricing (Component 4) ---
+
+
+class _FakeQuery:
+    """Minimal stand-in for a SQLAlchemy Query bound to a fixed result set."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeMark:
+    def __init__(self, ticker, strike, expiration, option_type, mid, delta):
+        self.ticker = ticker
+        self.strike = strike
+        self.expiration = expiration
+        self.option_type = option_type
+        self.mid = mid
+        self.delta = delta
+
+
+class _FakeQuote:
+    def __init__(self, ticker, last_price):
+        self.ticker = ticker
+        self.last_price = last_price
+
+
+class _FakeDB:
+    """A fake DB session whose ``query`` returns canned QuoteStub/OptionMarkStub rows."""
+
+    def __init__(self, quotes=None, marks=None):
+        self._quotes = quotes or []
+        self._marks = marks or []
+
+    def query(self, model):
+        name = getattr(model, "__name__", "")
+        if name == "QuoteStub":
+            return _FakeQuery(self._quotes)
+        if name == "OptionMarkStub":
+            return _FakeQuery(self._marks)
+        return _FakeQuery([])
+
+
+@pytest.mark.unit
+def test_stub_client_returns_schwab_shaped_quote_and_chain():
+    """StubSchwabClient output parses through build_option_leg_index unchanged."""
+    db = _FakeDB(
+        quotes=[_FakeQuote("SEEDA", 110.0)],
+        marks=[_FakeMark("SEEDA", 80.0, "2026-07-15", "call", 31.5, 0.90)],
+    )
+    client = StubSchwabClient(db)
+
+    quote = client.get_quote("SEEDA")
+    assert quote["lastPrice"] == 110.0
+
+    chain = client.get_option_chain("SEEDA")
+    assert "callExpDateMap" in chain and "putExpDateMap" in chain
+
+    index = build_option_leg_index({"SEEDA": chain}, spots_by_ticker={"SEEDA": 110.0})
+    entry = index[("SEEDA", "call", 80.0, "2026-07-15")]
+    assert entry["mid"] == 31.5
+    assert entry["delta"] == 0.90
+
+
+@pytest.mark.unit
+def test_stub_client_raises_on_missing_quote():
+    """A ticker with no stub quote raises SchwabClientError (live-client contract)."""
+    client = StubSchwabClient(_FakeDB())
+    with pytest.raises(SchwabClientError):
+        client.get_quote("NOPE")
+
+
+@pytest.mark.unit
+def test_stub_client_returns_empty_chain_when_no_marks():
+    """A ticker with no stub marks returns a valid empty chain (degrade path).
+
+    The "no live option mark" archetype must degrade to ``current_mid=None``,
+    not 500 the page — so the stub returns empty maps rather than raising.
+    """
+    client = StubSchwabClient(_FakeDB())
+    chain = client.get_option_chain("NOPE")
+    assert chain["callExpDateMap"] == {}
+    assert chain["putExpDateMap"] == {}
+
+
+@pytest.mark.unit
+def test_get_market_client_factory_selects_by_mode():
+    """live → SchwabClient; stub → StubSchwabClient."""
+    db = _FakeDB()
+    with patch("app.services.market_client.settings") as mock_settings:
+        mock_settings.pricing_mode = "live"
+        assert isinstance(get_market_client(db), SchwabClient)
+        mock_settings.pricing_mode = "stub"
+        assert isinstance(get_market_client(db), StubSchwabClient)

--- a/backend/tests/test_seed_qa.py
+++ b/backend/tests/test_seed_qa.py
@@ -42,7 +42,7 @@ def test_assert_seed_allowed_permits_non_production(env):
     """Non-prod environments proceed without raising."""
     with patch("app.services.seed_qa.settings") as mock_settings:
         mock_settings.app_env = env
-        assert_seed_allowed() is None
+        assert assert_seed_allowed() is None
 
 
 # --- Archetype contract (Components 2-3) ---
@@ -244,10 +244,25 @@ def test_stub_client_returns_empty_chain_when_no_marks():
 
 @pytest.mark.unit
 def test_get_market_client_factory_selects_by_mode():
-    """live → SchwabClient; stub → StubSchwabClient."""
+    """live → SchwabClient; stub → StubSchwabClient (non-prod)."""
     db = _FakeDB()
     with patch("app.services.market_client.settings") as mock_settings:
+        mock_settings.app_env = "qa"
         mock_settings.pricing_mode = "live"
         assert isinstance(get_market_client(db), SchwabClient)
         mock_settings.pricing_mode = "stub"
         assert isinstance(get_market_client(db), StubSchwabClient)
+
+
+@pytest.mark.unit
+def test_get_market_client_refuses_stub_on_production():
+    """Defense-in-depth: pricing_mode=stub on production falls back to live.
+
+    The configuration invariant (prod never sets PRICING_MODE) is the first
+    guard; this proves a stray prod override still cannot serve synthetic data.
+    """
+    db = _FakeDB()
+    with patch("app.services.market_client.settings") as mock_settings:
+        mock_settings.app_env = "production"
+        mock_settings.pricing_mode = "stub"
+        assert isinstance(get_market_client(db), SchwabClient)

--- a/backend/tests/test_seed_qa_integration.py
+++ b/backend/tests/test_seed_qa_integration.py
@@ -1,0 +1,185 @@
+"""Integration tests for the QA seed mechanism (issue #349).
+
+Full ORM stack against in-memory SQLite. Covers the idempotent tagged
+delete-then-reseed, dry-run no-write semantics, non-destructiveness toward
+untagged rows, the per-archetype derived state as persisted, and the CLI's
+non-zero exit on archetype failure.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import (
+    Base,
+    OptionMarkStub,
+    Position,
+    QuoteStub,
+)
+from app.services import journal
+from app.services.seed_qa import SEED_TAG_PREFIX, seed_qa
+
+
+@pytest.fixture()
+def db_session():
+    """In-memory SQLite session with the full schema created."""
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    yield session
+    session.close()
+
+
+def _seed_count(db) -> int:
+    """Count sentinel-tagged seeded positions."""
+    return (
+        db.query(Position)
+        .filter(Position.notes.like(f"{SEED_TAG_PREFIX}%"))
+        .count()
+    )
+
+
+@pytest.mark.integration
+def test_seed_inserts_all_seven_archetypes(db_session):
+    """AC: all archetypes present — seven seeded positions after a seed run."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        result = seed_qa(db_session)
+    assert result.positions_seeded == 7
+    assert result.ok
+    assert _seed_count(db_session) == 7
+    # Stub rows seeded for the feed-dependent archetypes.
+    assert db_session.query(QuoteStub).count() >= 1
+    assert db_session.query(OptionMarkStub).count() >= 1
+
+
+@pytest.mark.integration
+def test_seed_is_idempotent(db_session):
+    """AC: repeatable reseed — running twice yields 7 positions, not 14."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        seed_qa(db_session)
+        quotes_after_first = db_session.query(QuoteStub).count()
+        seed_qa(db_session)
+    assert _seed_count(db_session) == 7
+    # Stub rows are also reset, not doubled.
+    assert db_session.query(QuoteStub).count() == quotes_after_first
+
+
+@pytest.mark.integration
+def test_seed_preserves_untagged_rows(db_session):
+    """AC: non-destructive — a manually-added position survives reseed."""
+    manual = Position(
+        id=str(uuid.uuid4()),
+        ticker="MANUAL",
+        shares=100,
+        broker_cost_basis=1000.0,
+        status="open",
+        strategy="wheel",
+        opened_at="2026-01-01T00:00:00+00:00",
+        notes="hand-entered, not seeded",
+    )
+    db_session.add(manual)
+    db_session.commit()
+
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        seed_qa(db_session)
+
+    survivor = (
+        db_session.query(Position).filter(Position.ticker == "MANUAL").first()
+    )
+    assert survivor is not None
+    assert _seed_count(db_session) == 7
+
+
+@pytest.mark.integration
+def test_seed_dry_run_writes_nothing(db_session):
+    """AC: dry-run — dry_run=True writes no positions or stub rows."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        result = seed_qa(db_session, dry_run=True)
+    assert result.dry_run is True
+    assert result.positions_seeded == 0
+    assert db_session.query(Position).count() == 0
+    assert db_session.query(QuoteStub).count() == 0
+    assert db_session.query(OptionMarkStub).count() == 0
+
+
+@pytest.mark.integration
+def test_seed_nonzero_exit_on_archetype_failure(db_session):
+    """AC: exits non-zero on failure — a failed insert surfaces the key.
+
+    Force ``_insert_archetype`` to raise for one archetype; the run continues,
+    collects the failed key, and ``SeedResult.ok`` is False (the CLI maps that
+    to a non-zero exit).
+    """
+    from app.services import seed_qa as seed_mod
+
+    real_insert = seed_mod._insert_archetype
+
+    def _flaky_insert(db, archetype, *, now):
+        if archetype.key == "otm_call":
+            raise RuntimeError("forced insert failure")
+        return real_insert(db, archetype, now=now)
+
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        with patch.object(seed_mod, "_insert_archetype", _flaky_insert):
+            result = seed_qa(db_session)
+
+    assert not result.ok
+    assert "otm_call" in result.failed_archetypes
+    # The other six still seeded.
+    assert result.positions_seeded == 6
+
+
+@pytest.mark.integration
+def test_csp_archetype_persists_zero_share_basis(db_session):
+    """Archetype 5: CSP persists with 0 shares → per-share basis is None (#320)."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        seed_qa(db_session)
+    csp = (
+        db_session.query(Position).filter(Position.ticker == "SEEDE").first()
+    )
+    assert csp.shares == 0
+    response = journal.get_position(db_session, csp.id)
+    assert response["broker_cost_basis_per_share"] is None
+    assert response["adjusted_cost_basis_per_share"] is None
+
+
+@pytest.mark.integration
+def test_equity_archetype_adjusted_basis_differs_from_broker(db_session):
+    """Archetype 7: premium-bearing trades make adjusted/sh ≠ broker/sh (#320)."""
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        seed_qa(db_session)
+    equity = (
+        db_session.query(Position).filter(Position.ticker == "SEEDG").first()
+    )
+    response = journal.get_position(db_session, equity.id)
+    assert response["broker_cost_basis_per_share"] is not None
+    assert response["adjusted_cost_basis_per_share"] is not None
+    assert (
+        response["adjusted_cost_basis_per_share"]
+        != response["broker_cost_basis_per_share"]
+    )

--- a/backend/tests/test_stub_pricing_integration.py
+++ b/backend/tests/test_stub_pricing_integration.py
@@ -1,0 +1,137 @@
+"""Integration tests for the QA stub-pricing render paths (issue #349).
+
+Seeds the synthetic archetypes, switches ``pricing_mode`` to ``"stub"``, and
+drives the real dashboard + BTC-detail services to confirm the v1.7 surfaces
+render their intended states off the deterministic stub feed:
+
+- #318 assignment-risk depth → High / Watch / Low for archetypes 1 / 2 / 3.
+- #319 BTC panel populated with ``pricing_source="stub"`` (archetype 4) and the
+  degraded ``"unavailable"`` path (archetype 6).
+- #320 per-share basis is feed-independent (covered in the seed integration
+  suite); the CSP N/A gate is asserted here via the BTC analysis shape.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models.database import Base
+from app.services import seed_qa as seed_mod
+from app.services.btc_detail import build_btc_detail
+from app.services.dashboard import build_dashboard_payload
+
+
+@pytest.fixture()
+def stub_db():
+    """In-memory SQLite seeded with the archetypes under pricing_mode=stub.
+
+    Patches ``settings.app_env`` / ``settings.pricing_mode`` across every module
+    that reads them on the seed + render paths, so the whole flow runs in stub
+    mode with no live Schwab dependency.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_pragma(dbapi_conn, connection_record):
+        cursor = dbapi_conn.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.close()
+
+    Base.metadata.create_all(bind=engine)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+
+    with patch("app.services.seed_qa.settings") as seed_settings, patch(
+        "app.services.dashboard.settings"
+    ) as dash_settings, patch(
+        "app.services.market_client.settings"
+    ) as mc_settings, patch(
+        "app.services.btc_detail.settings"
+    ) as btc_settings:
+        for s in (seed_settings, dash_settings, mc_settings, btc_settings):
+            s.app_env = "qa"
+            s.pricing_mode = "stub"
+        seed_mod.seed_qa(session)
+        yield session
+
+    session.close()
+
+
+def _leg_risk_by_ticker(payload) -> dict[str, str]:
+    """Map each open leg's ticker → its assignment_risk bucket."""
+    return {leg["ticker"]: leg["assignment_risk"] for leg in payload["open_legs"]}
+
+
+def _position_id(db, ticker) -> str:
+    from app.models.database import Position
+
+    return db.query(Position).filter(Position.ticker == ticker).first().id
+
+
+def _leg_id_for_position(payload, position_id) -> str:
+    leg = next(
+        lg for lg in payload["open_legs"] if lg["position_id"] == position_id
+    )
+    return leg["id"]
+
+
+@pytest.mark.integration
+def test_dashboard_assignment_risk_high_watch_low_with_stub(stub_db):
+    """AC #318: archetypes 1/2/3 render High/Watch/Low off the stub feed."""
+    payload = build_dashboard_payload(stub_db)
+    risk = _leg_risk_by_ticker(payload)
+    assert risk["SEEDA"] == "high"  # deep-ITM, δ≈0.90
+    assert risk["SEEDB"] == "watch"  # near-dated ITM
+    assert risk["SEEDC"] == "low"  # OTM
+
+
+@pytest.mark.integration
+def test_btc_panel_populated_with_stub(stub_db):
+    """AC #319 live-mark path: archetype 4 → populated panel, pricing_source=stub."""
+    payload = build_dashboard_payload(stub_db)
+    pos_id = _position_id(stub_db, "SEEDD")
+    leg_id = _leg_id_for_position(payload, pos_id)
+
+    detail = build_btc_detail(stub_db, pos_id, leg_id)
+    assert detail is not None
+    assert detail["analysis"]["available"] is True
+    assert detail["analysis"]["scenarios"]  # non-empty scenario grid
+    assert detail["economics"]["pricing_source"] == "stub"
+    assert detail["economics"]["current_option_mid"] is not None
+
+
+@pytest.mark.integration
+def test_btc_degraded_when_mark_missing(stub_db):
+    """AC #319 degraded path: archetype 6 → '—' sentinel, pricing_source=unavailable."""
+    payload = build_dashboard_payload(stub_db)
+    pos_id = _position_id(stub_db, "SEEDF")
+    leg_id = _leg_id_for_position(payload, pos_id)
+
+    detail = build_btc_detail(stub_db, pos_id, leg_id)
+    assert detail is not None
+    # Quote present but no option mark → economics degrade to "unavailable".
+    assert detail["economics"]["pricing_source"] == "unavailable"
+    assert detail["economics"]["current_option_mid"] is None
+    assert detail["economics"]["cost_to_close"] is None
+
+
+@pytest.mark.integration
+def test_csp_btc_is_not_applicable(stub_db):
+    """AC #319 CC-only gate: archetype 5 (CSP) → analysis not available."""
+    payload = build_dashboard_payload(stub_db)
+    pos_id = _position_id(stub_db, "SEEDE")
+    leg_id = _leg_id_for_position(payload, pos_id)
+
+    detail = build_btc_detail(stub_db, pos_id, leg_id)
+    assert detail is not None
+    # The BTC decision math gates puts out (CC-scoped) → not available.
+    assert detail["analysis"]["available"] is False

--- a/backend/tests/test_stub_pricing_integration.py
+++ b/backend/tests/test_stub_pricing_integration.py
@@ -135,3 +135,31 @@ def test_csp_btc_is_not_applicable(stub_db):
     assert detail is not None
     # The BTC decision math gates puts out (CC-scoped) → not available.
     assert detail["analysis"]["available"] is False
+
+
+@pytest.mark.integration
+def test_stub_client_snapshots_data_and_retains_no_session(stub_db):
+    """Regression (#349): the stub client must snapshot its data at
+    construction and NOT touch the DB session afterwards.
+
+    The dashboard calls ``get_quote`` / ``get_option_chain`` from
+    ``ThreadPoolExecutor`` workers; a SQLAlchemy ``Session`` and its SQLite
+    connection used cross-thread raise ``sqlite3.InterfaceError: bad parameter
+    or other API misuse``, which silently degraded every leg's risk to "low"
+    (the original PR #351 CI failure). Locking the structural invariant — no
+    retained session, plain in-memory snapshot dicts — catches any
+    reintroduction of per-call DB access.
+    """
+    from app.services.market_client import StubSchwabClient
+
+    client = StubSchwabClient(stub_db)
+
+    # No retained session handle; data is held as plain dicts.
+    assert not hasattr(client, "_db")
+    assert isinstance(client._quotes, dict) and client._quotes
+    assert isinstance(client._marks, dict) and client._marks
+
+    # Serves from the snapshot even after the source session is closed.
+    stub_db.close()
+    assert client.get_quote("SEEDA")["lastPrice"] is not None
+    assert client.get_option_chain("SEEDA")["callExpDateMap"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -95,6 +95,11 @@ services:
       - path: ./backend/.env
         required: false
     environment:
+      # APP_ENV=production hard-blocks the `seed-qa` CLI (issue #349): synthetic
+      # test data can never be written to the prod database. PRICING_MODE is
+      # intentionally NOT set here, so it defaults to "live" — the QA stub
+      # pricing path is unreachable on prod by configuration.
+      - APP_ENV=production
       - FRED_API_KEY=${FRED_API_KEY}
       - DATABASE_URL=sqlite:///./data/regression_tool.db
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-}

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -34,6 +34,12 @@ services:
       - path: ./backend/.env
         required: false
     environment:
+      # APP_ENV=qa permits the `seed-qa` CLI (issue #349); PRICING_MODE=stub
+      # swaps in the deterministic in-DB stub-pricing provider so the v1.7
+      # covered-call surfaces (#318/#319) render their intended states without
+      # a live Schwab feed (QA runs in degraded, no-Schwab mode).
+      - APP_ENV=qa
+      - PRICING_MODE=stub
       - FRED_API_KEY=${FRED_API_KEY}
       - ALPHA_VANTAGE_API_KEY=${ALPHA_VANTAGE_API_KEY:-}
       - DATABASE_URL=sqlite:///./data/regression_tool.db


### PR DESCRIPTION
## Summary

Milestone **v1.7.1** (#44) — closes #349.

Gives QA (`qa.regression.shawnjsandy.com`) a repeatable, prod-safe way to seed the 7 position archetypes that exercise the v1.7.0 decision-support surfaces (#318 assignment-risk depth, #319 BTC decision panel, #320 per-share cost basis), so every release can be acceptance-tested on QA before promotion to prod.

Research surfaced that #318/#319 compute from a **live Schwab feed QA doesn't have** — so DB rows alone only validate #320 and the *degraded* states. This PR therefore also implements the QA-gated deterministic **stub-pricing layer**, lighting up the `pricing_source="stub"` value already frozen in the OpenAPI schema.

## What's included (5 components)

1. **`APP_ENV` + prod guard** — new `app_env` / `pricing_mode` settings; `assert_seed_allowed()` hard-blocks `APP_ENV=production` before any write (no override).
2. **`seed-qa` CLI** — `python -m app.cli seed-qa`, idempotent tagged delete-then-reseed (sentinel in `Position.notes`, non-destructive to manual QA rows), `--dry-run`, non-zero exit on any archetype failure.
3. **7 archetypes (SEEDA–SEEDG)** — frozen synthetic fixtures; DTE-relative expirations from `datetime.now(timezone.utc)`; derived state pinned directly (recomputer intentionally not run).
4. **Stub-pricing layer** — internal `QuoteStub`/`OptionMarkStub` tables + `get_market_client()` factory + `StubSchwabClient` (Schwab-shaped dicts). `pricing_source="stub"` emitted when `pricing_mode=stub`.
5. **Tests + ops** — 29 new tests (18 unit / 11 integration); `APP_ENV`/`PRICING_MODE` wired in QA + prod compose.

## Reviewer notes / risk

- **Behavior-neutral on prod.** The `dashboard.py` / `btc_detail.py` edits are gated by `pricing_mode` (default `live`); prod compose never sets `PRICING_MODE`, so `StubSchwabClient` is unreachable on prod.
- **`pricing_source="stub"` is a frozen schema value now made reachable** — not a contract change. No `breaking-api` label; no OpenAPI route-shape change (the two stub tables are internal, not response models).
- **`SchwabClient` re-exported** (`# noqa: F401`) in `dashboard.py`/`btc_detail.py` so 45 existing monkeypatch targets keep working unchanged — the factory instantiates the same class object.

## Test plan

- `cd backend && python -m pytest -m unit && python -m pytest -m integration` → green (1261 unit / 545 integration); classifier + tdd_red gate clean.
- Guard: `APP_ENV=production python -m app.cli seed-qa` → aborts exit 1, no write.
- `--dry-run` lists 7, writes nothing; seed → 7 positions; rerun → still 7 (idempotent).

## Post-merge (QA validation)

Merge → Deploy to QA → on the QA box: `APP_ENV=qa python -m app.cli seed-qa` → eyeball #318 (High/Watch/Low), #319 (populated BTC panel + `—` degraded), #320 (per-share basis) at `qa.regression.shawnjsandy.com`. Prod promotion (published release) gated on go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)