### PR TITLE
v1.7.3 — Deploy & QA hardening (#366 #367 #369 #370 #371 #373 #375)

### DIFF
--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -80,6 +80,12 @@ jobs:
             # (<<'ENDSSH') so the existing $(...) / $VAR expressions still run on
             # the BOX, not the runner — the build->pull swap must not change that.
             # Actions masks the secret token in logs.
+            # Combined stdout/stderr (2>&1) is tee'd to a runner file so the
+            # box-side ::SEED_RESULT:: / ::DISK_RESULT:: markers can be grepped
+            # out on the runner and surfaced to $GITHUB_STEP_SUMMARY (#366, #371)
+            # — the retry action otherwise swallows the heredoc's stdout. The
+            # pipe sits on the ssh command line; the heredoc body still feeds
+            # ssh's stdin. PIPESTATUS[0] (below) preserves the real ssh exit code.
             ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
               -i ~/.ssh/deploy_key \
               ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
@@ -87,7 +93,7 @@ jobs:
               '${{ inputs.backend_image_digest }}' \
               '${{ inputs.frontend_image_digest }}' \
               '${{ github.actor }}' \
-              '${{ secrets.GHCR_PULL_TOKEN }}' <<'ENDSSH'
+              '${{ secrets.GHCR_PULL_TOKEN }}' 2>&1 <<'ENDSSH' | tee /tmp/deploy_ssh.out
             set -e
             # Image-pinned deploy (#341/SUB-2, ADR #338): the compose files now
             # reference ghcr.io/ssandy33/regress-{backend,frontend}@${...DIGEST}.
@@ -123,6 +129,20 @@ jobs:
               docker compose -f ${{ inputs.compose_file }} rm -sf caddy
               PROJECT_NAME=$(basename "$(pwd)")
               docker volume rm "${PROJECT_NAME}_caddy_data" || true
+            fi
+            # Disk headroom pre-flight (#371): warn-by-default, NON-FATAL signal
+            # that the box is low on space BEFORE `docker compose pull` adds more.
+            # It must not block the very deploy that reclaims space (#369 builder
+            # prune runs at the end), so it only annotates + records — never exits.
+            # Surfaced to the runner step summary via the ::DISK_RESULT:: marker
+            # (greppable out of the tee'd SSH stdout on the runner — shared with
+            # the #366 ::SEED_RESULT:: mechanism).
+            DISK_WARN_PCT=85
+            USED_PCT=$(df --output=pcent / | tail -1 | tr -dc '0-9')
+            echo "Disk headroom: / at ${USED_PCT}% (threshold ${DISK_WARN_PCT}%)."
+            echo "::DISK_RESULT:: / at ${USED_PCT}% (threshold ${DISK_WARN_PCT}%)"
+            if [ -n "$USED_PCT" ] && [ "$USED_PCT" -ge "$DISK_WARN_PCT" ] 2>/dev/null; then
+              echo "::warning::Disk headroom: / at ${USED_PCT}% (>= ${DISK_WARN_PCT}%) on $(hostname) — reclaim space (see #369 builder prune)."
             fi
             # Pull the CI-built images by @sha256: digest from GHCR (#341/SUB-2,
             # ADR #338) instead of rebuilding on the box — prod runs the exact
@@ -179,6 +199,43 @@ jobs:
               exit 1
             fi
             echo "Smoke gate PASSED: ${FRONTEND_SVC}${SMOKE_PATH} is serving."
+            # Backend health probe (#370): additive to the frontend gate above.
+            # Probes GET /api/health INSIDE the backend container on the FastAPI
+            # in-container port (127.0.0.1:8000) — same in-container pattern as
+            # the frontend probe on :8080. Runs UNCONDITIONALLY (outside the
+            # `if environment = qa` seed block), so a crash-looping / non-200
+            # backend fails BOTH qa and prod deploys. Per #343 soft-fail
+            # semantics we assert ONLY on the HTTP status (GET /api/health
+            # returns 200 even when Schwab/FRED data sources are degraded) — we
+            # do not inspect per-source `outcome`.
+            BACKEND_HEALTH_PATH="/api/health"
+            BACKEND_SVC=$(docker compose -f ${{ inputs.compose_file }} config --services | grep -E '(^|-)backend$' | head -1)
+            if [ -z "$BACKEND_SVC" ]; then
+              echo "::error::Smoke gate (backend): could not resolve a backend service from ${{ inputs.compose_file }} — refusing to mark deploy healthy."
+              exit 1
+            fi
+            echo "Smoke gate (backend): probing ${BACKEND_SVC} http://127.0.0.1:8000${BACKEND_HEALTH_PATH} (status < 400 == healthy)"
+            BACKEND_OK=no
+            for attempt in 1 2 3 4 5 6 7 8 9 10; do
+              CODE=$(docker compose -f ${{ inputs.compose_file }} exec -T "$BACKEND_SVC" \
+                python -c "import sys,urllib.request;\
+                req=urllib.request.Request('http://127.0.0.1:8000'+sys.argv[1]);\
+                sys.stdout.write(str(urllib.request.urlopen(req,timeout=5).getcode()))" \
+                "$BACKEND_HEALTH_PATH" 2>/dev/null || echo "000")
+              echo "Smoke gate (backend) attempt ${attempt}/10: HTTP ${CODE}"
+              if [ "$CODE" -ge 200 ] 2>/dev/null && [ "$CODE" -lt 400 ] 2>/dev/null; then
+                BACKEND_OK=yes
+                break
+              fi
+              sleep 6
+            done
+            if [ "$BACKEND_OK" != yes ]; then
+              echo "::error::Smoke gate FAILED (backend): ${BACKEND_SVC}${BACKEND_HEALTH_PATH} did not return a healthy status after 10 attempts — failing the deploy."
+              docker compose -f ${{ inputs.compose_file }} ps
+              docker compose -f ${{ inputs.compose_file }} logs --tail=50 "$BACKEND_SVC" || true
+              exit 1
+            fi
+            echo "Smoke gate (backend) PASSED: ${BACKEND_SVC}${BACKEND_HEALTH_PATH} is healthy."
             # QA-only auto-seed (#349, hardened by ADR #359 / #360): keep QA
             # populated with the 7 v1.7 decision-support archetypes after every
             # deploy so #318/#319/#320 are always acceptance-testable on QA.
@@ -227,6 +284,11 @@ jobs:
               SEEDED_N=$(docker compose -f ${{ inputs.compose_file }} exec -T "$BACKEND_SVC" \
                 python -c "from app.models.database import SessionLocal, Position; from app.services.seed_qa import SEED_TAG_PREFIX; db=SessionLocal(); print(db.query(Position).filter(Position.notes.like(SEED_TAG_PREFIX + '%')).count()); db.close()" 2>/dev/null | tr -d '[:space:]' || true)
               echo "QA auto-seed: seeded=${SEEDED_N} (expected ${EXPECTED_SEED_COUNT})"
+              # Greppable marker (#366): the nick-fields/retry action swallows the
+              # heredoc's stdout, so this seeded=N never reaches the deploy log.
+              # The runner tees SSH stdout to /tmp/deploy_ssh.out and surfaces this
+              # marker to $GITHUB_STEP_SUMMARY (rendered outside the retry buffer).
+              echo "::SEED_RESULT:: seeded=${SEEDED_N} expected=${EXPECTED_SEED_COUNT}"
               if [ "$SEEDED_N" != "$EXPECTED_SEED_COUNT" ]; then
                 echo "::error::QA auto-seed: post-seed count seeded=${SEEDED_N} != expected ${EXPECTED_SEED_COUNT} — failing the deploy (a silent no-op must not look like success)."
                 exit 1
@@ -245,7 +307,29 @@ jobs:
               fi
             fi
             docker image prune -f
+            # Reclaim stale Docker build cache (#369). `docker image prune -f`
+            # above only removes dangling IMAGES; build cache accumulates
+            # separately and is the dominant disk-growth source on the box.
+            # `docker builder prune` removes only dangling/unreferenced cache by
+            # default; the `--filter until=168h` (7-day) age bound additionally
+            # preserves the last week of warm cache and never touches cache
+            # referenced by the currently-running prod+QA containers. Break-glass
+            # full reclaim is documented in deploy/RUNBOOK.md (docker builder
+            # prune -af).
+            docker builder prune -f --filter until=168h
+            echo "Build-cache prune complete (removed cache older than 168h)."
             ENDSSH
-            SSH_EXIT=$?
+            # PIPESTATUS[0] = ssh's exit (NOT tee's), preserved across the
+            # `... | tee /tmp/deploy_ssh.out` pipe on the ssh command line above.
+            # Plain $? would capture tee's exit and mask a failed deploy.
+            SSH_EXIT=${PIPESTATUS[0]}
             rm -f ~/.ssh/deploy_key
+            # Surface the captured markers to the run summary (#366, #371). Guarded
+            # so a prod run (no QA seed line) writes nothing and never fails: the
+            # `|| true` swallows grep's exit 1 on no-match, and $GITHUB_STEP_SUMMARY
+            # is a no-op append when empty.
+            if [ -f /tmp/deploy_ssh.out ]; then
+              grep '::SEED_RESULT::' /tmp/deploy_ssh.out | sed 's/.*::SEED_RESULT:: //' >> "$GITHUB_STEP_SUMMARY" || true
+              grep '::DISK_RESULT::' /tmp/deploy_ssh.out | sed 's/.*::DISK_RESULT:: //' >> "$GITHUB_STEP_SUMMARY" || true
+            fi
             exit $SSH_EXIT

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,14 +193,27 @@ jobs:
           fi
           echo "Release tag '${RELEASE_TAG}' resolves to commit ${COMMIT_SHA}."
 
-          # 2. Find the most-recent SUCCESSFUL Deploy run on that head_sha. The
-          #    QA Deploy run for this commit is the one that recorded the
-          #    qa-deployed-digests artifact.
-          RUN_ID=$(gh api \
+          # 2. Find the QA Deploy run on that head_sha that actually recorded
+          #    the qa-deployed-digests artifact. A single commit can have MORE
+          #    THAN ONE successful deploy.yml run (the QA push run that records
+          #    the artifact, plus any release / manual-prod run that does not),
+          #    so the newest successful run is NOT necessarily the QA one.
+          #    Iterate newest→oldest and pick the first run that has the
+          #    artifact — never assume position 0 (#373 / ADR #338).
+          CANDIDATE_RUN_IDS=$(gh api \
             "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${COMMIT_SHA}&status=success&per_page=100" \
-            --jq '.workflow_runs | sort_by(.run_started_at) | reverse | .[0].id // empty')
+            --jq '.workflow_runs | sort_by(.run_started_at) | reverse | .[].id')
+          RUN_ID=""
+          for id in ${CANDIDATE_RUN_IDS}; do
+            HAS_ARTIFACT=$(gh api "repos/${REPO}/actions/runs/${id}/artifacts?per_page=100" \
+              --jq '[.artifacts[].name] | index("qa-deployed-digests") != null')
+            if [ "${HAS_ARTIFACT}" = "true" ]; then
+              RUN_ID="${id}"
+              break
+            fi
+          done
           if [ -z "${RUN_ID}" ]; then
-            echo "::error::No successful '${WORKFLOW_FILE}' run found for commit ${COMMIT_SHA} (release '${RELEASE_TAG}'). The QA validation run for this commit must succeed before prod promotion. Break-glass: re-run the QA Deploy for ${COMMIT_SHA} (merge the commit to main or re-publish the RC prerelease), then re-publish this release."
+            echo "::error::No successful '${WORKFLOW_FILE}' run with a 'qa-deployed-digests' artifact found for commit ${COMMIT_SHA} (release '${RELEASE_TAG}'). The QA validation run for this commit must succeed and record its digests before prod promotion. Break-glass: re-run the QA Deploy for ${COMMIT_SHA} (merge the commit to main or re-publish the RC prerelease), then re-publish this release."
             exit 1
           fi
           echo "QA-validated Deploy run for ${COMMIT_SHA}: run ${RUN_ID}."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,12 +111,18 @@ jobs:
   # `docker buildx imagetools create` copies the existing manifest under a new
   # tag. It is NEVER a rebuild and NEVER a publish-time source re-resolution.
   #
-  # `needs.ci.outputs.{backend,frontend}-digest` is the recorded digest CI
-  # produced for the exact release commit (the same @sha256: bytes QA validated,
-  # since the frontend image is build-time env-agnostic — ADR #338 invariant).
-  # We feed that recorded digest to imagetools create; we do NOT resolve a bare
-  # tag from source. The promoted digest is then handed to deploy-prod so the
-  # box pulls the identical artifact.
+  # #373 (ADR #338) FIX: the promoted digest MUST be the byte-for-byte digest
+  # QA validated. The QA run and the release run are DIFFERENT workflow runs
+  # (QA fires on push/prerelease, prod on release:published — see the
+  # record-qa-digest comment above), so `needs.ci.outputs.*` here is the
+  # RELEASE-EVENT `ci` REBUILD, not the QA-validated artifact. Consuming it
+  # would ship a freshly-rebuilt image to prod — the exact thing ADR #338
+  # forbids. Instead we resolve the release tag's source commit, find the
+  # successful QA Deploy run for that commit, download its `qa-deployed-digests`
+  # artifact, and promote THOSE recorded @sha256: bytes. The release-event `ci`
+  # rebuild still runs (wired as `needs: [ci]`) but its digest outputs are no
+  # longer consumed by the prod path. If no QA artifact exists for the commit
+  # we FAIL CLOSED — never silently fall back to the rebuild.
   promote-prod:
     needs: [ci]
     if: >
@@ -128,18 +134,21 @@ jobs:
       # packages: write is required so `docker buildx imagetools create` can
       # re-tag (write a new manifest reference for) the recorded digest in GHCR.
       packages: write
+      # actions: read lets `gh run download` / the runs API reach the
+      # qa-deployed-digests artifact recorded by the (different) QA Deploy run.
+      actions: read
     outputs:
-      backend-digest: ${{ needs.ci.outputs.backend-digest }}
-      frontend-digest: ${{ needs.ci.outputs.frontend-digest }}
+      # #373: sourced from the QA-validated artifact, NOT needs.ci.outputs.*
+      # (which on a release event is a fresh rebuild).
+      backend-digest: ${{ steps.qa-digests.outputs.backend }}
+      frontend-digest: ${{ steps.qa-digests.outputs.frontend }}
     env:
       # The release tag the promoted image is re-tagged to. On a manual
       # production dispatch there is no release tag, so fall back to the supplied
       # ref. The promotion's coordinate of record is always the DIGEST below;
       # the tag is a human-readable convenience alias.
       RELEASE_TAG: ${{ github.event.release.tag_name || inputs.ref }}
-      # The RECORDED QA-validated digests — read as data, never re-resolved.
-      BACKEND_DIGEST: ${{ needs.ci.outputs.backend-digest }}
-      FRONTEND_DIGEST: ${{ needs.ci.outputs.frontend-digest }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -151,32 +160,152 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # #373 (ADR #338): consume the QA-validated digest artifact, NOT the
+      # release-event ci rebuild. Resolve the release tag's source commit,
+      # locate the successful QA Deploy run for that commit, download its
+      # qa-deployed-digests artifact, and parse the two recorded @sha256:
+      # digests into step outputs. Fail closed if no such artifact exists.
+      - name: Resolve & download QA-validated digests
+        id: qa-digests
+        env:
+          REPO: ${{ github.repository }}
+          WORKFLOW_FILE: deploy.yml
+        run: |
+          set -euo pipefail
+
+          if [ -z "${RELEASE_TAG}" ]; then
+            echo "::error::No release tag — refusing to promote. Supply an explicit tag via the 'ref' input for a manual production dispatch."
+            exit 1
+          fi
+
+          # 1. Resolve the release tag → its target commit SHA. A tag ref can
+          #    point at an annotated tag object; dereference to the commit.
+          REF_OBJ_TYPE=$(gh api "repos/${REPO}/git/refs/tags/${RELEASE_TAG}" --jq '.object.type' 2>/dev/null || echo "")
+          if [ -z "${REF_OBJ_TYPE}" ]; then
+            echo "::error::Could not resolve release tag '${RELEASE_TAG}' to a git ref in ${REPO}. Break-glass: confirm the tag exists, then re-publish the release."
+            exit 1
+          fi
+          if [ "${REF_OBJ_TYPE}" = "tag" ]; then
+            TAG_SHA=$(gh api "repos/${REPO}/git/refs/tags/${RELEASE_TAG}" --jq '.object.sha')
+            COMMIT_SHA=$(gh api "repos/${REPO}/git/tags/${TAG_SHA}" --jq '.object.sha')
+          else
+            COMMIT_SHA=$(gh api "repos/${REPO}/git/refs/tags/${RELEASE_TAG}" --jq '.object.sha')
+          fi
+          echo "Release tag '${RELEASE_TAG}' resolves to commit ${COMMIT_SHA}."
+
+          # 2. Find the most-recent SUCCESSFUL Deploy run on that head_sha. The
+          #    QA Deploy run for this commit is the one that recorded the
+          #    qa-deployed-digests artifact.
+          RUN_ID=$(gh api \
+            "repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?head_sha=${COMMIT_SHA}&status=success&per_page=100" \
+            --jq '.workflow_runs | sort_by(.run_started_at) | reverse | .[0].id // empty')
+          if [ -z "${RUN_ID}" ]; then
+            echo "::error::No successful '${WORKFLOW_FILE}' run found for commit ${COMMIT_SHA} (release '${RELEASE_TAG}'). The QA validation run for this commit must succeed before prod promotion. Break-glass: re-run the QA Deploy for ${COMMIT_SHA} (merge the commit to main or re-publish the RC prerelease), then re-publish this release."
+            exit 1
+          fi
+          echo "QA-validated Deploy run for ${COMMIT_SHA}: run ${RUN_ID}."
+
+          # 3. Download the recorded artifact from that run. Fail closed — never
+          #    fall back to a rebuild (the exact thing #373 / ADR #338 forbids).
+          if ! gh run download "${RUN_ID}" -n qa-deployed-digests -D qa-digests --repo "${REPO}"; then
+            echo "::error::No 'qa-deployed-digests' artifact on Deploy run ${RUN_ID} for commit ${COMMIT_SHA} (release '${RELEASE_TAG}'). Refusing to promote — a rebuild is forbidden by ADR #338. Break-glass: re-run the QA Deploy for ${COMMIT_SHA} to regenerate the artifact (it may have aged out of retention), then re-publish the release."
+            exit 1
+          fi
+
+          # 4. Parse the recorded digests (line format written by
+          #    record-qa-digest: backend-digest=sha256:... / frontend-digest=...).
+          DIGEST_FILE="qa-digests/qa-deployed-digests.txt"
+          if [ ! -f "${DIGEST_FILE}" ]; then
+            echo "::error::Downloaded artifact is missing qa-deployed-digests.txt. Refusing to promote."
+            exit 1
+          fi
+          QA_BACKEND_DIGEST=$(grep '^backend-digest=' "${DIGEST_FILE}" | cut -d= -f2-)
+          QA_FRONTEND_DIGEST=$(grep '^frontend-digest=' "${DIGEST_FILE}" | cut -d= -f2-)
+          if [ -z "${QA_BACKEND_DIGEST}" ] || [ -z "${QA_FRONTEND_DIGEST}" ]; then
+            echo "::error::Recorded QA digests are empty in ${DIGEST_FILE}. Refusing to promote."
+            exit 1
+          fi
+          echo "QA-validated backend digest:  ${QA_BACKEND_DIGEST}"
+          echo "QA-validated frontend digest: ${QA_FRONTEND_DIGEST}"
+
+          {
+            echo "backend=${QA_BACKEND_DIGEST}"
+            echo "frontend=${QA_FRONTEND_DIGEST}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Guard against empty release tag or digest
+        env:
+          # The QA-sourced digests parsed above — read as data, never re-resolved.
+          BACKEND_DIGEST: ${{ steps.qa-digests.outputs.backend }}
+          FRONTEND_DIGEST: ${{ steps.qa-digests.outputs.frontend }}
         run: |
           if [ -z "${RELEASE_TAG}" ]; then
             echo "::error::No release tag — refusing to promote. Supply an explicit tag via the 'ref' input for a manual production dispatch."
             exit 1
           fi
           if [ -z "${BACKEND_DIGEST}" ] || [ -z "${FRONTEND_DIGEST}" ]; then
-            echo "::error::Recorded digest missing — refusing to promote. The ci build-and-push-images job must emit backend-digest/frontend-digest."
+            echo "::error::QA-validated digest missing — refusing to promote. The QA Deploy run for this commit must have recorded the qa-deployed-digests artifact."
             exit 1
           fi
 
-      # Registry-side re-tag of the RECORDED digest. `imagetools create` copies
-      # the source manifest (referenced by @sha256:) to the release tag without
-      # pulling or rebuilding any layer. NO `docker build` / `docker compose
-      # build` appears anywhere on this prod path (ADR #338 §3, risk R2).
+      # Registry-side re-tag of the QA-VALIDATED digest. `imagetools create`
+      # copies the source manifest (referenced by @sha256:) to the release tag
+      # without pulling or rebuilding any layer. NO `docker build` / `docker
+      # compose build` appears anywhere on this prod path (ADR #338 §3, risk R2).
       - name: Promote backend digest to release tag (re-tag, no rebuild)
+        env:
+          BACKEND_DIGEST: ${{ steps.qa-digests.outputs.backend }}
         run: |
           docker buildx imagetools create \
             -t ghcr.io/ssandy33/regress-backend:${RELEASE_TAG} \
             ghcr.io/ssandy33/regress-backend@${BACKEND_DIGEST}
 
       - name: Promote frontend digest to release tag (re-tag, no rebuild)
+        env:
+          FRONTEND_DIGEST: ${{ steps.qa-digests.outputs.frontend }}
         run: |
           docker buildx imagetools create \
             -t ghcr.io/ssandy33/regress-frontend:${RELEASE_TAG} \
             ghcr.io/ssandy33/regress-frontend@${FRONTEND_DIGEST}
+
+      # #373 AC3: prove the digest now under the release tag in GHCR is the
+      # exact QA-validated digest — not a rebuild that slipped in. Inspect the
+      # promoted tag's manifest digest and assert byte-for-byte equality, then
+      # surface the verified pairing to the run summary.
+      - name: Verify promoted digest equals QA-validated digest (AC3)
+        env:
+          QA_BACKEND_DIGEST: ${{ steps.qa-digests.outputs.backend }}
+          QA_FRONTEND_DIGEST: ${{ steps.qa-digests.outputs.frontend }}
+        run: |
+          set -euo pipefail
+
+          PROMOTED_BACKEND=$(docker buildx imagetools inspect \
+            "ghcr.io/ssandy33/regress-backend:${RELEASE_TAG}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          PROMOTED_FRONTEND=$(docker buildx imagetools inspect \
+            "ghcr.io/ssandy33/regress-frontend:${RELEASE_TAG}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+
+          MISMATCH=0
+          if [ "${PROMOTED_BACKEND}" != "${QA_BACKEND_DIGEST}" ]; then
+            echo "::error::Prod promotion MISMATCH (backend): release tag '${RELEASE_TAG}' resolves to ${PROMOTED_BACKEND} but QA validated ${QA_BACKEND_DIGEST}. Refusing to deploy a non-QA-validated image (ADR #338)."
+            MISMATCH=1
+          fi
+          if [ "${PROMOTED_FRONTEND}" != "${QA_FRONTEND_DIGEST}" ]; then
+            echo "::error::Prod promotion MISMATCH (frontend): release tag '${RELEASE_TAG}' resolves to ${PROMOTED_FRONTEND} but QA validated ${QA_FRONTEND_DIGEST}. Refusing to deploy a non-QA-validated image (ADR #338)."
+            MISMATCH=1
+          fi
+          if [ "${MISMATCH}" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "Prod promotion verified: backend ${QA_BACKEND_DIGEST} == ${PROMOTED_BACKEND} (QA-validated digest)."
+          echo "Prod promotion verified: frontend ${QA_FRONTEND_DIGEST} == ${PROMOTED_FRONTEND} (QA-validated digest)."
+          {
+            echo "### Prod promotion verified (ADR #338 / #373)"
+            echo "- Prod promotion verified: backend \`${QA_BACKEND_DIGEST}\` == \`${PROMOTED_BACKEND}\` (QA-validated digest)."
+            echo "- Prod promotion verified: frontend \`${QA_FRONTEND_DIGEST}\` == \`${PROMOTED_FRONTEND}\` (QA-validated digest)."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # a full (non-RC) GitHub Release, or a manual production dispatch → PROD stack
   deploy-prod:
@@ -195,9 +324,9 @@ jobs:
       deploy_dir: ~/regress
       compose_file: docker-compose.prod.yml
       git_ref: ${{ github.event.release.tag_name || inputs.ref }}
-      # Pull the PROMOTED digest (#342/SUB-3) — the same @sha256: bytes QA
-      # validated and that promote-prod re-tagged to the release tag in GHCR.
-      # Sourced from the recorded CI digest, NOT a fresh build — the box never
-      # rebuilds the image.
+      # Pull the PROMOTED digest (#342/SUB-3, #373/ADR #338) — the same @sha256:
+      # bytes QA validated and that promote-prod re-tagged to the release tag in
+      # GHCR. promote-prod sources these from the qa-deployed-digests artifact of
+      # the QA run for this commit, NOT a fresh build — the box never rebuilds.
       backend_image_digest: ${{ needs.promote-prod.outputs.backend-digest }}
       frontend_image_digest: ${{ needs.promote-prod.outputs.frontend-digest }}

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.database import get_db
@@ -15,12 +15,26 @@ router = APIRouter(prefix="/api/dashboard", tags=["dashboard"])
 
 
 @router.get("", response_model=DashboardResponse)
-def get_dashboard(db: DBSession = Depends(get_db)) -> DashboardResponse:
+def get_dashboard(
+    response: Response,
+    db: DBSession = Depends(get_db),
+) -> DashboardResponse:
     """Return the composed dashboard payload in a single round-trip.
 
     Per CLAUDE.md, exception details are never echoed to clients — a generic
     500 message is returned and the underlying error is logged server-side.
     """
+    # Issue #367 — set ``Cache-Control: no-store`` so the Next standalone proxy
+    # and the browser never serve a previously-fetched body. The dashboard is
+    # fetched client-side via axios and proxied to this route by Next's
+    # ``rewrites()``; without this header the proxy/browser were free to return
+    # a stale payload after a QA reseed. The header is the canonical fix; the
+    # deploy-time ``qa-frontend`` restart (ADR #359 D4) is now redundant
+    # belt-and-suspenders, retained intentionally and removable in a future
+    # cleanup. Header-only change — the response body and ``response_model``
+    # are unchanged, so no OpenAPI snapshot regen is needed (kept out of the
+    # docstring on purpose: FastAPI emits docstrings into the OpenAPI snapshot).
+    response.headers["Cache-Control"] = "no-store"
     try:
         return build_dashboard_payload(db)
     except Exception:  # noqa: BLE001 — last-resort wrapper before HTTP 500

--- a/backend/app/services/action_engine.py
+++ b/backend/app/services/action_engine.py
@@ -353,9 +353,16 @@ def _itm_short_dte_actions(
                     f"Short {leg.get('type', 'put')} is ITM with {int(dte)} day"
                     f"{'s' if dte != 1 else ''} to expiration."
                 ),
+                # #375: route to the per-leg BTC decision screen (byte-identical
+                # to the buy-to-close cards) instead of the Journal data table —
+                # the leg id is already in scope, so the urgent ITM card lands on
+                # a decision view, not a dead-end.
                 "cta": {
-                    "label": "Manage in Journal",
-                    "href": f"/journal?position={quote(str(leg['position_id']), safe='')}",
+                    "label": "Review buy-to-close",
+                    "href": (
+                        f"/positions/{quote(str(leg['position_id']), safe='')}"
+                        f"/legs/{quote(str(leg['id']), safe='')}/btc"
+                    ),
                     "kind": "link",
                 },
                 # Sort metadata consumed by `_tie_breaker_for`.
@@ -387,11 +394,15 @@ def _short_dte_aggregate_actions(
             continue
         ticker = leg["ticker"]
         entry = by_ticker.get(ticker)
+        # #375: retain the min-DTE leg's own position_id + id so the aggregate
+        # card can route to that most-urgent leg's BTC decision screen. Strict
+        # `<` keeps first-seen ties (the first leg at a given min DTE wins).
         if entry is None or dte < entry["min_dte"]:
             by_ticker[ticker] = {
                 "ticker": ticker,
                 "min_dte": int(dte),
                 "position_id": leg["position_id"],
+                "leg_id": leg["id"],
                 "leg_count": (entry["leg_count"] + 1) if entry else 1,
             }
         else:
@@ -414,9 +425,15 @@ def _short_dte_aggregate_actions(
                     f"{count} open {leg_word} on {ticker} expire within "
                     f"{short_dte_max} days."
                 ),
+                # #375: route the aggregate card to the most-urgent (min-DTE)
+                # leg's BTC decision screen instead of the Journal data table,
+                # so a multi-leg ticker still lands on a decision view.
                 "cta": {
-                    "label": f"Manage {ticker}",
-                    "href": f"/journal?position={quote(str(entry['position_id']), safe='')}",
+                    "label": "Review buy-to-close",
+                    "href": (
+                        f"/positions/{quote(str(entry['position_id']), safe='')}"
+                        f"/legs/{quote(str(entry['leg_id']), safe='')}/btc"
+                    ),
                     "kind": "link",
                 },
                 "_dte": entry["min_dte"],

--- a/backend/tests/test_action_engine.py
+++ b/backend/tests/test_action_engine.py
@@ -1201,3 +1201,139 @@ class TestLargeLoserSubjectSpacingIssue164:
         assert "  " not in amount, (
             f"subject.amount must not contain a double space: {amount!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Issue #375 — expiration-urgency cards route to the per-leg BTC decision
+# screen instead of dead-ending on the Journal positions table.
+# ---------------------------------------------------------------------------
+
+
+class TestItmShortDteRoutesToBtc:
+    """`expiration.itm_short_dte` CTA targets the per-leg BTC route (#375)."""
+
+    @pytest.mark.unit
+    def test_itm_short_dte_cta_links_to_btc_route(self):
+        # C-1 — a single ITM short-DTE leg routes to its own BTC screen,
+        # byte-identical to the buy-to-close cards' route.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=3, moneyness_state="ITM", position_id="p-1")],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.itm_short_dte"
+        )
+        assert card["cta"]["href"] == "/positions/p-1/legs/l-1/btc"
+
+    @pytest.mark.unit
+    def test_itm_short_dte_cta_not_journal(self):
+        # C-2 — the dead-end Journal destination is gone.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=1),
+            positions=[],
+            open_legs=[_leg("l-1", dte=3, moneyness_state="ITM", position_id="p-1")],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.itm_short_dte"
+        )
+        assert "/journal?position=" not in card["cta"]["href"]
+
+
+class TestShortDteAggregateRoutesToBtc:
+    """`expiration.short_dte` aggregate CTA targets the min-DTE leg's BTC
+    route while keeping its aggregated summary subject + id (#375)."""
+
+    @pytest.mark.unit
+    def test_short_dte_aggregate_cta_links_to_min_dte_leg_btc(self):
+        # C-3 — two OTM legs on one ticker; the aggregate card routes to the
+        # most-urgent (min-DTE) leg, l-2 (dte=3), not l-1 (dte=5).
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=[],
+            open_legs=[
+                _leg("l-1", dte=5, moneyness_state="OTM", position_id="p-1"),
+                _leg("l-2", dte=3, moneyness_state="OTM", position_id="p-1"),
+            ],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.short_dte"
+        )
+        assert card["cta"]["href"] == "/positions/p-1/legs/l-2/btc"
+
+    @pytest.mark.unit
+    def test_short_dte_aggregate_cta_not_journal(self):
+        # C-4 — the dead-end Journal destination is gone.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=[],
+            open_legs=[
+                _leg("l-1", dte=5, moneyness_state="OTM", position_id="p-1"),
+                _leg("l-2", dte=3, moneyness_state="OTM", position_id="p-1"),
+            ],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.short_dte"
+        )
+        assert "/journal?position=" not in card["cta"]["href"]
+
+    @pytest.mark.unit
+    def test_short_dte_aggregate_retains_summary_subject_text(self):
+        # C-5 — the aggregated summary subject ("N legs ≤ X DTE") and the card
+        # id are unchanged by the routing fix (no regression of the summary).
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=[],
+            open_legs=[
+                _leg("l-1", dte=5, moneyness_state="OTM", position_id="p-1"),
+                _leg("l-2", dte=3, moneyness_state="OTM", position_id="p-1"),
+            ],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.short_dte"
+        )
+        assert card["subject"]["amount"] == "2 legs ≤ 7 DTE"
+        assert card["id"] == "expiration.short_dte.aapl"
+
+    @pytest.mark.unit
+    def test_short_dte_min_dte_tiebreak_first_seen(self):
+        # C-6 — two OTM legs at the same min DTE; the first-seen leg (l-1)
+        # wins the tie (strict `<`, deterministic), so the aggregate routes
+        # to l-1, not l-2.
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=[],
+            open_legs=[
+                _leg("l-1", dte=3, moneyness_state="OTM", position_id="p-1"),
+                _leg("l-2", dte=3, moneyness_state="OTM", position_id="p-1"),
+            ],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.short_dte"
+        )
+        assert card["cta"]["href"] == "/positions/p-1/legs/l-1/btc"
+
+    @pytest.mark.unit
+    def test_short_dte_aggregate_multi_position_same_ticker(self):
+        # C-7 — legs on different positions but the same ticker; the aggregate
+        # href must use the min-DTE leg's OWN position_id + id (guards the
+        # position_id/leg_id pairing, not a cross-leg mix).
+        actions = compute_next_actions(
+            status=_status(),
+            kpis=_kpis(open_legs=2),
+            positions=[],
+            open_legs=[
+                _leg("l-1", dte=6, moneyness_state="OTM", position_id="p-1"),
+                _leg("l-2", dte=2, moneyness_state="OTM", position_id="p-2"),
+            ],
+        )
+        card = next(
+            a for a in actions if a["action_id"] == "expiration.short_dte"
+        )
+        assert card["cta"]["href"] == "/positions/p-2/legs/l-2/btc"

--- a/backend/tests/test_dashboard_router.py
+++ b/backend/tests/test_dashboard_router.py
@@ -1,0 +1,57 @@
+"""Integration tests for the ``GET /api/dashboard`` cache-control header (#367).
+
+The dashboard is fetched client-side via axios and proxied to this route by
+Next's ``rewrites()``. Without a cache directive the Next standalone proxy and
+the browser were free to serve a stale body after a QA reseed (issue #367). The
+fix sets ``Cache-Control: no-store`` on the backend response. These tests prove
+the header is present (D-1) and that adding it did not change the response body
+schema (D-2) — i.e. it is a header-only change requiring no OpenAPI regen.
+
+Both tests run against the full FastAPI stack + in-memory SQLite (the
+``client`` fixture in ``conftest.py``) and so are integration-tier.
+"""
+
+import pytest
+
+from app.models.schemas import DashboardResponse
+
+
+def _patch_status(monkeypatch, *, schwab_configured: bool = False, fred_key: str = "") -> None:
+    """Stub Schwab/FRED status helpers so the route needs no real credentials."""
+
+    class _Mgr:
+        def is_configured(self) -> bool:
+            return schwab_configured
+
+        def get_refresh_token_expiry(self) -> str | None:
+            return None
+
+    monkeypatch.setattr("app.services.dashboard.SchwabTokenManager", lambda: _Mgr())
+    monkeypatch.setattr("app.services.dashboard.get_fred_api_key", lambda: fred_key)
+
+
+@pytest.mark.integration
+def test_dashboard_response_sets_no_store(client, monkeypatch):
+    """GET /api/dashboard returns ``Cache-Control: no-store`` (D-1, #367 AC1)."""
+    _patch_status(monkeypatch)
+
+    resp = client.get("/api/dashboard")
+
+    assert resp.status_code == 200
+    assert resp.headers.get("Cache-Control") == "no-store"
+
+
+@pytest.mark.integration
+def test_dashboard_no_store_does_not_change_body_schema(client, monkeypatch):
+    """Response body still validates against ``DashboardResponse`` (D-2, #367 AC1).
+
+    Guards that the ``no-store`` header is a header-only change: the payload
+    shape is unchanged, so no OpenAPI snapshot regen is required.
+    """
+    _patch_status(monkeypatch)
+
+    resp = client.get("/api/dashboard")
+
+    assert resp.status_code == 200
+    # Raises ValidationError if the body drifted from the contract.
+    DashboardResponse.model_validate(resp.json())

--- a/backend/tests/test_digest_promotion_config.py
+++ b/backend/tests/test_digest_promotion_config.py
@@ -69,22 +69,45 @@ class TestDigestPromotion:
 
     @pytest.mark.unit
     def test_promote_reads_recorded_qa_digest(self, deploy_workflow: dict) -> None:
-        """Promote re-tags the RECORDED digest (@sha256:), not a fresh resolution.
+        """Promote re-tags the QA-VALIDATED recorded digest, never a release rebuild.
 
-        The `imagetools create` source argument references the recorded digest
-        by `@${...DIGEST}`, and that digest is sourced from the CI build output
-        (`needs.ci.outputs.*-digest`) rather than resolved from a bare tag /
-        source at promote time.
+        #373 / ADR #338: on a ``release:published`` event the ``ci`` job is a
+        *fresh rebuild*, so ``needs.ci.outputs.*-digest`` is NOT the byte-for-byte
+        QA-validated artifact. ``promote-prod`` must instead download the recorded
+        ``qa-deployed-digests`` artifact and re-tag *those* ``@sha256:`` bytes.
+        This test locks that contract and is the regression guard against a
+        relapse to the ``needs.ci.outputs.*`` binding (the original bug).
         """
         promote = deploy_workflow["jobs"]["promote-prod"]
         run_text = _job_step_run_text(promote)
         # Source of the re-tag is a digest reference, not a bare tag.
         assert "ghcr.io/ssandy33/regress-backend@${BACKEND_DIGEST}" in run_text
         assert "ghcr.io/ssandy33/regress-frontend@${FRONTEND_DIGEST}" in run_text
-        # The digest env vars are bound to the RECORDED CI build outputs.
-        env = promote.get("env", {})
-        assert env.get("BACKEND_DIGEST") == "${{ needs.ci.outputs.backend-digest }}"
-        assert env.get("FRONTEND_DIGEST") == "${{ needs.ci.outputs.frontend-digest }}"
+        # The recorded QA digest artifact is consumed (downloaded) — proving the
+        # promoted digest is the QA-validated one, not the release-event rebuild.
+        assert "qa-deployed-digests" in run_text
+        # Every digest binding in the job resolves from the QA-artifact step
+        # outputs, and NONE rebinds to the release-event ci rebuild.
+        digest_bindings = []
+        for step in promote.get("steps", []):
+            if not isinstance(step, dict):
+                continue
+            step_env = step.get("env", {}) or {}
+            for key in ("BACKEND_DIGEST", "FRONTEND_DIGEST"):
+                if key in step_env:
+                    digest_bindings.append(step_env[key])
+        assert digest_bindings, "promote-prod must bind the digest env in its steps"
+        for binding in digest_bindings:
+            assert "needs.ci.outputs" not in binding, (
+                "promote-prod must NOT source the prod digest from the "
+                "release-event ci rebuild (#373 / ADR #338) — consume the "
+                "qa-deployed-digests artifact instead."
+            )
+            assert "steps.qa-digests.outputs" in binding
+        # The job outputs handed to deploy-prod also come from the QA artifact.
+        outputs = promote.get("outputs", {})
+        assert outputs.get("backend-digest") == "${{ steps.qa-digests.outputs.backend }}"
+        assert outputs.get("frontend-digest") == "${{ steps.qa-digests.outputs.frontend }}"
 
     @pytest.mark.unit
     def test_prod_path_has_no_build_step(self, deploy_workflow: dict) -> None:

--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -1064,3 +1064,64 @@ def test_dashboard_leg_delta_threads_from_chain(client, monkeypatch):
     assert leg["assignment_depth"] == "deep"
     assert leg["current_mid"] == pytest.approx(5.10)
     assert isinstance(leg["current_mid"], float)
+
+
+# ---------------------------------------------------------------------------
+# Issue #375 — expiration cards route to the per-leg BTC decision screen
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_dashboard_expiration_cards_link_to_btc(client, monkeypatch):
+    """C-8 — full stack: an ITM short-DTE leg and an OTM short-DTE aggregate
+    both surface CTAs to the per-leg BTC route, with no `/journal?position=`
+    dead-end (issue #375 AC1/AC2/AC3)."""
+    import re
+
+    _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
+
+    # AAPL put @ 175 with price 174 → ITM (per-leg `expiration.itm_short_dte`).
+    # TSLA put @ 200 with price 230 → OTM (aggregate `expiration.short_dte`).
+    quote_responses = {"AAPL": {"lastPrice": 174.0}, "TSLA": {"lastPrice": 230.0}}
+
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: quote_responses[ticker],
+    )
+
+    today = datetime(2026, 5, 5, tzinfo=timezone.utc).date()
+    monkeypatch.setattr(
+        "app.services.dashboard.date",
+        type("D", (), {"today": staticmethod(lambda: today)}),
+    )
+
+    aapl_id = _seed_position(client, ticker="AAPL", broker_cost_basis=17000.0)
+    _seed_trade(
+        client,
+        aapl_id,
+        trade_type="sell_put",
+        strike=175.0,
+        expiration="2026-05-08",  # 3 DTE → ITM short-DTE per-leg card
+    )
+    tsla_id = _seed_position(client, ticker="TSLA", broker_cost_basis=20000.0)
+    _seed_trade(
+        client,
+        tsla_id,
+        trade_type="sell_put",
+        strike=200.0,
+        expiration="2026-05-09",  # 4 DTE → OTM short-DTE aggregate card
+    )
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    cards_by_id = {a["action_id"]: a for a in data["next_actions"]}
+    assert "expiration.itm_short_dte" in cards_by_id
+    assert "expiration.short_dte" in cards_by_id
+
+    btc_route = re.compile(r"^/positions/[^/]+/legs/[^/]+/btc$")
+    for action_id in ("expiration.itm_short_dte", "expiration.short_dte"):
+        href = cards_by_id[action_id]["cta"]["href"]
+        assert btc_route.match(href), f"{action_id} href not BTC route: {href!r}"
+        assert "/journal?position=" not in href

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -1,0 +1,56 @@
+# Deploy Runbook
+
+Operational reference for the regress VPS (prod + QA stacks on one box).
+
+## Disk reclamation
+
+The box accumulates Docker build cache and dangling images over time. The
+deploy pipeline reclaims space automatically; this section documents the
+signals and the manual break-glass.
+
+### 85% pre-flight disk signal (#371)
+
+Before every `docker compose pull`, the SSH deploy
+(`.github/workflows/_deploy-ssh.yml`) runs a `df`-based pre-flight check on
+`/`:
+
+- Threshold: `DISK_WARN_PCT=85`.
+- It always logs an informational line — `Disk headroom: / at N% (threshold 85%).` —
+  and surfaces it to the run's Summary tab via the `::DISK_RESULT::` marker.
+- If `/` is at or above 85%, it emits a `::warning::` annotation naming the
+  host. **The warning is non-fatal by design** — it must not block the very
+  deploy that reclaims space (see the builder prune below).
+
+If you see the warning repeatedly, run the break-glass full reclaim below.
+
+### 168h builder-prune bound (#369)
+
+At the end of every deploy, after `docker image prune -f` (which removes only
+dangling images), the deploy runs:
+
+```
+docker builder prune -f --filter until=168h
+```
+
+- `docker builder prune` removes dangling/unreferenced build cache by default.
+- The `--filter until=168h` (7-day) age bound additionally preserves the last
+  week of warm cache, so routine CI rebuilds stay fast.
+- It never touches cache referenced by the currently-running prod + QA
+  containers — running images are not build cache, and `docker image prune -f`
+  only removes dangling images. Both prod and QA containers stay `Up`.
+
+Verify after a deploy: `docker system df` shows reclaimed build cache;
+`docker compose -f docker-compose.prod.yml ps` and the QA `ps` both show
+containers `Up`.
+
+### Break-glass: full reclaim
+
+When the 85% warning persists or the box is critically low on space, run a
+full, unbounded build-cache reclaim on the box:
+
+```
+docker builder prune -af
+```
+
+This removes **all** build cache (not just cache older than 168h), so the next
+CI build will be a cold build. Use only when the bounded prune is not enough.

--- a/deploy/RUNBOOK.md
+++ b/deploy/RUNBOOK.md
@@ -28,7 +28,7 @@ If you see the warning repeatedly, run the break-glass full reclaim below.
 At the end of every deploy, after `docker image prune -f` (which removes only
 dangling images), the deploy runs:
 
-```
+```bash
 docker builder prune -f --filter until=168h
 ```
 
@@ -48,7 +48,7 @@ containers `Up`.
 When the 85% warning persists or the box is critically low on space, run a
 full, unbounded build-cache reclaim on the box:
 
-```
+```bash
 docker builder prune -af
 ```
 

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # ============================================================
 # Regression Analysis Tool — Update Script
 # ============================================================
+#
+# Disk reclamation (#369): this script prunes dangling images at the end
+# (docker image prune -f). The CI deploy path additionally runs a bounded
+# build-cache prune (docker builder prune -f --filter until=168h). For a manual
+# full reclaim when the box is low on space, see deploy/RUNBOOK.md
+# ("Disk reclamation") — break-glass is `docker builder prune -af`.
 
 APP_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$APP_DIR"
@@ -49,6 +55,8 @@ docker compose -f docker-compose.prod.yml ps
 echo ""
 
 # Clean up old images
+# Build cache is pruned by the CI deploy (docker builder prune --filter
+# until=168h); for a manual full reclaim see deploy/RUNBOOK.md.
 echo ">>> Pruning old Docker images..."
 docker image prune -f
 echo ""

--- a/frontend/e2e/dashboard.spec.js
+++ b/frontend/e2e/dashboard.spec.js
@@ -374,4 +374,48 @@ test.describe('Dashboard route @smoke @e2e', () => {
     await expect(pill).toContainText('Schwab token expiring');
     await expect(pill).not.toContainText('Schwab calls failing');
   });
+
+  // Issue #367 — the dashboard data must never be served from a stale cache
+  // after a QA reseed. The backend sets ``Cache-Control: no-store`` on
+  // ``/api/dashboard``; this header survives the Next ``rewrites()`` proxy hop
+  // and reaches the browser. We assert (a) the response carries the no-store
+  // directive, and (b) a reload issues a fresh network request rather than
+  // serving the previous body from cache.
+  test('dashboard reflects fresh data without reload-from-cache @e2e', async ({ page }) => {
+    let requestCount = 0;
+
+    // Fulfil with the no-store header so the asserted directive mirrors the
+    // backend contract (the header itself is integration-tested in
+    // backend/tests/test_dashboard_router.py::test_dashboard_response_sets_no_store).
+    await page.route('**/api/dashboard', (route) => {
+      requestCount += 1;
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'cache-control': 'no-store' },
+        body: JSON.stringify(POPULATED_PAYLOAD),
+      });
+    });
+
+    // Capture the network response to assert the cache directive.
+    const firstResponse = page.waitForResponse((resp) =>
+      resp.url().includes('/api/dashboard')
+    );
+    await page.goto('/dashboard');
+    const resp = await firstResponse;
+    expect((resp.headers()['cache-control'] || '').toLowerCase()).toContain('no-store');
+
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByTestId('dashboard-page')).toBeVisible();
+    expect(requestCount).toBe(1);
+
+    // Reload must trigger a fresh request, not a cache hit.
+    const reloadResponse = page.waitForResponse((resp2) =>
+      resp2.url().includes('/api/dashboard')
+    );
+    await page.reload();
+    await reloadResponse;
+    await page.waitForLoadState('networkidle');
+    expect(requestCount).toBe(2);
+  });
 });

--- a/frontend/e2e/dashboard.spec.js
+++ b/frontend/e2e/dashboard.spec.js
@@ -407,7 +407,12 @@ test.describe('Dashboard route @smoke @e2e', () => {
 
     await page.waitForLoadState('networkidle');
     await expect(page.getByTestId('dashboard-page')).toBeVisible();
-    expect(requestCount).toBe(1);
+    // At least one fetch happened on mount. Don't pin an exact count — React
+    // Strict Mode double-invokes the effect in dev, so capture the baseline
+    // instead of asserting exactly-once. The behaviour under test is that a
+    // reload issues a *fresh* request (below), not the mount-fetch count.
+    const countAfterLoad = requestCount;
+    expect(countAfterLoad).toBeGreaterThanOrEqual(1);
 
     // Reload must trigger a fresh request, not a cache hit.
     const reloadResponse = page.waitForResponse((resp2) =>
@@ -416,6 +421,6 @@ test.describe('Dashboard route @smoke @e2e', () => {
     await page.reload();
     await reloadResponse;
     await page.waitForLoadState('networkidle');
-    expect(requestCount).toBe(2);
+    expect(requestCount).toBeGreaterThan(countAfterLoad);
   });
 });


### PR DESCRIPTION
## v1.7.3 — Deploy & QA Hardening

Single integration PR for milestone #47. Implemented via 4 parallel workers off disjoint file sets, merged in DAG order **B → A → C → D**. Anchors: RCA #368, ADR #338, ADR #359.

### Issues closed
| # | Lane | Summary |
|---|---|---|
| #369 | A | Reclaim Docker build cache in deploy — bounded `docker builder prune --filter until=168h` + `deploy/RUNBOOK.md` |
| #370 | A | Smoke gate probes backend `/api/health` (additive); a down/crash-looping backend now fails the deploy (qa + prod) |
| #371 | A | Disk-headroom pre-flight (`df` on `/`, `DISK_WARN_PCT=85`) — operator-visible warning before `docker compose pull` |
| #366 | A | QA auto-seed `seeded=N` surfaced to `$GITHUB_STEP_SUMMARY` outside the retry buffer; fail-on-mismatch gate preserved |
| #373 | B | `promote-prod` consumes the recorded `qa-deployed-digests` artifact and re-tags those `@sha256:` bytes (no rebuild); asserts + surfaces `prod_digest == qa_digest`; fails closed if no QA artifact (ADR #338) |
| #375 | C | Expiration-urgency cards route to the per-leg BTC decision screen (`/positions/{pos}/legs/{leg}/btc`), retaining the min-DTE leg through aggregation — no more Journal dead-end |
| #367 | D | `Cache-Control: no-store` on `/api/dashboard` so a QA reseed surfaces without a container bounce (root cause was the backend header, not Next.js caching) |

### Worker DAG (disjoint file ownership)
- **A** `_deploy-ssh.yml` + `deploy/RUNBOOK.md` + `deploy/update.sh` (#369/#370/#371/#366)
- **B** `deploy.yml` `promote-prod` (#373)
- **C** `backend/app/services/action_engine.py` + tests (#375)
- **D** `backend/app/routers/dashboard.py` + tests + `frontend/e2e/dashboard.spec.js` (#367)

### Integration bridge edit
`backend/tests/test_digest_promotion_config.py::test_promote_reads_recorded_qa_digest` previously asserted the **old buggy** contract (prod digest bound to `needs.ci.outputs.*`, the release-event rebuild) — its docstring wrongly called that "the recorded digest." Rewrote it as a regression guard locking #373's correct contract (consume `qa-deployed-digests`, bind from `steps.qa-digests.outputs.*`, never `needs.ci.outputs.*`).

### Tests
- Backend: full suite green; new unit + integration coverage for #375 (8 tests) and #367 (2 integration); classifier + tdd_red + OpenAPI-drift gates green.
- Frontend: D-3 `@e2e` appended to `dashboard.spec.js`; Playwright tag check green.

### Deploy-YAML verification (not exercised by PR CI — checked on the post-merge QA Deploy run)
Lanes A & B run only on push-to-main/release. On the QA Deploy after merge, confirm: disk-headroom line, `Build-cache prune complete`, `Smoke gate (backend) PASSED: …/api/health`, and `seeded=7 expected=7` in the run Summary. #373's prod path is validated on the next intentional release (we stop at QA).

### Release flow
Per release policy: **merge → auto-deploy to QA → verify → STOP before prod.** Do not publish the prod-promoting GitHub release without explicit go-ahead. Dependabot bumps #352/#353/#354/#358 land separately on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)