### PR TITLE
fix(seed-qa): scrub stale schwab_* tokens on reset to prevent QA crash-loop (#379)

### DIFF
--- a/backend/app/services/seed_qa.py
+++ b/backend/app/services/seed_qa.py
@@ -47,6 +47,7 @@ from sqlalchemy.orm import Session as DBSession
 
 from app.config import settings
 from app.models.database import (
+    AppSetting,
     OptionMarkStub,
     Position,
     QuoteStub,
@@ -54,6 +55,7 @@ from app.models.database import (
     TradeEntryCompliance,
 )
 from app.services.backup import create_backup
+from app.services.encryption import ENCRYPTED_SETTING_KEYS
 
 logger = logging.getLogger(__name__)
 
@@ -334,15 +336,27 @@ def _full_reset(db: DBSession) -> None:
 
     Bulk-deletes every row from ``trade_entry_compliance`` (a FK child of
     ``trades``), ``trades``, ``positions``, ``quote_stubs``, and
-    ``option_mark_stubs`` — *not* only sentinel-tagged rows. This leaves
-    ``app_settings`` / ``sessions`` / ``watchlist`` untouched so QA stays
-    signed-in and configured (resolved blast radius, ADR #359 Q2).
+    ``option_mark_stubs`` — *not* only sentinel-tagged rows. This leaves the
+    rest of ``app_settings`` / ``sessions`` / ``watchlist`` untouched so QA
+    stays signed-in and configured (resolved blast radius, ADR #359 Q2).
 
     The deletes are ordered child-before-parent and use bulk ``query().delete()``
     rather than ORM-cascade deletes because (a) the project does not enable
     ``PRAGMA foreign_keys=ON`` so SQL-level cascade never fires, and (b) a bulk
     delete is the same pattern :func:`journal.clear_all_journal_data` uses for a
     large parent set.
+
+    **Schwab-token scrub (#379):** also clears the sensitive ``schwab_*`` token
+    keys (:data:`encryption.ENCRYPTED_SETTING_KEYS`) from ``app_settings``. QA
+    runs in no-Schwab mode (``SCHWAB_ENCRYPTION_KEY`` unset), and the backend's
+    startup security check (``app/main.py`` ``_run_security_checks``) fails closed
+    — crash-looping the container — if those tokens exist without a key. Stale
+    tokens can land in the persistent QA volume from a historical prod-snapshot
+    restore (predating the ``qa-refresh-db.sh`` #332 scrub) or a manual
+    ``schwab-auth``; without this scrub they survive every reseed and re-trip the
+    check. This mirrors the ``qa-refresh-db.sh`` #332 guard for the synthetic-seed
+    path. Only the 4 token keys are removed — ``schwab_*_expires`` /
+    ``schwab_account_value`` and all other settings are preserved.
 
     **SAFETY:** callers MUST invoke :func:`assert_seed_allowed` first — this
     function performs no guard of its own and is catastrophic on production.
@@ -352,6 +366,9 @@ def _full_reset(db: DBSession) -> None:
     db.query(Position).delete(synchronize_session=False)
     db.query(QuoteStub).delete(synchronize_session=False)
     db.query(OptionMarkStub).delete(synchronize_session=False)
+    db.query(AppSetting).filter(
+        AppSetting.key.in_(ENCRYPTED_SETTING_KEYS)
+    ).delete(synchronize_session=False)
     db.commit()
 
 

--- a/backend/tests/test_seed_qa_integration.py
+++ b/backend/tests/test_seed_qa_integration.py
@@ -28,6 +28,7 @@ from app.models.database import (
     WatchlistTicker,
 )
 from app.services import journal
+from app.services.encryption import ENCRYPTED_SETTING_KEYS
 from app.services.seed_qa import (
     EXPECTED_ARCHETYPE_COUNT,
     SEED_TAG_PREFIX,
@@ -188,6 +189,46 @@ def test_seed_full_reset_preserves_auth_config_watchlist(db_session):
     assert db_session.query(Session).count() == 1
     assert db_session.query(WatchlistTicker).filter_by(ticker="AAPL").count() == 1
     # And the archetypes seeded alongside the preserved state.
+    assert _seed_count(db_session) == EXPECTED_ARCHETYPE_COUNT
+
+
+@pytest.mark.integration
+def test_seed_full_reset_scrubs_schwab_tokens(db_session):
+    """#379: the reset clears the 4 sensitive ``schwab_*`` token keys from
+    app_settings (mirroring the ``qa-refresh-db.sh`` #332 scrub) so a QA reseed
+    can never leave the backend crash-looping on EncryptionKeyMissing. Stale
+    tokens otherwise survive every reseed because the reset preserves
+    app_settings. Non-sensitive ``schwab_*`` keys and unrelated settings stay.
+    """
+    # Stale sensitive tokens — the crash-loop trigger when no key is set.
+    for key in ENCRYPTED_SETTING_KEYS:
+        db_session.add(AppSetting(key=key, value="stale-encrypted-secret"))
+    # Non-sensitive schwab row + an unrelated setting that MUST survive.
+    db_session.add(AppSetting(key="schwab_access_token_expires", value="2026-01-01"))
+    db_session.add(AppSetting(key="rules_config", value="{}"))
+    db_session.commit()
+
+    with patch("app.services.seed_qa.settings") as mock_settings:
+        mock_settings.app_env = "qa"
+        seed_qa(db_session)
+
+    # All 4 sensitive token keys are scrubbed.
+    remaining = {
+        row.key
+        for row in db_session.query(AppSetting)
+        .filter(AppSetting.key.in_(ENCRYPTED_SETTING_KEYS))
+        .all()
+    }
+    assert remaining == set()
+    # Non-sensitive schwab key + unrelated setting preserved.
+    assert (
+        db_session.query(AppSetting)
+        .filter_by(key="schwab_access_token_expires")
+        .count()
+        == 1
+    )
+    assert db_session.query(AppSetting).filter_by(key="rules_config").count() == 1
+    # Archetypes still seeded alongside the scrub.
     assert _seed_count(db_session) == EXPECTED_ARCHETYPE_COUNT
 
 


### PR DESCRIPTION
## Problem
`seed_qa._full_reset()` preserved all of `app_settings`, so stale `schwab_*` token rows survive every QA reseed. With `SCHWAB_ENCRYPTION_KEY` unset (QA no-Schwab mode), the backend startup security check (`app/main.py:_run_security_checks`) fails closed and **crash-loops the container** — taking all QA `/api/*` to 502 behind Caddy. Observed 2026-06-19 after the v1.7.3 QA deploy (see #379).

## Fix
Clear the 4 sensitive keys (`encryption.ENCRYPTED_SETTING_KEYS`: `schwab_access_token`, `schwab_refresh_token`, `schwab_app_key`, `schwab_app_secret`) from `app_settings` in `_full_reset`, mirroring the `qa-refresh-db.sh` #332 guard for the synthetic-seed path. So a QA reseed always lands in a bootable no-Schwab state regardless of how tokens entered the volume.

- Non-sensitive `schwab_*` rows (`*_expires`, `schwab_account_value`) and all other settings are **preserved** — only the 4 token keys are removed.
- Existing `test_seed_full_reset_preserves_auth_config_watchlist` still passes (it preserves `rules_config` / sessions / watchlist).

## Test
`test_seed_full_reset_scrubs_schwab_tokens` (integration): seeds the 4 token keys + a non-sensitive `schwab_*_expires` + an unrelated setting → runs `seed_qa` → asserts the 4 tokens are gone, the non-sensitive rows survive, and the 7 archetypes still seed. Local: `32 passed`.

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)