### PR TITLE
chore(deps): bump cryptography 46.0.7 → 48.0.1 in /backend (supersedes #358)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,6 @@ pytest-cov==6.0.0
 schemathesis>=4.0,<5
 scipy==1.14.1
 PyJWT==2.13.0
-cryptography==46.0.7
+cryptography==48.0.1
 PyYAML==6.0.2
 yfinance==0.2.50


### PR DESCRIPTION
Supersedes the stale Dependabot PR #358 (conflicted on `requirements.txt` after #352/pyjwt merged). Re-applies the identical one-line cryptography bump cleanly off main. 48.0.1 already passed full backend CI on #358 before it went stale; the app only uses Fernet, whose API is unchanged across 46→48.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)