### PR TITLE
fix(qa-deploy): scrub stale schwab_* tokens before backend start (#379 root cause)

### DIFF
--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -149,6 +149,20 @@ jobs:
             # artifact CI tested. Compose/Caddyfile still arrive via the
             # `git reset --hard` above.
             docker compose -f ${{ inputs.compose_file }} pull
+            # QA pre-start Schwab-token scrub (#379 root-cause fix). QA boots
+            # with SCHWAB_ENCRYPTION_KEY unset; if stale schwab_* token rows sit
+            # in the persistent QA volume (a prod-snapshot restore or a manual
+            # schwab-auth), the backend's fail-closed startup check crash-loops
+            # the container — taking all QA /api/* to 502. The #380 seed scrub
+            # can't recover this: it runs via `compose exec` into a container the
+            # tokens prevent from starting (a deadlock). So we scrub FIRST, from
+            # a one-off container that never boots the app, BEFORE `up -d`. Image
+            # is already pulled above. QA-only — prod legitimately holds tokens +
+            # the key, and seed-qa's APP_ENV=production guard never reaches here.
+            if [ "${{ inputs.environment }}" = "qa" ]; then
+              COMPOSE_FILE="${{ inputs.compose_file }}" PROJECT="$(basename "$(pwd)")" \
+                bash deploy/qa-scrub-schwab-tokens.sh
+            fi
             docker compose -f ${{ inputs.compose_file }} up -d
             if [ "$HAS_CADDY" = yes ]; then
               docker compose -f ${{ inputs.compose_file }} restart caddy

--- a/backend/scripts/scrub_schwab_tokens.py
+++ b/backend/scripts/scrub_schwab_tokens.py
@@ -1,0 +1,79 @@
+"""Pre-start Schwab-token scrub for QA (root-cause fix for #379).
+
+QA runs with ``SCHWAB_ENCRYPTION_KEY`` unset. The backend's fail-closed startup
+check (:func:`app.main._run_security_checks`) refuses to boot when the sensitive
+``schwab_*`` token rows exist in ``app_settings`` without the key — crash-looping
+the container and taking all QA ``/api/*`` to 502 behind Caddy (#379).
+
+The #380 scrub lives in :func:`app.services.seed_qa._full_reset`, which runs via
+``docker compose exec qa-backend ...`` — and ``exec`` needs a *running*
+container. Once the tokens are present the backend cannot stay up, so the
+exec-based scrub can never fire: a deadlock. This module breaks it. It is
+invoked from a one-off container BEFORE ``compose up -d`` (see
+``deploy/qa-scrub-schwab-tokens.sh``), connects straight to the SQLite file via
+stdlib ``sqlite3``, and never imports the FastAPI app or triggers the security
+check — so it works even when the long-running backend cannot boot.
+
+The key list is :data:`app.services.encryption.ENCRYPTED_SETTING_KEYS` — the same
+source of truth as the startup check and the #380 seed scrub, so the three can
+never drift.
+
+Idempotent: a missing ``app_settings`` table (a fresh QA volume, before the
+backend's ``init_db`` has run) or zero matching rows is a no-op that returns 0.
+
+Usage (inside the backend container, cwd ``/app``):
+    python -m scripts.scrub_schwab_tokens [db_path]
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+
+from app.services.encryption import ENCRYPTED_SETTING_KEYS
+
+# The QA volume mounts the SQLite DB here (docker-compose.qa.yml:
+# DATABASE_URL=sqlite:///./data/regression_tool.db, WORKDIR /app).
+DEFAULT_DB_PATH = "/app/data/regression_tool.db"
+
+
+def scrub_schwab_tokens(db_path: str = DEFAULT_DB_PATH) -> int:
+    """Delete the sensitive ``schwab_*`` token rows from ``app_settings``.
+
+    Returns the number of rows deleted. A missing ``app_settings`` table is
+    treated as "nothing to scrub" (returns 0) so the scrub is safe to run
+    against a freshly-created QA volume before the backend's ``init_db``.
+
+    Only the keys in :data:`ENCRYPTED_SETTING_KEYS` are removed —
+    ``schwab_*_expires`` / ``schwab_account_value`` and all other settings are
+    preserved (they do not trip the startup security check).
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        table_exists = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='app_settings'"
+        ).fetchone()
+        if not table_exists:
+            return 0
+        keys = sorted(ENCRYPTED_SETTING_KEYS)
+        placeholders = ",".join("?" for _ in keys)
+        cur = conn.execute(
+            f"DELETE FROM app_settings WHERE key IN ({placeholders})", keys
+        )
+        conn.commit()
+        return cur.rowcount
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    db_path = args[0] if args else DEFAULT_DB_PATH
+    deleted = scrub_schwab_tokens(db_path)
+    print(f"Scrubbed {deleted} Schwab token row(s) from {db_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_qa_prestart_scrub_wiring.py
+++ b/backend/tests/test_qa_prestart_scrub_wiring.py
@@ -1,0 +1,65 @@
+"""Regression guard for the QA pre-start Schwab-token scrub wiring (#379).
+
+The scrub (``scripts/scrub_schwab_tokens``, wrapped by
+``deploy/qa-scrub-schwab-tokens.sh``) only fixes the #379 crash-loop deadlock if
+it runs BEFORE the backend container starts. These static-text assertions pin
+that ordering in both deploy paths — the CI workflow
+(``.github/workflows/_deploy-ssh.yml``) and the manual ``deploy/qa-deploy.sh`` —
+so a future edit can't silently move the scrub after ``up -d`` (which would
+re-deadlock: the backend would crash-loop before the scrub could run).
+
+Pure file-text assertions — no app, no TestClient, no DB session, no network —
+so ``@pytest.mark.unit``, matching ``test_qa_compose_config.py``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEPLOY_SSH_WF = REPO_ROOT / ".github" / "workflows" / "_deploy-ssh.yml"
+QA_DEPLOY_SH = REPO_ROOT / "deploy" / "qa-deploy.sh"
+SCRUB_SH = REPO_ROOT / "deploy" / "qa-scrub-schwab-tokens.sh"
+
+SCRUB_SCRIPT_REF = "deploy/qa-scrub-schwab-tokens.sh"
+
+
+@pytest.mark.unit
+def test_scrub_script_exists_and_invokes_the_python_module():
+    text = SCRUB_SH.read_text()
+    # The scrub COMMAND must use a one-off `run --no-deps` container (overrides
+    # the uvicorn CMD so the fail-closed lifespan check never runs), NOT
+    # `compose exec` (which needs a running container — the very thing the
+    # tokens prevent). Assert the exact command shape rather than the absence of
+    # the word "exec" (which legitimately appears in the explanatory header).
+    assert 'run --rm --no-deps "$BACKEND_SVC" python -m scripts.scrub_schwab_tokens' in text
+
+
+@pytest.mark.unit
+def test_ci_deploy_runs_scrub_before_up():
+    text = DEPLOY_SSH_WF.read_text()
+    assert SCRUB_SCRIPT_REF in text, "CI deploy must invoke the pre-start scrub"
+    scrub_idx = text.index(SCRUB_SCRIPT_REF)
+    # Anchor on the actual command, not the several `up -d` mentions in comments.
+    up_idx = text.index("docker compose -f ${{ inputs.compose_file }} up -d")
+    assert scrub_idx < up_idx, "scrub must run BEFORE `up -d` or the deadlock returns"
+
+
+@pytest.mark.unit
+def test_ci_deploy_scrub_is_qa_only():
+    """Prod legitimately holds Schwab tokens + the key — the scrub must be
+    guarded behind environment == qa so it never strips prod's tokens."""
+    text = DEPLOY_SSH_WF.read_text()
+    scrub_idx = text.index(SCRUB_SCRIPT_REF)
+    guard_idx = text.rindex('inputs.environment }}" = "qa"', 0, scrub_idx)
+    # The qa guard opens shortly before the scrub invocation (same if-block).
+    assert 0 <= scrub_idx - guard_idx < 600
+
+
+@pytest.mark.unit
+def test_manual_qa_deploy_runs_scrub_before_up():
+    text = QA_DEPLOY_SH.read_text()
+    assert SCRUB_SCRIPT_REF in text, "qa-deploy.sh must invoke the pre-start scrub"
+    scrub_idx = text.index(SCRUB_SCRIPT_REF)
+    up_idx = text.index("$COMPOSE up -d")
+    assert scrub_idx < up_idx, "scrub must run BEFORE `up -d` or the deadlock returns"

--- a/backend/tests/test_scrub_schwab_tokens.py
+++ b/backend/tests/test_scrub_schwab_tokens.py
@@ -1,0 +1,141 @@
+"""Unit tests for the pre-start Schwab-token scrub (root-cause fix for #379).
+
+The scrub runs from a one-off container BEFORE ``compose up -d`` so the backend
+can boot even when stale ``schwab_*`` tokens sit in the persistent QA volume
+without ``SCHWAB_ENCRYPTION_KEY`` (the #380 ``seed_qa`` scrub can't help — it
+runs via ``compose exec`` into a container that the very tokens prevent from
+starting; see ``scripts/scrub_schwab_tokens`` module docstring).
+
+These tests drive the pure function against throwaway SQLite files (no FastAPI
+app, no TestClient, no conftest session, no network) — ``@pytest.mark.unit``,
+matching the repo precedent for ``scripts/*`` helper tests (e.g.
+``test_reconcile_positions``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from app.services.encryption import ENCRYPTED_SETTING_KEYS
+from scripts.scrub_schwab_tokens import main, scrub_schwab_tokens
+
+
+def _make_db(path, settings):
+    """Create a SQLite DB with an ``app_settings`` table seeded from ``settings``."""
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO app_settings (key, value) VALUES (?, ?)",
+        list(settings.items()),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _keys(path):
+    conn = sqlite3.connect(path)
+    try:
+        return {row[0] for row in conn.execute("SELECT key FROM app_settings")}
+    finally:
+        conn.close()
+
+
+@pytest.mark.unit
+def test_scrubs_all_sensitive_token_keys(tmp_path):
+    db = tmp_path / "regression_tool.db"
+    seeded = {k: "secret" for k in ENCRYPTED_SETTING_KEYS}
+    _make_db(db, seeded)
+
+    deleted = scrub_schwab_tokens(str(db))
+
+    assert deleted == len(ENCRYPTED_SETTING_KEYS)
+    assert _keys(str(db)) == set()
+
+
+@pytest.mark.unit
+def test_preserves_non_sensitive_settings(tmp_path):
+    db = tmp_path / "regression_tool.db"
+    _make_db(
+        db,
+        {
+            "schwab_access_token": "a",
+            "schwab_refresh_token": "r",
+            "schwab_app_key": "k",
+            "schwab_app_secret": "s",
+            # Non-sensitive schwab rows + an unrelated setting MUST survive:
+            # they don't trip the startup security check.
+            "schwab_access_token_expires": "2026-01-01",
+            "schwab_account_value:__default__": "1000",
+            "nextauth_secret": "keep-me",
+        },
+    )
+
+    deleted = scrub_schwab_tokens(str(db))
+
+    assert deleted == 4
+    assert _keys(str(db)) == {
+        "schwab_access_token_expires",
+        "schwab_account_value:__default__",
+        "nextauth_secret",
+    }
+
+
+@pytest.mark.unit
+def test_key_list_matches_security_check_source_of_truth(tmp_path):
+    """The scrub must delete exactly the keys the startup check trips on —
+    binding it to ENCRYPTED_SETTING_KEYS so the two can never drift."""
+    db = tmp_path / "regression_tool.db"
+    # One row per sensitive key plus a decoy that looks schwab-ish but isn't
+    # in the trip list.
+    seeded = {k: "v" for k in ENCRYPTED_SETTING_KEYS}
+    seeded["schwab_refresh_token_expires"] = "2026-01-01"
+    _make_db(db, seeded)
+
+    scrub_schwab_tokens(str(db))
+
+    assert _keys(str(db)) == {"schwab_refresh_token_expires"}
+
+
+@pytest.mark.unit
+def test_idempotent_second_run_deletes_zero(tmp_path):
+    db = tmp_path / "regression_tool.db"
+    _make_db(db, {k: "v" for k in ENCRYPTED_SETTING_KEYS})
+
+    assert scrub_schwab_tokens(str(db)) == len(ENCRYPTED_SETTING_KEYS)
+    assert scrub_schwab_tokens(str(db)) == 0
+
+
+@pytest.mark.unit
+def test_missing_app_settings_table_is_a_noop(tmp_path):
+    """A fresh QA volume has the DB file but no tables yet (init_db runs at
+    backend startup, AFTER this pre-start scrub). That must be a clean no-op,
+    not a crash."""
+    db = tmp_path / "regression_tool.db"
+    sqlite3.connect(db).close()  # empty DB file, no app_settings table
+
+    assert scrub_schwab_tokens(str(db)) == 0
+
+
+@pytest.mark.unit
+def test_empty_app_settings_table_is_a_noop(tmp_path):
+    db = tmp_path / "regression_tool.db"
+    _make_db(db, {})
+
+    assert scrub_schwab_tokens(str(db)) == 0
+
+
+@pytest.mark.unit
+def test_main_cli_scrubs_and_reports(tmp_path, capsys):
+    db = tmp_path / "regression_tool.db"
+    _make_db(db, {k: "v" for k in ENCRYPTED_SETTING_KEYS})
+
+    rc = main([str(db)])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert f"Scrubbed {len(ENCRYPTED_SETTING_KEYS)} Schwab token row(s)" in out
+    assert _keys(str(db)) == set()

--- a/deploy/qa-deploy.sh
+++ b/deploy/qa-deploy.sh
@@ -52,6 +52,13 @@ echo ""
 #   echo "$GHCR_PULL_TOKEN" | docker login ghcr.io -u <user> --password-stdin
 echo ">>> Pulling and starting QA containers..."
 $COMPOSE pull
+# Pre-start Schwab-token scrub (#379 root-cause fix): clear any stale schwab_*
+# token rows from the persistent QA volume BEFORE `up -d`, so the backend's
+# fail-closed startup check (no SCHWAB_ENCRYPTION_KEY on QA) can't crash-loop
+# it. Runs from a one-off container that never boots the app — works even when
+# the long-running backend can't start. See deploy/qa-scrub-schwab-tokens.sh.
+COMPOSE_FILE="docker-compose.qa.yml" PROJECT="regress-qa" \
+    bash deploy/qa-scrub-schwab-tokens.sh
 $COMPOSE up -d
 echo ""
 

--- a/deploy/qa-scrub-schwab-tokens.sh
+++ b/deploy/qa-scrub-schwab-tokens.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================
+# QA pre-start Schwab-token scrub (root-cause fix for #379)
+# ============================================================
+# QA runs with SCHWAB_ENCRYPTION_KEY unset. The backend's fail-closed startup
+# check (app/main.py _run_security_checks) refuses to boot when the 4 sensitive
+# schwab_* token rows exist in app_settings without the key — crash-looping the
+# container and taking all QA /api/* to 502 behind Caddy (#379).
+#
+# The #380 scrub lives in seed_qa._full_reset(), which runs via
+# `docker compose exec qa-backend ...` — and `exec` needs a RUNNING container.
+# Once the tokens are present the backend can't stay up, so the exec-based scrub
+# can never fire: a deadlock. This script breaks it by running the scrub from a
+# ONE-OFF container (`compose run --no-deps`, command overridden to a bare
+# `python -m scripts.scrub_schwab_tokens`) that connects straight to the SQLite
+# file and never imports the FastAPI app / triggers the security check. Mirrors
+# the qa-refresh-db.sh #332 scrub, but on the synthetic-seed deploy path and
+# BEFORE the long-running backend starts.
+#
+# MUST run BEFORE `docker compose up -d`. Idempotent: deleting 0 rows (or a
+# fresh volume with no app_settings table yet) is a clean no-op. The key list
+# lives in app.services.encryption.ENCRYPTED_SETTING_KEYS — single source of
+# truth shared with the startup check and the #380 seed scrub.
+#
+# Usage (from the QA clone at /root/regress-qa):
+#   bash deploy/qa-scrub-schwab-tokens.sh
+#
+# Overrides (used by the CI deploy path, .github/workflows/_deploy-ssh.yml):
+#   COMPOSE_FILE=docker-compose.qa.yml PROJECT=regress-qa \
+#     bash deploy/qa-scrub-schwab-tokens.sh
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.qa.yml}"
+PROJECT="${PROJECT:-regress-qa}"
+COMPOSE="docker compose -p ${PROJECT} -f ${COMPOSE_FILE}"
+
+# Resolve the backend service from the compose file (handles `qa-backend`).
+BACKEND_SVC=$($COMPOSE config --services | grep -E '(^|-)backend$' | head -1)
+if [ -z "$BACKEND_SVC" ]; then
+    echo "ERROR: qa-scrub: could not resolve a backend service from ${COMPOSE_FILE}." >&2
+    exit 1
+fi
+
+echo ">>> Pre-start Schwab-token scrub (QA boots without SCHWAB_ENCRYPTION_KEY)..."
+# --no-deps: don't pull up qa-frontend etc. --rm: leave no stray container.
+# The overridden command (`python -m ...`) bypasses the uvicorn CMD, so the
+# fail-closed lifespan check never runs — this works even mid-crash-loop.
+$COMPOSE run --rm --no-deps "$BACKEND_SVC" python -m scripts.scrub_schwab_tokens


### PR DESCRIPTION
## Problem

QA backend crash-looped again on the 2026-06-20 deploy (`EncryptionKeyMissing`, 703 restarts / exit 3, all `/api/*` → 502 behind Caddy). **Not** the cryptography 46→48 bump (#381) — the traceback is the fail-closed startup security check, and the DB had all 4 sensitive `schwab_*` token rows back in `app_settings`.

#380 was supposed to fix this (#379) but **its scrub can never run in this failure mode**:

- The scrub lives in `seed_qa._full_reset()`, reachable only via `docker compose exec qa-backend python -m app.cli seed-qa`.
- `exec` needs a **running** container.
- When the stale tokens are present, `_run_security_checks` crash-loops the backend before any exec can attach.
- So the exec-based scrub deadlocks against the very rows it would remove.

The tokens re-enter the persistent QA volume via a prod-snapshot restore or a manual `schwab-auth`; once there, #380 is structurally dead.

## Fix (option 1 — pre-start scrub)

Scrub the tokens from a **one-off container BEFORE `up -d`**, command overridden to a bare `python -m scripts.scrub_schwab_tokens` so it never imports the FastAPI app / triggers the security check. Works even mid-crash-loop. Mirrors the `qa-refresh-db.sh` (#332) scrub, but on the synthetic-seed deploy path and before the long-running backend starts.

| File | Change |
|---|---|
| `backend/scripts/scrub_schwab_tokens.py` | Pure, idempotent scrub keyed on `encryption.ENCRYPTED_SETTING_KEYS` (shared source of truth with the startup check + #380 seed scrub — they can't drift). Missing `app_settings` table (fresh volume) → no-op. |
| `deploy/qa-scrub-schwab-tokens.sh` | One-off-container wrapper, reused by both deploy paths. |
| `.github/workflows/_deploy-ssh.yml` | Runs scrub **QA-only**, between `pull` and `up -d`. |
| `deploy/qa-deploy.sh` | Same, on the manual path. |

## Tests

- `test_scrub_schwab_tokens.py` — 7 unit: scrubs all 4 sensitive keys, preserves non-sensitive (`*_expires` / `account_value` / unrelated), key list bound to `ENCRYPTED_SETTING_KEYS`, idempotent, missing/empty table no-op, CLI.
- `test_qa_prestart_scrub_wiring.py` — 4 unit guards: scrub runs before `up -d` in both deploy paths, QA-only guard, one-off-`run`-not-`exec` command shape.

All 11 green; classifier OK; `seed_qa` integration suite green; workflow YAML + shell syntax clean.

## Caveat

The live `python -m scripts.scrub_schwab_tokens` path can't be exercised on the box until the backend image rebuilds with this code (deployed image predates the script). The mechanism (`compose run --no-deps … python …`) is already proven by `qa-refresh-db.sh`, and the module logic is unit-covered — it'll work on the first QA deploy carrying this branch.

QA was manually recovered (cleared the 4 trigger keys + restart) before this PR; it's currently healthy.

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)