### PR TITLE
fix(equity): surface unmatched sells in import preview + result (AC3c/Q2)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -597,6 +597,10 @@ class ImportPreviewTrade(BaseModel):
     # dividend rows; None otherwise (issue #385, PRD #384 Q1).
     close_reason: Optional[str] = None
     is_duplicate: bool
+    # True for an equity sell with no shares to draw on — it will be skipped at
+    # import time, so the preview flags it instead of showing "New" (AC3c /
+    # PRD #384 Q2). Default False so option/buy/dividend rows are unaffected.
+    is_unmatched: bool = False
 
 
 class ImportPreviewResponse(BaseModel):
@@ -604,6 +608,9 @@ class ImportPreviewResponse(BaseModel):
     trades: list[ImportPreviewTrade]
     total: int
     duplicates: int
+    # Count of rows flagged ``is_unmatched`` (unmatched equity sells that will be
+    # skipped on import). Default 0; excluded from ``new_count`` (issue: AC3c).
+    unmatched: int = 0
     new_count: int
 
 

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -220,6 +220,59 @@ def is_duplicate(
     return query.first() is not None
 
 
+def _detect_unmatched_sells(db: Session, mapped_trades: list[dict]) -> set[int]:
+    """Return the indices of ``mapped_trades`` that are equity sells with no
+    shares to draw on.
+
+    Replays the same per-ticker running-share simulation
+    :func:`execute_mapped_import` uses, so the preview and the execute path
+    AGREE on exactly which ``sell_stock`` rows will be skipped as unmatched
+    (AC3c / PRD #384 Q2). Seeds each ticker from its existing open position so a
+    sell can legitimately draw on already-owned/assigned shares; buys earlier in
+    the same import grow the balance; duplicate rows are already reflected in the
+    existing share count and do not move the balance.
+    """
+    running: dict[str, int] = {}
+    unmatched: set[int] = set()
+
+    def _seed(ticker: str) -> int:
+        if ticker not in running:
+            existing = (
+                db.query(Position)
+                .filter(Position.ticker == ticker, Position.status == "open")
+                .order_by(Position.opened_at.desc())
+                .first()
+            )
+            running[ticker] = existing.shares if existing else 0
+        return running[ticker]
+
+    for idx, mapped in enumerate(mapped_trades):
+        ticker = mapped["ticker"]
+        trade_type = mapped["trade_type"]
+        quantity = mapped.get("quantity") or 0
+        if is_duplicate(
+            db,
+            ticker,
+            mapped.get("strike"),
+            mapped.get("expiration"),
+            trade_type,
+            mapped["opened_at"],
+            unit_amount=mapped.get("unit_amount"),
+            quantity=mapped.get("quantity"),
+            close_reason=mapped.get("close_reason"),
+        ):
+            continue
+        if trade_type == "buy_stock":
+            running[ticker] = _seed(ticker) + quantity
+        elif trade_type == "sell_stock":
+            available = _seed(ticker)
+            if quantity > available:
+                unmatched.add(idx)
+                continue
+            running[ticker] = available - quantity
+    return unmatched
+
+
 def build_preview(
     db: Session,
     mapped_trades: list[dict],
@@ -229,14 +282,19 @@ def build_preview(
 
     Shared between the API preview path (``preview_import``) and the CSV
     preview path so both produce identical response shapes and apply the same
-    duplicate-detection logic.
+    duplicate-detection logic. Equity sells that cannot be covered are flagged
+    ``is_unmatched`` (and excluded from ``new_count``) so the user sees, before
+    confirming, that they will be skipped — matching what
+    :func:`execute_mapped_import` actually does (AC3c / PRD #384 Q2).
     """
     masked_account = (
         f"****{account_number[-4:]}" if len(account_number) >= 4 else account_number
     )
+    unmatched_indices = _detect_unmatched_sells(db, mapped_trades)
     trades: list[dict] = []
     duplicates = 0
-    for mapped in mapped_trades:
+    unmatched = 0
+    for idx, mapped in enumerate(mapped_trades):
         dup = is_duplicate(
             db,
             mapped["ticker"],
@@ -248,16 +306,20 @@ def build_preview(
             quantity=mapped.get("quantity"),
             close_reason=mapped.get("close_reason"),
         )
+        is_unmatched = idx in unmatched_indices
         if dup:
             duplicates += 1
-        trades.append({**mapped, "is_duplicate": dup})
+        elif is_unmatched:
+            unmatched += 1
+        trades.append({**mapped, "is_duplicate": dup, "is_unmatched": is_unmatched})
 
     return {
         "account_number": masked_account,
         "trades": trades,
         "total": len(trades),
         "duplicates": duplicates,
-        "new_count": len(trades) - duplicates,
+        "unmatched": unmatched,
+        "new_count": len(trades) - duplicates - unmatched,
     }
 
 
@@ -295,26 +357,16 @@ def execute_mapped_import(
     seen_position_ids: set[str] = set()
     skipped_unmatched: list[dict] = []
 
-    # Per-ticker running share balance, seeded from each ticker's existing open
-    # position so an equity sell can legitimately draw on already-owned /
-    # assigned shares. Lazily populated the first time a ticker is seen.
-    running_shares: dict[str, int] = {}
+    # Unmatched-sell pre-check (AC3c): equity sells with no shares to draw on
+    # are skipped and recorded, never inserted (prevents negative shares at the
+    # user-visible layer). Computed once here from the SAME simulation
+    # ``build_preview`` uses, so the preview's "will skip" flag and what we
+    # actually skip can never drift.
+    unmatched_indices = _detect_unmatched_sells(db, mapped_trades)
 
-    def _seed_running_shares(ticker: str) -> int:
-        if ticker not in running_shares:
-            existing = (
-                db.query(Position)
-                .filter(Position.ticker == ticker, Position.status == "open")
-                .order_by(Position.opened_at.desc())
-                .first()
-            )
-            running_shares[ticker] = existing.shares if existing else 0
-        return running_shares[ticker]
-
-    for mapped in mapped_trades:
+    for idx, mapped in enumerate(mapped_trades):
         ticker = mapped["ticker"]
         trade_type = mapped["trade_type"]
-        quantity = mapped.get("quantity") or 0
 
         if is_duplicate(
             db,
@@ -327,36 +379,26 @@ def execute_mapped_import(
             quantity=mapped.get("quantity"),
             close_reason=mapped.get("close_reason"),
         ):
-            # A duplicate equity row is already reflected in the existing
-            # position's share balance — do NOT touch ``running_shares``.
             skipped += 1
             continue
 
-        # Unmatched-sell pre-check (AC3c): an equity sell with no shares to draw
-        # from is skipped and recorded, never inserted (prevents negative shares
-        # at the user-visible layer). Buys grow the running balance.
-        if trade_type == "buy_stock":
-            running_shares[ticker] = _seed_running_shares(ticker) + quantity
-        elif trade_type == "sell_stock":
-            available = _seed_running_shares(ticker)
-            if quantity > available:
-                logger.warning(
-                    "Skipping unmatched equity sell with no shares to draw on",
-                    extra={
-                        "event": "equity_import.unmatched_sell",
-                        "outcome": "no_data",
-                        "ticker": ticker,
-                    },
-                )
-                skipped_unmatched.append(
-                    {
-                        "ticker": ticker,
-                        "opened_at": mapped["opened_at"],
-                        "quantity": quantity,
-                    }
-                )
-                continue
-            running_shares[ticker] = available - quantity
+        if idx in unmatched_indices:
+            logger.warning(
+                "Skipping unmatched equity sell with no shares to draw on",
+                extra={
+                    "event": "equity_import.unmatched_sell",
+                    "outcome": "no_data",
+                    "ticker": ticker,
+                },
+            )
+            skipped_unmatched.append(
+                {
+                    "ticker": ticker,
+                    "opened_at": mapped["opened_at"],
+                    "quantity": mapped.get("quantity") or 0,
+                }
+            )
+            continue
 
         position = (
             db.query(Position)

--- a/backend/app/services/schwab_import.py
+++ b/backend/app/services/schwab_import.py
@@ -231,6 +231,13 @@ def _detect_unmatched_sells(db: Session, mapped_trades: list[dict]) -> set[int]:
     sell can legitimately draw on already-owned/assigned shares; buys earlier in
     the same import grow the balance; duplicate rows are already reflected in the
     existing share count and do not move the balance.
+
+    The simulation walks rows in **chronological order** (by ``opened_at``), not
+    file order: Schwab CSV exports are often newest-first, so a sell can be
+    listed *above* the buy that covers it. Walking by date prevents falsely
+    flagging such a sell as unmatched. Returned indices are into the ORIGINAL
+    ``mapped_trades`` list so callers can match by position. (The recomputer
+    re-sorts the ledger on replay regardless, so insertion order is unaffected.)
     """
     running: dict[str, int] = {}
     unmatched: set[int] = set()
@@ -246,7 +253,13 @@ def _detect_unmatched_sells(db: Session, mapped_trades: list[dict]) -> set[int]:
             running[ticker] = existing.shares if existing else 0
         return running[ticker]
 
-    for idx, mapped in enumerate(mapped_trades):
+    # Stable chronological order; ties keep original file order (ascending index).
+    chronological = sorted(
+        range(len(mapped_trades)),
+        key=lambda i: mapped_trades[i].get("opened_at") or "",
+    )
+    for idx in chronological:
+        mapped = mapped_trades[idx]
         ticker = mapped["ticker"]
         trade_type = mapped["trade_type"]
         quantity = mapped.get("quantity") or 0

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -2528,6 +2528,11 @@
             },
             "title": "Trades",
             "type": "array"
+          },
+          "unmatched": {
+            "default": 0,
+            "title": "Unmatched",
+            "type": "integer"
           }
         },
         "required": [
@@ -2570,6 +2575,11 @@
           },
           "is_duplicate": {
             "title": "Is Duplicate",
+            "type": "boolean"
+          },
+          "is_unmatched": {
+            "default": false,
+            "title": "Is Unmatched",
             "type": "boolean"
           },
           "opened_at": {

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -887,3 +887,35 @@ class TestPreviewFlagsUnmatchedSells:
         preview = build_preview(db_session, mapped)
         assert preview["unmatched"] == 0
         assert all(t["is_unmatched"] is False for t in preview["trades"])
+
+    def test_buy_listed_after_sell_but_earlier_in_time_is_matched(self, db_session):
+        # CodeRabbit #397: Schwab exports are often newest-first, so the sell can
+        # be listed ABOVE the buy that covers it. Chronological simulation must
+        # NOT flag it as unmatched.
+        from app.services.schwab_import import build_preview
+
+        mapped = [
+            _equity_mapped("F", "sell_stock", "2026-03-20", unit_amount=15.0, quantity=50),
+            _equity_mapped("F", "buy_stock", "2026-03-01", unit_amount=11.0, quantity=100),
+        ]
+        preview = build_preview(db_session, mapped)
+        assert preview["unmatched"] == 0
+        assert all(t["is_unmatched"] is False for t in preview["trades"])
+
+        result = execute_mapped_import(db_session, mapped)
+        assert result["skipped_unmatched"] == []
+        assert result["imported"] == 2
+
+    def test_sell_chronologically_before_any_buy_is_unmatched(self, db_session):
+        # The sell (01-01) genuinely precedes the buy (02-01) in time, even though
+        # the buy is listed first -> correctly flagged unmatched.
+        from app.services.schwab_import import build_preview
+
+        mapped = [
+            _equity_mapped("F", "buy_stock", "2026-02-01", unit_amount=11.0, quantity=100),
+            _equity_mapped("F", "sell_stock", "2026-01-01", unit_amount=15.0, quantity=50),
+        ]
+        preview = build_preview(db_session, mapped)
+        assert preview["unmatched"] == 1
+        by = {(t["ticker"], t["trade_type"]): t for t in preview["trades"]}
+        assert by[("F", "sell_stock")]["is_unmatched"] is True

--- a/backend/tests/test_schwab_import.py
+++ b/backend/tests/test_schwab_import.py
@@ -834,3 +834,56 @@ class TestDedupDiscriminatorComposition:
         # Option lifecycle types are NOT equity — they keep the 5-tuple key.
         assert "sell_put" not in _EQUITY_TRADE_TYPES
         assert "assignment" not in _EQUITY_TRADE_TYPES
+
+
+@pytest.mark.integration
+class TestPreviewFlagsUnmatchedSells:
+    """The preview must flag unmatched equity sells (AC3c / PRD #384 Q2) and the
+    flag must agree with what execute_mapped_import actually skips."""
+
+    def test_preview_flags_unmatched_sell_and_excludes_from_new_count(self, db_session):
+        from app.services.schwab_import import build_preview
+
+        mapped = [
+            _equity_mapped("F", "buy_stock", "2026-03-01", unit_amount=11.0, quantity=100),
+            _equity_mapped("F", "sell_stock", "2026-03-20", unit_amount=15.0, quantity=50),
+            _equity_mapped("T", "sell_stock", "2026-03-28", unit_amount=18.0, quantity=100),
+        ]
+        preview = build_preview(db_session, mapped)
+
+        assert preview["total"] == 3
+        assert preview["duplicates"] == 0
+        assert preview["unmatched"] == 1
+        # buy F + matched sell F count as importable; the unmatched T sell does not.
+        assert preview["new_count"] == 2
+
+        by_ticker = {(t["ticker"], t["trade_type"]): t for t in preview["trades"]}
+        assert by_ticker[("T", "sell_stock")]["is_unmatched"] is True
+        assert by_ticker[("F", "sell_stock")]["is_unmatched"] is False
+        assert by_ticker[("F", "buy_stock")]["is_unmatched"] is False
+
+    def test_preview_flag_agrees_with_execute_skip(self, db_session):
+        from app.services.schwab_import import build_preview
+
+        mapped = [
+            _equity_mapped("F", "buy_stock", "2026-03-01", unit_amount=11.0, quantity=100),
+            _equity_mapped("T", "sell_stock", "2026-03-28", unit_amount=18.0, quantity=100),
+        ]
+        preview = build_preview(db_session, mapped)  # read-only
+        result = execute_mapped_import(db_session, mapped)
+
+        # The preview's unmatched count must equal what execute actually skipped.
+        assert preview["unmatched"] == len(result["skipped_unmatched"]) == 1
+        assert result["skipped_unmatched"][0]["ticker"] == "T"
+        assert result["imported"] == 1  # only the F buy
+
+    def test_preview_no_unmatched_when_all_sells_covered(self, db_session):
+        from app.services.schwab_import import build_preview
+
+        mapped = [
+            _equity_mapped("F", "buy_stock", "2026-03-01", unit_amount=11.0, quantity=100),
+            _equity_mapped("F", "sell_stock", "2026-03-20", unit_amount=15.0, quantity=100),
+        ]
+        preview = build_preview(db_session, mapped)
+        assert preview["unmatched"] == 0
+        assert all(t["is_unmatched"] is False for t in preview["trades"])

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -2488,6 +2488,11 @@ export interface components {
             total: number;
             /** Trades */
             trades: components["schemas"]["ImportPreviewTrade"][];
+            /**
+             * Unmatched
+             * @default 0
+             */
+            unmatched: number;
         };
         /** ImportPreviewTrade */
         ImportPreviewTrade: {
@@ -2499,6 +2504,11 @@ export interface components {
             fees: number;
             /** Is Duplicate */
             is_duplicate: boolean;
+            /**
+             * Is Unmatched
+             * @default false
+             */
+            is_unmatched: boolean;
             /** Opened At */
             opened_at: string;
             /** Premium */

--- a/frontend/components/journal/ImportModal.jsx
+++ b/frontend/components/journal/ImportModal.jsx
@@ -175,6 +175,22 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
                 <li>Positions created: {result.positions_created}</li>
               </ul>
             </div>
+            {result.skipped_unmatched && result.skipped_unmatched.length > 0 && (
+              <div
+                data-testid="import-unmatched-warning"
+                className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-4"
+              >
+                <p className="text-amber-800 dark:text-amber-200 font-medium">
+                  Skipped {result.skipped_unmatched.length} unmatched{' '}
+                  {result.skipped_unmatched.length === 1 ? 'sell' : 'sells'}
+                </p>
+                <p className="mt-1 text-sm text-amber-700 dark:text-amber-300">
+                  These stock sells had no prior shares to draw on (
+                  {[...new Set(result.skipped_unmatched.map((s) => s.ticker))].join(', ')}
+                  ). Import the matching buys first, then re-import to capture them.
+                </p>
+              </div>
+            )}
             <button onClick={onClose} className="px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700">
               Done
             </button>
@@ -183,7 +199,8 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
           <div data-testid="import-preview" className="space-y-4">
             <p className="text-sm text-slate-600 dark:text-slate-400">
               {preview.account_number ? `Account: ${preview.account_number} | ` : ''}
-              {preview.total} trades found | {preview.duplicates} duplicates | {preview.new_count} new
+              {preview.total} trades found | {preview.duplicates} duplicates
+              {preview.unmatched > 0 ? ` | ${preview.unmatched} unmatched` : ''} | {preview.new_count} new
             </p>
 
             {emptyPreview && mode === MODES.API && (
@@ -280,6 +297,10 @@ export default function ImportModal({ onClose, onPreview, onImport, onPreviewCsv
                           {t.is_duplicate ? (
                             <span data-testid="duplicate-badge" className="px-2 py-0.5 text-xs font-medium rounded-full bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
                               Duplicate
+                            </span>
+                          ) : t.is_unmatched ? (
+                            <span data-testid="unmatched-badge" title="No prior shares to draw on — will be skipped on import" className="px-2 py-0.5 text-xs font-medium rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+                              Unmatched — will skip
                             </span>
                           ) : (
                             <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300">

--- a/frontend/e2e/equity-na-rendering.spec.js
+++ b/frontend/e2e/equity-na-rendering.spec.js
@@ -338,3 +338,65 @@ test.describe('Equity journal rendering (issues #389 + #387) @e2e', () => {
     await expect(dividendRow.getByTestId('na-placeholder')).toHaveCount(3);
   });
 });
+
+// --- Unmatched-sell surfacing (AC3c / PRD #384 Q2) ---------------------------
+
+// A buy + an unmatched sell (no prior shares): the sell is flagged in the
+// preview and reported in the result instead of being silently dropped.
+const UNMATCHED_PREVIEW = {
+  account_number: '',
+  trades: [
+    {
+      ticker: 'F', trade_type: 'buy_stock', strike: null, expiration: null,
+      premium: 0.0, unit_amount: 11.0, fees: 0.0, quantity: 100,
+      opened_at: '2026-03-01', close_reason: null, is_duplicate: false, is_unmatched: false,
+    },
+    {
+      ticker: 'T', trade_type: 'sell_stock', strike: null, expiration: null,
+      premium: 0.0, unit_amount: 18.0, fees: 0.65, quantity: 100,
+      opened_at: '2026-03-28', close_reason: null, is_duplicate: false, is_unmatched: true,
+    },
+  ],
+  total: 2, duplicates: 0, unmatched: 1, new_count: 1,
+};
+
+const UNMATCHED_RESULT = {
+  imported: 1, skipped_duplicates: 0, positions_created: 1,
+  skipped_unmatched: [{ ticker: 'T', opened_at: '2026-03-28', quantity: 100 }],
+};
+
+test.describe('Unmatched equity sells (AC3c / PRD #384 Q2) @e2e', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupPreviewMocks(page, UNMATCHED_PREVIEW);
+    await page.goto('/journal');
+  });
+
+  test('preview flags the unmatched sell and counts it', async ({ page }) => {
+    await openCsvPreview(page);
+    const badge = page.getByTestId('unmatched-badge');
+    await expect(badge).toHaveCount(1);
+    await expect(badge).toContainText('Unmatched');
+    await expect(page.getByTestId('import-preview')).toContainText('1 unmatched');
+  });
+
+  test('result modal reports the skipped unmatched sell', async ({ page }) => {
+    await page.route('**/api/journal/import/csv', (route) => {
+      if (route.request().method() === 'POST') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(UNMATCHED_RESULT),
+        });
+      }
+      return route.continue();
+    });
+    await openCsvPreview(page);
+    await page.getByTestId('confirm-import-btn').click();
+    const result = page.getByTestId('import-result');
+    await expect(result).toBeVisible();
+    const warning = page.getByTestId('import-unmatched-warning');
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText('Skipped 1 unmatched');
+    await expect(warning).toContainText('T');
+  });
+});


### PR DESCRIPTION
## Why

QA on v1.8.0 (#392) surfaced a gap: an **unmatched equity sell** (a `sell_stock` with no prior shares) is correctly skipped by the backend — no negative shares — but the UI never said so. The preview showed the row as **"New"**, and the result modal reported `Imported: 6` of 7 with no explanation. PRD #384 **Q2** explicitly requires: *"surface it in the import preview as an explicit 'unmatched sell — will be skipped' line so the user can import the missing buy first."* So this is an **AC3c/Q2 surfacing gap**, caught before prod.

## What

- **`_detect_unmatched_sells(db, mapped_trades)`** — one running-share simulation now shared by **both** `build_preview` and `execute_mapped_import`, so the preview's flag and the actual skip can never drift. (Execute's inline logic was refactored onto it; 102 existing import tests still pass unchanged.)
- **`build_preview`** flags each unmatched sell (`is_unmatched`), counts them (`unmatched`), and excludes them from `new_count`.
- **Schema**: `ImportPreviewTrade.is_unmatched` + `ImportPreviewResponse.unmatched` (default `False`/`0` — option/buy/dividend rows unaffected).
- **Frontend** (`ImportModal.jsx`): amber **"Unmatched — will skip"** preview badge, an **"N unmatched"** count in the summary line, and a **result-modal warning** listing the skipped tickers with guidance to import the buys first.

## Tests

- Backend integration: preview flags the unmatched sell, excludes it from `new_count`, and **agrees with what `execute` skips** (same simulation).
- E2E (2): preview badge + count; result-modal warning.
- Full suite **1939 passed**; classifier / TEST-MATRIX / ac_registry / tdd_red gates all clean; openapi + types regenerated.

Completes v1.8.0's AC3c so it ships meeting all its ACs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)