### PR TITLE
fix(deploy): QA token-scrub was eating the deploy heredoc's stdin (silent no-op deploys)

### DIFF
--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -160,8 +160,16 @@ jobs:
             # is already pulled above. QA-only — prod legitimately holds tokens +
             # the key, and seed-qa's APP_ENV=production guard never reaches here.
             if [ "${{ inputs.environment }}" = "qa" ]; then
+              # ``</dev/null`` is load-bearing: this whole script is piped to
+              # ``bash -s`` over ssh stdin (the <<'ENDSSH' heredoc). The scrub's
+              # ``docker compose run`` would otherwise inherit that stdin and
+              # consume the REST of the heredoc (``up -d --force-recreate``, the
+              # smoke gate, the seed, the digest assertion) as the container's
+              # input — they would silently never execute and the deploy would
+              # still report success on the stale container. Detaching stdin
+              # here keeps the remaining deploy steps runnable.
               COMPOSE_FILE="${{ inputs.compose_file }}" PROJECT="$(basename "$(pwd)")" \
-                bash deploy/qa-scrub-schwab-tokens.sh
+                bash deploy/qa-scrub-schwab-tokens.sh </dev/null
             fi
             # --force-recreate (PR: deploy stale-container fix): plain `up -d`
             # can leave the OLD container running when only the pinned image

--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -160,14 +160,9 @@ jobs:
             # is already pulled above. QA-only — prod legitimately holds tokens +
             # the key, and seed-qa's APP_ENV=production guard never reaches here.
             if [ "${{ inputs.environment }}" = "qa" ]; then
-              # ``</dev/null`` is load-bearing: this whole script is piped to
-              # ``bash -s`` over ssh stdin (the <<'ENDSSH' heredoc). The scrub's
-              # ``docker compose run`` would otherwise inherit that stdin and
-              # consume the REST of the heredoc (``up -d --force-recreate``, the
-              # smoke gate, the seed, the digest assertion) as the container's
-              # input — they would silently never execute and the deploy would
-              # still report success on the stale container. Detaching stdin
-              # here keeps the remaining deploy steps runnable.
+              # </dev/null is load-bearing — without it the scrub's `compose run`
+              # reads this ssh heredoc as stdin and swallows the rest of the
+              # deploy (up -d, seed, digest assert). See the scrub script header.
               COMPOSE_FILE="${{ inputs.compose_file }}" PROJECT="$(basename "$(pwd)")" \
                 bash deploy/qa-scrub-schwab-tokens.sh </dev/null
             fi

--- a/backend/tests/test_qa_prestart_scrub_wiring.py
+++ b/backend/tests/test_qa_prestart_scrub_wiring.py
@@ -32,7 +32,14 @@ def test_scrub_script_exists_and_invokes_the_python_module():
     # `compose exec` (which needs a running container — the very thing the
     # tokens prevent). Assert the exact command shape rather than the absence of
     # the word "exec" (which legitimately appears in the explanatory header).
-    assert 'run --rm --no-deps "$BACKEND_SVC" python -m scripts.scrub_schwab_tokens' in text
+    # -T + </dev/null are load-bearing: the scrub runs from the deploy heredoc
+    # (ssh pipes the whole script to `bash -s`); an attached stdin makes
+    # `compose run` swallow the rest of the heredoc (up -d / seed / digest
+    # assert). Pin them so the stale-container fix can't silently regress.
+    assert (
+        'run --rm --no-deps -T "$BACKEND_SVC" '
+        "python -m scripts.scrub_schwab_tokens </dev/null"
+    ) in text
 
 
 @pytest.mark.unit

--- a/deploy/qa-scrub-schwab-tokens.sh
+++ b/deploy/qa-scrub-schwab-tokens.sh
@@ -46,4 +46,9 @@ echo ">>> Pre-start Schwab-token scrub (QA boots without SCHWAB_ENCRYPTION_KEY).
 # --no-deps: don't pull up qa-frontend etc. --rm: leave no stray container.
 # The overridden command (`python -m ...`) bypasses the uvicorn CMD, so the
 # fail-closed lifespan check never runs — this works even mid-crash-loop.
-$COMPOSE run --rm --no-deps "$BACKEND_SVC" python -m scripts.scrub_schwab_tokens
+# -T (no TTY) + </dev/null: when this runs from the deploy heredoc (ssh pipes
+# the whole script to `bash -s`), an attached stdin makes `compose run` consume
+# the REST of the heredoc as the container's input — silently swallowing the
+# subsequent `up -d` / seed / digest-assert steps (the QA stale-container
+# incident). Detach stdin so only this scrub runs in the one-off container.
+$COMPOSE run --rm --no-deps -T "$BACKEND_SVC" python -m scripts.scrub_schwab_tokens </dev/null


### PR DESCRIPTION
## The bug

QA auto-deploys have been **silent no-ops since #380**. The deploy runs as one heredoc piped to `bash -s` over ssh stdin. The QA-only Schwab-token scrub runs `docker compose run …` **without `-T` and without detaching stdin**, so it inherits the ssh stdin and **consumes the rest of the heredoc** — `up -d --force-recreate`, the smoke gate, the seed, and the #395 digest assertion — as the scrub container's input. Those lines never execute.

Result: the running container is never recreated, yet `deploy-qa` reports **success** (nothing failed — the steps simply didn't run). The v1.8.0 release exposed it: QA sat **46h on the pre-release image** across three "successful" deploys; it only updated when recreated by hand. The #395 digest assertion that should have caught this was itself swallowed by the scrub.

## Fix

Detach the scrub from the heredoc stdin:
- `</dev/null` on the scrub invocation in `_deploy-ssh.yml`
- `-T` + `</dev/null` on the `docker compose run` inside `deploy/qa-scrub-schwab-tokens.sh` (defence in depth)

After this, the QA deploy reaches `up -d --force-recreate`, the seed, and the digest assertion — so QA auto-deploys actually deploy, and a stale container now fails the deploy (the #395 guarantee, finally reachable on QA).

## Scope / safety

- **Prod is unaffected** — the scrub is QA-only (`if environment == qa`), so prod deploys already reach `up -d`. The v1.8.0 prod release does not depend on this.
- ⚠️ Deploy workflows aren't covered by PR CI. The real gate is the **first post-merge QA Deploy run** — confirm it recreates the container and logs `digest-assert OK`.
- QA is currently on the #397 image (hand-recreated); this makes the *automation* correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)