### PR TITLE
fix(deploy): digest-assert must read RepoDigests from the image, not the container

### DIFF
--- a/.github/workflows/_deploy-ssh.yml
+++ b/.github/workflows/_deploy-ssh.yml
@@ -188,7 +188,12 @@ jobs:
               if [ -z "$svc" ]; then echo "::warning::digest-assert: no '${role}' service in ${{ inputs.compose_file }} — skipping"; return 0; fi
               cid=$(docker compose -f ${{ inputs.compose_file }} ps -q "$svc")
               if [ -z "$cid" ]; then echo "::error::digest-assert: ${svc} has no running container after up -d"; return 1; fi
-              running=$(docker inspect "$cid" --format '{{range .RepoDigests}}{{println .}}{{end}}' | sed -n 's/.*@//p' | head -1)
+              # RepoDigests lives on the IMAGE, not the container — resolve the
+              # container's image id first, then read the image's repo digest.
+              # (Inspecting the container for RepoDigests yields <none> and
+              # false-fails the assert.)
+              img=$(docker inspect "$cid" --format '{{.Image}}')
+              running=$(docker inspect "$img" --format '{{range .RepoDigests}}{{println .}}{{end}}' | sed -n 's/.*@//p' | head -1)
               if [ -n "$want" ] && [ "$running" != "$want" ]; then
                 echo "::error::digest-assert: ${svc} is running '${running:-<none>}' but the deploy pinned '${want}' — stale container, failing the deploy."
                 return 1


### PR DESCRIPTION
## Problem

The #398 stdin fix made the #395 digest assertion finally *run* on QA deploys — and it immediately **false-failed** every deploy:

```
digest-assert: qa-backend is running '<none>' but the deploy pinned 'sha256:44bbbf5d…' — stale container, failing the deploy.
```

The container **was** correctly recreated to the pinned image (verified: `Up 2 minutes`, healthy, latest code). The assertion was wrong: it ran `docker inspect <container> --format '{{range .RepoDigests}}…'`, but **`RepoDigests` is an image field, not a container field** → `map has no entry for key "RepoDigests"` → `<none>`.

## Fix

Resolve the container's image id first, then read the image's repo digest:

```sh
img=$(docker inspect "$cid" --format '{{.Image}}')
running=$(docker inspect "$img" --format '{{range .RepoDigests}}{{println .}}{{end}}' | sed -n 's/.*@//p' | head -1)
```

Verified on the QA box: this yields `ghcr.io/ssandy33/regress-backend@sha256:44bbbf5d…`, matching `BACKEND_IMAGE_DIGEST`.

## Net effect of the deploy-fix chain

- #395 — force-recreate + digest assertion (assertion had this resolution bug)
- #398 — stop the scrub eating the deploy stdin (made the rest of the deploy, incl. the assertion, actually run)
- **this** — correct the assertion's digest resolution

After this, a QA deploy recreates the container (✅ already proven) **and** the assertion passes, so the smoke gate + seed run and the deploy goes green. A genuinely stale container still fails (the digest won't match).

## Current QA state

QA is healthy on the latest image (`44bbbf5d`) — the failed deploy still recreated the container; only the post-recreate assertion aborted (before the seed). The DB seed (SEEDA–H) persists across recreate.

⚠️ Deploy workflows aren't covered by PR CI — the real gate is the next QA Deploy run; I'll confirm it goes fully green with `digest-assert OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)