### PR TITLE
Bump FastAPI(version=) 1.6.1 → 1.8.0 + regen OpenAPI snapshot (#403)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -137,7 +137,7 @@ def _run_security_checks():
 app = FastAPI(
     title="Financial Regression Analysis Tool",
     description="Backend API for financial data fetching, caching, and regression analysis",
-    version="1.6.1",
+    version="1.8.0",
     lifespan=lifespan,
 )
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -6031,7 +6031,7 @@
   "info": {
     "description": "Backend API for financial data fetching, caching, and regression analysis",
     "title": "Financial Regression Analysis Tool",
-    "version": "1.6.1"
+    "version": "1.8.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## What
Bumps `FastAPI(version=...)` in `backend/app/main.py` from the stale `1.6.1` to `1.8.0`, and regenerates `backend/openapi/openapi.json` so the committed snapshot's `info.version` matches.

## Why
The version string was several minors behind the current release line (surfaced during v1.8.0 release readiness, deliberately deferred to the v1.9.x catch-all). It only affects the version reported in `/docs` and the OpenAPI snapshot — no routing or behavior impact.

## Approach decision (per AC)
- **One-time hardcoded bump**, not a single-version-constant wiring. Rationale: this is scoped housekeeping on the patch line; a hardcoded literal matches the existing pattern and is the lowest-risk change. Sourcing the version from a single constant (to avoid recurring staleness) is the better long-term fix but is a larger change that touches the release process — out of scope for this housekeeping patch. Worth a follow-up if version drift recurs.
- **Target value `1.8.0`**: the latest *completed* release milestone whose work is merged to `main` / deployed to QA. `v1.9.0` is still in flight (unreleased), so setting `1.9.0` would overstate an unshipped version; `1.8.0` accurately reflects what `main`/QA currently embodies.

## Snapshot regen
Per CLAUDE.md, `info.version` flows from `FastAPI(version=...)` into the committed snapshot (the regen script intentionally does **not** override it), so a version bump is a deliberate API event that *should* show in the snapshot diff.

- Ran `python -m openapi.regen` → only `info.version` changed (`1.6.1` → `1.8.0`), 55 paths, no other drift.
- `python -m openapi.regen --check` (CI drift-check mirror) passes: `OK: openapi.json matches current code`.
- **No `frontend/api/generated/types.ts` ripple** — `openapi-typescript` does not emit `info.version`, confirmed no version references in the generated types. No `npm run types:regen` needed.

## AC checklist
- [x] `FastAPI(version=...)` reflects the current release line
- [x] Approach (hardcode vs. constant) decided and documented above
- [x] `openapi.json` `info.version` diff committed in the same PR; drift check green
- [x] Confirmed no generated-types ripple

Closes #403