### PR TITLE
fix(a11y): associate Settings form fields with labels (#408)

### DIFF
--- a/frontend/components/settings/SettingsPage.jsx
+++ b/frontend/components/settings/SettingsPage.jsx
@@ -300,6 +300,8 @@ export default function SettingsPage() {
 
             <div className="flex gap-2">
               <input
+                id="fred-api-key"
+                name="fred-api-key"
                 type="password"
                 value={fredKey}
                 onChange={(e) => setFredKey(e.target.value)}
@@ -641,8 +643,10 @@ export default function SettingsPage() {
 
             <div className="space-y-4">
               <div>
-                <label className="block text-sm text-slate-700 dark:text-slate-300 mb-1">Default Date Range</label>
+                <label htmlFor="default-date-range" className="block text-sm text-slate-700 dark:text-slate-300 mb-1">Default Date Range</label>
                 <select
+                  id="default-date-range"
+                  name="default-date-range"
                   value={settings?.default_date_range_years || 5}
                   onChange={(e) => handleUpdateSetting('default_date_range_years', e.target.value)}
                   className="w-full px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-700 text-slate-900 dark:text-slate-100"

--- a/frontend/e2e/settings-a11y.spec.js
+++ b/frontend/e2e/settings-a11y.spec.js
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Settings page accessibility — form-field labeling (issue #408).
+ *
+ * The General tab's "Default Date Range" <select> and the FRED API Key
+ * <input type="password"> shipped with no id/name, and the Default Date Range
+ * <label> had no htmlFor — so screen readers could not announce the select and
+ * password managers could not target the key field.
+ *
+ * These assertions fail on the pre-fix markup (the ids/htmlFor did not exist)
+ * and pass once id/name/htmlFor are wired. Only the generic settings endpoint
+ * needs mocking; the remaining load calls fail gracefully and the General tab
+ * (which holds both controls) renders regardless.
+ */
+function settingsResponse() {
+  return {
+    fred_api_key_set: false,
+    cache_ttl_daily_hours: 24,
+    cache_ttl_monthly_days: 30,
+    default_date_range_years: 5,
+    theme: 'system',
+    schwab_configured: false,
+    schwab_token_expires: null,
+    okr_target_yield: null,
+  };
+}
+
+test.describe('Settings page form-field a11y @smoke @e2e', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/settings', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(settingsResponse()),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'ok' }),
+      });
+    });
+    await page.goto('/settings');
+    // General tab is the default; assert it is active before checking controls.
+    await expect(page.getByTestId('settings-tab-general')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  test('FRED API key input has id and name', async ({ page }) => {
+    const input = page.locator('#fred-api-key');
+    await expect(input).toHaveCount(1);
+    await expect(input).toHaveAttribute('name', 'fred-api-key');
+    await expect(input).toHaveAttribute('type', 'password');
+  });
+
+  test('Default Date Range label is associated with its select', async ({ page }) => {
+    await expect(page.locator('label[for="default-date-range"]')).toHaveCount(1);
+    const select = page.locator('#default-date-range');
+    await expect(select).toHaveCount(1);
+    await expect(select).toHaveAttribute('name', 'default-date-range');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the three accessibility defects on `/settings` (General tab) reported in #408:

- `<input type="password">` (FRED API Key) gains `id="fred-api-key"` and `name="fred-api-key"`.
- `<select>` (Default Date Range) gains `id="default-date-range"` and `name="default-date-range"`.
- `<label>` (Default Date Range) gains `htmlFor="default-date-range"`.

All changes are additive attribute wiring — no logic or styling change.

## Test

Adds `frontend/e2e/settings-a11y.spec.js` (`@smoke @e2e`) asserting:
- `#fred-api-key` exists with `name="fred-api-key"` and `type="password"`.
- `label[for="default-date-range"]` exists.
- `#default-date-range` exists with `name="default-date-range"`.

These fail on the pre-fix markup and pass after.

Closes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)