### PR TITLE
fix(a11y): label analysis sidebar controls and add page <h1> (#409)

### DIFF
--- a/frontend/app/analysis/page.jsx
+++ b/frontend/app/analysis/page.jsx
@@ -212,6 +212,10 @@ export default function AnalysisPage() {
         onRun={handleRun}
         onSave={() => setSaveOpen(true)}
       >
+        {/* Single page-level <h1> anchors the heading hierarchy for assistive
+            tech in every state (loading / error / empty / results). Visually
+            hidden because the page chrome carries the visible title. (#409) */}
+        <h1 className="sr-only">Regression Analysis</h1>
         {loading ? (
           <LoadingSkeleton />
         ) : error && !result ? (

--- a/frontend/components/controls/AssetSelector.jsx
+++ b/frontend/components/controls/AssetSelector.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useAssetSearch } from '../../hooks/useAssetSearch';
 import { categoryLabel } from '../../utils/formatters';
 
-export default function AssetSelector({ value, onChange, multi = false, placeholder }) {
+export default function AssetSelector({ value, onChange, multi = false, placeholder, id, name }) {
   const { query, setQuery, grouped, loading, recentAssets, addRecent } = useAssetSearch();
   const [open, setOpen] = useState(false);
   const wrapperRef = useRef(null);
@@ -73,6 +73,8 @@ export default function AssetSelector({ value, onChange, multi = false, placehol
       {/* Search input */}
       <div className="relative">
         <input
+          id={id}
+          name={name}
           type="text"
           value={open ? query : (multi ? query : (value || query))}
           onChange={(e) => {

--- a/frontend/components/controls/DateRangePicker.jsx
+++ b/frontend/components/controls/DateRangePicker.jsx
@@ -36,7 +36,7 @@ export default function DateRangePicker({ startDate, endDate, onStartChange, onE
 
   return (
     <div>
-      <label className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1.5">
+      <label htmlFor="date-start" className="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1.5">
         Date Range
       </label>
 
@@ -61,6 +61,8 @@ export default function DateRangePicker({ startDate, endDate, onStartChange, onE
       <div className="flex gap-2">
         <div className="flex-1">
           <DatePicker
+            id="date-start"
+            name="date-start"
             selected={start}
             onChange={handleManualChange(onStartChange)}
             dateFormat="yyyy-MM-dd"
@@ -71,6 +73,8 @@ export default function DateRangePicker({ startDate, endDate, onStartChange, onE
         </div>
         <div className="flex-1">
           <DatePicker
+            id="date-end"
+            name="date-end"
             selected={end}
             onChange={handleManualChange(onEndChange)}
             dateFormat="yyyy-MM-dd"

--- a/frontend/components/layout/Sidebar.jsx
+++ b/frontend/components/layout/Sidebar.jsx
@@ -66,7 +66,7 @@ export default function Sidebar({
           <>
             <div>
               <div className="flex items-center justify-between mb-1.5">
-                <label className="text-xs font-medium text-slate-500 dark:text-slate-400">
+                <label htmlFor="asset-search" className="text-xs font-medium text-slate-500 dark:text-slate-400">
                   {mode === 'multi-factor' ? 'Dependent Variable' : 'Asset'}
                 </label>
                 <button
@@ -77,6 +77,8 @@ export default function Sidebar({
                 </button>
               </div>
               <AssetSelector
+                id="asset-search"
+                name="asset-search"
                 value={asset}
                 onChange={setAsset}
                 placeholder="Search assets..."
@@ -115,8 +117,10 @@ export default function Sidebar({
 
         {/* Earnings overlay (linear mode only) */}
         {mode === 'linear' && (
-          <label className="flex items-center gap-2 cursor-pointer">
+          <label htmlFor="show-earnings" className="flex items-center gap-2 cursor-pointer">
             <input
+              id="show-earnings"
+              name="show-earnings"
               type="checkbox"
               checked={showEarnings}
               onChange={(e) => setShowEarnings(e.target.checked)}

--- a/frontend/e2e/analysis-a11y.spec.js
+++ b/frontend/e2e/analysis-a11y.spec.js
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * /analysis sidebar accessibility — form-field labeling + page heading (#409).
+ *
+ * The sidebar's asset search, both date-range inputs, and the earnings-dates
+ * checkbox shipped with no id/name; their labels had no htmlFor; and the page
+ * had no <h1>. These assertions fail on the pre-fix markup and pass once the
+ * id/name/htmlFor wiring and the page <h1> are added.
+ *
+ * The page defaults to linear mode (where the earnings checkbox renders) and a
+ * fresh browser context starts with empty storage, so the default applies. The
+ * FRED health endpoint is mocked as configured to suppress the setup wizard.
+ */
+test.describe('Analysis sidebar form-field a11y @smoke @e2e', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/settings/health/fred', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ configured: true, valid: true, error: null }),
+      })
+    );
+    await page.goto('/analysis');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('asset search input has an id and an associated label', async ({ page }) => {
+    await expect(page.locator('#asset-search')).toHaveCount(1);
+    await expect(page.locator('label[for="asset-search"]')).toHaveCount(1);
+  });
+
+  test('both date-range inputs have ids', async ({ page }) => {
+    await expect(page.locator('#date-start')).toHaveCount(1);
+    await expect(page.locator('#date-end')).toHaveCount(1);
+  });
+
+  test('earnings-dates checkbox has an id in linear mode', async ({ page }) => {
+    await expect(page.locator('#show-earnings')).toHaveCount(1);
+  });
+
+  test('the page has exactly one <h1>', async ({ page }) => {
+    await expect(page.locator('h1')).toHaveCount(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the form-label and heading defects on `/analysis` reported in #409:

- `AssetSelector` now accepts `id`/`name` props; the sidebar's asset search passes `asset-search`, and its label gains `htmlFor="asset-search"`.
- `DateRangePicker` Start/End inputs gain `id`/`name` `date-start`/`date-end`; the "Date Range" label gains `htmlFor="date-start"`.
- The earnings-dates checkbox gains `id`/`name` `show-earnings`; its wrapping label gains `htmlFor="show-earnings"`.
- A single visually-hidden `<h1>Regression Analysis</h1>` is added inside the page `<Layout>` so the heading hierarchy has a root in every state (loading / error / empty / results). The existing `<h2>` elements are unchanged.

All changes are additive — no logic or styling change.

## Test

Adds `frontend/e2e/analysis-a11y.spec.js` (`@smoke @e2e`) asserting `#asset-search` + `label[for="asset-search"]`, `#date-start`, `#date-end`, `#show-earnings` (linear mode), and exactly one `h1`. These fail on the pre-fix markup and pass after.

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)