### PR TITLE
fix(a11y): label option-scanner filters and fix heading order (#410)

### DIFF
--- a/frontend/components/options/ChainFilters.jsx
+++ b/frontend/components/options/ChainFilters.jsx
@@ -58,10 +58,12 @@ export default function ChainFilters({
       <div className="flex-1 overflow-y-auto">
         {/* Asset Section */}
         <div className="p-4 space-y-4">
-          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Asset</h3>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Asset</h2>
           <div>
-            <label className={labelClass}>Ticker Symbol</label>
+            <label htmlFor="scanner-ticker" className={labelClass}>Ticker Symbol</label>
             <input
+              id="scanner-ticker"
+              name="scanner-ticker"
               type="text"
               value={ticker}
               onChange={(e) => setTicker(e.target.value.toUpperCase())}
@@ -74,10 +76,13 @@ export default function ChainFilters({
 
         {/* Strategy Section */}
         <div className="pt-4 p-4 space-y-4 border-t border-slate-200 dark:border-slate-700">
-          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Strategy</h3>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Strategy</h2>
           <div>
-            <label className={labelClass}>Strategy</label>
-            <div className="flex rounded-lg border border-slate-300 dark:border-slate-600 overflow-hidden">
+            {/* Not a native form control — the strategy picker is a button
+                toggle group, so this is a labelling <span>, not a <label>,
+                and the group is named via aria-labelledby. (#410) */}
+            <span id="scanner-strategy-label" className={labelClass}>Strategy</span>
+            <div role="group" aria-labelledby="scanner-strategy-label" className="flex rounded-lg border border-slate-300 dark:border-slate-600 overflow-hidden">
               <button
                 onClick={() => setStrategy('cash_secured_put')}
                 className={`flex-1 py-2 text-xs font-medium transition-colors ${
@@ -105,8 +110,10 @@ export default function ChainFilters({
           {strategy === 'covered_call' && (
             <>
               <div>
-                <label className={labelClass}>Cost Basis ($)</label>
+                <label htmlFor="scanner-cost-basis" className={labelClass}>Cost Basis ($)</label>
                 <input
+                  id="scanner-cost-basis"
+                  name="scanner-cost-basis"
                   type="number"
                   step="0.01"
                   value={costBasis}
@@ -116,8 +123,10 @@ export default function ChainFilters({
                 />
               </div>
               <div>
-                <label className={labelClass}>Shares Held</label>
+                <label htmlFor="scanner-shares-held" className={labelClass}>Shares Held</label>
                 <input
+                  id="scanner-shares-held"
+                  name="scanner-shares-held"
                   type="number"
                   step="100"
                   value={sharesHeld}
@@ -127,8 +136,10 @@ export default function ChainFilters({
                 />
               </div>
               <div>
-                <label className={labelClass}>Min Call Distance % (10% Rule)</label>
+                <label htmlFor="scanner-call-distance" className={labelClass}>Min Call Distance % (10% Rule)</label>
                 <input
+                  id="scanner-call-distance"
+                  name="scanner-call-distance"
                   type="number"
                   step="0.5"
                   value={callDistance}
@@ -142,8 +153,10 @@ export default function ChainFilters({
           {/* CSP Fields */}
           {strategy === 'cash_secured_put' && (
             <div>
-              <label className={labelClass}>Capital Available ($)</label>
+              <label htmlFor="scanner-capital" className={labelClass}>Capital Available ($)</label>
               <input
+                id="scanner-capital"
+                name="scanner-capital"
                 type="number"
                 step="100"
                 value={capitalAvailable}
@@ -157,32 +170,40 @@ export default function ChainFilters({
 
         {/* Filters Section */}
         <div className="pt-4 p-4 space-y-4 border-t border-slate-200 dark:border-slate-700">
-          <h3 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Filters</h3>
+          <h2 className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Filters</h2>
 
           {/* DTE Range */}
           <div>
-            <label className={labelClass}>DTE Range (days)</label>
+            <label htmlFor="scanner-dte-min" className={labelClass}>DTE Range (days)</label>
             <div className="flex gap-2 items-center">
               <input
+                id="scanner-dte-min"
+                name="scanner-dte-min"
                 type="number"
                 value={minDte}
                 onChange={(e) => setMinDte(parseInt(e.target.value) || 0)}
                 className={`${inputClass} w-20 text-center`}
+                aria-label="DTE Range minimum (days)"
               />
               <span className="text-xs text-slate-400">to</span>
               <input
+                id="scanner-dte-max"
+                name="scanner-dte-max"
                 type="number"
                 value={maxDte}
                 onChange={(e) => setMaxDte(parseInt(e.target.value) || 0)}
                 className={`${inputClass} w-20 text-center`}
+                aria-label="DTE Range maximum (days)"
               />
             </div>
           </div>
 
           {/* Monthly Return Target */}
           <div>
-            <label className={labelClass}>Monthly Return Target (%)</label>
+            <label htmlFor="scanner-return-target" className={labelClass}>Monthly Return Target (%)</label>
             <input
+              id="scanner-return-target"
+              name="scanner-return-target"
               type="number"
               step="0.1"
               value={returnTarget}
@@ -193,30 +214,38 @@ export default function ChainFilters({
 
           {/* Delta Range */}
           <div>
-            <label className={labelClass}>Delta Range</label>
+            <label htmlFor="scanner-delta-min" className={labelClass}>Delta Range</label>
             <div className="flex gap-2 items-center">
               <input
+                id="scanner-delta-min"
+                name="scanner-delta-min"
                 type="number"
                 step="0.01"
                 value={minDelta}
                 onChange={(e) => setMinDelta(parseFloat(e.target.value) || 0)}
                 className={`${inputClass} w-20 text-center`}
+                aria-label="Delta Range minimum"
               />
               <span className="text-xs text-slate-400">to</span>
               <input
+                id="scanner-delta-max"
+                name="scanner-delta-max"
                 type="number"
                 step="0.01"
                 value={maxDelta}
                 onChange={(e) => setMaxDelta(parseFloat(e.target.value) || 0)}
                 className={`${inputClass} w-20 text-center`}
+                aria-label="Delta Range maximum"
               />
             </div>
           </div>
 
           {/* Earnings Buffer */}
           <div>
-            <label className={labelClass}>Earnings Buffer (days)</label>
+            <label htmlFor="scanner-earnings-buffer" className={labelClass}>Earnings Buffer (days)</label>
             <input
+              id="scanner-earnings-buffer"
+              name="scanner-earnings-buffer"
               type="number"
               value={earningsBuffer}
               onChange={(e) => setEarningsBuffer(parseInt(e.target.value) || 0)}

--- a/frontend/components/options/OptionScanner.jsx
+++ b/frontend/components/options/OptionScanner.jsx
@@ -19,6 +19,10 @@ export default function OptionScannerPage() {
 
   return (
     <div className="h-screen flex flex-col bg-slate-100 dark:bg-slate-900">
+      {/* Single page-level <h1> roots the heading hierarchy before any <h2>;
+          visually hidden because the sidebar/header carry the visible title.
+          Demoted sidebar section headers (<h2>) follow it in DOM order. (#410) */}
+      <h1 className="sr-only">Option Scanner</h1>
       <Header sessions={[]} onLoadSession={() => {}} />
 
       <div className="flex-1 flex overflow-hidden">

--- a/frontend/e2e/options-scanner-a11y.spec.js
+++ b/frontend/e2e/options-scanner-a11y.spec.js
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * /options scanner accessibility — form-field labeling + heading order (#410).
+ *
+ * Every ChainFilters input shipped with no id/name, its labels had no htmlFor,
+ * the page had no <h1>, and three <h3> section headers preceded the content
+ * <h2> (broken order). These assertions fail on the pre-fix markup and pass
+ * once id/name/htmlFor are wired, the section headers are demoted to <h2>, and
+ * a single page <h1> is added before them in DOM order.
+ *
+ * CSP is the default strategy (its inputs render immediately); the Covered Call
+ * inputs render only after toggling strategy, so they are checked separately.
+ */
+test.describe('Options scanner form-field a11y @smoke @e2e', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('**/api/settings/health/schwab', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ configured: true, valid: true, error: null, token_expiry: null }),
+      })
+    );
+    await page.goto('/options');
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('always-visible + CSP inputs have ids', async ({ page }) => {
+    for (const id of [
+      '#scanner-ticker',
+      '#scanner-capital',
+      '#scanner-dte-min',
+      '#scanner-dte-max',
+      '#scanner-return-target',
+      '#scanner-delta-min',
+      '#scanner-delta-max',
+      '#scanner-earnings-buffer',
+    ]) {
+      await expect(page.locator(id)).toHaveCount(1);
+    }
+  });
+
+  test('Covered Call inputs have ids after toggling strategy', async ({ page }) => {
+    await page.getByRole('button', { name: 'Covered Call' }).click();
+    for (const id of ['#scanner-cost-basis', '#scanner-shares-held', '#scanner-call-distance']) {
+      await expect(page.locator(id)).toHaveCount(1);
+    }
+  });
+
+  test('every label[for] in the scanner resolves to an existing input', async ({ page }) => {
+    const orphanLabels = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('aside label[for]'));
+      return labels
+        .map((l) => l.getAttribute('for'))
+        .filter((id) => !document.getElementById(id));
+    });
+    expect(orphanLabels).toEqual([]);
+  });
+
+  test('the page has exactly one <h1> and it is the first heading in DOM order', async ({ page }) => {
+    await expect(page.locator('h1')).toHaveCount(1);
+    const firstHeadingTag = await page
+      .locator('h1, h2, h3, h4, h5, h6')
+      .first()
+      .evaluate((el) => el.tagName);
+    expect(firstHeadingTag).toBe('H1');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the form-label and heading defects on `/options` reported in #410 (the highest-volume instance of the systemic a11y pattern):

- All **11** `ChainFilters` inputs gain a unique `id` and `name` (`scanner-ticker`, `scanner-capital`, `scanner-dte-min/max`, `scanner-return-target`, `scanner-delta-min/max`, `scanner-earnings-buffer`, `scanner-cost-basis`, `scanner-shares-held`, `scanner-call-distance`).
- The 9 native-control labels gain `htmlFor`; the dual DTE/Delta range inputs also get `aria-label` so both the min and max ends are individually named (a single label can only point at one).
- The **Strategy** label pointed at a button-toggle group, not a native input — it becomes a `<span id="scanner-strategy-label">` and the toggle group is named via `role="group"` + `aria-labelledby`.
- The three sidebar section headers ("Asset", "Strategy", "Filters") are demoted from `<h3>` to `<h2>`, and a single visually-hidden `<h1>Option Scanner</h1>` is added before them in DOM order so the heading hierarchy has a root and order is valid.

All changes are additive markup/attribute wiring — no logic or styling change.

## Test

Adds `frontend/e2e/options-scanner-a11y.spec.js` (`@smoke @e2e`) asserting: the always-visible/CSP input ids exist; the Covered Call input ids exist after toggling strategy; every `aside label[for]` resolves to an existing input; exactly one `h1`; and the first heading in DOM order is the `h1`. These fail on the pre-fix markup and pass after.

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)