### PR TITLE
test(csp): production securitypolicyviolation regression guard for /dashboard (#405)

### DIFF
--- a/frontend/e2e/csp-nonce.prod.spec.js
+++ b/frontend/e2e/csp-nonce.prod.spec.js
@@ -162,3 +162,106 @@ test.describe('Nonce CSP — production build (#229)', () => {
     ).toHaveLength(0);
   });
 });
+
+/**
+ * Issue #405 — no `script-src` eval violation on the production dashboard.
+ *
+ * The report: Chrome DevTools' *Issues* panel flags a `Content-Security-Policy`
+ * violation on the prod `/dashboard` — `script-src` blocking a string-eval
+ * (`eval()` / `new Function()`). The subtlety is that a *caught* eval probe —
+ * e.g. a bundled `globalThis` polyfill's `Function("return this")()` fallback,
+ * or zod v4's `allowsEval` check — still fires the `securitypolicyviolation`
+ * DOM event *before* the exception is swallowed. The hydration tests (here and
+ * in `csp-nonce.spec.js`) listen on `page.on('console')`, which sees thrown /
+ * logged CSP errors but NOT a silently-caught probe — so neither catches this
+ * class of violation.
+ *
+ * This test lives in the *production-build* suite deliberately. It cannot go in
+ * `csp-nonce.spec.js`: that runs against `next dev`, whose
+ * `react-server-dom-turbopack` **development** runtime legitimately uses `eval`
+ * (hot-reload / flight protocol), firing `securitypolicyviolation` events that
+ * never exist in a production build. Only `next build && next start` (this
+ * config) reproduces what prod actually serves — the same reasoning that put
+ * the #229 guard here rather than in the dev suite.
+ *
+ * On current `main` this passes: a headless-Chromium load of the production
+ * `/dashboard` under the live `script-src 'self' 'nonce-…' 'wasm-unsafe-eval'`
+ * policy (no `'unsafe-eval'`) fires **zero** eval violations. The only
+ * `Function("return this")()` in the browser chunks is short-circuited by a
+ * `typeof globalThis === 'object'` guard and never executes in a modern
+ * browser; zod is a Node-only build-time dependency that never reaches the
+ * bundle. The reported symptom traced to a stale prod image predating the
+ * current Turbopack chunk isolation (Hypothesis C in the issue). This test is
+ * the behavioral regression guard — it goes red if any future change (or a
+ * stale deploy) reintroduces a runtime eval the policy blocks on the dashboard,
+ * and it does so WITHOUT adding `'unsafe-eval'` (the wrong fix, per the AC).
+ *
+ * Run: `npm run test:e2e:prod`. (CI does not run the prod suite yet — issue
+ * #231.)
+ */
+test.describe('Dashboard eval-probe CSP regression — production build (#405)', () => {
+  test('no script-src eval securitypolicyviolation fires on the production /dashboard', async ({
+    page,
+    request,
+  }) => {
+    // The securitypolicyviolation event only fires on a rendered page. With
+    // auth configured `/dashboard` 307s to /auth/signin (matcher-excluded), so
+    // there is no page to observe — skip cleanly, matching the tests above.
+    const probe = await fetchDashboard(request);
+    test.skip(
+      probe.status() >= 300 && probe.status() < 400,
+      'Auth enforced — /dashboard redirects; eval-probe check needs a rendered page',
+    );
+
+    // Register the listener before any page script runs (addInitScript) so a
+    // probe firing during early module evaluation is captured. Collect into a
+    // page-context array and read it back after load — more robust than parsing
+    // console text.
+    await page.addInitScript(() => {
+      window.__cspViolations = [];
+      document.addEventListener('securitypolicyviolation', (event) => {
+        window.__cspViolations.push({
+          violatedDirective: event.violatedDirective,
+          blockedURI: event.blockedURI,
+          sourceFile: event.sourceFile,
+          lineNumber: event.lineNumber,
+          sample: event.sample,
+        });
+      });
+    });
+
+    const response = await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The nonce CSP must actually be in force — a missing policy would make a
+    // "zero violations" result meaningless. Assert the exact prod directive.
+    const scriptSrc = scriptSrcDirective(
+      response.headers()['content-security-policy'],
+    );
+    expect(scriptSrc, 'script-src directive is present').not.toBe('');
+    expect(scriptSrc, 'a per-request nonce is present').toMatch(
+      /'nonce-[A-Za-z0-9+/=]+'/,
+    );
+    expect(
+      scriptSrc,
+      "the wrong fix — 'unsafe-eval' — must NOT be present (issue #405 AC)",
+    ).not.toContain("'unsafe-eval'");
+
+    // Give lazily-imported client chunks (e.g. plotly) a beat to evaluate — the
+    // point at which a bundled eval probe would fire — before reading results.
+    await page.waitForTimeout(2000);
+
+    const violations = await page.evaluate(() => window.__cspViolations || []);
+    // Scope to script-src / eval-family violations — the subject of #405.
+    const evalViolations = violations.filter((v) =>
+      /script-src|eval/i.test(`${v.violatedDirective} ${v.blockedURI}`),
+    );
+
+    expect(
+      evalViolations,
+      `no script-src eval CSP violations on /dashboard: ${JSON.stringify(
+        evalViolations,
+      )}`,
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #405 — the reported prod-dashboard `script-src` eval CSP violation.

**Root cause: stale prod image at report time (Hypothesis C).** The symptom does **not** reproduce on the current `main` production build. This PR ships the regression guard the AC asks for and verifies the current bundle is clean; merging redeploys QA from clean `main` (the Hypothesis-C remedy).

## Evidence gathered this pass (beyond prior triage)

- **Fresh `next build`** (`BUILD_ID nhfbRArmCClMGmgqYUexd`, 47 static chunks): the only eval-family code in the browser chunks is `Function("return this")()` — a `globalThis` polyfill fallback short-circuited by `typeof globalThis === 'object' && globalThis`, so it never executes in a modern browser. Prior triages grepped only for `new Function` / `allowsEval` and missed this minified bare-`Function(` form; it turns out to be guarded dead code regardless.
- **Runtime proof:** a headless-Chromium load of the production `/dashboard` under the live `script-src 'self' 'nonce-…' 'wasm-unsafe-eval'` policy (no `'unsafe-eval'`) fires **zero** `securitypolicyviolation` events. plotly does not eval at runtime; zod is a Node-only build-time dep and never reaches the bundle.
- **Why the dev suite can't host this:** `next dev`'s `react-server-dom-turbopack` **development** runtime legitimately uses `eval` (hot-reload / flight), firing violations that never exist in production. So the guard lives in the **production-build** suite (`csp-nonce.prod.spec.js`, `npm run test:e2e:prod`) — the same reasoning that placed the #229 prod guard there. The AC said "extend `csp-nonce.spec.js`," but that file runs against `next dev` where the assertion is structurally impossible for a dev-only reason.

## Change

- Adds one test to `frontend/e2e/csp-nonce.prod.spec.js`: listens for the `securitypolicyviolation` DOM event (the exact signal Chrome's Issues panel records — a *caught* probe that `page.on('console')` misses) across a full production `/dashboard` load and asserts **zero** `script-src`/eval violations. Also asserts a nonce is present and `'unsafe-eval'` is absent.
- **CSP middleware untouched.** No `'unsafe-eval'`. No production code change.

## Acceptance criteria

- [x] `script-src` gains no `'unsafe-eval'` (asserted by the test; middleware untouched).
- [x] Regression test listening for `securitypolicyviolation` on `/dashboard` (added, prod suite).
- [x] Zod-probe path — N/A: zod is Node-only, not in the browser bundle (verified).
- [x] Stale-image path — this is the root cause; merge redeploys QA clean, and the new test guards recurrence.
- [ ] **One residual human step:** eyeball prod DevTools → Issues on `/dashboard` once after this merge redeploys, to confirm zero violations live. Prod and QA serve identical CSP and the production bundle is proven eval-clean, so a recurrence is not expected.

## Test plan

```
cd frontend && npm run test:e2e:prod   # e2e/csp-nonce.prod.spec.js
```
All 4 prod CSP tests pass (3 existing #229 + the new #405 guard).

Note: the prod e2e suite is not yet wired into CI (issue #231); it runs green locally. This test is green on current `main` because the code is already clean — it goes red if a future change or stale deploy reintroduces a runtime eval on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)