### PR TITLE
fix(test): make dashboard freshness assertion weekend-robust (integration flake)

### DIFF
--- a/backend/tests/test_integration_dashboard.py
+++ b/backend/tests/test_integration_dashboard.py
@@ -1253,15 +1253,25 @@ def test_dashboard_cache_status_quote_driven(client, monkeypatch):
     research/data cache buckets (the #417 bug).
 
     Two positions: one with a minute-old quote (fresh under any market-hours
-    reference) and one with a 3-day-old quote (stale under any reference). The
-    3-day offset makes the assertion independent of when the suite runs (RTH,
-    weekend, or after-hours), per CLAUDE.md's no-pinned-now guidance.
+    reference) and one with a clearly-stale quote. The stale offset must survive
+    the *market-hours-aware* reference: outside RTH the age is measured against
+    the most recent session close (Fri 16:00 ET on a weekend), NOT wall-clock
+    ``now`` (see ``_market_reference_now`` in app/services/dashboard.py). A quote
+    seeded ``now − 3d`` can therefore read as little as ~0.3 market-days old when
+    the suite runs pre-open on a Monday (quote = Fri 09:00 ET, reference = Fri
+    16:00 ET) — which is what made this assertion flake on weekend/pre-open CI
+    runs. Seeding ``now − 6d`` keeps the market-adjusted age ≥ ~3.3 days at every
+    hour of the week, restoring the run-time independence per CLAUDE.md's
+    no-pinned-now guidance.
     """
     _patch_status(monkeypatch, schwab_configured=True, fred_key="abc123")
 
     now = datetime.now(timezone.utc)
     fresh_ms = int((now - timedelta(minutes=1)).timestamp() * 1000)
-    stale_ms = int((now - timedelta(days=3)).timestamp() * 1000)
+    # 6d, not 3d: the age is measured against the most recent session close when
+    # the market is shut, so a 3d seed can fall below the 2d floor on weekend /
+    # pre-open runs. 6d clears it with margin at every run time.
+    stale_ms = int((now - timedelta(days=6)).timestamp() * 1000)
     quote_responses = {
         "NOK": {"lastPrice": 12.5, "quoteTime": fresh_ms},
         "BB": {"lastPrice": 4.2, "quoteTime": stale_ms},
@@ -1288,7 +1298,7 @@ def test_dashboard_cache_status_quote_driven(client, monkeypatch):
     assert cache["displayed_total"] == 2
     assert cache["displayed_stale"] == 1
     assert cache["stalest_symbol"] == "BB"
-    assert cache["stalest_age_seconds"] >= 2 * 24 * 3600  # ~3 days
+    assert cache["stalest_age_seconds"] >= 2 * 24 * 3600  # ≥2d (6d seed, session-close adjusted)
 
     rows = {r["ticker"]: r for r in data["positions"]}
     assert rows["BB"]["quote_stale"] is True


### PR DESCRIPTION
## Problem

`backend/tests/test_integration_dashboard.py::test_dashboard_cache_status_quote_driven` is failing on `main`, blocking the **Backend tests (integration)** required check — and therefore **every PR to `main`** (it's a required check with `enforce_admins: true`). It surfaced blocking PR #427.

```
FAILED ... test_dashboard_cache_status_quote_driven - assert 146605 >= ((2 * 24) * 3600)
```

## Root cause — a weekend/pre-open time-flake

The test seeds the stale quote at `now − 3 days` and asserts `stalest_age_seconds >= 2 days`. But quote age is measured against a **market-hours-aware reference** (`_market_reference_now` in `app/services/dashboard.py`), not wall-clock `now`: when the market is shut it uses the **most recent session close**. On a weekend run, a 3-day-old quote is measured against Friday 16:00 ET, yielding only ~1.7 market-days (the observed 146605s); on a Monday pre-open run it can bottom out at ~0.3 market-days. Either way it falls below the 2-day floor. The docstring *claimed* the 3-day offset made the assertion run-time independent — it didn't account for the session-close reference.

## Fix

Seed the stale quote at `now − 6 days` and document the market-hours reference. Simulating the production `_market_reference_now` / `_most_recent_session_close` across all 168 hours of a week:

| seed | worst-case market-adjusted age | `>= 2d`? |
|------|-------------------------------|----------|
| 3d   | 0.29d (Mon 09:00 ET pre-open) | ❌ FAIL  |
| 6d   | 3.29d (Mon 09:00 ET pre-open) | ✅ PASS  |

6d clears the 2-day floor with margin at every hour of the week. **Test-only change; production dashboard logic untouched.** All other assertions (`displayed_total==2`, `displayed_stale==1`, `stalest_symbol=="BB"`, NOK fresh) are unaffected.

## Test plan

`cd backend && python -m pytest tests/test_integration_dashboard.py::test_dashboard_cache_status_quote_driven` — passes at any run time (verified by deterministic simulation of the production market-reference functions; CI is the authoritative gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)