### PR TITLE
fix(ci): GHCR prune aborts on non-empty exclusion set (bash ${!ARR[*]:-default} trap)

### DIFF
--- a/.github/workflows/ghcr-prune.yml
+++ b/.github/workflows/ghcr-prune.yml
@@ -194,7 +194,16 @@ jobs:
           while IFS= read -r d; do
             [ -n "${d}" ] && EXCLUDED_DIGEST["${d}"]=1
           done <<< "${DEPLOYED_DIGESTS}"
-          echo "Deployed digests excluded from delete: ${!EXCLUDED_DIGEST[*]:-<none>}"
+          # NOTE: use an explicit size check, not ${!ARR[*]:-default}. Combining
+          # associative-array key-listing (${!ARR[*]}) with :-default makes bash
+          # fall back to *indirect expansion* on the array's values (all "1"),
+          # which errors with `1 1 1 1: invalid variable name` and aborts the job
+          # under `set -e` whenever the exclusion set is non-empty.
+          if [ "${#EXCLUDED_DIGEST[@]}" -gt 0 ]; then
+            echo "Deployed digests excluded from delete: ${!EXCLUDED_DIGEST[*]}"
+          else
+            echo "Deployed digests excluded from delete: <none>"
+          fi
 
           prune_package() {
             local pkg="$1"


### PR DESCRIPTION
The scheduled **GHCR retention prune** ([run 29719243630](https://github.com/ssandy33/regress/actions/runs/29719243630)) has been failing with `line 12: 1 1 1 1: invalid variable name` and aborting **before any pruning runs**.

**Root cause:** the excluded-digest log line used `${!EXCLUDED_DIGEST[*]:-<none>}`. Combining associative-array key-listing (`${!ARR[*]}`) with a `:-default` makes bash fall back to **indirect expansion** on the array's *values* (every entry is `=1`, so 4 deployed digests → `"1 1 1 1"`), which it then treats as a variable name → `invalid variable name` → `set -e` kills the job. It only triggers when the exclusion set is **non-empty** — which it now always is (live + N-1 + N-2 digests), so the prune has silently stopped running.

**Impact:** low — old GHCR image versions just aren't pruned (registry storage grows); prod/QA unaffected, and the safety gate wouldn't delete live/rollback images anyway.

**Fix:** replace the fragile expansion with an explicit `${#ARR[@]}` size check.

**Validation:** this workflow is schedule-only (not exercised by PR CI). After merge I'll trigger it via `workflow_dispatch` with `dry_run=true` to confirm it runs clean without deleting anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)