### PR TITLE
v1.9.2 — Account-summary reconcile against a fresh broker value (#429)

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -789,6 +789,13 @@ DASHBOARD_ACTION_TONE = Literal["opportunity", "warning"]
 # empty state rendered as muted italic "no prior close" when the symbol has no
 # prior close, rather than a bare em-dash.
 DASHBOARD_DAY_STATE = Literal["populated", "no_prior_close"]
+# New in v1.9.2 (#429) — tri-state broker-reconciliation verdict. Replaces the
+# bare ``reconciles: bool`` as the source of truth so a broker net-liquidation
+# that is stale-beyond-the-freshness-window (the 15-min cache false-positive that
+# #429 fixes) renders as an honest "unavailable"/"can't confirm" rather than a
+# red "doesn't reconcile". ``reconciles`` stays for back-compat (True iff
+# ``reconciled``).
+DASHBOARD_RECONCILE_STATE = Literal["reconciled", "mismatch", "unavailable"]
 # New in v1.9.0 (#422, PRD #415 R6 / ADR #416 Option B) — the cost basis a
 # risk/review trigger evaluated against. "raw" flags a largest-loser card that
 # fired on the RAW broker-basis drawdown (per ADR #416, raw drives the trigger so
@@ -1110,12 +1117,27 @@ class DashboardAccountSummary(BaseModel):
     ``day_change`` / ``day_change_pct`` / ``day_state`` fields (R3, #421) are the
     account-level day change composed from per-position equity day changes.
 
-    The ``account_value`` / ``equity_mv`` / ``option_mv`` / ``cash`` / ``reconciles``
-    reconciliation fields (R1/R2/R4) are populated by the account-totals worker
-    (extends ``schwab_account_value``); the #421 spine emits them as ``None`` /
-    ``False`` (the "Connect Schwab to reconcile" unavailable state) until that
-    worker lands. All fields are additive/defaulted so the payload validates
-    either way.
+    The ``account_value`` / ``equity_mv`` / ``option_mv`` / ``cash`` /
+    ``reconcile_state`` reconciliation fields (R1/R2/R4) are populated by the
+    account-totals worker (extends ``schwab_account_value``); the #421 spine
+    emits them as ``None`` / ``"unavailable"`` (the "Connect Schwab to
+    reconcile" state) until that worker lands. All fields are
+    additive/defaulted so the payload validates either way.
+
+    ``reconcile_state`` (#429) is the tri-state parity verdict:
+
+    * ``"reconciled"`` — the tool-composed account value matches the broker's
+      *fresh* net-liquidation within quote-timing tolerance.
+    * ``"mismatch"`` — the two disagree beyond tolerance on *fresh* broker
+      data (a real discrepancy worth surfacing loudly).
+    * ``"unavailable"`` — the broker net-liquidation is stale beyond the
+      reconcile-freshness window, disconnected, or otherwise unresolvable. The
+      parity check can't be confirmed right now; render it muted, NOT as a red
+      "doesn't reconcile" (which the 15-min-stale cache used to false-positive
+      — #429).
+
+    ``reconciles`` is retained (back-compat) and is ``True`` iff
+    ``reconcile_state == "reconciled"``.
     """
 
     account_value: Optional[float] = None
@@ -1126,6 +1148,7 @@ class DashboardAccountSummary(BaseModel):
     day_change_pct: Optional[float] = None
     day_state: DASHBOARD_DAY_STATE = "no_prior_close"
     reconciles: bool = False
+    reconcile_state: DASHBOARD_RECONCILE_STATE = "unavailable"
 
 
 class DashboardResponse(BaseModel):

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -40,7 +40,10 @@ from app.services.dashboard_legs import (
     parse_iso_to_utc,
 )
 from app.services.rules_config import load_rules_config
-from app.services.schwab_account_value import get_account_value
+from app.services.schwab_account_value import (
+    AccountValueResult,
+    get_account_value,
+)
 from app.services.schwab_auth import SchwabAuthError, SchwabTokenManager
 # ``SchwabClient`` is re-exported into this module's namespace as the stable
 # monkeypatch surface the dashboard integration tests target
@@ -73,14 +76,28 @@ ACTIVITY_PER_SIDE_LIMIT = 30
 # linked in PR #114 description.
 QUOTE_FANOUT_WORKERS = 8
 
-# Account-value reconciliation tolerance (#420 R1). The tool-composed
-# ``account_value`` (equity MV + option MV + cash) is reconciled to the broker's
-# reported net-liquidation within the GREATER of an absolute floor and a
-# percentage of the broker value — wide enough to absorb the known stale-quote
-# drift (~$17 in the 2026-07-04 evidence) so ``reconciles=false`` signals a real
-# discrepancy, not normal quote-timing noise (Risk #4).
+# Account-value reconciliation tolerance (#420 R1, resized by #429). The
+# tool-composed ``account_value`` (equity MV + option MV + cash) is reconciled to
+# the broker's reported net-liquidation within the GREATER of an absolute floor
+# and a percentage of the broker value. Sized for **quote-timing drift only** —
+# the ~$1.89 last-trade-vs-close spread in the 2026-07-19 evidence — NOT for
+# cache staleness. Staleness is handled separately: the reconcile only runs
+# against a broker net-liq that is fresh within ``RECONCILE_FRESH_WINDOW`` (see
+# below); a stale broker value reads ``"unavailable"``, never ``"mismatch"``.
 RECONCILE_ABS_TOLERANCE = 5.0
 RECONCILE_PCT_TOLERANCE = 0.001
+# Reconcile-freshness window (#429). The broker ``liquidationValue`` is cached
+# for 15 minutes (``schwab_account_value._CACHE_TTL``), but the tool's equity
+# side is live (per-request quote fan-out). Comparing live equity against a
+# 15-min-stale broker value false-positived ``reconciles=false`` on ~$11 of
+# cache drift (the reported bug). We only trust the broker value for the parity
+# check if it was captured within this short window — close enough to the live
+# quotes to be contemporaneous. A cached value fresh within this window is used
+# as-is (NO extra Schwab round-trip); a value staler than this triggers exactly
+# one contemporaneous refresh so both sides reflect ~the same moment. If the
+# refresh can't produce a fresh value (disconnected / transient failure), the
+# reconcile reads ``"unavailable"`` rather than comparing against stale data.
+RECONCILE_FRESH_WINDOW = timedelta(minutes=2)
 # QA-only synthetic account balances (stub pricing_mode). Seeded by seed_qa so
 # the Account Summary strip renders "populated" on QA where there is no live
 # Schwab feed (#420 QA-demoable data).
@@ -998,12 +1015,34 @@ def _reconciles(account_value: float, broker_net_liq: float) -> bool:
     """Return True iff ``account_value`` is within tolerance of ``broker_net_liq``.
 
     Tolerance is the greater of :data:`RECONCILE_ABS_TOLERANCE` and
-    :data:`RECONCILE_PCT_TOLERANCE` × |broker net-liq| (Risk #4).
+    :data:`RECONCILE_PCT_TOLERANCE` × |broker net-liq| — sized for quote-timing
+    drift only (#429). Staleness is gated upstream by
+    :func:`_reconcile_state`, not absorbed here.
     """
     tolerance = max(
         RECONCILE_ABS_TOLERANCE, RECONCILE_PCT_TOLERANCE * abs(broker_net_liq)
     )
     return abs(account_value - broker_net_liq) <= tolerance
+
+
+def _reconcile_state(
+    account_value: float,
+    broker_net_liq: float,
+    broker_value_fresh: bool,
+) -> str:
+    """Resolve the tri-state parity verdict (#429).
+
+    * ``broker_value_fresh is False`` → ``"unavailable"`` — the broker
+      net-liquidation is stale beyond :data:`RECONCILE_FRESH_WINDOW` (or a
+      refresh couldn't produce a contemporaneous value). We cannot honestly
+      compare a live equity side against a stale broker value, so the parity
+      check is "can't confirm right now", NOT a red mismatch.
+    * fresh + within tolerance → ``"reconciled"``.
+    * fresh + outside tolerance → ``"mismatch"`` — a real discrepancy.
+    """
+    if not broker_value_fresh:
+        return "unavailable"
+    return "reconciled" if _reconciles(account_value, broker_net_liq) else "mismatch"
 
 
 def _empty_account_summary() -> dict:
@@ -1023,7 +1062,23 @@ def _empty_account_summary() -> dict:
         # day change reads "no prior close".
         "day_state": "no_prior_close",
         "reconciles": False,
+        "reconcile_state": "unavailable",
     }
+
+
+def _broker_value_is_fresh(
+    result: AccountValueResult, now: Optional[datetime] = None
+) -> bool:
+    """Return True iff ``result.cached_at`` is within :data:`RECONCILE_FRESH_WINDOW`.
+
+    The broker net-liquidation is only trustworthy for the parity check if it
+    was captured close enough to the live equity quotes to be contemporaneous
+    (#429). A missing ``cached_at`` is treated as not-fresh.
+    """
+    if result.cached_at is None:
+        return False
+    reference = now or datetime.now(timezone.utc)
+    return (reference - result.cached_at) < RECONCILE_FRESH_WINDOW
 
 
 def _resolve_account_balances(
@@ -1031,23 +1086,47 @@ def _resolve_account_balances(
 ) -> Optional[dict]:
     """Resolve broker cash + net-liquidation for the account-summary strip.
 
-    Returns ``{"cash": float, "broker_net_liq": Optional[float]}`` or ``None``
-    when no balance source is available (→ empty "Connect Schwab" state).
+    Returns ``{"cash": float, "broker_net_liq": Optional[float],
+    "broker_value_fresh": bool}`` or ``None`` when no balance source is
+    available (→ empty "Connect Schwab" state).
 
-    * **Live** (``schwab_configured``): reads the extended
-      :func:`schwab_account_value.get_account_value` (15-min cached; never
-      raises). Requires a parseable ``cash`` — a net-liq without cash is not
-      enough to render the cash tile honestly.
+    * **Live** (``schwab_configured``): reads
+      :func:`schwab_account_value.get_account_value` with a
+      **reconcile-freshness gate** (#429). The first call respects the 15-min
+      cache (NO round-trip on a cache hit). If the resolved broker value is
+      fresh within :data:`RECONCILE_FRESH_WINDOW`, it is used as-is — no extra
+      Schwab round-trip. If it is stale-for-reconcile (older than the window),
+      exactly one ``force_refresh`` fetch is made so the broker net-liq
+      reflects ~the same moment as the live equity quotes. Requires a
+      parseable ``cash`` — a net-liq without cash is not enough to render the
+      cash tile honestly. ``broker_value_fresh`` reports whether the final
+      value is within the window; a refresh that couldn't produce a fresh
+      value (disconnected / transient failure) reads ``False`` →
+      ``"unavailable"`` reconcile, never a stale-driven ``"mismatch"``.
     * **QA stub** (``pricing_mode == "stub"``): reads the synthetic
       ``qa_account_balances`` ``app_settings`` row seeded by ``seed_qa``. A
       null ``broker_net_liq`` means "reconcile against the tool's own
-      composed value" (QA has no independent broker figure).
+      composed value" (QA has no independent broker figure); it is
+      ``broker_value_fresh=True`` by construction (synthetic, contemporaneous)
+      so the QA strip demos the green ``"reconciled"`` state.
     """
     if schwab_configured:
+        now = datetime.now(timezone.utc)
+        # First call respects the 15-min cache — no round-trip on a cache hit.
         result = get_account_value(db)
+        if not _broker_value_is_fresh(result, now):
+            # Cached broker value is stale for the reconcile window → one
+            # contemporaneous refresh so it lines up with the live equity
+            # quotes. Skipped entirely when the value is already fresh (no
+            # needless Schwab round-trip).
+            result = get_account_value(db, force_refresh=True)
         if result.status not in ("ok", "stale") or result.cash is None:
             return None
-        return {"cash": result.cash, "broker_net_liq": result.total_capital}
+        return {
+            "cash": result.cash,
+            "broker_net_liq": result.total_capital,
+            "broker_value_fresh": _broker_value_is_fresh(result, now),
+        }
 
     if settings.pricing_mode == "stub" and settings.app_env != "production":
         try:
@@ -1072,7 +1151,13 @@ def _resolve_account_balances(
             broker_net_liq, (int, float)
         ):
             broker_net_liq = None
-        return {"cash": float(cash), "broker_net_liq": broker_net_liq}
+        # Synthetic QA balances are contemporaneous by construction — mark them
+        # fresh so the QA strip demos the green "reconciled" state (#429).
+        return {
+            "cash": float(cash),
+            "broker_net_liq": broker_net_liq,
+            "broker_value_fresh": True,
+        }
 
     return None
 
@@ -1107,11 +1192,17 @@ def _build_account_summary(
         account_value = equity_mv + option_mv + cash
 
         # No independent broker net-liq (QA synthetic) → reconcile against the
-        # tool's own composed value so the happy-path "reconciles" state renders.
+        # tool's own composed value so the happy-path "reconciled" state renders.
         broker_net_liq = balances["broker_net_liq"]
         if broker_net_liq is None:
             broker_net_liq = account_value
-        reconciles = _reconciles(account_value, broker_net_liq)
+        # Tri-state verdict (#429): a stale-beyond-window broker value reads
+        # "unavailable", never a false "mismatch". ``reconciles`` is derived for
+        # back-compat (True iff "reconciled").
+        broker_value_fresh = balances.get("broker_value_fresh", False)
+        reconcile_state = _reconcile_state(
+            account_value, broker_net_liq, broker_value_fresh
+        )
 
         summary.update(
             {
@@ -1119,7 +1210,8 @@ def _build_account_summary(
                 "equity_mv": equity_mv,
                 "option_mv": option_mv,
                 "cash": cash,
-                "reconciles": reconciles,
+                "reconcile_state": reconcile_state,
+                "reconciles": reconcile_state == "reconciled",
             }
         )
 

--- a/backend/openapi/openapi.json
+++ b/backend/openapi/openapi.json
@@ -958,7 +958,7 @@
         "type": "object"
       },
       "DashboardAccountSummary": {
-        "description": "Broker-reconciliation strip payload (v1.9.0, PRD #415 R1/R2/R3-account).\n\nNew top-level ``account_summary`` key on the dashboard response. The\n``day_change`` / ``day_change_pct`` / ``day_state`` fields (R3, #421) are the\naccount-level day change composed from per-position equity day changes.\n\nThe ``account_value`` / ``equity_mv`` / ``option_mv`` / ``cash`` / ``reconciles``\nreconciliation fields (R1/R2/R4) are populated by the account-totals worker\n(extends ``schwab_account_value``); the #421 spine emits them as ``None`` /\n``False`` (the \"Connect Schwab to reconcile\" unavailable state) until that\nworker lands. All fields are additive/defaulted so the payload validates\neither way.",
+        "description": "Broker-reconciliation strip payload (v1.9.0, PRD #415 R1/R2/R3-account).\n\nNew top-level ``account_summary`` key on the dashboard response. The\n``day_change`` / ``day_change_pct`` / ``day_state`` fields (R3, #421) are the\naccount-level day change composed from per-position equity day changes.\n\nThe ``account_value`` / ``equity_mv`` / ``option_mv`` / ``cash`` /\n``reconcile_state`` reconciliation fields (R1/R2/R4) are populated by the\naccount-totals worker (extends ``schwab_account_value``); the #421 spine\nemits them as ``None`` / ``\"unavailable\"`` (the \"Connect Schwab to\nreconcile\" state) until that worker lands. All fields are\nadditive/defaulted so the payload validates either way.\n\n``reconcile_state`` (#429) is the tri-state parity verdict:\n\n* ``\"reconciled\"`` — the tool-composed account value matches the broker's\n  *fresh* net-liquidation within quote-timing tolerance.\n* ``\"mismatch\"`` — the two disagree beyond tolerance on *fresh* broker\n  data (a real discrepancy worth surfacing loudly).\n* ``\"unavailable\"`` — the broker net-liquidation is stale beyond the\n  reconcile-freshness window, disconnected, or otherwise unresolvable. The\n  parity check can't be confirmed right now; render it muted, NOT as a red\n  \"doesn't reconcile\" (which the 15-min-stale cache used to false-positive\n  — #429).\n\n``reconciles`` is retained (back-compat) and is ``True`` iff\n``reconcile_state == \"reconciled\"``.",
         "properties": {
           "account_value": {
             "anyOf": [
@@ -1034,6 +1034,16 @@
               }
             ],
             "title": "Option Mv"
+          },
+          "reconcile_state": {
+            "default": "unavailable",
+            "enum": [
+              "reconciled",
+              "mismatch",
+              "unavailable"
+            ],
+            "title": "Reconcile State",
+            "type": "string"
           },
           "reconciles": {
             "default": false,

--- a/backend/tests/test_dashboard_account_summary.py
+++ b/backend/tests/test_dashboard_account_summary.py
@@ -12,7 +12,7 @@ Layer split (PRD #261 R3): pure-function composition + extraction are
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -82,7 +82,14 @@ def _open_position(**overrides) -> dict:
 
 
 def _account_result(**overrides) -> AccountValueResult:
-    base = dict(status="ok", total_capital=10000.0, cash=1365.26)
+    # Default ``cached_at`` is "now" so the broker value is fresh within the
+    # reconcile window (#429) unless a test overrides it with a stale timestamp.
+    base = dict(
+        status="ok",
+        total_capital=10000.0,
+        cash=1365.26,
+        cached_at=datetime.now(timezone.utc),
+    )
     base.update(overrides)
     return AccountValueResult(**base)
 
@@ -397,6 +404,7 @@ def test_dashboard_payload_has_account_summary(client, monkeypatch):
     assert summary["equity_mv"] == pytest.approx(17500.0)  # 100 shares @ 175
     assert summary["account_value"] == pytest.approx(17500.0 + 1365.26)
     assert summary["reconciles"] is True
+    assert summary["reconcile_state"] == "reconciled"
 
 
 @pytest.mark.integration
@@ -411,6 +419,7 @@ def test_dashboard_account_summary_empty_when_disconnected(client, monkeypatch):
     assert summary["account_value"] is None
     assert summary["cash"] is None
     assert summary["reconciles"] is False
+    assert summary["reconcile_state"] == "unavailable"
 
 
 @pytest.mark.integration
@@ -473,3 +482,221 @@ def test_realized_pl_sourced_from_journal_only(client, monkeypatch):
     # … but realized P/L stays 0: no closed premium, no equity realized P&L.
     assert kpis["realized_pl"] == pytest.approx(0.0)
     assert kpis["realized_pl_pct"] is None
+
+
+# -- #429: tri-state reconcile against a freshness-bounded broker value -------
+#
+# The 2026-07-19 bug: a live-computed account value reconciled against a
+# 15-min-cached (stale) broker ``liquidationValue`` false-positived
+# ``reconciles=false`` on ~$11 of cache drift. Fixed by gating the reconcile on
+# broker-value freshness (``RECONCILE_FRESH_WINDOW``) and a tri-state verdict:
+# fresh+near → ``reconciled``; fresh+far → ``mismatch``; stale/unresolved →
+# ``unavailable`` (never a false ``mismatch``).
+
+# Prod evidence numbers (issue #429):
+_EVID_EQUITY = 8519.89
+_EVID_OPTION_CTC = 42.00  # short leg → option_mv = -42.00
+_EVID_CASH = 1398.59
+_EVID_COMPUTED = _EVID_EQUITY - _EVID_OPTION_CTC + _EVID_CASH  # 9876.48
+_EVID_BROKER_LIVE = 9874.59  # Schwab live/close → gap $1.89 (within tolerance)
+_EVID_BROKER_STALE = 9865.59  # 15-min-cached → gap ~$10.89 (the false negative)
+
+
+class TestReconcileStatePredicate:
+    @pytest.mark.unit
+    def test_state_reconciled_when_fresh_and_within_tolerance(self):
+        from app.services.dashboard import _reconcile_state
+
+        assert _reconcile_state(10002.0, 10000.0, broker_value_fresh=True) == "reconciled"
+
+    @pytest.mark.unit
+    def test_state_mismatch_when_fresh_and_outside_tolerance(self):
+        from app.services.dashboard import _reconcile_state
+
+        assert _reconcile_state(10500.0, 10000.0, broker_value_fresh=True) == "mismatch"
+
+    @pytest.mark.unit
+    def test_state_unavailable_when_stale_even_if_within_tolerance(self):
+        # A stale broker value never reconciles OR mismatches — it's unknown.
+        from app.services.dashboard import _reconcile_state
+
+        assert _reconcile_state(10000.0, 10000.0, broker_value_fresh=False) == "unavailable"
+
+    @pytest.mark.unit
+    def test_state_unavailable_when_stale_even_if_far_apart(self):
+        from app.services.dashboard import _reconcile_state
+
+        assert _reconcile_state(10500.0, 10000.0, broker_value_fresh=False) == "unavailable"
+
+
+class TestBrokerValueFreshness:
+    @pytest.mark.unit
+    def test_fresh_within_window(self):
+        from app.services.dashboard import _broker_value_is_fresh
+
+        now = datetime.now(timezone.utc)
+        result = _account_result(cached_at=now - timedelta(seconds=30))
+        assert _broker_value_is_fresh(result, now) is True
+
+    @pytest.mark.unit
+    def test_stale_beyond_window(self):
+        from app.services.dashboard import _broker_value_is_fresh
+
+        now = datetime.now(timezone.utc)
+        result = _account_result(cached_at=now - timedelta(minutes=20))
+        assert _broker_value_is_fresh(result, now) is False
+
+    @pytest.mark.unit
+    def test_missing_cached_at_is_not_fresh(self):
+        from app.services.dashboard import _broker_value_is_fresh
+
+        result = _account_result(cached_at=None)
+        assert _broker_value_is_fresh(result) is False
+
+
+class TestBuildAccountSummaryReconcileState:
+    @pytest.mark.unit
+    def test_reconciled_on_fresh_within_tolerance_regression(self):
+        # AC1 — the 2026-07-19 numbers reconcile against a FRESH broker value:
+        # computed $9,876.48 vs live $9,874.59 = $1.89 gap, within tolerance.
+        rows = [_row(notional=_EVID_EQUITY)]
+        legs = [_leg(cost_to_close=_EVID_OPTION_CTC)]
+        with patch(
+            "app.services.dashboard.get_account_value",
+            return_value=_account_result(
+                cash=_EVID_CASH, total_capital=_EVID_BROKER_LIVE
+            ),
+        ):
+            summary = _build_account_summary(
+                db=None, position_rows=rows, open_legs=legs, schwab_configured=True
+            )
+        assert summary["account_value"] == pytest.approx(_EVID_COMPUTED)
+        assert summary["reconcile_state"] == "reconciled"
+        assert summary["reconciles"] is True
+
+    @pytest.mark.unit
+    def test_unavailable_on_stale_broker_not_mismatch_regression(self):
+        # AC2 — the exact false-negative: computed $9,876.48 vs STALE cached
+        # $9,865.59 is ~$11 apart (beyond tolerance), but because the broker
+        # value is stale the verdict is "unavailable", NOT "mismatch"/False.
+        rows = [_row(notional=_EVID_EQUITY)]
+        legs = [_leg(cost_to_close=_EVID_OPTION_CTC)]
+        stale = datetime.now(timezone.utc) - timedelta(minutes=20)
+        with patch(
+            "app.services.dashboard.get_account_value",
+            return_value=_account_result(
+                cash=_EVID_CASH, total_capital=_EVID_BROKER_STALE, cached_at=stale
+            ),
+        ):
+            summary = _build_account_summary(
+                db=None, position_rows=rows, open_legs=legs, schwab_configured=True
+            )
+        assert summary["reconcile_state"] == "unavailable"
+        assert summary["reconcile_state"] != "mismatch"
+        assert summary["reconciles"] is False
+        # Headline account value is still the computed sum (ties to positions).
+        assert summary["account_value"] == pytest.approx(_EVID_COMPUTED)
+
+    @pytest.mark.unit
+    def test_mismatch_on_fresh_beyond_tolerance(self):
+        # AC3 — a genuine discrepancy on FRESH data reads "mismatch" (alarming).
+        rows = [_row(notional=_EVID_EQUITY)]
+        legs = []
+        with patch(
+            "app.services.dashboard.get_account_value",
+            return_value=_account_result(
+                cash=_EVID_CASH, total_capital=_EVID_EQUITY + _EVID_CASH + 500.0
+            ),
+        ):
+            summary = _build_account_summary(
+                db=None, position_rows=rows, open_legs=legs, schwab_configured=True
+            )
+        assert summary["reconcile_state"] == "mismatch"
+        assert summary["reconciles"] is False
+
+
+class TestReconcileNoRoundTripWhenFresh:
+    @pytest.mark.unit
+    def test_no_schwab_roundtrip_when_fresh_cached(self, monkeypatch):
+        # AC4 — a fresh cached broker value is used as-is; the Schwab client is
+        # never invoked (no needless round-trip).
+        from app.services import schwab_account_value as sav
+        from app.services.dashboard import _resolve_account_balances
+
+        sav.clear_cache()
+        now = datetime.now(timezone.utc)
+        sav._cache["__default__"] = AccountValueResult(
+            status="ok",
+            total_capital=_EVID_BROKER_LIVE,
+            cash=_EVID_CASH,
+            cached_at=now,
+        )
+        calls = {"n": 0}
+
+        class _SpyClient:
+            def get_accounts(self):
+                calls["n"] += 1
+                return []
+
+        monkeypatch.setattr(sav, "SchwabClient", _SpyClient)
+        try:
+            balances = _resolve_account_balances(db=None, schwab_configured=True)
+        finally:
+            sav.clear_cache()
+
+        assert balances is not None
+        assert balances["broker_value_fresh"] is True
+        assert calls["n"] == 0
+
+
+@pytest.mark.integration
+def test_dashboard_reconcile_unavailable_when_broker_stale(client, monkeypatch):
+    """#429 wiring: a stale broker net-liq surfaces reconcile_state=unavailable
+    end-to-end — the headline account value still renders, but the parity check
+    is honestly 'can't confirm', not a red mismatch."""
+    _patch_status(monkeypatch, schwab_configured=True)
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 175.0},
+    )
+    stale = datetime.now(timezone.utc) - timedelta(minutes=20)
+    # Accept the force_refresh kwarg (the stale path retries with it) but keep
+    # returning a stale value so the reconcile stays unavailable.
+    monkeypatch.setattr(
+        "app.services.dashboard.get_account_value",
+        lambda db, **kw: _account_result(
+            cash=1365.26, total_capital=17500.0 + 1365.26 - 250.0, cached_at=stale
+        ),
+    )
+    _seed_position(client)
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    summary = resp.json()["account_summary"]
+    assert summary["reconcile_state"] == "unavailable"
+    assert summary["reconciles"] is False
+    assert summary["account_value"] is not None
+
+
+@pytest.mark.integration
+def test_dashboard_reconcile_reconciled_when_broker_fresh(client, monkeypatch):
+    """#429 wiring: a fresh broker net-liq within tolerance surfaces
+    reconcile_state=reconciled end-to-end."""
+    _patch_status(monkeypatch, schwab_configured=True)
+    monkeypatch.setattr(
+        "app.services.dashboard.SchwabClient.get_quote",
+        lambda self, ticker: {"lastPrice": 175.0},
+    )
+    monkeypatch.setattr(
+        "app.services.dashboard.get_account_value",
+        lambda db, **kw: _account_result(
+            cash=1365.26, total_capital=17500.0 + 1365.26
+        ),
+    )
+    _seed_position(client)
+
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    summary = resp.json()["account_summary"]
+    assert summary["reconcile_state"] == "reconciled"
+    assert summary["reconciles"] is True

--- a/backend/tests/test_stub_pricing_integration.py
+++ b/backend/tests/test_stub_pricing_integration.py
@@ -207,3 +207,10 @@ def test_stub_dashboard_populates_day_change(stub_db):
     summary = payload["account_summary"]
     assert summary["day_state"] == "populated"
     assert summary["day_change"] is not None
+
+    # QA reconcile (#429): the synthetic balances have no live broker
+    # liquidationValue, so the strip reconciles the tool's own composed value
+    # against itself and reads the green "reconciled" demo state — NOT a scary
+    # "mismatch" or a stale "unavailable".
+    assert summary["reconcile_state"] == "reconciled"
+    assert summary["reconciles"] is True

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -1802,12 +1802,27 @@ export interface components {
          *     ``day_change`` / ``day_change_pct`` / ``day_state`` fields (R3, #421) are the
          *     account-level day change composed from per-position equity day changes.
          *
-         *     The ``account_value`` / ``equity_mv`` / ``option_mv`` / ``cash`` / ``reconciles``
-         *     reconciliation fields (R1/R2/R4) are populated by the account-totals worker
-         *     (extends ``schwab_account_value``); the #421 spine emits them as ``None`` /
-         *     ``False`` (the "Connect Schwab to reconcile" unavailable state) until that
-         *     worker lands. All fields are additive/defaulted so the payload validates
-         *     either way.
+         *     The ``account_value`` / ``equity_mv`` / ``option_mv`` / ``cash`` /
+         *     ``reconcile_state`` reconciliation fields (R1/R2/R4) are populated by the
+         *     account-totals worker (extends ``schwab_account_value``); the #421 spine
+         *     emits them as ``None`` / ``"unavailable"`` (the "Connect Schwab to
+         *     reconcile" state) until that worker lands. All fields are
+         *     additive/defaulted so the payload validates either way.
+         *
+         *     ``reconcile_state`` (#429) is the tri-state parity verdict:
+         *
+         *     * ``"reconciled"`` — the tool-composed account value matches the broker's
+         *       *fresh* net-liquidation within quote-timing tolerance.
+         *     * ``"mismatch"`` — the two disagree beyond tolerance on *fresh* broker
+         *       data (a real discrepancy worth surfacing loudly).
+         *     * ``"unavailable"`` — the broker net-liquidation is stale beyond the
+         *       reconcile-freshness window, disconnected, or otherwise unresolvable. The
+         *       parity check can't be confirmed right now; render it muted, NOT as a red
+         *       "doesn't reconcile" (which the 15-min-stale cache used to false-positive
+         *       — #429).
+         *
+         *     ``reconciles`` is retained (back-compat) and is ``True`` iff
+         *     ``reconcile_state == "reconciled"``.
          */
         DashboardAccountSummary: {
             /** Account Value */
@@ -1828,6 +1843,12 @@ export interface components {
             equity_mv?: number | null;
             /** Option Mv */
             option_mv?: number | null;
+            /**
+             * Reconcile State
+             * @default unavailable
+             * @enum {string}
+             */
+            reconcile_state: "reconciled" | "mismatch" | "unavailable";
             /**
              * Reconciles
              * @default false

--- a/frontend/components/dashboard/AccountSummaryRow.jsx
+++ b/frontend/components/dashboard/AccountSummaryRow.jsx
@@ -21,7 +21,16 @@ import { formatCurrency, formatPercent } from '../../utils/formatters';
  *   - unavailable (broker not connected → `summary.cash == null`) → account /
  *     cash tiles show `—` with a "Connect Schwab to reconcile" hint. Distinct
  *     from a false `$0`.
- *   - populated → figures + reconciliation flag.
+ *   - populated → figures + reconciliation badge.
+ *
+ * Reconcile badge (#429) — tri-state `summary.reconcile_state`, surfaced on the
+ * account-value hero tile via `data-reconcile-state` (plus the back-compat
+ * `data-reconciles`):
+ *   - `reconciled` → quiet ✓ (the parity check passed on fresh broker data).
+ *   - `unavailable` → muted "reconcile unavailable" — the broker net-liq is
+ *     stale/disconnected and can't be confirmed right now. NOT alarming.
+ *   - `mismatch` → the only alarming state (amber): a real discrepancy on
+ *     fresh broker data.
  *
  * Grid: `grid-cols-2 lg:grid-cols-4`; Account value spans 2 cols (hero).
  */
@@ -31,6 +40,38 @@ function plColor(value) {
   if (value > 0) return 'text-green-600 dark:text-green-400';
   if (value < 0) return 'text-red-600 dark:text-red-400';
   return undefined;
+}
+
+function ReconcileBadge({ state }) {
+  if (state === 'reconciled') {
+    return (
+      <span
+        data-reconcile-badge="reconciled"
+        className="inline-flex items-center gap-1 text-xs text-green-600 dark:text-green-400 mt-1"
+      >
+        <span aria-hidden="true">✓</span> reconciled with broker
+      </span>
+    );
+  }
+  if (state === 'mismatch') {
+    return (
+      <span
+        data-reconcile-badge="mismatch"
+        className="inline-flex items-center gap-1 text-xs font-medium text-amber-600 dark:text-amber-400 mt-1"
+      >
+        <span aria-hidden="true">⚠</span> doesn&apos;t match broker
+      </span>
+    );
+  }
+  // unavailable — muted "can't confirm", never alarming.
+  return (
+    <span
+      data-reconcile-badge="unavailable"
+      className="inline-flex items-center gap-1 text-xs text-slate-400 dark:text-slate-500 mt-1"
+    >
+      reconcile unavailable
+    </span>
+  );
 }
 
 function signedCurrency(value) {
@@ -81,6 +122,11 @@ export default function AccountSummaryRow({ summary, loading }) {
 
   const cashValue = connected ? formatCurrency(summary.cash) : '—';
 
+  // Reconcile verdict (#429) — tri-state. Only surfaced once the broker
+  // balance resolves (connected); the disconnected strip already shows the
+  // "Connect Schwab to reconcile" hint in the subtext.
+  const reconcileState = summary.reconcile_state || 'unavailable';
+
   // Day change (#421 R3) — populated independently of broker reconciliation.
   const dayState = summary.day_state || 'no_prior_close';
   const dayPopulated = dayState === 'populated' && summary.day_change != null;
@@ -100,15 +146,23 @@ export default function AccountSummaryRow({ summary, loading }) {
     >
       {/* Account value hero — emphasis (blue ring + span) applied by the parent
           wrapper so the shared StatCard recipe stays intact (design spec). */}
-      <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg">
+      <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg relative">
         <StatCard
           label="Account value"
           value={accountValue}
           subtext={breakdown}
           tooltip={connected ? breakdown : undefined}
           dataTestid="kpi-account-value"
-          dataAttrs={{ 'data-reconciles': summary.reconciles ? 'true' : 'false' }}
+          dataAttrs={{
+            'data-reconciles': summary.reconciles ? 'true' : 'false',
+            'data-reconcile-state': reconcileState,
+          }}
         />
+        {connected && (
+          <div className="px-4 pb-3 -mt-2">
+            <ReconcileBadge state={reconcileState} />
+          </div>
+        )}
       </div>
       <StatCard
         label="Cash & sweep"

--- a/frontend/e2e/dashboard-account-parity.spec.js
+++ b/frontend/e2e/dashboard-account-parity.spec.js
@@ -50,6 +50,7 @@ const BASE_PAYLOAD = {
     day_change_pct: null,
     day_state: 'no_prior_close',
     reconciles: true,
+    reconcile_state: 'reconciled',
   },
 };
 
@@ -94,9 +95,14 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
     const accountValue = page.getByTestId('kpi-account-value');
     await expect(accountValue).toContainText('$10,526.76');
     await expect(accountValue).toHaveAttribute('data-reconciles', 'true');
+    await expect(accountValue).toHaveAttribute('data-reconcile-state', 'reconciled');
     // Reconciliation breakdown is traceable in the subtext.
     await expect(accountValue).toContainText('Equity $9,166.00');
     await expect(accountValue).toContainText('Cash $1,365.26');
+    // Quiet reconciled badge (sibling of the tile within the hero wrapper).
+    await expect(page.locator('[data-reconcile-badge="reconciled"]')).toContainText(
+      'reconciled with broker'
+    );
 
     await expect(page.getByTestId('kpi-cash')).toContainText('$1,365.26');
   });
@@ -145,5 +151,55 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
     // Cash renders an em-dash, never a false $0.
     await expect(page.getByTestId('kpi-cash')).toContainText('—');
     await expect(page.getByTestId('kpi-cash')).not.toContainText('$0');
+  });
+
+  test('reconcile_state=unavailable → muted "reconcile unavailable", not alarming (#429)', async ({
+    page,
+  }) => {
+    const stale = {
+      ...BASE_PAYLOAD,
+      account_summary: {
+        ...BASE_PAYLOAD.account_summary,
+        reconciles: false,
+        reconcile_state: 'unavailable',
+      },
+    };
+    await mockDashboard(page, { ...stale, kpis: KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const accountValue = page.getByTestId('kpi-account-value');
+    // Headline value still renders (ties to the positions below).
+    await expect(accountValue).toContainText('$10,526.76');
+    await expect(accountValue).toHaveAttribute('data-reconcile-state', 'unavailable');
+    await expect(accountValue).toHaveAttribute('data-reconciles', 'false');
+    // Muted "can't confirm" copy — NOT a red "doesn't match".
+    await expect(page.locator('[data-reconcile-badge="unavailable"]')).toContainText(
+      'reconcile unavailable'
+    );
+    await expect(page.locator('[data-reconcile-badge="mismatch"]')).toHaveCount(0);
+  });
+
+  test('reconcile_state=mismatch → alarming "doesn\'t match broker" (#429)', async ({
+    page,
+  }) => {
+    const mismatch = {
+      ...BASE_PAYLOAD,
+      account_summary: {
+        ...BASE_PAYLOAD.account_summary,
+        reconciles: false,
+        reconcile_state: 'mismatch',
+      },
+    };
+    await mockDashboard(page, { ...mismatch, kpis: KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const accountValue = page.getByTestId('kpi-account-value');
+    await expect(accountValue).toHaveAttribute('data-reconcile-state', 'mismatch');
+    await expect(accountValue).toHaveAttribute('data-reconciles', 'false');
+    await expect(page.locator('[data-reconcile-badge="mismatch"]')).toContainText(
+      "doesn't match broker"
+    );
   });
 });


### PR DESCRIPTION
Fixes the parity **reconcile flag reading False** even when the account value is within ~$2 of the broker (v1.9.0 R1). Root cause: it compared a *freshly-computed* account value (live equity quotes + options + cash) against a **15-min-cached** broker `liquidationValue`.

Closes #429

### Fix
- **Freshness-gated reconcile** (`RECONCILE_FRESH_WINDOW = 2 min`): a broker value already fresh is used with **no extra Schwab round-trip**; a stale one triggers exactly **one** refresh so both sides are contemporaneous; if it still can't be freshened, the state is **`unavailable`**, never a stale-driven mismatch. Tolerance (`max($5, 0.1%)`) is now documented as quote-timing-only.
- **Tri-state `reconcile_state`**: `reconciled` / `mismatch` / `unavailable` (additive; `reconciles: bool` retained). Frontend renders the three states distinctly (`data-reconcile-state`).
- Headline stays the computed sum (it must equal the positions shown).

### Tests
Regression on the exact 2026-07-19 numbers: fresh $9,874.59 → **reconciled**; stale $9,865.59 → **unavailable** (not mismatch); fresh $500-off → **mismatch**; no round-trip when already fresh. Full backend suite **2062 passed**. OpenAPI/types/TEST-MATRIX regenerated, drift-clean. QA path reads **reconciled**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)