### PR TITLE
ci: give the Playwright shakedown a real backend + health-gate (stabilize flake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,6 +331,53 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      # Shakedown stabilization (ci/stabilize-shakedown): the Playwright
+      # webServer only starts the Next.js dev server; nothing here starts the
+      # backend, so every /api/* the frontend proxies to localhost:8000 got
+      # ECONNREFUSED and any spec that touched a real endpoint (or SSR/proxy)
+      # flaked. Start a stub-pricing backend on 8000 and health-gate on it so
+      # the proxy has something to answer before Playwright runs. Mirrors the
+      # backend-integration job (Python 3.12 + backend/requirements.txt) and the
+      # QA stub path (PRICING_MODE=stub, no live Schwab; ephemeral SQLite DB).
+      # NEXTAUTH_SECRET is intentionally NOT set — auth is opt-in on that var
+      # (frontend/middleware.js + auth.js); setting it would enforce auth and
+      # redirect the dashboard specs to /auth/signin.
+      - name: Set up Python 3.12 (backend for e2e)
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: pip install -r requirements.txt
+
+      - name: Start backend (stub pricing, ephemeral SQLite)
+        working-directory: backend
+        env:
+          PRICING_MODE: stub
+          APP_ENV: development
+          DATABASE_URL: sqlite:///./ci_e2e.db
+        run: |
+          nohup uvicorn app.main:app --host 127.0.0.1 --port 8000 \
+            --log-level warning > /tmp/backend-e2e.log 2>&1 &
+          echo "Backend launched (pid $!)"
+
+      - name: Wait for backend health
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf http://localhost:8000/api/health > /dev/null; then
+              echo "Backend healthy after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Backend did not answer /api/health within 90s"
+          echo "----- backend log -----"
+          cat /tmp/backend-e2e.log || true
+          exit 1
+
       # Quality v1 — Wave 2 (#270): enforce @smoke / @e2e tagging convention.
       # Fails the job if any frontend/e2e/*.spec.js (non-prod) has an untagged
       # test() or test.describe() call at column 0. See CLAUDE.md "Testing
@@ -357,4 +404,5 @@ jobs:
           path: |
             frontend/playwright-report
             frontend/test-results
+            /tmp/backend-e2e.log
           if-no-files-found: ignore

--- a/frontend/e2e/mode-switch.spec.js
+++ b/frontend/e2e/mode-switch.spec.js
@@ -9,6 +9,17 @@ const MODES = [
 
 test.describe('Regression mode selector bar @e2e', () => {
   test.beforeEach(async ({ page }) => {
+    // Mock the FRED health endpoint as configured to suppress the setup
+    // wizard, matching the convention in analysis-a11y / stats-grouped-display.
+    // Without this, a fresh (unconfigured) backend reports configured:false and
+    // the SetupWizard's full-screen overlay intercepts the mode-button clicks.
+    await page.route('**/api/settings/health/fred', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ configured: true, valid: true, error: null }),
+      })
+    );
     await page.goto('/analysis');
     await page.waitForLoadState('networkidle');
   });


### PR DESCRIPTION
## Problem

The **Frontend Playwright (shakedown)** CI job is flaky-red on nearly every run. It's `continue-on-error: true` (non-blocking) but its red is noise and gives no real e2e signal.

### Two root causes

1. **No backend was started.** The `frontend-playwright` job only ran `npx playwright test`, which starts the *frontend* dev server via Playwright's `webServer`. Nothing started the backend, so every `/api/*` the Next.js server proxied to `localhost:8000` got **`ECONNREFUSED`**. Specs that fully mock `/api/*` (via `page.route`) passed; any that hit a real endpoint (or SSR/proxy) flaked.
2. **`MissingSecret` (NextAuth) is only noise.** Confirmed it fails **no** test — it comes from the client `SessionProvider` polling `/api/auth/session`. Auth is opt-in on `NEXTAUTH_SECRET` (`frontend/middleware.js` + `auth.js`); **setting it would enforce auth and redirect the dashboard specs to `/auth/signin`**, so it is intentionally left unset.

## The fix

In the `frontend-playwright` job, start a backend and health-gate on it before Playwright runs:

- Add Python 3.12 setup + `pip install -r backend/requirements.txt` (mirrors `backend-integration`).
- Launch `uvicorn app.main:app --port 8000` in the background with **`PRICING_MODE=stub`** (no live Schwab, QA stub path) + `APP_ENV=development` + an ephemeral SQLite DB.
- Bounded curl-retry loop on **`GET /api/health` → 200** (90s cap) — this health-gate kills the `ECONNREFUSED` race. Backend startup adds ~1 min.
- Backend log is uploaded with the Playwright report on failure.

### One real spec fix (not env)

`mode-switch.spec.js` was the single spec that *relied* on the old ECONNREFUSED behavior. With a real (unconfigured) backend, `/analysis` reports FRED `configured:false` and the `SetupWizard` full-screen overlay intercepts the mode-button clicks (8 failures). Fixed by mocking `/api/settings/health/fred` as `configured:true` in the spec's `beforeEach` — matching the existing convention already used by `analysis-a11y.spec.js` and `stats-grouped-display.spec.js`.

## Validation (local, py3.12 + stub backend on :8000)

- Backend starts in stub mode and answers `/api/health` → `200`.
- **@smoke:** 83 passed, 4 skipped.
- **@e2e:** 418 passed, 13 skipped, 8 failed → all 8 were `mode-switch.spec.js` → **10 passed** after the fred-health mock.
- `MissingSecret` / `ClientFetchError` appear in webserver stdout but fail no test (root cause 2 confirmed).

The shakedown run on this PR is the CI-side proof — see the checks below.

## Not changed

- `continue-on-error` stays `true`; no branch-protection change. This just makes the job actually pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)