### PR TITLE
v1.9.3 — Dashboard visual fixes (#436, #437)

### DIFF
--- a/frontend/components/common/StatCard.jsx
+++ b/frontend/components/common/StatCard.jsx
@@ -4,6 +4,12 @@
  * Hoisted from the inline `StatCard` in StatsPanel.jsx so the dashboard and
  * the regression results panel can share a visual recipe. Adds an optional
  * `subtext` prop for the dashboard's two-line tiles ("3 stock · 1 cash").
+ *
+ * `footer` renders inside the bordered box, below the subtext — a slot for
+ * tile-local affordances (e.g. the reconcile badge, #436) that must live
+ * WITHIN the card border, not escape below it. `h-full` lets the tile stretch
+ * to the grid row height so a row of StatCards shares one baseline even when
+ * one tile carries a footer.
  */
 export default function StatCard({
   label,
@@ -13,12 +19,13 @@ export default function StatCard({
   colorClass,
   dataTestid,
   dataAttrs,
+  footer,
 }) {
   return (
     <div
       data-testid={dataTestid}
       {...(dataAttrs || {})}
-      className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 relative group"
+      className="h-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 relative group"
     >
       <div className="text-xs text-slate-500 dark:text-slate-400 mb-1">{label}</div>
       <div
@@ -33,6 +40,7 @@ export default function StatCard({
           {subtext}
         </div>
       )}
+      {footer}
       {tooltip && (
         <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-slate-800 dark:bg-slate-600 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-10">
           {tooltip}

--- a/frontend/components/common/StatusPill.jsx
+++ b/frontend/components/common/StatusPill.jsx
@@ -11,6 +11,12 @@ import Link from 'next/link';
  * onto the rendered element (e.g. ``{ 'data-freshness-state': 'stale' }``) so
  * callers can attach frozen test/contract attributes without bloating the
  * primitive's prop list.
+ *
+ * ``variant`` (#437): ``'status'`` (default) renders the colored health dot.
+ * ``'count'`` renders a numeric badge instead of a dot — for INFORMATIONAL
+ * counts (e.g. the journal position count) that share the strip but are NOT
+ * health signals. A grey status dot in a row of green health dots reads as
+ * "degraded"; the count badge makes "this is a tally, not a status" explicit.
  */
 const STATE_CLASSES = {
   ok: 'bg-emerald-500',
@@ -26,14 +32,26 @@ export default function StatusPill({
   dataTestid,
   title,
   dataAttrs = {},
+  variant = 'status',
+  count,
 }) {
   const dot = STATE_CLASSES[state] ?? STATE_CLASSES.neutral;
-  const inner = (
-    <>
+  const marker =
+    variant === 'count' ? (
+      // The number is meaningful content (a tally), so it stays readable to
+      // assistive tech — unlike the health dot, whose color carries nothing.
+      <span className="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-slate-100 dark:bg-slate-700 text-slate-700 dark:text-slate-200 text-xs font-semibold tabular-nums">
+        {count}
+      </span>
+    ) : (
       <span
         className={`inline-block w-2.5 h-2.5 rounded-full ${dot}`}
         aria-hidden="true"
       />
+    );
+  const inner = (
+    <>
+      {marker}
       <span className="text-sm text-slate-700 dark:text-slate-200">{label}</span>
     </>
   );

--- a/frontend/components/dashboard/AccountSummaryRow.jsx
+++ b/frontend/components/dashboard/AccountSummaryRow.jsx
@@ -145,8 +145,11 @@ export default function AccountSummaryRow({ summary, loading }) {
       className="grid grid-cols-2 lg:grid-cols-4 gap-4"
     >
       {/* Account value hero — emphasis (blue ring + span) applied by the parent
-          wrapper so the shared StatCard recipe stays intact (design spec). */}
-      <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg relative">
+          wrapper so the shared StatCard recipe stays intact (design spec).
+          The reconcile badge is passed as the StatCard `footer` so it renders
+          INSIDE the tile's bordered box rather than escaping below it (#436);
+          `h-full` keeps the three tiles on one height baseline. */}
+      <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg h-full">
         <StatCard
           label="Account value"
           value={accountValue}
@@ -157,12 +160,8 @@ export default function AccountSummaryRow({ summary, loading }) {
             'data-reconciles': summary.reconciles ? 'true' : 'false',
             'data-reconcile-state': reconcileState,
           }}
+          footer={connected ? <ReconcileBadge state={reconcileState} /> : null}
         />
-        {connected && (
-          <div className="px-4 pb-3 -mt-2">
-            <ReconcileBadge state={reconcileState} />
-          </div>
-        )}
       </div>
       <StatCard
         label="Cash & sweep"

--- a/frontend/components/dashboard/StatusStrip.jsx
+++ b/frontend/components/dashboard/StatusStrip.jsx
@@ -76,7 +76,15 @@ function cachePill(cache) {
 
 function journalPill(journal) {
   const count = journal?.positions_count ?? 0;
-  return { state: 'neutral', label: `Journal ${count} positions` };
+  // Informational count, NOT a health signal (#437): render a numeric badge
+  // rather than a grey status dot so it doesn't read as "journal degraded"
+  // next to the green health pills. Links to /journal.
+  return {
+    variant: 'count',
+    count,
+    label: count === 1 ? 'position in Journal' : 'positions in Journal',
+    title: `${count} open ${count === 1 ? 'position' : 'positions'} in your journal`,
+  };
 }
 
 export default function StatusStrip({ status }) {

--- a/frontend/e2e/dashboard-account-parity.spec.js
+++ b/frontend/e2e/dashboard-account-parity.spec.js
@@ -208,11 +208,12 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
   }) => {
     await mockDashboard(page, { ...BASE_PAYLOAD, kpis: KPIS });
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     // The badge is a DESCENDANT of the account-value tile's bordered box —
-    // not a sibling floating below it (the #436 defect).
+    // not a sibling floating below it (the #436 defect). The visibility +
+    // count assertions auto-wait for render, so no whole-page networkidle.
     const accountValue = page.getByTestId('kpi-account-value');
+    await expect(accountValue).toBeVisible();
     await expect(
       accountValue.locator('[data-reconcile-badge="reconciled"]')
     ).toHaveCount(1);

--- a/frontend/e2e/dashboard-account-parity.spec.js
+++ b/frontend/e2e/dashboard-account-parity.spec.js
@@ -202,4 +202,33 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
       "doesn't match broker"
     );
   });
+
+  test('reconcile badge renders INSIDE the account tile; strip tiles share height parity (#436)', async ({
+    page,
+  }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The badge is a DESCENDANT of the account-value tile's bordered box —
+    // not a sibling floating below it (the #436 defect).
+    const accountValue = page.getByTestId('kpi-account-value');
+    await expect(
+      accountValue.locator('[data-reconcile-badge="reconciled"]')
+    ).toHaveCount(1);
+
+    // The three tiles in the reconciliation strip share one height baseline
+    // (the badge no longer makes the account tile taller than its neighbours).
+    const [aBox, cBox, dBox] = await Promise.all([
+      page.getByTestId('kpi-account-value').boundingBox(),
+      page.getByTestId('kpi-cash').boundingBox(),
+      page.getByTestId('kpi-day-change').boundingBox(),
+    ]);
+    expect(aBox).not.toBeNull();
+    expect(cBox).not.toBeNull();
+    expect(dBox).not.toBeNull();
+    // Allow 1px for sub-pixel rounding.
+    expect(Math.abs(aBox.height - cBox.height)).toBeLessThanOrEqual(1);
+    expect(Math.abs(aBox.height - dBox.height)).toBeLessThanOrEqual(1);
+  });
 });

--- a/frontend/e2e/dashboard-journal-pill.spec.js
+++ b/frontend/e2e/dashboard-journal-pill.spec.js
@@ -78,17 +78,23 @@ test.describe('Dashboard journal count pill (#437) @e2e', () => {
     const journal = page.getByTestId('status-pill-journal');
     await expect(journal).toBeVisible();
 
-    // The number is present as a tally, and the copy names it as a journal
-    // count — NOT the old health-pill phrasing "Journal 4 positions".
-    await expect(journal).toContainText('4');
+    // The tally is an exact numeric badge child — the count itself, not a
+    // color dot that happens to sit beside a new label.
+    await expect(journal.locator('span').filter({ hasText: /^4$/ })).toHaveCount(1);
+    // It is NOT a health pill: health dots are aria-hidden color spans; the
+    // count variant carries no such dot.
+    await expect(journal.locator('span[aria-hidden="true"]')).toHaveCount(0);
     await expect(journal).toContainText('positions in Journal');
+    // Descriptive hover names it as a journal tally, not a status.
+    await expect(journal).toHaveAttribute('title', '4 open positions in your journal');
 
     // Navigational: the count links to the journal.
     await expect(journal).toHaveAttribute('href', '/journal');
 
-    // It is NOT a health pill: the three real health pills carry no numeric
-    // content in their dot, so the journal item alone surfaces its count text.
-    await expect(page.getByTestId('status-pill-schwab')).toContainText('Schwab connected');
+    // Contrast: the real health pills DO carry an aria-hidden color dot.
+    await expect(
+      page.getByTestId('status-pill-schwab').locator('span[aria-hidden="true"]')
+    ).toHaveCount(1);
   });
 
   test('singular copy when exactly one journaled position', async ({ page }) => {
@@ -100,8 +106,9 @@ test.describe('Dashboard journal count pill (#437) @e2e', () => {
     await page.waitForLoadState('networkidle');
 
     const journal = page.getByTestId('status-pill-journal');
-    await expect(journal).toContainText('1');
+    await expect(journal.locator('span').filter({ hasText: /^1$/ })).toHaveCount(1);
     await expect(journal).toContainText('position in Journal');
     await expect(journal).not.toContainText('positions in Journal');
+    await expect(journal).toHaveAttribute('title', '1 open position in your journal');
   });
 });

--- a/frontend/e2e/dashboard-journal-pill.spec.js
+++ b/frontend/e2e/dashboard-journal-pill.spec.js
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E for #437 — the journal count on the dashboard status strip is an
+ * INFORMATIONAL tally, not a health signal.
+ *
+ * Regression guard: a grey status dot sitting in a row of green health pills
+ * (Schwab / FRED / Quotes) reads as "journal degraded." The journal item must
+ * instead render a numeric count badge (variant="count") carrying the number,
+ * with descriptive copy, and still link to /journal.
+ */
+
+const BASE_PAYLOAD = {
+  generated_at: '2026-07-04T13:42:00+00:00',
+  status: {
+    schwab: { configured: true, valid: true, expires_at: '2026-09-01T00:00:00+00:00' },
+    fred: { configured: true, valid: true },
+    cache: { fresh: 12, stale: 0, very_stale: 0, total: 12 },
+    journal: { positions_count: 4 },
+  },
+  positions: [],
+  open_legs: [],
+  recent_activity: [],
+  data_meta: {
+    is_stale: false,
+    fetched_at: '2026-07-04T13:42:00+00:00',
+    sources_unavailable: [],
+  },
+  account_summary: {
+    account_value: 10526.76,
+    equity_mv: 9166.0,
+    option_mv: -4.5,
+    cash: 1365.26,
+    day_change: null,
+    day_change_pct: null,
+    day_state: 'no_prior_close',
+    reconciles: true,
+    reconcile_state: 'reconciled',
+  },
+  kpis: {
+    open_positions: 0,
+    open_positions_breakdown: { stock: 0, csp: 0, cc: 0, wheel: 0, holding: 0 },
+    notional_value: 0,
+    notional_change_pct: 0.0,
+    open_legs: 0,
+    open_legs_breakdown: { puts: 0, calls: 0 },
+    unrealized_pl: 0,
+    unrealized_pl_pct: 0,
+    includes_options: false,
+    largest_risk: null,
+    premium_collected_total: 0,
+    premium_collected_trades: 0,
+    premium_collected_ytd: 0,
+    realized_pl: 0,
+    realized_pl_pct: null,
+    largest_loser: null,
+  },
+};
+
+function mockDashboard(page, payload) {
+  return page.route('**/api/dashboard', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    })
+  );
+}
+
+test.describe('Dashboard journal count pill (#437) @e2e', () => {
+  test('journal count renders as a count badge with descriptive copy and links to /journal', async ({
+    page,
+  }) => {
+    await mockDashboard(page, BASE_PAYLOAD);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const journal = page.getByTestId('status-pill-journal');
+    await expect(journal).toBeVisible();
+
+    // The number is present as a tally, and the copy names it as a journal
+    // count — NOT the old health-pill phrasing "Journal 4 positions".
+    await expect(journal).toContainText('4');
+    await expect(journal).toContainText('positions in Journal');
+
+    // Navigational: the count links to the journal.
+    await expect(journal).toHaveAttribute('href', '/journal');
+
+    // It is NOT a health pill: the three real health pills carry no numeric
+    // content in their dot, so the journal item alone surfaces its count text.
+    await expect(page.getByTestId('status-pill-schwab')).toContainText('Schwab connected');
+  });
+
+  test('singular copy when exactly one journaled position', async ({ page }) => {
+    await mockDashboard(page, {
+      ...BASE_PAYLOAD,
+      status: { ...BASE_PAYLOAD.status, journal: { positions_count: 1 } },
+    });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const journal = page.getByTestId('status-pill-journal');
+    await expect(journal).toContainText('1');
+    await expect(journal).toContainText('position in Journal');
+    await expect(journal).not.toContainText('positions in Journal');
+  });
+});


### PR DESCRIPTION
Patch release fixing two dashboard visual defects reported against v1.9.2.

## Closes
- Closes #436 — reconcile badge renders outside the Account value tile, breaking tile height parity
- Closes #437 — journal count pill reads as a health signal

## #436 — Reconcile badge escapes the card + unequal tile heights
The reconcile badge was a sibling of the account-value `StatCard`, inside the blue emphasis ring but **outside** the card's bordered box — so it floated below the border, and the extra height made the account tile taller than Cash & sweep / Day change.

**Fix:** `StatCard` gets an optional `footer` slot rendered *inside* the bordered box; the badge is passed through it. `h-full` stretches the three tiles to one grid-row height baseline.

## #437 — Journal count reads as "degraded"
The journal item used a grey `state: 'neutral'` status dot next to the green health pills, reading as "journal not connected" rather than an informational count.

**Fix:** new `StatusPill` `variant="count"` renders a numeric tally badge (count stays readable to assistive tech, unlike the color-only health dot); journal pill switches to it with clearer, singular-aware copy ("N positions in Journal"), still linking to `/journal`.

> ⚠️ #437 was filed `needs-design`. This ships a pragmatic in-strip treatment (count badge). If the designer prefers relocating the count out of the health strip entirely, that's a clean follow-up — the `variant="count"` primitive supports either direction.

## Tests
- `frontend/e2e/dashboard-account-parity.spec.js` — appended #436 regression: badge is a descendant of the account-value tile's bordered box; the three strip tiles share height parity.
- `frontend/e2e/dashboard-journal-pill.spec.js` (new) — #437: journal renders a count badge with descriptive copy + `/journal` link; singular copy at count === 1.

Frontend has no unit/integration tier (PRD #261) — Playwright e2e is the only frontend runner. These dashboard specs are auth-gated and only run green in CI (local runs redirect to sign-in without `GITHUB_ID/SECRET`). ESLint + `check-playwright-tags.sh` pass locally.

## Not applicable
- No route/response-shape changes → no OpenAPI/frontend-types regen.
- No new user-facing data shape → no QA seed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)