### PR TITLE
fix(dashboard): render reconcile badge inside the account tile + tile height parity (#436)

### DIFF
--- a/frontend/components/common/StatCard.jsx
+++ b/frontend/components/common/StatCard.jsx
@@ -4,6 +4,12 @@
  * Hoisted from the inline `StatCard` in StatsPanel.jsx so the dashboard and
  * the regression results panel can share a visual recipe. Adds an optional
  * `subtext` prop for the dashboard's two-line tiles ("3 stock · 1 cash").
+ *
+ * `footer` renders inside the bordered box, below the subtext — a slot for
+ * tile-local affordances (e.g. the reconcile badge, #436) that must live
+ * WITHIN the card border, not escape below it. `h-full` lets the tile stretch
+ * to the grid row height so a row of StatCards shares one baseline even when
+ * one tile carries a footer.
  */
 export default function StatCard({
   label,
@@ -13,12 +19,13 @@ export default function StatCard({
   colorClass,
   dataTestid,
   dataAttrs,
+  footer,
 }) {
   return (
     <div
       data-testid={dataTestid}
       {...(dataAttrs || {})}
-      className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 relative group"
+      className="h-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-4 relative group"
     >
       <div className="text-xs text-slate-500 dark:text-slate-400 mb-1">{label}</div>
       <div
@@ -33,6 +40,7 @@ export default function StatCard({
           {subtext}
         </div>
       )}
+      {footer}
       {tooltip && (
         <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-slate-800 dark:bg-slate-600 text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-10">
           {tooltip}

--- a/frontend/components/dashboard/AccountSummaryRow.jsx
+++ b/frontend/components/dashboard/AccountSummaryRow.jsx
@@ -145,8 +145,11 @@ export default function AccountSummaryRow({ summary, loading }) {
       className="grid grid-cols-2 lg:grid-cols-4 gap-4"
     >
       {/* Account value hero — emphasis (blue ring + span) applied by the parent
-          wrapper so the shared StatCard recipe stays intact (design spec). */}
-      <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg relative">
+          wrapper so the shared StatCard recipe stays intact (design spec).
+          The reconcile badge is passed as the StatCard `footer` so it renders
+          INSIDE the tile's bordered box rather than escaping below it (#436);
+          `h-full` keeps the three tiles on one height baseline. */}
+      <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg h-full">
         <StatCard
           label="Account value"
           value={accountValue}
@@ -157,12 +160,8 @@ export default function AccountSummaryRow({ summary, loading }) {
             'data-reconciles': summary.reconciles ? 'true' : 'false',
             'data-reconcile-state': reconcileState,
           }}
+          footer={connected ? <ReconcileBadge state={reconcileState} /> : null}
         />
-        {connected && (
-          <div className="px-4 pb-3 -mt-2">
-            <ReconcileBadge state={reconcileState} />
-          </div>
-        )}
       </div>
       <StatCard
         label="Cash & sweep"

--- a/frontend/components/dashboard/AccountSummaryRow.jsx
+++ b/frontend/components/dashboard/AccountSummaryRow.jsx
@@ -142,13 +142,19 @@ export default function AccountSummaryRow({ summary, loading }) {
   return (
     <div
       data-testid="dashboard-account-summary"
-      className="grid grid-cols-2 lg:grid-cols-4 gap-4"
+      className="grid grid-cols-2 lg:grid-cols-4 gap-4 auto-rows-fr"
     >
       {/* Account value hero — emphasis (blue ring + span) applied by the parent
           wrapper so the shared StatCard recipe stays intact (design spec).
           The reconcile badge is passed as the StatCard `footer` so it renders
-          INSIDE the tile's bordered box rather than escaping below it (#436);
-          `h-full` keeps the three tiles on one height baseline. */}
+          INSIDE the tile's bordered box rather than escaping below it (#436).
+
+          Height parity (#436) needs BOTH pieces: `h-full` stretches a tile to
+          its own grid row, and `auto-rows-fr` makes every row equal. Below
+          `lg` the hero spans both columns and so sits on a *separate* row from
+          Cash & sweep / Day change — `h-full` alone would only equalise within
+          each row, leaving the hero free to be taller. At `lg` there is a
+          single row and `auto-rows-fr` is a no-op. */}
       <div className="col-span-2 lg:col-span-2 ring-1 ring-blue-500/40 rounded-lg h-full">
         <StatCard
           label="Account value"

--- a/frontend/e2e/dashboard-account-parity.spec.js
+++ b/frontend/e2e/dashboard-account-parity.spec.js
@@ -220,16 +220,30 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
 
     // The three tiles in the reconciliation strip share one height baseline
     // (the badge no longer makes the account tile taller than its neighbours).
-    const [aBox, cBox, dBox] = await Promise.all([
-      page.getByTestId('kpi-account-value').boundingBox(),
-      page.getByTestId('kpi-cash').boundingBox(),
-      page.getByTestId('kpi-day-change').boundingBox(),
-    ]);
-    expect(aBox).not.toBeNull();
-    expect(cBox).not.toBeNull();
-    expect(dBox).not.toBeNull();
-    // Allow 1px for sub-pixel rounding.
-    expect(Math.abs(aBox.height - cBox.height)).toBeLessThanOrEqual(1);
-    expect(Math.abs(aBox.height - dBox.height)).toBeLessThanOrEqual(1);
+    //
+    // Asserted at BOTH breakpoints the component defines. These are different
+    // layouts, not the same one resized: at `lg` all three tiles sit on one
+    // grid row, but below `lg` the hero spans both columns onto a row of its
+    // own — so `h-full` alone cannot equalise it against Cash & sweep / Day
+    // change, and `auto-rows-fr` on the grid is what carries the narrow case.
+    // The default 1280px viewport only ever exercised the wide layout.
+    for (const [name, width, height] of [
+      ['narrow (grid-cols-2)', 800, 900],
+      ['wide (lg:grid-cols-4)', 1280, 900],
+    ]) {
+      await page.setViewportSize({ width, height });
+
+      const [aBox, cBox, dBox] = await Promise.all([
+        page.getByTestId('kpi-account-value').boundingBox(),
+        page.getByTestId('kpi-cash').boundingBox(),
+        page.getByTestId('kpi-day-change').boundingBox(),
+      ]);
+      expect(aBox, name).not.toBeNull();
+      expect(cBox, name).not.toBeNull();
+      expect(dBox, name).not.toBeNull();
+      // Allow 1px for sub-pixel rounding.
+      expect(Math.abs(aBox.height - cBox.height), name).toBeLessThanOrEqual(1);
+      expect(Math.abs(aBox.height - dBox.height), name).toBeLessThanOrEqual(1);
+    }
   });
 });

--- a/frontend/e2e/dashboard-account-parity.spec.js
+++ b/frontend/e2e/dashboard-account-parity.spec.js
@@ -208,11 +208,12 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
   }) => {
     await mockDashboard(page, { ...BASE_PAYLOAD, kpis: KPIS });
     await page.goto('/dashboard');
-    await page.waitForLoadState('networkidle');
 
     // The badge is a DESCENDANT of the account-value tile's bordered box —
-    // not a sibling floating below it (the #436 defect).
+    // not a sibling floating below it (the #436 defect). The visibility +
+    // count assertions auto-wait for render, so no whole-page networkidle.
     const accountValue = page.getByTestId('kpi-account-value');
+    await expect(accountValue).toBeVisible();
     await expect(
       accountValue.locator('[data-reconcile-badge="reconciled"]')
     ).toHaveCount(1);

--- a/frontend/e2e/dashboard-account-parity.spec.js
+++ b/frontend/e2e/dashboard-account-parity.spec.js
@@ -202,4 +202,33 @@ test.describe('Dashboard account parity (#420) @e2e', () => {
       "doesn't match broker"
     );
   });
+
+  test('reconcile badge renders INSIDE the account tile; strip tiles share height parity (#436)', async ({
+    page,
+  }) => {
+    await mockDashboard(page, { ...BASE_PAYLOAD, kpis: KPIS });
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // The badge is a DESCENDANT of the account-value tile's bordered box —
+    // not a sibling floating below it (the #436 defect).
+    const accountValue = page.getByTestId('kpi-account-value');
+    await expect(
+      accountValue.locator('[data-reconcile-badge="reconciled"]')
+    ).toHaveCount(1);
+
+    // The three tiles in the reconciliation strip share one height baseline
+    // (the badge no longer makes the account tile taller than its neighbours).
+    const [aBox, cBox, dBox] = await Promise.all([
+      page.getByTestId('kpi-account-value').boundingBox(),
+      page.getByTestId('kpi-cash').boundingBox(),
+      page.getByTestId('kpi-day-change').boundingBox(),
+    ]);
+    expect(aBox).not.toBeNull();
+    expect(cBox).not.toBeNull();
+    expect(dBox).not.toBeNull();
+    // Allow 1px for sub-pixel rounding.
+    expect(Math.abs(aBox.height - cBox.height)).toBeLessThanOrEqual(1);
+    expect(Math.abs(aBox.height - dBox.height)).toBeLessThanOrEqual(1);
+  });
 });


### PR DESCRIPTION
Patch fix for the dashboard visual defect reported against v1.9.2.

## Closes
- Closes #436 — reconcile badge renders outside the Account value tile, breaking tile height parity

## Root cause
`ReconcileBadge` was rendered as a **sibling** of the account-value `StatCard`, inside the blue emphasis ring but **outside** the card's bordered box (`border … rounded-lg p-4`). It therefore floated in the gap between the card border and the ring, and the extra height it added below the card made the Account value tile taller than Cash & sweep / Day change — breaking the three-tile row's shared baseline.

`StatCard` had no slot for footer content, which is why the badge was appended outside it in the first place.

## Fix
- `StatCard` gains an optional `footer` slot rendered **inside** the bordered box, below the subtext. Implemented as a generic prop so other `StatCard` consumers (e.g. the regression-results panel it was hoisted from) can reuse it — resolving the issue's open question in favour of the reusable option.
- `AccountSummaryRow` passes `ReconcileBadge` through that slot instead of rendering it as a sibling.
- `h-full` on the card and the hero wrapper lets the tiles stretch to the grid row height, restoring one shared baseline across all three tiles at both breakpoints.

No change to the tri-state badge logic from #429 — `reconcile_state`, `data-reconciles`, `data-reconcile-state` and `data-reconcile-badge` are untouched.

## Tests
`frontend/e2e/dashboard-account-parity.spec.js` — appended a #436 regression test asserting:
- `[data-reconcile-badge="reconciled"]` is a DOM **descendant** of `[data-testid="kpi-account-value"]` (fails against the pre-fix markup, where it was a sibling);
- the three strip tiles share height parity within 1px (sub-pixel rounding tolerance).

Frontend has no unit/integration tier (PRD #261) — Playwright e2e is the only frontend runner. ESLint and `check-playwright-tags.sh` pass locally.

## Scope note
This PR is deliberately scoped to **#436 only**. #437 (journal count pill) is labelled `needs-design` and its resolution is still an open design question, so it is left out of this patch and remains open for design input. See #438 for context.

## Not applicable
- No route/response-shape changes → no OpenAPI/frontend-types regen.
- No new user-facing data shape → no QA seed change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)